### PR TITLE
Fix installation of missing boot files with bundle-add

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,67 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: true
+AlignConsecutiveAssignments: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Linux
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IndentCaseLabels: false
+IndentWidth:     8
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Always
+...
+

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ autom4te.cache/
 compile
 config.*
 configure
+coverage/
 cscope.*
 data/check-update.service
 data/check-update.timer
@@ -31,11 +32,14 @@ ltmain.sh
 m4/
 missing
 regression/*.out
+src/*.gcda
+src/*.gcno
 stamp-h1
 swupd
 swupd-client*tar.gz
 swupd_*
 tap-driver.sh
 test-suite.log
+test/*.gcno
 test/functional/*/*/*/*/*.tar
 test/functional/*/*/*/*/*/*.tar

--- a/Makefile.am
+++ b/Makefile.am
@@ -144,6 +144,18 @@ dist_check_SCRIPTS = \
 	functional-tests.py
 endif
 
+if COVERAGE
+AM_CFLAGS += --coverage
+
+coverage: coverage-clean
+	mkdir -p coverage
+	lcov --compat-libtool --directory . --capture --output-file coverage/report
+	genhtml -o coverage/ coverage/report
+
+coverage-clean:
+	rm -rf coverage
+endif
+
 release:
 	@git rev-parse v$(PACKAGE_VERSION) &> /dev/null; \
 	if [ "$$?" -eq 0 ]; then \

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,8 @@ swupd_SOURCES = \
 	$(swupd_check_update_SOURCES) \
 	$(swupd_verify_SOURCES) \
 	$(clr_bundle_add_SOURCES) \
-	$(clr_bundle_rm_SOURCES)
+	$(clr_bundle_rm_SOURCES) \
+	$(swupd_search_SOURCES)
 
 check_PROGRAMS = \
 	swupd_bsdiff_bench \
@@ -59,6 +60,7 @@ libswupd_la_LDFLAGS = \
 swupd_update_SOURCES = src/main.c
 swupd_verify_SOURCES = src/verify.c
 swupd_check_update_SOURCES = src/check_update.c
+swupd_search_SOURCES = src/search.c
 
 clr_bundle_add_SOURCES = src/clr_bundle_add.c
 clr_bundle_rm_SOURCES = src/clr_bundle_rm.c

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,25 @@ AC_ARG_ENABLE(
   [AS_HELP_STRING([--disable-tests], [Do not enable unit or functional test framework (enabled by default)])]
 )
 
+have_coverage=no
+AC_ARG_ENABLE(coverage, AS_HELP_STRING([--enable-coverage], [enable test coverage]))
+if test "$enable_coverage" = "yes" ; then
+        AC_CHECK_PROG(lcov_found, [lcov], [yes], [no])
+        if test "$lcov_found" = "no" ; then
+                AC_MSG_ERROR([*** lcov support requested but the program was not found])
+        else
+                lcov_version_major="`lcov --version | cut -d ' ' -f 4 | cut -d '.' -f 1`"
+                lcov_version_minor="`lcov --version | cut -d ' ' -f 4 | cut -d '.' -f 2`"
+                if test "$lcov_version_major" -eq 1 -a "$lcov_version_minor" -lt 10; then
+                        AC_MSG_ERROR([*** lcov version is too old. 1.10 required])
+                else
+			have_coverage=yes
+			AC_DEFINE([COVERAGE], [1], [Coverage enabled])
+                fi
+        fi
+fi
+AM_CONDITIONAL([COVERAGE], [test "$have_coverage" = "yes"])
+
 AC_ARG_WITH([systemdsystemunitdir], AS_HELP_STRING([--with-systemdsystemunitdir=DIR],
             [path to systemd system service dir @<:@default=/usr/lib/systemd/system@:>@]), [unitpath=${withval}],
             [unitpath="$($PKG_CONFIG --variable=systemdsystemunitdir systemd)"])

--- a/include/list.h
+++ b/include/list.h
@@ -10,7 +10,7 @@ struct list {
 };
 
 typedef int (*comparison_fn_t)(const void *a, const void *b);
-typedef void (*list_free_data_fn_t) (void *data);
+typedef void (*list_free_data_fn_t)(void *data);
 
 /* creates a new list item, store data, and inserts item in list (which can
  * be NULL). Returns created link, or NULL if failure. Created link can be

--- a/include/swupd-error.h
+++ b/include/swupd-error.h
@@ -1,23 +1,23 @@
 #ifndef __INCLUDE_GUARD_SWUPD_ERROR_H
 #define __INCLUDE_GUARD_SWUPD_ERROR_H
 
-#define EBUNDLE_MISMATCH	2  /* at least one local bundle mismatches from MoM */
-#define EBUNDLE_REMOVE		3  /* cannot delete local bundle filename */
-#define EMOM_NOTFOUND		4  /* MoM cannot be loaded into memory (this could imply network issue) */
-#define ETYPE_CHANGED_FILE_RM	5  /* do_staging() couldn't delete a file which must be deleted */
-#define EDIR_OVERWRITE		6  /* do_staging() couldn't overwrite a directory */
-#define EDOTFILE_WRITE		7  /* do_staging() couldn't create a dotfile */
-#define ERECURSE_MANIFEST	8  /* error while recursing a manifest */
-#define ELOCK_FILE		9  /* cannot get the lock */
-#define EPREP_MOUNT		10 /* failed to prepare mount points */
-#define ECURL_INIT		11 /* cannot initialize curl agent */
-#define EINIT_GLOBALS		12 /* cannot initialize globals */
-#define EBUNDLE_NOT_TRACKED	13 /* bundle is not tracked on the system */
-#define EMANIFEST_LOAD		14 /* cannot load manifest into memory */
-#define EINVALID_OPTION		15 /* invalid command option */
-#define ENOSWUPDSERVER		16 /* no net connection to swupd server */
-#define EFULLDOWNLOAD		17 /* full_download problem */
-#define ENET404			404 /* download 404'd */
-#define EBUNDLE_INSTALL		18 /* Cannot install bundles */
+#define EBUNDLE_MISMATCH 2      /* at least one local bundle mismatches from MoM */
+#define EBUNDLE_REMOVE 3	/* cannot delete local bundle filename */
+#define EMOM_NOTFOUND 4		/* MoM cannot be loaded into memory (this could imply network issue) */
+#define ETYPE_CHANGED_FILE_RM 5 /* do_staging() couldn't delete a file which must be deleted */
+#define EDIR_OVERWRITE 6	/* do_staging() couldn't overwrite a directory */
+#define EDOTFILE_WRITE 7	/* do_staging() couldn't create a dotfile */
+#define ERECURSE_MANIFEST 8     /* error while recursing a manifest */
+#define ELOCK_FILE 9		/* cannot get the lock */
+#define EPREP_MOUNT 10		/* failed to prepare mount points */
+#define ECURL_INIT 11		/* cannot initialize curl agent */
+#define EINIT_GLOBALS 12	/* cannot initialize globals */
+#define EBUNDLE_NOT_TRACKED 13  /* bundle is not tracked on the system */
+#define EMANIFEST_LOAD 14       /* cannot load manifest into memory */
+#define EINVALID_OPTION 15      /* invalid command option */
+#define ENOSWUPDSERVER 16       /* no net connection to swupd server */
+#define EFULLDOWNLOAD 17	/* full_download problem */
+#define ENET404 404		/* download 404'd */
+#define EBUNDLE_INSTALL 18      /* Cannot install bundles */
 
 #endif

--- a/include/swupd-internal.h
+++ b/include/swupd-internal.h
@@ -7,5 +7,6 @@ extern int hashdump_main(int argc, char **argv);
 extern int update_main(int argc, char **argv);
 extern int verify_main(int argc, char **argv);
 extern int check_update_main(int argc, char **argv);
+extern int search_main(int argc, char **argv);
 
 #endif

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -10,23 +10,23 @@
 #include <dirent.h>
 #include "swupd-error.h"
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
 /* WARNING: keep SWUPD_VERSION_INCR in sync with server definition  */
-#define SWUPD_VERSION_INCR		10
+#define SWUPD_VERSION_INCR 10
 #define SWUPD_VERSION_IS_DEVEL(v) (((v) % SWUPD_VERSION_INCR) == 8)
 #define SWUPD_VERSION_IS_RESVD(v) (((v) % SWUPD_VERSION_INCR) == 9)
 
 #ifndef LINE_MAX
-#define LINE_MAX	_POSIX2_LINE_MAX
+#define LINE_MAX _POSIX2_LINE_MAX
 #endif
 
 #define PATH_MAXLEN 4096
 #define CURRENT_OS_VERSION -1
 
-#define UNUSED_PARAM  __attribute__ ((__unused__))
+#define UNUSED_PARAM __attribute__((__unused__))
 
 #define MAX_TRIES 3
 
@@ -48,7 +48,7 @@ struct manifest {
 	int manifest_version;
 	uint64_t contentsize;
 	struct list *files;
-	struct list *manifests; /* struct file for possible manifests */
+	struct list *manifests;    /* struct file for possible manifests */
 	struct list *submanifests; /* struct manifest for subscribed manifests */
 	char *component;
 };
@@ -64,43 +64,43 @@ extern bool need_update_boot;
 extern bool need_update_bootloader;
 
 struct update_stat {
-	uint64_t	st_mode;
-	uint64_t	st_uid;
-	uint64_t	st_gid;
-	uint64_t	st_rdev;
-	uint64_t	st_size;
+	uint64_t st_mode;
+	uint64_t st_uid;
+	uint64_t st_gid;
+	uint64_t st_rdev;
+	uint64_t st_size;
 };
 
 #define DIGEST_LEN_SHA256 64
 /* +1 for null termination */
-#define SWUPD_HASH_LEN (DIGEST_LEN_SHA256+1)
+#define SWUPD_HASH_LEN (DIGEST_LEN_SHA256 + 1)
 
 struct file {
 	char *filename;
 	char hash[SWUPD_HASH_LEN];
 	bool use_xattrs;
-	int  last_change;
+	int last_change;
 	struct update_stat stat;
 
-	unsigned int is_dir		: 1;
-	unsigned int is_file		: 1;
-	unsigned int is_link		: 1;
-	unsigned int is_deleted		: 1;
-	unsigned int is_manifest	: 1;
+	unsigned int is_dir : 1;
+	unsigned int is_file : 1;
+	unsigned int is_link : 1;
+	unsigned int is_deleted : 1;
+	unsigned int is_manifest : 1;
 
-	unsigned int is_config		: 1;
-	unsigned int is_state		: 1;
-	unsigned int is_boot		: 1;
-	unsigned int is_rename		: 1;
-	unsigned int is_orphan		: 1;
-	unsigned int do_not_update	: 1;
+	unsigned int is_config : 1;
+	unsigned int is_state : 1;
+	unsigned int is_boot : 1;
+	unsigned int is_rename : 1;
+	unsigned int is_orphan : 1;
+	unsigned int do_not_update : 1;
 
-	struct file *peer;	/* same file in another manifest */
-	struct file *deltapeer;	/* the file to do the binary delta against; often same as "peer" except in rename cases */
+	struct file *peer;      /* same file in another manifest */
+	struct file *deltapeer; /* the file to do the binary delta against; often same as "peer" except in rename cases */
 	struct header *header;
 
-	char *staging;		/* output name used during download & staging */
-	CURL *curl;		/* curl handle if downloading */
+	char *staging; /* output name used during download & staging */
+	CURL *curl;    /* curl handle if downloading */
 };
 
 extern bool download_only;
@@ -183,10 +183,10 @@ extern void swupd_curl_set_requested_version(int v);
 extern double swupd_query_url_content_size(char *url);
 extern size_t swupd_download_file(void *ptr, size_t size, size_t nmemb, void *userdata);
 extern int swupd_curl_get_file(const char *url, char *filename, struct file *file,
-			    char *tmp_version, bool pack);
-#define SWUPD_CURL_LOW_SPEED_LIMIT	1
-#define SWUPD_CURL_CONNECT_TIMEOUT	30
-#define SWUPD_CURL_RCV_TIMEOUT		120
+			       char *tmp_version, bool pack);
+#define SWUPD_CURL_LOW_SPEED_LIMIT 1
+#define SWUPD_CURL_CONNECT_TIMEOUT 30
+#define SWUPD_CURL_RCV_TIMEOUT 120
 extern CURLcode swupd_curl_set_basic_options(CURL *curl, const char *url);
 
 extern struct list *subs;
@@ -207,11 +207,11 @@ extern int recurse_manifest(struct manifest *manifest, const char *component);
 extern void consolidate_submanifests(struct manifest *manifest);
 extern void debug_write_manifest(struct manifest *manifest, char *filename);
 extern void populate_file_struct(struct file *file, char *filename);
-extern bool verify_file(struct file* file, char *filename);
+extern bool verify_file(struct file *file, char *filename);
 extern void unlink_all_staged_content(struct file *file);
 extern void link_renames(struct list *newfiles, struct manifest *from_manifest);
 extern void dump_file_descriptor_leaks(void);
-extern FILE * fopen_exclusive(const char *filename); /* no mode, opens for write only */
+extern FILE *fopen_exclusive(const char *filename); /* no mode, opens for write only */
 extern int rm_staging_dir_contents(const char *rel_path);
 extern int create_required_dirs(void);
 extern void dump_file_info(struct file *file);
@@ -257,12 +257,12 @@ extern int install_bundles(char **bundles);
 /* some disk sizes constants for the various features:
  *   ...consider adding build automation to catch at build time
  *      if the build's artifacts are larger than these thresholds */
-#define MANIFEST_REQUIRED_SIZE (1024 * 1024 * 100) 	/* 100M */
-#define FREE_MARGIN 10					/* 10%  */
+#define MANIFEST_REQUIRED_SIZE (1024 * 1024 * 100) /* 100M */
+#define FREE_MARGIN 10				   /* 10%  */
 
 /****************************************************************/
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -111,7 +111,6 @@ extern bool verify_bundles_only;
 extern bool ignore_config;
 extern bool ignore_state;
 extern bool ignore_orphans;
-extern bool fix;
 extern char *format_string;
 extern char *path_prefix;
 extern bool set_format_string(char *userinput);
@@ -141,7 +140,7 @@ extern int read_version_from_subvol_file(char *path_prefix);
 
 extern bool check_network(void);
 
-extern bool ignore(struct file *file);
+extern bool ignore(struct file *file, bool fix);
 extern bool is_config(char *filename);
 extern bool is_state(char *filename);
 extern void apply_heuristics(struct file *file);

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -180,6 +180,7 @@ extern int swupd_curl_init(void);
 extern void swupd_curl_cleanup(void);
 extern void swupd_curl_set_current_version(int v);
 extern void swupd_curl_set_requested_version(int v);
+extern double swupd_query_url_content_size(char *url);
 extern size_t swupd_download_file(void *ptr, size_t size, size_t nmemb, void *userdata);
 extern int swupd_curl_get_file(const char *url, char *filename, struct file *file,
 			    char *tmp_version, bool pack);

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -413,7 +413,7 @@ int install_bundles(char **bundles)
 		file = iter->data;
 		iter = iter->next;
 
-		if (file->is_deleted || file->do_not_update || ignore(file)) {
+		if (file->is_deleted || file->do_not_update || ignore(file, true)) {
 			continue;
 		}
 

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -268,7 +268,6 @@ int remove_bundle(const char *bundle_name)
 		goto out_free_curl;
 	}
 
-
 	ret = load_manifests(current_version, current_version, "MoM", NULL, &current_mom);
 	if (ret != 0) {
 		goto out_free_curl;
@@ -277,7 +276,7 @@ int remove_bundle(const char *bundle_name)
 	/* load all tracked bundles into memory */
 	read_subscriptions_alt();
 	/* now popout the one to be removed */
-	ret =  unload_tracked_bundle(bundle_name);
+	ret = unload_tracked_bundle(bundle_name);
 	if (ret != 0) {
 		goto out_free_mom;
 	}
@@ -356,7 +355,6 @@ int install_bundles(char **bundles)
 		goto clean_and_exit;
 	}
 
-
 	ret = load_manifests(current_version, current_version, "MoM", NULL, &mom);
 	if (ret != 0) {
 		printf("Cannot load official manifest MoM for version %i\n", current_version);
@@ -398,7 +396,7 @@ int install_bundles(char **bundles)
 
 	/* step 3: download neccessary packs */
 
-	ret  = rm_staging_dir_contents("download");
+	ret = rm_staging_dir_contents("download");
 
 	printf("Downloading required packs...\n");
 	ret = download_subscribed_packs(0, current_version, true);

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -33,7 +33,7 @@
 static void print_help(const char *name)
 {
 	printf("Usage:\n");
-	printf("   swupd %s [options] bundlename\n\n", basename((char*)name));
+	printf("   swupd %s [options] bundlename\n\n", basename((char *)name));
 	printf("Help Options:\n");
 	printf("   -h, --help              Show help options\n");
 	printf("   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
@@ -45,13 +45,13 @@ static void print_help(const char *name)
 }
 
 static const struct option prog_opts[] = {
-	{"help", no_argument, 0, 'h'},
-	{"url", required_argument, 0, 'u'},
-	{"port", required_argument, 0, 'P'},
-	{"format", required_argument, 0, 'F'},
-	{"force", no_argument, 0, 'x'},
-	{"path", required_argument, 0, 'p'},
-	{0, 0, 0, 0}
+	{ "help", no_argument, 0, 'h' },
+	{ "url", required_argument, 0, 'u' },
+	{ "port", required_argument, 0, 'P' },
+	{ "format", required_argument, 0, 'F' },
+	{ "force", no_argument, 0, 'x' },
+	{ "path", required_argument, 0, 'p' },
+	{ 0, 0, 0, 0 }
 };
 
 static bool parse_options(int argc, char **argv)
@@ -62,48 +62,48 @@ static bool parse_options(int argc, char **argv)
 
 	while ((opt = getopt_long(argc, argv, "hxu:P:F:p:", prog_opts, NULL)) != -1) {
 		switch (opt) {
-			case '?':
-			case 'h':
-				print_help(argv[0]);
-				exit(EXIT_SUCCESS);
-			case 'u':
-				if (!optarg) {
-					printf("error: invalid --url argument\n\n");
-					goto err;
-				}
-				if (version_server_urls[0]) {
-					free(version_server_urls[0]);
-				}
-				string_or_die(&version_server_urls[0], "%s", optarg);
-				break;
-			case 'P':
-				if (sscanf(optarg, "%ld", &update_server_port) != 1) {
-					printf("Invalid --port argument\n\n");
-					goto err;
-				}
-				break;
-			case 'F':
-				if (!optarg || !set_format_string(optarg)) {
-					printf("Invalid --format argument\n\n");
-					goto err;
-				}
-				break;
-			case 'p': /* default empty path_prefix checks the running OS */
-				if (!optarg) {
-					printf("Invalid --path argument\n\n");
-					goto err;
-				}
-				if (path_prefix) { /* multiple -p options */
-					free(path_prefix);
-				}
-				string_or_die(&path_prefix, "%s", optarg);
-				break;
-			case 'x':
-				force = true;
-				break;
-			default:
-				printf("error: unrecognized option\n\n");
+		case '?':
+		case 'h':
+			print_help(argv[0]);
+			exit(EXIT_SUCCESS);
+		case 'u':
+			if (!optarg) {
+				printf("error: invalid --url argument\n\n");
 				goto err;
+			}
+			if (version_server_urls[0]) {
+				free(version_server_urls[0]);
+			}
+			string_or_die(&version_server_urls[0], "%s", optarg);
+			break;
+		case 'P':
+			if (sscanf(optarg, "%ld", &update_server_port) != 1) {
+				printf("Invalid --port argument\n\n");
+				goto err;
+			}
+			break;
+		case 'F':
+			if (!optarg || !set_format_string(optarg)) {
+				printf("Invalid --format argument\n\n");
+				goto err;
+			}
+			break;
+		case 'p': /* default empty path_prefix checks the running OS */
+			if (!optarg) {
+				printf("Invalid --path argument\n\n");
+				goto err;
+			}
+			if (path_prefix) { /* multiple -p options */
+				free(path_prefix);
+			}
+			string_or_die(&path_prefix, "%s", optarg);
+			break;
+		case 'x':
+			force = true;
+			break;
+		default:
+			printf("error: unrecognized option\n\n");
+			goto err;
 		}
 	}
 
@@ -114,7 +114,6 @@ static bool parse_options(int argc, char **argv)
 err:
 	print_help(argv[0]);
 	return false;
-
 }
 
 static int check_update()
@@ -142,7 +141,8 @@ static int check_update()
 	}
 }
 
-int check_update_main(int argc, char **argv) {
+int check_update_main(int argc, char **argv)
+{
 	int ret;
 	copyright_header("software update checker");
 

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -44,8 +44,7 @@ static void print_help(const char *name)
 	printf("\n");
 }
 
-static const struct option prog_opts[] =
-{
+static const struct option prog_opts[] = {
 	{"help", no_argument, 0, 'h'},
 	{"url", required_argument, 0, 'u'},
 	{"port", required_argument, 0, 'P'},

--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -38,9 +38,10 @@
 bool list = false;
 static char **bundles;
 
-static void print_help(const char *name) {
+static void print_help(const char *name)
+{
 	printf("Usage:\n");
-	printf("   swupd %s [options] [bundle1 bundle2 (...)]\n\n", basename((char*)name));
+	printf("   swupd %s [options] [bundle1 bundle2 (...)]\n\n", basename((char *)name));
 	printf("Help Options:\n");
 	printf("   -h, --help              Show help options\n");
 	printf("   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
@@ -53,14 +54,14 @@ static void print_help(const char *name) {
 }
 
 static const struct option prog_opts[] = {
-	{"help", no_argument, 0, 'h'},
-	{"url", required_argument, 0, 'u'},
-	{"port", required_argument, 0, 'P'},
-	{"list", no_argument, 0, 'l'},
-	{"path", required_argument, 0, 'p'},
-	{"format", required_argument, 0, 'F'},
-	{"force", no_argument, 0, 'x'},
-	{0, 0, 0, 0}
+	{ "help", no_argument, 0, 'h' },
+	{ "url", required_argument, 0, 'u' },
+	{ "port", required_argument, 0, 'P' },
+	{ "list", no_argument, 0, 'l' },
+	{ "path", required_argument, 0, 'p' },
+	{ "format", required_argument, 0, 'F' },
+	{ "force", no_argument, 0, 'x' },
+	{ 0, 0, 0, 0 }
 };
 
 static bool parse_options(int argc, char **argv)

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -38,9 +38,10 @@
 
 static char *bundle_name = NULL;
 
-static void print_help(const char *name) {
+static void print_help(const char *name)
+{
 	printf("Usage:\n");
-	printf("   swupd %s [options] bundlename\n\n", basename((char*)name));
+	printf("   swupd %s [options] bundlename\n\n", basename((char *)name));
 	printf("Help Options:\n");
 	printf("   -h, --help              Show help options\n");
 	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
@@ -51,12 +52,12 @@ static void print_help(const char *name) {
 }
 
 static const struct option prog_opts[] = {
-	{"help", no_argument, 0, 'h'},
-	{"path", required_argument, 0, 'p'},
-	{"url", required_argument, 0, 'u'},
-	{"port", required_argument, 0, 'P'},
-	{"force", no_argument, 0, 'x'},
-	{0, 0, 0, 0}
+	{ "help", no_argument, 0, 'h' },
+	{ "path", required_argument, 0, 'p' },
+	{ "url", required_argument, 0, 'u' },
+	{ "port", required_argument, 0, 'P' },
+	{ "force", no_argument, 0, 'x' },
+	{ 0, 0, 0, 0 }
 };
 
 static bool parse_options(int argc, char **argv)
@@ -118,7 +119,6 @@ static bool parse_options(int argc, char **argv)
 err:
 	print_help(argv[0]);
 	return false;
-
 }
 
 int bundle_remove_main(int argc, char **argv)

--- a/src/curl.c
+++ b/src/curl.c
@@ -399,7 +399,7 @@ CURLcode swupd_curl_set_basic_options(CURL *curl, const char *url)
 	}
 
 	if (strncmp(url, content_server_urls[1], strlen(content_server_urls[1])) == 0) {
-#warning SECURITY HOLE since we can't SSL pin arbitrary servers
+#warning "SECURITY HOLE since we can't SSL pin arbitrary servers"
 		curl_ret = swupd_curl_set_security_opts(curl);
 		if (curl_ret != CURLE_OK) {
 			goto exit;
@@ -425,7 +425,7 @@ CURLcode swupd_curl_set_basic_options(CURL *curl, const char *url)
 		goto exit;
 	}
 
-#warning setup a means to validate IPv6 works end to end
+#warning "setup a means to validate IPv6 works end to end"
 	curl_ret = curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
 	if (curl_ret != CURLE_OK) {
 		goto exit;

--- a/src/curl.c
+++ b/src/curl.c
@@ -143,7 +143,7 @@ static size_t swupd_download_version_to_memory(void *ptr, size_t size, size_t nm
 /* curl easy CURLOPT_WRITEFUNCTION callback */
 size_t swupd_download_file(void *ptr, size_t size, size_t nmemb, void *userdata)
 {
-	struct file *file = (struct file*)userdata;
+	struct file *file = (struct file *)userdata;
 	const char *outfile;
 	int fd;
 	FILE *f;
@@ -151,7 +151,7 @@ size_t swupd_download_file(void *ptr, size_t size, size_t nmemb, void *userdata)
 
 	outfile = file->staging;
 
-	fd = open(outfile, O_CREAT | O_RDWR , 00600);
+	fd = open(outfile, O_CREAT | O_RDWR, 00600);
 	if (fd < 0) {
 		printf("Error: Cannot open %s for write: %s\n",
 		       outfile, strerror(errno));
@@ -166,7 +166,7 @@ size_t swupd_download_file(void *ptr, size_t size, size_t nmemb, void *userdata)
 		return -1;
 	}
 
-	written = fwrite(ptr, size*nmemb, 1, f);
+	written = fwrite(ptr, size * nmemb, 1, f);
 
 	fflush(f);
 	fclose(f);
@@ -175,7 +175,7 @@ size_t swupd_download_file(void *ptr, size_t size, size_t nmemb, void *userdata)
 		return -1;
 	}
 
-	return size*nmemb;
+	return size * nmemb;
 }
 
 /* Download a single file SYNCHRONOUSLY
@@ -216,13 +216,13 @@ int swupd_curl_get_file(const char *url, char *filename, struct file *file,
 
 		if (lstat(filename, &stat) == 0) {
 			if (pack) {
-				curl_ret = curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE, (curl_off_t) stat.st_size);
+				curl_ret = curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE, (curl_off_t)stat.st_size);
 			} else {
 				unlink(filename);
 			}
 		}
 
-		curl_ret = curl_easy_setopt(curl, CURLOPT_PRIVATE, (void*)local);
+		curl_ret = curl_easy_setopt(curl, CURLOPT_PRIVATE, (void *)local);
 		if (curl_ret != CURLE_OK) {
 			goto exit;
 		}
@@ -230,7 +230,7 @@ int swupd_curl_get_file(const char *url, char *filename, struct file *file,
 		if (curl_ret != CURLE_OK) {
 			goto exit;
 		}
-		curl_ret = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void*)local);
+		curl_ret = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)local);
 		if (curl_ret != CURLE_OK) {
 			goto exit;
 		}
@@ -242,7 +242,7 @@ int swupd_curl_get_file(const char *url, char *filename, struct file *file,
 		if (curl_ret != CURLE_OK) {
 			goto exit;
 		}
-		curl_ret = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void*)in_memory_version_string);
+		curl_ret = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)in_memory_version_string);
 		if (curl_ret != CURLE_OK) {
 			goto exit;
 		}
@@ -266,58 +266,58 @@ exit:
 	if (curl_ret == CURLE_OK) {
 		/* curl command succeeded, download might've failed, let our caller handle */
 		switch (ret) {
-			case 200:
-			case 206:
-				err = 0;
-				break;
-			case 403:
-				err = -EACCES;
-				break;
-			case 404:
-				err = -ENET404;
-				break;
-			default:
-				err = -1;
-				break;
+		case 200:
+		case 206:
+			err = 0;
+			break;
+		case 403:
+			err = -EACCES;
+			break;
+		case 404:
+			err = -ENET404;
+			break;
+		default:
+			err = -1;
+			break;
 		}
 	} else { /* download failed but let our caller do it */
 		switch (curl_ret) {
-			case CURLE_COULDNT_RESOLVE_PROXY:
-				printf("Curl: Could not resolve proxy\n");
-				err = -1;
-				break;
-			case CURLE_COULDNT_RESOLVE_HOST:
-				printf("Curl: Could not resolve host - '%s'\n", url);
-				err = -1;
-				break;
-			case CURLE_COULDNT_CONNECT:
-				err = -ENONET;
-				break;
-			case CURLE_PARTIAL_FILE:
-				printf("Curl: File incompletely downloaded from '%s' to '%s'\n",
-							url, filename);
-				err = -1;
-				break;
-			case CURLE_RECV_ERROR:
-				printf("Curl: Failure receiving data from server\n");
-				err = -ENOLINK;
-				break;
-			case CURLE_WRITE_ERROR:
-				printf("Curl: Error downloading to local file - %s\n", filename);
-				err = -EIO;
-				break;
-			case CURLE_OPERATION_TIMEDOUT:
-				printf("Curl: Communicating with server timed out.\n");
-				err = -ETIMEDOUT;
-				break;
-			case CURLE_SSL_CACERT_BADFILE:
-				printf("Curl: Bad SSL Cert file, cannot ensure secure connection\n");
-				err = -1;
-				break;
-			default :
-				printf("Curl error: %d - see curl.h for details\n", curl_ret);
-				err = -1;
-				break;
+		case CURLE_COULDNT_RESOLVE_PROXY:
+			printf("Curl: Could not resolve proxy\n");
+			err = -1;
+			break;
+		case CURLE_COULDNT_RESOLVE_HOST:
+			printf("Curl: Could not resolve host - '%s'\n", url);
+			err = -1;
+			break;
+		case CURLE_COULDNT_CONNECT:
+			err = -ENONET;
+			break;
+		case CURLE_PARTIAL_FILE:
+			printf("Curl: File incompletely downloaded from '%s' to '%s'\n",
+			       url, filename);
+			err = -1;
+			break;
+		case CURLE_RECV_ERROR:
+			printf("Curl: Failure receiving data from server\n");
+			err = -ENOLINK;
+			break;
+		case CURLE_WRITE_ERROR:
+			printf("Curl: Error downloading to local file - %s\n", filename);
+			err = -EIO;
+			break;
+		case CURLE_OPERATION_TIMEDOUT:
+			printf("Curl: Communicating with server timed out.\n");
+			err = -ETIMEDOUT;
+			break;
+		case CURLE_SSL_CACERT_BADFILE:
+			printf("Curl: Bad SSL Cert file, cannot ensure secure connection\n");
+			err = -1;
+			break;
+		default:
+			printf("Curl error: %d - see curl.h for details\n", curl_ret);
+			err = -1;
+			break;
 		}
 	}
 
@@ -333,7 +333,6 @@ exit:
 
 	return err;
 }
-
 
 static CURLcode swupd_curl_set_security_opts(CURL *curl)
 {
@@ -365,7 +364,7 @@ static CURLcode swupd_curl_set_security_opts(CURL *curl)
 		goto exit;
 	}
 
-	curl_ret = curl_easy_setopt(curl, CURLOPT_CAPATH , UPDATE_CA_CERTS_PATH);
+	curl_ret = curl_easy_setopt(curl, CURLOPT_CAPATH, UPDATE_CA_CERTS_PATH);
 	if (curl_ret != CURLE_OK) {
 		goto exit;
 	}

--- a/src/curl.c
+++ b/src/curl.c
@@ -89,7 +89,7 @@ void swupd_curl_set_requested_version(int v)
 	req_version = v;
 }
 
-static size_t filesize_from_header_cb(void *func, size_t size, size_t nmemb, void *data)
+static size_t filesize_from_header_cb(void UNUSED_PARAM *func, size_t size, size_t nmemb, void UNUSED_PARAM *data)
 {
 	/* Drop the header, we just want file size */
 	return (size_t)(size * nmemb);

--- a/src/curl.c
+++ b/src/curl.c
@@ -370,11 +370,13 @@ static CURLcode swupd_curl_set_security_opts(CURL *curl)
 		goto exit;
 	}
 
+#if 0
 	// TODO: add the below when you know the paths:
-	//curl_easy_setopt(curl, CURLOPT_CRLFILE, path-to-cert-revoc-list);
-	//if (curl_ret != CURLE_OK) {
-	//	goto exit;
-	//}
+	curl_easy_setopt(curl, CURLOPT_CRLFILE, path-to-cert-revoc-list);
+	if (curl_ret != CURLE_OK) {
+		goto exit;
+	}
+#endif
 
 exit:
 	return curl_ret;

--- a/src/curl.c
+++ b/src/curl.c
@@ -89,6 +89,42 @@ void swupd_curl_set_requested_version(int v)
 	req_version = v;
 }
 
+static size_t filesize_from_header_cb(void *func, size_t size, size_t nmemb, void *data)
+{
+	/* Drop the header, we just want file size */
+	return (size_t)(size * nmemb);
+}
+
+double swupd_query_url_content_size(char *url)
+{
+	CURLcode curl_ret;
+	double content_size;
+
+	if (!curl) {
+		return -1;
+	}
+
+	curl_easy_reset(curl);
+
+	/* Set buffer for error string */
+	curl_ret = curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
+	curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, filesize_from_header_cb);
+	curl_ret = curl_easy_setopt(curl, CURLOPT_HEADER, 0L);
+	curl_ret = curl_easy_setopt(curl, CURLOPT_URL, url);
+
+	curl_ret = curl_easy_perform(curl);
+	if (curl_ret != CURLE_OK) {
+		return -1;
+	}
+
+	curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &content_size);
+	if (curl_ret != CURLE_OK) {
+		return -1;
+	}
+
+	return content_size;
+}
+
 static size_t swupd_download_version_to_memory(void *ptr, size_t size, size_t nmemb, void *userdata)
 {
 	char *tmp_version = (char *)userdata;

--- a/src/delta.c
+++ b/src/delta.c
@@ -38,9 +38,7 @@
 #include "swupd.h"
 #include "xattrs.h"
 
-
-static void do_delta(struct file* file);
-
+static void do_delta(struct file *file);
 
 void try_delta(struct file *file)
 {
@@ -84,7 +82,7 @@ static void do_delta(struct file *file)
 	struct stat stat;
 
 	string_or_die(&deltafile, "%s/delta/%i-%i-%s", STATE_DIR,
-			file->deltapeer->last_change, file->last_change, file->hash);
+		      file->deltapeer->last_change, file->last_change, file->hash);
 
 	/* check if the full file is there already, because if it is, don't do the delta */
 	string_or_die(&filename, "%s/staged/%s", STATE_DIR, file->hash);

--- a/src/download.c
+++ b/src/download.c
@@ -72,7 +72,8 @@ static struct swupd_curl_hashbucket swupd_curl_hashmap[SWUPD_CURL_HASH_BUCKETS];
  * returns 1 if no download is needed
  * returns 0 if download is needed
  * returns -1 if error */
-static int swupd_curl_hashmap_insert(struct file *file) {
+static int swupd_curl_hashmap_insert(struct file *file)
+{
 	struct list *iter;
 	struct file *tmp;
 	char *tar_dotfile;
@@ -162,7 +163,7 @@ int start_full_download(bool pipelining)
 
 static void free_curl_list_data(void *data)
 {
-	struct file *file = (struct file*)data;
+	struct file *file = (struct file *)data;
 	CURL *curl = file->curl;
 	if (curl != NULL) {
 		curl_multi_remove_handle(mcurl, curl);
@@ -173,7 +174,7 @@ static void free_curl_list_data(void *data)
 void clean_curl_multi_queue(void)
 {
 	int i;
-	struct swupd_curl_hashbucket* bucket;
+	struct swupd_curl_hashbucket *bucket;
 
 	for (i = 0; i < SWUPD_CURL_HASH_BUCKETS; i++) {
 		bucket = &swupd_curl_hashmap[i];
@@ -220,11 +221,11 @@ static int check_tarfile_content(struct file *file, const char *tarfilename)
 
 		c = strchr(buffer, '\n');
 		if (c) {
-			*c  = 0;
+			*c = 0;
 		}
-		if (c && (c != buffer) && (*(c-1)=='/')) {
+		if (c && (c != buffer) && (*(c - 1) == '/')) {
 			/* strip trailing '/' from directory tar */
-			*(c-1) = 0;
+			*(c - 1) = 0;
 		}
 		if (strcmp(buffer, file->hash) != 0) {
 			err = -1;
@@ -290,7 +291,7 @@ static void untar_full_download(void *data)
 
 	/* modern tar will automatically determine the compression type used */
 	string_or_die(&tarcommand, "tar -C %s/staged/ " TAR_PERM_ATTR_ARGS " -xf %s 2> /dev/null",
-			STATE_DIR, tarfile);
+		      STATE_DIR, tarfile);
 
 	err = system(tarcommand);
 	if (WIFEXITED(err)) {
@@ -455,11 +456,11 @@ void full_download(struct file *file)
 	CURLcode curl_ret = CURLE_OK;
 
 	ret = swupd_curl_hashmap_insert(file);
-	if (ret > 0) {		/* no download needed */
+	if (ret > 0) { /* no download needed */
 		/* File already exists - report success */
 		ret = 0;
 		goto out_good;
-	} else if (ret < 0) {	/* error */
+	} else if (ret < 0) { /* error */
 		goto out_bad;
 	} /* else (ret == 0)	   download needed */
 
@@ -485,7 +486,7 @@ void full_download(struct file *file)
 		goto out_bad;
 	}
 
-	curl_ret = curl_easy_setopt(curl, CURLOPT_PRIVATE, (void*)file);
+	curl_ret = curl_easy_setopt(curl, CURLOPT_PRIVATE, (void *)file);
 	if (curl_ret != CURLE_OK) {
 		goto out_bad;
 	}
@@ -493,7 +494,7 @@ void full_download(struct file *file)
 	if (curl_ret != CURLE_OK) {
 		goto out_bad;
 	}
-	curl_ret = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void*)file);
+	curl_ret = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)file);
 	if (curl_ret != CURLE_OK) {
 		goto out_bad;
 	}

--- a/src/download.c
+++ b/src/download.c
@@ -393,12 +393,14 @@ static int perform_curl_io_and_complete(int *left)
 			file->staging = NULL;
 		}
 
-/* NOTE: Intentionally no removal of file from hashmap.  All needed files
- * need determined and queued in one complete preparation phase.  Once all
- * needed files are all present, they can be staged.  Otherwise a complex
- * datastructure and retries are needed to insure only one download of a file
- * happens fully to success AND a HASH.tar is uncompressed to and HASH and
- * staged to the _multiple_ filenames with that hash. */
+		/* NOTE: Intentionally no removal of file from hashmap.  All
+		 * needed files need determined and queued in one complete
+		 * preparation phase.  Once all needed files are all present,
+		 * they can be staged.  Otherwise a complex datastructure and
+		 * retries are needed to insure only one download of a file
+		 * happens fully to success AND a HASH.tar is uncompressed to
+		 * and HASH and staged to the _multiple_ filenames with that
+		 * hash. */
 
 		curl_multi_remove_handle(mcurl, handle);
 		curl_easy_cleanup(handle);

--- a/src/filedesc.c
+++ b/src/filedesc.c
@@ -30,7 +30,6 @@
 
 #include "swupd.h"
 
-
 void dump_file_descriptor_leaks(void)
 {
 	DIR *dir;

--- a/src/globals.c
+++ b/src/globals.c
@@ -44,7 +44,6 @@ bool ignore_config = true;
 bool ignore_state = true;
 #endif
 bool ignore_orphans = true;
-bool fix = false;
 char *format_string = NULL;
 char *path_prefix = NULL; /* must always end in '/' */
 char *mounted_dirs = NULL;

--- a/src/globals.c
+++ b/src/globals.c
@@ -46,7 +46,7 @@ bool ignore_state = true;
 bool ignore_orphans = true;
 bool fix = false;
 char *format_string = NULL;
-char *path_prefix = NULL;      /* must always end in '/' */
+char *path_prefix = NULL; /* must always end in '/' */
 char *mounted_dirs = NULL;
 char *bundle_to_add = NULL;
 struct timeval start_time;
@@ -58,7 +58,7 @@ struct timeval start_time;
  */
 bool download_only;
 bool have_manifest_diskspace = false; /* assume no until checked */
-bool have_network = false; /* assume no access until proved */
+bool have_network = false;	    /* assume no access until proved */
 #define URL_COUNT 2
 char *version_server_urls[URL_COUNT] = {
 	NULL,
@@ -149,7 +149,7 @@ bool init_globals(void)
 		}
 
 		len = strlen(path_prefix);
-		if (!len || (path_prefix[len-1] != '/')) {
+		if (!len || (path_prefix[len - 1] != '/')) {
 			string_or_die(&tmp, "%s/", path_prefix);
 			free(path_prefix);
 			path_prefix = tmp;
@@ -160,7 +160,7 @@ bool init_globals(void)
 	ret = stat(path_prefix, &statbuf);
 	if (ret != 0 || !S_ISDIR(statbuf.st_mode)) {
 		printf("Bad path_prefix %s (%s), cannot continue.\n",
-			path_prefix, strerror(errno));
+		       path_prefix, strerror(errno));
 		return false;
 	}
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -37,13 +37,13 @@
 
 void hash_assign(char *src, char *dst)
 {
-	memcpy(dst, src, SWUPD_HASH_LEN-1);
-	dst[SWUPD_HASH_LEN-1] = '\0';
+	memcpy(dst, src, SWUPD_HASH_LEN - 1);
+	dst[SWUPD_HASH_LEN - 1] = '\0';
 }
 
 bool hash_compare(char *hash1, char *hash2)
 {
-	if (bcmp(hash1, hash2, SWUPD_HASH_LEN-1) == 0) {
+	if (bcmp(hash1, hash2, SWUPD_HASH_LEN - 1) == 0) {
 		return true;
 	} else {
 		return false;
@@ -128,14 +128,14 @@ static void hmac_compute_key(const char *filename,
 	}
 
 	hmac_sha256_for_data(key, (const unsigned char *)updt_stat,
-				    sizeof(struct update_stat),
-				    (const unsigned char *)xattrs_blob,
-				    xattrs_blob_len);
+			     sizeof(struct update_stat),
+			     (const unsigned char *)xattrs_blob,
+			     xattrs_blob_len);
 
 	if (hash_is_zeros(key)) {
 		*key_len = 0;
 	} else {
-		*key_len = SWUPD_HASH_LEN-1;
+		*key_len = SWUPD_HASH_LEN - 1;
 	}
 
 	if (xattrs_blob_len != 0) {
@@ -187,9 +187,9 @@ int compute_hash(struct file *file, char *filename)
 		if (ret >= 0) {
 			hmac_compute_key(filename, &file->stat, key, &key_len, file->use_xattrs);
 			hmac_sha256_for_string(file->hash,
-					(const unsigned char *)key,
-					key_len,
-					link);
+					       (const unsigned char *)key,
+					       key_len,
+					       link);
 			return 0;
 		} else {
 			return -1;
@@ -199,9 +199,9 @@ int compute_hash(struct file *file, char *filename)
 	if (file->is_dir) {
 		hmac_compute_key(filename, &file->stat, key, &key_len, file->use_xattrs);
 		hmac_sha256_for_string(file->hash,
-					(const unsigned char *)key,
-					key_len,
-					file->filename);	//file->filename not filename
+				       (const unsigned char *)key,
+				       key_len,
+				       file->filename); //file->filename not filename
 		return 0;
 	}
 
@@ -217,10 +217,10 @@ int compute_hash(struct file *file, char *filename)
 
 	hmac_compute_key(filename, &file->stat, key, &key_len, file->use_xattrs);
 	hmac_sha256_for_data(file->hash,
-				(const unsigned char *)key,
-				key_len,
-				blob,
-				file->stat.st_size);
+			     (const unsigned char *)key,
+			     key_len,
+			     blob,
+			     file->stat.st_size);
 	munmap(blob, file->stat.st_size);
 	fclose(fl);
 	return 0;

--- a/src/hashdump.c
+++ b/src/hashdump.c
@@ -34,14 +34,15 @@
 
 static struct option opts[] = {
 	{ "no-xattrs", 0, NULL, 'n' },
-	{ "basepath",  1, NULL, 'b' },
-	{ "help",      0, NULL, 'h' },
+	{ "basepath", 1, NULL, 'b' },
+	{ "help", 0, NULL, 'h' },
 	{ 0, 0, NULL, 0 }
 };
 
-static void usage(const char *name) {
+static void usage(const char *name)
+{
 	printf("Usage:\n");
-	printf("   swupd %s [OPTION...] filename\n\n", basename((char*)name));
+	printf("   swupd %s [OPTION...] filename\n\n", basename((char *)name));
 	printf("Help Options:\n");
 	printf("   -h, --help              Show help options\n\n");
 	printf("Application Options:\n");
@@ -54,7 +55,7 @@ static void usage(const char *name) {
 
 int hashdump_main(int argc, char **argv)
 {
-	struct file* file;
+	struct file *file;
 	char *fullname;
 	int ret;
 
@@ -74,7 +75,7 @@ int hashdump_main(int argc, char **argv)
 			break;
 		}
 
-		switch(c) {
+		switch (c) {
 		case 'n':
 			file->use_xattrs = false;
 			break;
@@ -122,7 +123,7 @@ int hashdump_main(int argc, char **argv)
 	}
 
 	printf("Calculating hash %s xattrs for: (%s) ... %s\n",
-	       (file->use_xattrs ? "with":"without"), path_prefix, file->filename);
+	       (file->use_xattrs ? "with" : "without"), path_prefix, file->filename);
 	fullname = mk_full_filename(path_prefix, file->filename);
 	printf("fullname=%s\n", fullname);
 	populate_file_struct(file, fullname);

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -38,7 +38,6 @@
 #include "config.h"
 #include "swupd.h"
 
-
 void check_root(void)
 {
 	if (getuid() != 0) {
@@ -122,17 +121,17 @@ void unlink_all_staged_content(struct file *file)
 	/* delta file */
 	if (file->peer) {
 		string_or_die(&filename, "%s/delta/%i-%i-%s", STATE_DIR,
-		    file->peer->last_change, file->last_change, file->hash);
+			      file->peer->last_change, file->last_change, file->hash);
 		unlink(filename);
 		free(filename);
 	}
 }
 
-FILE * fopen_exclusive(const char *filename) /* no mode, opens for write only */
+FILE *fopen_exclusive(const char *filename) /* no mode, opens for write only */
 {
 	int fd;
 
-	fd = open(filename,O_CREAT | O_EXCL | O_RDWR , 00600);
+	fd = open(filename, O_CREAT | O_EXCL | O_RDWR, 00600);
 	if (fd < 0) {
 		return NULL;
 	}
@@ -145,7 +144,7 @@ int create_required_dirs(void)
 	int i;
 	char *dir;
 #define STATE_DIR_COUNT 3
-	const char *dirs[] = {"delta","staged","download"};
+	const char *dirs[] = { "delta", "staged", "download" };
 	struct stat buf;
 	bool missing = false;
 
@@ -280,7 +279,7 @@ char *mk_full_filename(const char *prefix, const char *path)
 		if (fname == NULL) {
 			abort();
 		}
-	} else if (strcmp(&prefix[strlen(prefix)-1], "/") == 0) {
+	} else if (strcmp(&prefix[strlen(prefix) - 1], "/") == 0) {
 		// chroot and need to strip trailing "/" from prefix
 		char *tmp = strdup(prefix);
 		if (tmp == NULL) {
@@ -302,7 +301,7 @@ char *mk_full_filename(const char *prefix, const char *path)
 bool is_directory_mounted(const char *filename)
 {
 	char *fname;
-	bool  ret = false;
+	bool ret = false;
 	char *tmp;
 
 	if (mounted_dirs == NULL) {
@@ -325,8 +324,8 @@ bool is_directory_mounted(const char *filename)
 // expects filename w/o path_prefix prepended
 bool is_under_mounted_directory(const char *filename)
 {
-	bool  ret = false;
-	int   err;
+	bool ret = false;
+	int err;
 	char *token;
 	char *mountpoint;
 	char *dir;
@@ -436,7 +435,8 @@ exit:
 	return ret;
 }
 
-int swupd_rm(const char *filename) {
+int swupd_rm(const char *filename)
+{
 	struct stat stat;
 	int ret;
 
@@ -483,7 +483,6 @@ int rm_bundle_file(const char *bundle)
 out:
 	free(filename);
 	return ret;
-
 }
 
 #if 0
@@ -544,7 +543,7 @@ void dump_file_info(struct file *file)
 
 void free_file_data(void *data)
 {
-	struct file *file = (struct file *) data;
+	struct file *file = (struct file *)data;
 
 	if (!file) {
 		return;
@@ -602,7 +601,6 @@ out_fds:
 	dump_file_descriptor_leaks();
 
 	return ret;
-
 }
 
 /* this function prints the initial message for all utils
@@ -647,20 +645,20 @@ void delete_motd(void)
 
 int is_dirname_link(const char *fullname)
 {
-    int ret = -1;
-    char *real_path = NULL;
-    real_path = realpath(fullname, NULL);
-    if (!real_path) {
-        printf("Failed to get real path of %s\n", fullname);
-        return -1;
-    }
-
-    if (strcmp(real_path, fullname) != 0) {
-        ret = 1;
-    } else {
-        ret = 0;
+	int ret = -1;
+	char *real_path = NULL;
+	real_path = realpath(fullname, NULL);
+	if (!real_path) {
+		printf("Failed to get real path of %s\n", fullname);
+		return -1;
 	}
 
-    free(real_path);
-    return ret;
+	if (strcmp(real_path, fullname) != 0) {
+		ret = 1;
+	} else {
+		ret = 0;
+	}
+
+	free(real_path);
+	return ret;
 }

--- a/src/heuristics.c
+++ b/src/heuristics.c
@@ -113,14 +113,21 @@ void apply_heuristics(struct file *file)
 	config_file_heuristics(file);
 }
 
-bool ignore(struct file *file)
+/* Determines whether or not FILE should be ignored for this swupd action. The
+ * value of FIX_MISSING depends on which action is being run; for actions that
+ * may modify the filesystem (e.g. update, bundle-add), FIX_MISSING should be
+ * true; otherwise, it should be false. Note that a 'verify' action (without
+ * --fix) does not modify the filesystem, so FIX_MISSING must be false unless
+ *  --fix is specified.
+ */
+bool ignore(struct file *file, bool fix_missing)
 {
 	if ((file->is_config) ||
 	    is_config(file->filename) || // ideally we trust the manifest but short term reapply check here
 	    (file->is_state) ||
 	    is_state(file->filename) ||			    // ideally we trust the manifest but short term reapply check here
-	    (file->is_boot && fix && file->is_deleted) ||   // shouldn't happen
-	    (file->is_boot && !fix && !file->is_deleted) || // default ignore
+	    (file->is_boot && fix_missing && file->is_deleted) ||   // shouldn't happen
+	    (file->is_boot && !fix_missing && !file->is_deleted) || // default ignore
 	    (ignore_orphans && file->is_orphan)) {
 		update_skip++;
 		file->do_not_update = 1;

--- a/src/heuristics.c
+++ b/src/heuristics.c
@@ -89,7 +89,7 @@ static void boot_file_heuristics(struct file *file)
 {
 	if ((strncmp(file->filename, "/boot/", 6) == 0) ||
 	    (strncmp(file->filename, "/usr/lib/modules/", 17) == 0)) {
-			file->is_boot = 1;
+		file->is_boot = 1;
 	}
 
 	if (strncmp(file->filename, "/usr/lib/kernel/", 16) == 0) {
@@ -118,8 +118,8 @@ bool ignore(struct file *file)
 	if ((file->is_config) ||
 	    is_config(file->filename) || // ideally we trust the manifest but short term reapply check here
 	    (file->is_state) ||
-	    is_state(file->filename) || // ideally we trust the manifest but short term reapply check here
-	    (file->is_boot &&  fix &&  file->is_deleted) || // shouldn't happen
+	    is_state(file->filename) ||			    // ideally we trust the manifest but short term reapply check here
+	    (file->is_boot && fix && file->is_deleted) ||   // shouldn't happen
 	    (file->is_boot && !fix && !file->is_deleted) || // default ignore
 	    (ignore_orphans && file->is_orphan)) {
 		update_skip++;

--- a/src/list.c
+++ b/src/list.c
@@ -65,7 +65,8 @@ static struct list *list_alloc_item(void *data)
 }
 
 // Merges two sorted lists
-static struct list *list_merge(struct list *list1, struct list *list2, comparison_fn_t comparison_fn) {
+static struct list *list_merge(struct list *list1, struct list *list2, comparison_fn_t comparison_fn)
+{
 	struct list *merged_list = NULL;
 	struct list *merged_list_head = NULL;
 	while (list1 && list2) {

--- a/src/main.c
+++ b/src/main.c
@@ -35,22 +35,23 @@
 static bool cmd_line_status = false;
 
 static const struct option prog_opts[] = {
-	{"download", no_argument, 0, 'd'},
-	{"help", no_argument, 0, 'h'},
-	{"url", required_argument, 0, 'u'},
-	{"port", required_argument, 0, 'P'},
-	{"contenturl", required_argument, 0, 'c'},
-	{"versionurl", required_argument, 0, 'v'},
-	{"status", no_argument, 0, 's'},
-	{"format", required_argument, 0, 'F'},
-	{"path", required_argument, 0, 'p'},
-	{"force", no_argument, 0, 'x'},
-	{0, 0, 0, 0}
+	{ "download", no_argument, 0, 'd' },
+	{ "help", no_argument, 0, 'h' },
+	{ "url", required_argument, 0, 'u' },
+	{ "port", required_argument, 0, 'P' },
+	{ "contenturl", required_argument, 0, 'c' },
+	{ "versionurl", required_argument, 0, 'v' },
+	{ "status", no_argument, 0, 's' },
+	{ "format", required_argument, 0, 'F' },
+	{ "path", required_argument, 0, 'p' },
+	{ "force", no_argument, 0, 'x' },
+	{ 0, 0, 0, 0 }
 };
 
-static void print_help(const char *name) {
+static void print_help(const char *name)
+{
 	printf("Usage:\n");
-	printf("   swupd %s [OPTION...]\n\n", basename((char*)name));
+	printf("   swupd %s [OPTION...]\n\n", basename((char *)name));
 	printf("Help Options:\n");
 	printf("   -h, --help              Show help options\n\n");
 	printf("Application Options:\n");

--- a/src/main.c
+++ b/src/main.c
@@ -55,12 +55,12 @@ static void print_help(const char *name) {
 	printf("   -h, --help              Show help options\n\n");
 	printf("Application Options:\n");
 	printf("   -d, --download          Download all content, but do not actually install the update\n");
-#warning remove user configurable url when alternative exists
+#warning "remove user configurable url when alternative exists"
 	printf("   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
 	printf("   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
-#warning remove user configurable content url when alternative exists
+#warning "remove user configurable content url when alternative exists"
 	printf("   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
-#warning remove user configurable version url when alternative exists
+#warning "remove user configurable version url when alternative exists"
 	printf("   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
 	printf("   -s, --status            Show current OS version and latest version available on server\n");
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -554,9 +554,7 @@ struct list *create_update_list(struct manifest *current, struct manifest *serve
 {
 	struct list *output = NULL;
 	struct list *list;
-	bool fix_tmp = fix;
 
-	fix = true;
 	update_count = 0;
 	update_skip = 0;
 	list = list_head(server->files);
@@ -569,7 +567,7 @@ struct list *create_update_list(struct manifest *current, struct manifest *serve
 		    (file->is_rename && file_has_different_hash_in_older_manifest(current, file))) {
 
 			/* check and if needed mark as do_not_update */
-			ignore(file);
+			ignore(file, true);
 			/* check if we need to run scripts/update the bootloader/etc */
 			apply_heuristics(file);
 
@@ -578,7 +576,6 @@ struct list *create_update_list(struct manifest *current, struct manifest *serve
 	}
 	update_count = list_len(output) - update_skip;
 
-	fix = fix_tmp;
 	return output;
 }
 

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -402,7 +402,7 @@ static int try_delta_manifest_download(int current, int new, char *component, st
 	struct stat buf;
 
 	if (strcmp(component, "MoM") == 0) {
-#warning need to crypto validate MoM and allow delta
+#warning "need to crypto validate MoM and allow delta"
 		return -1;
 	}
 

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -54,12 +54,12 @@ static int file_sort_hash(const void* a, const void* b)
 #endif
 
 /* sort by full path filename */
-int file_sort_filename(const void* a, const void* b)
+int file_sort_filename(const void *a, const void *b)
 {
 	struct file *A, *B;
 	int ret;
-	A = (struct file *) a;
-	B = (struct file *) b;
+	A = (struct file *)a;
+	B = (struct file *)b;
 
 	ret = strcmp(A->filename, B->filename);
 	if (ret) {
@@ -75,11 +75,11 @@ int file_sort_filename(const void* a, const void* b)
 	return 0;
 }
 
-static int file_sort_version(const void* a, const void* b)
+static int file_sort_version(const void *a, const void *b)
 {
 	struct file *A, *B;
-	A = (struct file *) a;
-	B = (struct file *) b;
+	A = (struct file *)a;
+	B = (struct file *)b;
 
 	if (A->last_change < B->last_change) {
 		return -1;
@@ -126,7 +126,7 @@ static int file_has_different_hash_in_older_manifest(struct manifest *from_manif
 			continue;
 		}
 		if (!strcmp(file->filename, searched_file->filename) &&
-				hash_compare(file->hash, searched_file->hash)) {
+		    hash_compare(file->hash, searched_file->hash)) {
 			return 1;
 		}
 	}
@@ -176,7 +176,7 @@ static struct manifest *manifest_from_file(int version, char *component)
 		goto err_close;
 	}
 
-	if (strncmp(line, "MANIFEST\t", 9)!=0) {
+	if (strncmp(line, "MANIFEST\t", 9) != 0) {
 		goto err_close;
 	}
 
@@ -187,7 +187,7 @@ static struct manifest *manifest_from_file(int version, char *component)
 	}
 
 	line[0] = 0;
-	while (strcmp(line, "\n")!=0) {
+	while (strcmp(line, "\n") != 0) {
 		/* read the header */
 		line[0] = 0;
 		if (fgets(line, MANIFEST_LINE_MAXLEN - 1, infile) == NULL) {
@@ -210,13 +210,13 @@ static struct manifest *manifest_from_file(int version, char *component)
 			goto err_close;
 		}
 
-		if (strncmp(line,"version:", 8) == 0) {
+		if (strncmp(line, "version:", 8) == 0) {
 			manifest_hdr_version = strtoull(c, NULL, 10);
 			if (manifest_hdr_version != version) {
 				goto err_close;
 			}
 		}
-		if (strncmp(line,"contentsize:", 12) == 0) {
+		if (strncmp(line, "contentsize:", 12) == 0) {
 			contentsize = strtoull(c, NULL, 10);
 		}
 	}
@@ -336,7 +336,7 @@ static struct manifest *manifest_from_file(int version, char *component)
 		} else {
 			manifest->files = list_prepend_data(manifest->files, file);
 		}
-		count ++;
+		count++;
 	}
 
 	fclose(infile);
@@ -346,7 +346,6 @@ err:
 err_close:
 	fclose(infile);
 	return NULL;
-
 }
 
 #if 0
@@ -370,7 +369,7 @@ void print_manifest_filenames(struct manifest *m)
 
 static void free_manifest_data(void *data)
 {
-	struct manifest *manifest = (struct manifest *) data;
+	struct manifest *manifest = (struct manifest *)data;
 
 	free_manifest(manifest);
 }
@@ -512,7 +511,7 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 	}
 
 	string_or_die(&tar, "tar -C %s/%i -xf %s/%i/Manifest.%s.tar 2> /dev/null",
-			STATE_DIR, version, STATE_DIR, version, component);
+		      STATE_DIR, version, STATE_DIR, version, component);
 
 	/* this is is historically a point of odd errors */
 	ret = system(tar);
@@ -567,7 +566,7 @@ struct list *create_update_list(struct manifest *current, struct manifest *serve
 		list = list->next;
 
 		if ((file->last_change > current->version) ||
-				(file->is_rename && file_has_different_hash_in_older_manifest(current, file))) {
+		    (file->is_rename && file_has_different_hash_in_older_manifest(current, file))) {
 
 			/* check and if needed mark as do_not_update */
 			ignore(file);
@@ -680,7 +679,6 @@ void link_submanifests(struct manifest *m1, struct manifest *m2)
 	}
 }
 
-
 /* if component is specified explicitly, pull in submanifest only for that
  * if component is not specified, pull in any tracked component submanifest */
 int recurse_manifest(struct manifest *manifest, const char *component)
@@ -727,7 +725,6 @@ int recurse_manifest(struct manifest *manifest, const char *component)
 
 	return 0;
 }
-
 
 void consolidate_submanifests(struct manifest *manifest)
 {

--- a/src/packs.c
+++ b/src/packs.c
@@ -35,7 +35,6 @@
 #include "swupd.h"
 #include "signature.h"
 
-
 static int download_pack(int oldversion, int newversion, char *module)
 {
 	FILE *tarfile = NULL;
@@ -78,7 +77,7 @@ static int download_pack(int oldversion, int newversion, char *module)
 
 	printf("Extracting pack.\n");
 	string_or_die(&tar, "tar -C %s " TAR_PERM_ATTR_ARGS " -xf %s/pack-%s-from-%i-to-%i.tar 2> /dev/null",
-			STATE_DIR, STATE_DIR, module, oldversion, newversion);
+		      STATE_DIR, STATE_DIR, module, oldversion, newversion);
 
 	err = system(tar);
 	if (WIFEXITED(err)) {

--- a/src/search.c
+++ b/src/search.c
@@ -1,0 +1,503 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2012-2016 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Authors:
+ *         Arjan van de Ven <arjan@linux.intel.com>
+ *         Timothy C. Pepper <timothy.c.pepper@linux.intel.com>
+ *         Brad Peters <brad.t.peters@intel.com>
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <fcntl.h>
+#include <getopt.h>
+
+#include "swupd.h"
+#include "config.h"
+
+char *search_string;
+char search_type = '0';
+bool display_all = false; /* Show all hits, or simplify output and show just first bundle match */
+bool display_files = false; /* Just display all files found in Manifest set */
+bool init = false;
+
+/* Supported default search paths */
+char *lib_paths[] = {
+	"/usr/lib",
+	NULL
+};
+
+char *bin_paths[] = {
+	"/usr/bin/",
+	NULL
+};
+
+static void print_help(const char *name) {
+	printf("Usage:\n");
+	printf("	swupd %s [Options] 'search_term'\n", basename((char*)name));
+	printf("		'search_term': A substring of a binary, library or filename (default)\n");
+	printf("		Return: Bundle name : filename matching search term\n\n");
+
+	printf("Help Options:\n");
+	printf("   -h, --help              Display this help\n");
+	printf("   -l, --library           Search paths where libraries are located for a match\n");
+	printf("   -b, --binary            Search paths where binaries are located for a match\n"); 
+	printf("   -e, --everywhere        Search system-wide for a match\n");
+	printf("   -a, --all               Display all matches. Default is to show the first only\n");
+	printf("   -d, --display-files	   Output full file list, no search done\n");
+	printf("   -i, --init              Download all manifests then return, no search done\n");
+	printf("   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
+	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
+	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
+	printf("\n");
+}
+
+static const struct option prog_opts[] = {
+	{"help", no_argument, 0, 'h'},
+	{"url", required_argument, 0, 'u'},
+	{"library", no_argument, 0, 'l'},
+	{"binary", no_argument, 0, 'b'},
+	{"everywhere", no_argument, 0, 'e'},
+	{"path", required_argument, 0, 'p'},
+	{"format", required_argument, 0, 'F'},
+	{"init", no_argument, 0, 'i'},
+	{"all", no_argument, 0, 'a'},
+	{"display-files", no_argument, 0, 'd'},
+	{0, 0, 0, 0}
+};
+
+
+static bool parse_options(int argc, char **argv)
+{
+	int opt;
+
+	set_format_string(NULL);
+
+	while ((opt = getopt_long(argc, argv, "hu:p:F:lbeiad", prog_opts, NULL)) != -1) {
+		switch (opt) {
+		case '?':
+		case 'h':
+			print_help(argv[0]);
+			exit(0);
+		case 'u':
+			if (!optarg) {
+				printf("error: invalid --url argument\n\n");
+				goto err;
+			}
+			if (version_server_urls[0]) {
+				free(version_server_urls[0]);
+			}
+			if (content_server_urls[0]) {
+				free(content_server_urls[0]);
+			}
+			string_or_die(&version_server_urls[0], "%s", optarg);
+			string_or_die(&content_server_urls[0], "%s", optarg);
+
+			break;
+		case 'p': /* default empty path_prefix verifies the running OS */
+			if (!optarg) {
+				printf("Invalid --path argument\n\n");
+				goto err;
+			}
+			if (path_prefix) {
+				/* multiple -p options */
+				free(path_prefix);
+			}
+			string_or_die(&path_prefix, "%s", optarg);
+
+			break;
+		case 'F':
+			if (!optarg || !set_format_string(optarg)) {
+				printf("Invalid --format argument\n\n");
+				goto err;
+			}
+			break;
+		case 'l':
+			if (search_type != '0') {
+				printf("Error, cannot specify multiple search types "
+							"(-l, -b, and -e are mutually exclusive)\n");
+				goto err;
+			}
+
+			search_type = 'l';
+			break;
+		case 'i':
+			init = true;
+			break;
+		case 'b':
+			if (search_type != '0') {
+				printf("Error, cannot specify multiple search types "
+							"(-l, -b, and -e are mutually exclusive)\n");
+				goto err;
+			}
+
+			search_type = 'b';
+			break;
+		case 'e':
+			if (search_type != '0') {
+				printf("Error, cannot specify multiple search types "
+							"(-l, -b, and -e are mutually exclusive)\n");
+				goto err;
+			}
+
+			search_type = 'e';
+			break;
+		case 'a':
+			display_all = true;
+			break;
+		case 'd':
+			display_files = true;
+			break;
+		default:
+			printf("Error: unrecognized option: -'%c',\n\n", opt);
+			goto err;
+		}
+	}
+
+	if ((optind == argc) && (!init) && (!display_files)) {
+		printf("Error: Search term missing\n\n");
+		print_help(argv[0]);
+		return false;
+	}
+
+	search_string = argv[optind];
+
+	if (optind + 1 < argc) {
+		printf("Error, only 1 search term supported at a time\n");
+		return false;
+	}
+
+	return true;
+
+err:
+	print_help(argv[0]);
+	return false;
+}
+
+/* file_search()
+ * Attempt to match path and substring of filename. Base op for 'swupd search'
+ * Path must match exact case, filename is case insensitive
+ */
+bool file_search(char *filename, char *path, char *search_term)
+{
+	char *pos;
+
+	if (display_files) {
+		printf("    %s\n", filename);
+		return false;
+	}
+
+	pos = strstr(filename, path);
+	if (pos == NULL ) {
+		return false;
+	}
+
+	/* match filename or substring of filename */
+	if (strcasestr(pos + strlen(path), search_term)) {
+		return true;
+	}
+
+	return false;
+}
+
+/* report_find()
+ * Report out, respecting verbosity
+ */
+void report_find(char *bundle, char *file)
+{
+	printf("'%s'  :  '%s'\n", bundle, file);
+}
+
+/* do_search()
+ * Description: Perform a lookup of the specified search string in all Clear manifests
+ * for the current os release.
+ */
+void do_search(struct manifest *MoM, char search_type, char *search_term)
+{
+	struct list *list;
+	struct list *sublist;
+	struct file *file;
+	struct file *subfile;
+	struct manifest *subman = NULL;
+	int i, ret;
+	bool done_with_bundle, done = false;
+	bool hit = false;
+
+	list = MoM->manifests;
+	while (list && !done) {
+		file = list->data;
+		list = list->next;
+		done_with_bundle = false;
+
+		/* Load sub-manifest */
+		ret = load_manifests(file->last_change, file->last_change, file->filename, NULL, &subman);
+		if (ret != 0) {
+			printf("Failed to load manifest %s\n", file->filename);
+			continue;
+		}
+
+
+		if (display_files) {
+			/* Display bundle name. Marked up for pattern matchability */
+			printf("--Bundle: %s--\n", file->filename);
+		}
+
+		/* Loop through sub-manifest, searching for files matching the desired pattern */
+		sublist = subman->files;
+		while (sublist && !done_with_bundle) {
+			subfile = sublist->data;
+			sublist = sublist->next;
+
+			if (!subfile->is_file) { continue; }
+
+			if (display_files) {
+				/* Just display filename */
+				file_search(subfile->filename, NULL, NULL);
+			} else if (search_type == 'e') {
+				/* Search for exact match, not path addition */
+				if (file_search(subfile->filename, "", search_term)) {
+					report_find(file->filename, subfile->filename);
+					hit = true;
+					if (!display_all) {
+						done = true;
+					}
+
+					done_with_bundle = true;
+					break;
+				}
+			} else if (search_type == 'l') {
+				/* Check each supported library path for a match */
+				for (i = 0; lib_paths[i] != NULL; i++) {
+					if (file_search(subfile->filename, lib_paths[i], search_term)) {
+						report_find(file->filename, subfile->filename);
+						hit = true;
+						if (!display_all) {
+							done = true;
+						}
+
+						done_with_bundle = true;
+						break;
+					}
+				}
+			} else if (search_type == 'b') {
+				/* Check each supported path for binaries */
+				for (i = 0; bin_paths[i] != NULL; i++) {
+					if (file_search(subfile->filename, bin_paths[i], search_term)) {
+						report_find(file->filename, subfile->filename);
+						hit = true;
+						if (!display_all) {
+							done = true;
+						}
+
+						done_with_bundle = true;
+						break;
+					}
+				}
+			} else {
+				printf("Unrecognized search type. -b or -l supported\n");
+				done = true;
+				break;
+			}
+		}
+
+		free_manifest(subman);
+	}
+
+	if (!hit) {
+		printf("Search term not found.\n");
+	}
+}
+
+static double query_total_download_size(struct list *list)
+{
+	double ret;
+	double size_sum = 0;
+	struct file *file;
+	char *untard_file, *url;
+
+	while (list) {
+		file = list->data;
+		list = list->next;
+
+		string_or_die(&untard_file, "%s/%i/Manifest.%s", STATE_DIR, file->last_change,
+						file->filename);
+
+		if (access(untard_file, F_OK) == -1) {
+			/* Does not exist client-side. Must download */
+			string_or_die(&url, "%s/%i/Manifest.%s.tar", preferred_content_url,
+							file->last_change, file->filename);
+
+			ret = swupd_query_url_content_size(url);
+			if (ret != -1) {
+				/* Convert file size from bytes to MB */
+				ret = ret/1000000;
+				size_sum += ret;
+			} else {
+				return ret;
+			}
+		}
+	}
+
+	free(untard_file);
+	return size_sum;
+}
+
+
+/* download_manifests()
+ * Description: To search Clear bundles for a particular entry, a complete set of
+ *		manifests must be downloaded. This function does so, asynchronously, using
+ *		the curl_multi interface */
+int download_manifests(struct manifest **MoM)
+{
+	struct list *list;
+	struct file *file;
+	char *tarfile, *untard_file, *url;
+	struct manifest *subMan = NULL;
+	int current_version;
+	int ret = 0;
+	double size;
+
+	current_version = read_version_from_subvol_file(path_prefix);
+	swupd_curl_set_current_version(current_version);
+
+	ret = load_manifests(current_version, current_version, "MoM", NULL, MoM);
+	if (ret != 0) {
+		printf("Cannot load official manifest MoM for version %i\n", current_version);
+		return ret;
+	}
+
+	subscription_versions_from_MoM(*MoM, 0);
+
+	list = (*MoM)->manifests;
+	size = query_total_download_size(list);
+	if (size == -1) {
+		printf("Downloading manifests. Expect a delay, up to 100MB may be downloaded\n");
+	} else if (size > 0) {
+		printf("Downloading Clear Linux manifests\n");
+		printf("   %.2f MB total...\n\n", size);
+	}
+
+	while (list) {
+		file = list->data;
+		list = list->next;
+
+		create_and_append_subscription(file->filename);
+
+		string_or_die(&untard_file, "%s/%i/Manifest.%s", STATE_DIR, file->last_change,
+						file->filename);
+
+		string_or_die(&tarfile, "%s/%i/Manifest.%s.tar", STATE_DIR, file->last_change,
+						file->filename);
+
+		if (access(untard_file, F_OK) == -1) {
+			/* Do download */
+			printf(" '%s' manifest...\n", file->filename);
+
+			ret = load_manifests(current_version, file->last_change, file->filename, NULL, &subMan);
+			if (ret != 0) {
+				printf("Cannot load official manifest MoM for version %i\n", current_version);
+			}
+
+			free_manifest(subMan);
+		}
+
+		if (access(untard_file, F_OK) == -1) {
+			string_or_die(&url, "%s/%i/Manifest.%s.tar", preferred_content_url, current_version,
+							file->filename);
+
+			printf("Error: Failure reading from %s\n", url);
+			free(url);
+		}
+
+		unlink(tarfile);
+		free(untard_file);
+		free(tarfile);
+	}
+
+	return ret;
+}
+
+int search_main(int argc, char **argv)
+{
+	int ret = 0;
+	int lock_fd;
+	struct manifest *MoM = NULL;
+
+	if (!parse_options(argc, argv) ||
+		create_required_dirs()) {
+		return EXIT_FAILURE;
+	}
+
+	if (search_type == '0') {
+		/* Default to a system-side search */
+		search_type = 'e';
+	}
+
+	if (!init_globals()) {
+		ret = EINIT_GLOBALS;
+		goto clean_exit;
+	}
+
+	ret = swupd_init(&lock_fd);
+	if (ret != 0) {
+		printf("Failed swupd initialization, exiting now.\n");
+		goto clean_exit;
+	}
+
+	if (!check_network()) {
+		printf("Error: Network issue, unable to proceed with update\n");
+		ret = EXIT_FAILURE;
+		goto clean_exit;
+	}
+
+	if (!init) {
+		printf("Searching for '%s'\n\n", search_string);
+	}
+
+	ret = download_manifests(&MoM);
+	if (ret != 0) {
+		printf("Error: Failed to download manifests\n");
+		goto clean_exit;
+	}
+
+	if (init) {
+		printf("Successfully retreived manifests. Exiting\n");
+		ret = 0;
+		goto clean_exit;
+	}
+
+	/* Arbitrary upper limit to ensure we aren't getting handed garbage */
+	if (!display_files &&
+		((strlen(search_string) <= 0) || (strlen(search_string) > NAME_MAX))) {
+		printf("Error - search string invalid\n");
+		ret = EXIT_FAILURE;
+		goto clean_exit;
+	}
+
+	do_search(MoM, search_type, search_string);
+
+clean_exit:
+	free_manifest(MoM);
+	free_globals();
+	swupd_curl_cleanup();
+
+	return ret;
+}

--- a/src/search.c
+++ b/src/search.c
@@ -35,7 +35,7 @@
 
 char *search_string;
 char search_type = '0';
-bool display_all = false; /* Show all hits, or simplify output and show just first bundle match */
+bool display_all = false;   /* Show all hits, or simplify output and show just first bundle match */
 bool display_files = false; /* Just display all files found in Manifest set */
 bool init = false;
 
@@ -50,16 +50,17 @@ char *bin_paths[] = {
 	NULL
 };
 
-static void print_help(const char *name) {
+static void print_help(const char *name)
+{
 	printf("Usage:\n");
-	printf("	swupd %s [Options] 'search_term'\n", basename((char*)name));
+	printf("	swupd %s [Options] 'search_term'\n", basename((char *)name));
 	printf("		'search_term': A substring of a binary, library or filename (default)\n");
 	printf("		Return: Bundle name : filename matching search term\n\n");
 
 	printf("Help Options:\n");
 	printf("   -h, --help              Display this help\n");
 	printf("   -l, --library           Search paths where libraries are located for a match\n");
-	printf("   -b, --binary            Search paths where binaries are located for a match\n"); 
+	printf("   -b, --binary            Search paths where binaries are located for a match\n");
 	printf("   -e, --everywhere        Search system-wide for a match\n");
 	printf("   -a, --all               Display all matches. Default is to show the first only\n");
 	printf("   -d, --display-files	   Output full file list, no search done\n");
@@ -71,19 +72,18 @@ static void print_help(const char *name) {
 }
 
 static const struct option prog_opts[] = {
-	{"help", no_argument, 0, 'h'},
-	{"url", required_argument, 0, 'u'},
-	{"library", no_argument, 0, 'l'},
-	{"binary", no_argument, 0, 'b'},
-	{"everywhere", no_argument, 0, 'e'},
-	{"path", required_argument, 0, 'p'},
-	{"format", required_argument, 0, 'F'},
-	{"init", no_argument, 0, 'i'},
-	{"all", no_argument, 0, 'a'},
-	{"display-files", no_argument, 0, 'd'},
-	{0, 0, 0, 0}
+	{ "help", no_argument, 0, 'h' },
+	{ "url", required_argument, 0, 'u' },
+	{ "library", no_argument, 0, 'l' },
+	{ "binary", no_argument, 0, 'b' },
+	{ "everywhere", no_argument, 0, 'e' },
+	{ "path", required_argument, 0, 'p' },
+	{ "format", required_argument, 0, 'F' },
+	{ "init", no_argument, 0, 'i' },
+	{ "all", no_argument, 0, 'a' },
+	{ "display-files", no_argument, 0, 'd' },
+	{ 0, 0, 0, 0 }
 };
-
 
 static bool parse_options(int argc, char **argv)
 {
@@ -133,7 +133,7 @@ static bool parse_options(int argc, char **argv)
 		case 'l':
 			if (search_type != '0') {
 				printf("Error, cannot specify multiple search types "
-							"(-l, -b, and -e are mutually exclusive)\n");
+				       "(-l, -b, and -e are mutually exclusive)\n");
 				goto err;
 			}
 
@@ -145,7 +145,7 @@ static bool parse_options(int argc, char **argv)
 		case 'b':
 			if (search_type != '0') {
 				printf("Error, cannot specify multiple search types "
-							"(-l, -b, and -e are mutually exclusive)\n");
+				       "(-l, -b, and -e are mutually exclusive)\n");
 				goto err;
 			}
 
@@ -154,7 +154,7 @@ static bool parse_options(int argc, char **argv)
 		case 'e':
 			if (search_type != '0') {
 				printf("Error, cannot specify multiple search types "
-							"(-l, -b, and -e are mutually exclusive)\n");
+				       "(-l, -b, and -e are mutually exclusive)\n");
 				goto err;
 			}
 
@@ -206,7 +206,7 @@ bool file_search(char *filename, char *path, char *search_term)
 	}
 
 	pos = strstr(filename, path);
-	if (pos == NULL ) {
+	if (pos == NULL) {
 		return false;
 	}
 
@@ -254,7 +254,6 @@ void do_search(struct manifest *MoM, char search_type, char *search_term)
 			continue;
 		}
 
-
 		if (display_files) {
 			/* Display bundle name. Marked up for pattern matchability */
 			printf("--Bundle: %s--\n", file->filename);
@@ -266,7 +265,9 @@ void do_search(struct manifest *MoM, char search_type, char *search_term)
 			subfile = sublist->data;
 			sublist = sublist->next;
 
-			if (!subfile->is_file) { continue; }
+			if (!subfile->is_file) {
+				continue;
+			}
 
 			if (display_files) {
 				/* Just display filename */
@@ -338,17 +339,17 @@ static double query_total_download_size(struct list *list)
 		list = list->next;
 
 		string_or_die(&untard_file, "%s/%i/Manifest.%s", STATE_DIR, file->last_change,
-						file->filename);
+			      file->filename);
 
 		if (access(untard_file, F_OK) == -1) {
 			/* Does not exist client-side. Must download */
 			string_or_die(&url, "%s/%i/Manifest.%s.tar", preferred_content_url,
-							file->last_change, file->filename);
+				      file->last_change, file->filename);
 
 			ret = swupd_query_url_content_size(url);
 			if (ret != -1) {
 				/* Convert file size from bytes to MB */
-				ret = ret/1000000;
+				ret = ret / 1000000;
 				size_sum += ret;
 			} else {
 				return ret;
@@ -359,7 +360,6 @@ static double query_total_download_size(struct list *list)
 	free(untard_file);
 	return size_sum;
 }
-
 
 /* download_manifests()
  * Description: To search Clear bundles for a particular entry, a complete set of
@@ -402,10 +402,10 @@ int download_manifests(struct manifest **MoM)
 		create_and_append_subscription(file->filename);
 
 		string_or_die(&untard_file, "%s/%i/Manifest.%s", STATE_DIR, file->last_change,
-						file->filename);
+			      file->filename);
 
 		string_or_die(&tarfile, "%s/%i/Manifest.%s.tar", STATE_DIR, file->last_change,
-						file->filename);
+			      file->filename);
 
 		if (access(untard_file, F_OK) == -1) {
 			/* Do download */
@@ -421,7 +421,7 @@ int download_manifests(struct manifest **MoM)
 
 		if (access(untard_file, F_OK) == -1) {
 			string_or_die(&url, "%s/%i/Manifest.%s.tar", preferred_content_url, current_version,
-							file->filename);
+				      file->filename);
 
 			printf("Error: Failure reading from %s\n", url);
 			free(url);
@@ -442,7 +442,7 @@ int search_main(int argc, char **argv)
 	struct manifest *MoM = NULL;
 
 	if (!parse_options(argc, argv) ||
-		create_required_dirs()) {
+	    create_required_dirs()) {
 		return EXIT_FAILURE;
 	}
 
@@ -486,7 +486,7 @@ int search_main(int argc, char **argv)
 
 	/* Arbitrary upper limit to ensure we aren't getting handed garbage */
 	if (!display_files &&
-		((strlen(search_string) <= 0) || (strlen(search_string) > NAME_MAX))) {
+	    ((strlen(search_string) <= 0) || (strlen(search_string) > NAME_MAX))) {
 		printf("Error - search string invalid\n");
 		ret = EXIT_FAILURE;
 		goto clean_exit;

--- a/src/signature.c
+++ b/src/signature.c
@@ -34,16 +34,15 @@
 #include "signature.h"
 #include "swupd.h"
 
-
 /*
  * Implementation flavors:
  *   FAKE ..... do nothing, always return success
  *   FORGIVE .. do everything, always return success
  *   REAL ..... do everything, return the real status
  */
-#define IMPL_FAKE    0
+#define IMPL_FAKE 0
 #define IMPL_FORGIVE 1
-#define IMPL_REAL    2
+#define IMPL_REAL 2
 
 #warning "TODO pick signing scheme"
 #if defined(SWUPD_LINUX_ROOTFS)
@@ -82,8 +81,8 @@ void signature_terminate(void)
 {
 	if (initialized) {
 		X509_STORE_free(x509_store); // undocumented...
-		ERR_free_strings(); // undoes ERR_load_crypto_strings
-		EVP_cleanup();      // undoes OpenSSL_add_all_algorithms
+		ERR_free_strings();	  // undoes ERR_load_crypto_strings
+		EVP_cleanup();		     // undoes OpenSSL_add_all_algorithms
 		initialized = false;
 	}
 }
@@ -129,7 +128,7 @@ exit:
 }
 
 static X509_STORE *create_store(const char *ca_filename, const char *ca_dirname,
-			 const char *crl_filename)
+				const char *crl_filename)
 {
 	X509_STORE *store = X509_STORE_new();
 

--- a/src/signature.c
+++ b/src/signature.c
@@ -45,7 +45,7 @@
 #define IMPL_FORGIVE 1
 #define IMPL_REAL    2
 
-#warning TODO pick signing scheme
+#warning "TODO pick signing scheme"
 #if defined(SWUPD_LINUX_ROOTFS)
 #define IMPL IMPL_FAKE
 #endif

--- a/src/staging.c
+++ b/src/staging.c
@@ -62,7 +62,7 @@ static int create_staging_renamedir(char *rename_tmpdir)
 }
 
 /* Do the staging of new files into the filesystem */
-#warning do_staging is currently not able to be run in parallel
+#warning "do_staging is currently not able to be run in parallel"
 /* Consider adding a remove_leftovers() that runs in verify/fix in order to
  * allow this function to mkdtemp create folders for parallel build */
 int do_staging(struct file *file)

--- a/src/staging.c
+++ b/src/staging.c
@@ -126,7 +126,7 @@ int do_staging(struct file *file)
 	memset(&s, 0, sizeof(struct stat));
 	ret = lstat(statfile, &s);
 	if (ret == 0) {
-		if ((file->is_dir  && !S_ISDIR(s.st_mode)) ||
+		if ((file->is_dir && !S_ISDIR(s.st_mode)) ||
 		    (file->is_link && !S_ISLNK(s.st_mode)) ||
 		    (file->is_file && !S_ISREG(s.st_mode))) {
 			//file type changed, move old out of the way for new
@@ -162,8 +162,8 @@ int do_staging(struct file *file)
 			goto out;
 		}
 		string_or_die(&tarcommand, "tar -C %s " TAR_PERM_ATTR_ARGS " -cf - '%s' 2> /dev/null | "
-			"tar -C %s%s " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
-			rename_tmpdir, base, path_prefix, rel_dir);
+					   "tar -C %s%s " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
+			      rename_tmpdir, base, path_prefix, rel_dir);
 		ret = system(tarcommand);
 		if (WIFEXITED(ret)) {
 			ret = WEXITSTATUS(ret);
@@ -200,8 +200,8 @@ int do_staging(struct file *file)
 				goto out;
 			}
 			string_or_die(&tarcommand, "tar -C %s/staged " TAR_PERM_ATTR_ARGS " -cf - '.update.%s' 2> /dev/null | "
-				"tar -C %s%s " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
-				STATE_DIR, base, path_prefix, rel_dir);
+						   "tar -C %s%s " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
+				      STATE_DIR, base, path_prefix, rel_dir);
 			ret = system(tarcommand);
 			if (WIFEXITED(ret)) {
 				ret = WEXITSTATUS(ret);
@@ -246,7 +246,8 @@ out:
 }
 
 /* caller should not call this function for do_not_update marked files */
-int rename_staged_file_to_final(struct file *file) {
+int rename_staged_file_to_final(struct file *file)
+{
 	int ret;
 	char *target;
 
@@ -296,14 +297,14 @@ int rename_staged_file_to_final(struct file *file) {
 			ret = rename(target, lostnfound);
 			if (ret < 0 && errno != ENOTEMPTY && errno != EEXIST) {
 				printf("Error: failed to move %s to lost+found: %s\n",
-					base, strerror(errno));
+				       base, strerror(errno));
 			}
 			free(lostnfound);
 		} else {
 			ret = rename(file->staging, target);
 			if (ret < 0) {
 				printf("Error: failed to rename staged %s to final: %s\n",
-					file->hash, strerror(errno));
+				       file->hash, strerror(errno));
 			}
 			unlink(file->staging);
 		}

--- a/src/stats.c
+++ b/src/stats.c
@@ -28,9 +28,6 @@
 
 #include "swupd.h"
 
-
-
-
 static int new_files;
 static int deleted_files;
 static int changed_files;
@@ -39,7 +36,6 @@ static int deleted_manifests;
 static int changed_manifests;
 static int delta_miss;
 static int delta_hit;
-
 
 void account_new_file(void)
 {
@@ -76,12 +72,10 @@ void account_delta_hit(void)
 	delta_hit++;
 }
 
-
 void account_delta_miss(void)
 {
 	delta_miss++;
 }
-
 
 void print_statistics(int version1, int version2)
 {

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -36,12 +36,11 @@ struct list *subs;
 
 static void free_subscription_data(void *data)
 {
-	struct sub *sub = (struct sub *) data;
+	struct sub *sub = (struct sub *)data;
 
 	free(sub->component);
 	free(sub);
 }
-
 
 void free_subscriptions(void)
 {
@@ -75,12 +74,11 @@ void read_subscriptions_alt(void)
 			}
 			if (ent->d_type == DT_REG) {
 				if (component_subscribed(ent->d_name)) {
-				/*  This is considered odd since means two files same name on same folder */
+					/*  This is considered odd since means two files same name on same folder */
 					continue;
 				}
 
 				create_and_append_subscription(ent->d_name);
-
 			}
 		}
 

--- a/src/swupd.c
+++ b/src/swupd.c
@@ -39,6 +39,7 @@ static struct subcmd commands[] = {
 	{ "update", "Update to latest OS version", update_main },
 	{ "verify", "Verify content for OS version", verify_main },
 	{ "check-update", "Checks if a new OS version is available", check_update_main},
+	{ "search", "Search Clear Linux for a binary or library", search_main },
 	{ 0 }
 };
 

--- a/src/swupd.c
+++ b/src/swupd.c
@@ -38,7 +38,7 @@ static struct subcmd commands[] = {
 	{ "hashdump", "Dumps the HMAC hash of a file", hashdump_main },
 	{ "update", "Update to latest OS version", update_main },
 	{ "verify", "Verify content for OS version", verify_main },
-	{ "check-update", "Checks if a new OS version is available", check_update_main},
+	{ "check-update", "Checks if a new OS version is available", check_update_main },
 	{ "search", "Search Clear Linux for a binary or library", search_main },
 	{ 0 }
 };
@@ -49,10 +49,11 @@ static const struct option prog_opts[] = {
 	{ 0 }
 };
 
-static void print_help(const char *name) {
+static void print_help(const char *name)
+{
 	printf("Usage:\n");
-	printf("    %s [OPTION...]\n", basename((char*)name));
-	printf(" or %s [OPTION...] SUBCOMMAND [OPTION...]\n\n", basename((char*)name));
+	printf("    %s [OPTION...]\n", basename((char *)name));
+	printf(" or %s [OPTION...] SUBCOMMAND [OPTION...]\n\n", basename((char *)name));
 	printf("Help Options:\n");
 	printf("   -h, --help              Show help options\n");
 	printf("   -v, --version           Output version information and exit\n\n");
@@ -65,7 +66,7 @@ static void print_help(const char *name) {
 		entry++;
 	}
 	printf("\n");
-	printf("To view subcommand options, run `%s SUBCOMMAND --help'\n", basename((char*)name));
+	printf("To view subcommand options, run `%s SUBCOMMAND --help'\n", basename((char *)name));
 }
 
 static int subcmd_index(char *arg)

--- a/src/update.c
+++ b/src/update.c
@@ -96,7 +96,7 @@ static int update_loop(struct list *updates)
 	struct list *iter;
 	struct list *failed = NULL;
 	int err;
-	int retries = 0; /* We only want to go through the download loop once */
+	int retries = 0;  /* We only want to go through the download loop once */
 	int timeout = 10; /* Amount of seconds for first download retry */
 
 TRY_DOWNLOAD:
@@ -188,7 +188,6 @@ TRY_DOWNLOAD:
 
 	/* NOTE: critical section starts when update_loop() calls do_staging() */
 	/*********** critical section ends *************************************/
-
 
 	return ret;
 }
@@ -369,7 +368,7 @@ download_packs:
 
 	if ((latest_version < server_version) && (ret == 0)) {
 		printf("Update successful. System updated from version %d to version %d\n",
-					latest_version, server_version);
+		       latest_version, server_version);
 	} else if (ret == 0) {
 		printf("Update complete. System already up-to-date at version %d\n", latest_version);
 	}

--- a/src/update.c
+++ b/src/update.c
@@ -113,10 +113,11 @@ TRY_DOWNLOAD:
 		failed = full_download_loop(updates, 0);
 	}
 
-	/* if (rm_staging_dir_contents("download")) {
+#if 0
+	if (rm_staging_dir_contents("download")) {
 		return -1;
-	   }
-	 */
+	}
+#endif
 
 	/* Set retries only if failed downloads exist, and only retry a fixed
 	   amount of times */
@@ -185,8 +186,8 @@ TRY_DOWNLOAD:
 
 	sync();
 
-//NOTE: critical section starts when update_loop() calls do_staging()
-/*************************************************** critical section ends ***************************************************/
+	/* NOTE: critical section starts when update_loop() calls do_staging() */
+	/*********** critical section ends *************************************/
 
 
 	return ret;
@@ -249,9 +250,9 @@ int main_update()
 		goto clean_curl;
 	}
 
+load_current_manifests:
 	/* Step 3: setup manifests */
 
-load_current_manifests:
 	/* get the from/to MoM manifests */
 	printf("Querying current manifest.\n");
 	ret = load_manifests(latest_version, latest_version, "MoM", NULL, &current_manifest);

--- a/src/verify.c
+++ b/src/verify.c
@@ -36,7 +36,6 @@
 #include "swupd.h"
 #include "signature.h"
 
-
 static bool cmdline_option_fix = false;
 static bool cmdline_option_install = false;
 static bool cmdline_option_quick = false;
@@ -55,26 +54,26 @@ static int file_extraneous_count;
 static int file_deleted_count;
 static int file_not_deleted_count;
 
-
 static const struct option prog_opts[] = {
-	{"help", no_argument, 0, 'h'},
-	{"manifest", required_argument, 0, 'm'},
-	{"path", required_argument, 0, 'p'},
-	{"url", required_argument, 0, 'u'},
-	{"port", required_argument, 0, 'P'},
-	{"contenturl", required_argument, 0, 'c'},
-	{"versionurl", required_argument, 0, 'v'},
-	{"fix", no_argument, 0, 'f'},
-	{"install", no_argument, 0, 'i'},
-	{"format", required_argument, 0, 'F'},
-	{"quick", no_argument, 0, 'q'},
-	{"force", no_argument, 0, 'x'},
-	{0, 0, 0, 0}
+	{ "help", no_argument, 0, 'h' },
+	{ "manifest", required_argument, 0, 'm' },
+	{ "path", required_argument, 0, 'p' },
+	{ "url", required_argument, 0, 'u' },
+	{ "port", required_argument, 0, 'P' },
+	{ "contenturl", required_argument, 0, 'c' },
+	{ "versionurl", required_argument, 0, 'v' },
+	{ "fix", no_argument, 0, 'f' },
+	{ "install", no_argument, 0, 'i' },
+	{ "format", required_argument, 0, 'F' },
+	{ "quick", no_argument, 0, 'q' },
+	{ "force", no_argument, 0, 'x' },
+	{ 0, 0, 0, 0 }
 };
 
-static void print_help(const char *name) {
+static void print_help(const char *name)
+{
 	printf("Usage:\n");
-	printf("   swupd %s [OPTION...]\n\n", basename((char*)name));
+	printf("   swupd %s [OPTION...]\n\n", basename((char *)name));
 	printf("Help Options:\n");
 	printf("   -h, --help              Show help options\n\n");
 	printf("Application Options:\n");
@@ -316,7 +315,7 @@ static int get_missing_files(struct manifest *official_manifest)
 {
 	int ret;
 	struct list *failed = NULL;
-	int retries = 0; /* We only want to go through the download loop once */
+	int retries = 0;  /* We only want to go through the download loop once */
 	int timeout = 10; /* Amount of seconds for first download retry */
 
 RETRY_DOWNLOADS:
@@ -555,7 +554,7 @@ static void remove_orphaned_files(struct manifest *official_manifest)
 				file_not_deleted_count++;
 				if (errno != ENOTEMPTY) {
 					printf("Failed to remove empty folder %s (%i: %s)\n",
-						fullname, errno, strerror(errno));
+					       fullname, errno, strerror(errno));
 				} else {
 					//FIXME: Add force removal option?
 					printf("Couldn't remove directory containing untracked files: %s\n", fullname);

--- a/src/verify.c
+++ b/src/verify.c
@@ -319,9 +319,9 @@ static int get_missing_files(struct manifest *official_manifest)
 	int retries = 0; /* We only want to go through the download loop once */
 	int timeout = 10; /* Amount of seconds for first download retry */
 
+RETRY_DOWNLOADS:
 	/* when fixing (not installing): queue download and mark any files
 	 * which are already verified OK */
-RETRY_DOWNLOADS:
 	ret = start_full_download(true);
 	if (ret != 0) {
 		/* If we hit this point, the network is accessible but we were
@@ -700,13 +700,12 @@ int verify_main(int argc, char **argv)
 		deal_with_hash_mismatches(official_manifest, repair);
 	}
 
+brick_the_system_and_clean_curl:
 	/* clean up */
 
 	/*
 	 * naming convention: All exit goto labels must follow the "brick_the_system_and_FOO:" pattern
 	 */
-
-brick_the_system_and_clean_curl:
 
 	/* report a summary of what we managed to do and not do */
 	printf("Inspected %i files\n", file_checked_count);

--- a/src/verify.c
+++ b/src/verify.c
@@ -455,7 +455,7 @@ static void deal_with_hash_mismatches(struct manifest *official_manifest, bool r
 		iter = iter->next;
 
 		if (file->is_deleted ||
-		    ignore(file)) {
+		    ignore(file, false)) {
 			continue;
 		}
 

--- a/src/xattrs.c
+++ b/src/xattrs.c
@@ -55,7 +55,7 @@ static int xattr_get_value(const char *path, const char *name, char **blob,
 	/* realloc needed len + 1 in case we need to add final zero
 	 * to ensure consistent blob */
 	value = realloc(*blob, *blob_len + len +
-			(action == XATTRS_ACTION_GET_BLOB ? 1 : 0));
+				   (action == XATTRS_ACTION_GET_BLOB ? 1 : 0));
 	if (!value) {
 		abort();
 	}
@@ -101,7 +101,7 @@ static int get_xattr_name_count(const char *names_list, ssize_t len)
 
 static int cmp_xattr_name_ptrs(const void *ptr1, const void *ptr2)
 {
-	return strcmp(*(char * const *)ptr1, *(char * const *)ptr2);
+	return strcmp(*(char *const *)ptr1, *(char *const *)ptr2);
 }
 
 static const char **get_sorted_xattr_name_table(const char *names, int n)
@@ -109,7 +109,7 @@ static const char **get_sorted_xattr_name_table(const char *names, int n)
 	const char **table;
 	int i;
 
-	table = calloc(1, n * sizeof(char*));
+	table = calloc(1, n * sizeof(char *));
 	if (!table) {
 		abort();
 	}
@@ -119,7 +119,7 @@ static const char **get_sorted_xattr_name_table(const char *names, int n)
 		names += strlen(names) + 1;
 	}
 
-	qsort(table, n, sizeof(char*), cmp_xattr_name_ptrs);
+	qsort(table, n, sizeof(char *), cmp_xattr_name_ptrs);
 
 	return table;
 }
@@ -134,7 +134,8 @@ static const char **get_sorted_xattr_name_table(const char *names, int n)
 static void xattrs_do_action(xattrs_action_type_t action,
 			     const char *src_filename,
 			     const char *dst_filename,
-			     char **blob, size_t *blob_len) {
+			     char **blob, size_t *blob_len)
+{
 	ssize_t len;
 	char *list;
 	int ret = 0;

--- a/test/bsdiff_bench.c
+++ b/test/bsdiff_bench.c
@@ -49,11 +49,13 @@ int main(int UNUSED_PARAM argc, char UNUSED_PARAM **argv)
 	struct file *file1, *file2;
 
 	ret = stat(argv[1], &st1);
-	if (ret)
+	if (ret) {
 		exit(0);
+	}
 	ret = stat(argv[2], &st2);
-	if (ret)
+	if (ret) {
 		exit(0);
+	}
 
 	file1 = calloc(1, sizeof(struct file));
 	assert(file1);
@@ -86,8 +88,9 @@ int main(int UNUSED_PARAM argc, char UNUSED_PARAM **argv)
 		gettimeofday(&before, NULL);
 		for (i = 0; i < 10000; i++) {
 			ret = apply_bsdiff_delta(argv[1], "result", "output.bsdiff");
-			if (i > 500 && time(NULL) - start > 5)
+			if (i > 500 && time(NULL) - start > 5) {
 				break;
+			}
 		}
 		gettimeofday(&after, NULL);
 		populate_file_struct(file1, "result");

--- a/test/bsdiff_bench.c
+++ b/test/bsdiff_bench.c
@@ -80,7 +80,7 @@ int main(int UNUSED_PARAM argc, char UNUSED_PARAM **argv)
 		unlink("output.bsdiff");
 		make_bsdiff_delta(argv[1], argv[2], "output.bsdiff", algo);
 
-		stat("output.bsdiff", &bu); 
+		stat("output.bsdiff", &bu);
 
 		start = time(NULL);
 		gettimeofday(&before, NULL);
@@ -109,13 +109,12 @@ int main(int UNUSED_PARAM argc, char UNUSED_PARAM **argv)
 	}
 
 	printf("file, %s, orgsize, %i, best, %i, unc, %i, %5.3f, bzip, %i, %5.3f, gzip, %i, %5.3f, xz, %i, %5.3f, zeros, %i, %5.3f\n",
-		argv[1], (int)(st1.st_size+st2.st_size)/2,  size[0], 
-		size[1], (a[1] - b[1])/count[1],
-		size[2], (a[2] - b[2])/count[2],
-		size[3], (a[3] - b[3])/count[3],
-		size[4], (a[4] - b[4])/count[4],
-		size[5], (a[5] - b[5])/count[5]);
-
+	       argv[1], (int)(st1.st_size + st2.st_size) / 2, size[0],
+	       size[1], (a[1] - b[1]) / count[1],
+	       size[2], (a[2] - b[2]) / count[2],
+	       size[3], (a[3] - b[3]) / count[3],
+	       size[4], (a[4] - b[4]) / count[4],
+	       size[5], (a[5] - b[5]) / count[5]);
 
 	return ret;
 }

--- a/test/fuzz.c
+++ b/test/fuzz.c
@@ -49,7 +49,6 @@ static void banner(void)
 	exit(0);
 }
 
-
 static void corrupt_file(int thread)
 {
 	struct stat statb;
@@ -58,7 +57,7 @@ static void corrupt_file(int thread)
 	char filename[PATH_MAXLEN];
 	int ret;
 
-	int r,b;
+	int r, b;
 
 	sprintf(filename, OUTDIR "tempfile.%i", thread);
 	ret = stat(filename, &statb);
@@ -113,7 +112,6 @@ static int check_valgrind(int thread)
 	return 1;
 }
 
-
 static void *do_fuzz(void *data)
 {
 	int i = 1000;
@@ -136,10 +134,8 @@ static void *do_fuzz(void *data)
 		/* step 3: randomly corrupt the "tempfile" into a "corrupt" file*/
 		corrupt_file(thread);
 		/* step 4: run valgrind on the bspatch program with the "corrupt" file */
-		if (asprintf(&command, "valgrind --leak-check=no --log-file="
-				OUTDIR "valgrind.log.%i bspatch %s "
-				OUTDIR "output.%i " OUTDIR "corrupt.%i > /dev/null",
-				thread, from_files[thread], thread, thread) <= 0)
+		if (asprintf(&command, "valgrind --leak-check=no --log-file=" OUTDIR "valgrind.log.%i bspatch %s " OUTDIR "output.%i " OUTDIR "corrupt.%i > /dev/null",
+			     thread, from_files[thread], thread, thread) <= 0)
 			assert(0);
 
 		ret = system(command);
@@ -152,30 +148,28 @@ static void *do_fuzz(void *data)
 
 			t = time(NULL);
 			if (asprintf(&command2, "mv " OUTDIR "corrupt.%i " OUTDIR "failed/corrupt.%i-%i",
-					thread, thread, t) <= 0)
+				     thread, thread, t) <= 0)
 				assert(0);
 			ret = system(command2);
-			assert(ret==0);
+			assert(ret == 0);
 			free(command2);
 			if (asprintf(&command2, "mv " OUTDIR "valgrind.log.%i " OUTDIR "failed/valgrind.%i-%i",
-					thread, thread, t) <= 0)
+				     thread, thread, t) <= 0)
 				assert(0);
 			ret = system(command2);
-			assert(ret==0);
+			assert(ret == 0);
 			free(command2);
 			if (asprintf(&command2, "cp %s " OUTDIR "failed/original.%i-%i",
-					from_files[thread], thread, t) <= 0)
+				     from_files[thread], thread, t) <= 0)
 				assert(0);
 			ret = system(command2);
-			assert(ret==0);
+			assert(ret == 0);
 			free(command2);
 			printf("x");
 			sleep(1); /* make sure no duplicates exist */
-		} else
-			if (i % 10 == 0)
-				printf(".");
+		} else if (i % 10 == 0)
+			printf(".");
 		fflush(stdout);
-
 	}
 	return NULL;
 }
@@ -192,7 +186,6 @@ int main(int argc, char **argv)
 
 	srand(time(NULL));
 
-
 	/* step 1: make a "failed" directory */
 	mkdir(OUTDIR, S_IRWXU);
 	mkdir(OUTDIR "failed", S_IRWXU);
@@ -200,7 +193,8 @@ int main(int argc, char **argv)
 	while (1) {
 
 		for (i = 1; i <= THREAD_COUNT; i++) {
-			p = 0; q = 0;
+			p = 0;
+			q = 0;
 			while (p == 0 || q == 0) {
 				p = (rand() % argc);
 				q = (rand() % argc);

--- a/test/fuzz.c
+++ b/test/fuzz.c
@@ -71,8 +71,9 @@ static void corrupt_file(int thread)
 	assert(inp != NULL);
 	ret = fread(buf, statb.st_size, 1, inp);
 	fclose(inp);
-	if (ret != 1)
+	if (ret != 1) {
 		return;
+	}
 
 	/* corrupt at least 1 byte, with 1/2 chance of doing one more byte etc */
 	do {
@@ -135,8 +136,9 @@ static void *do_fuzz(void *data)
 		corrupt_file(thread);
 		/* step 4: run valgrind on the bspatch program with the "corrupt" file */
 		if (asprintf(&command, "valgrind --leak-check=no --log-file=" OUTDIR "valgrind.log.%i bspatch %s " OUTDIR "output.%i " OUTDIR "corrupt.%i > /dev/null",
-			     thread, from_files[thread], thread, thread) <= 0)
+			     thread, from_files[thread], thread, thread) <= 0) {
 			assert(0);
+		}
 
 		ret = system(command);
 		free(command);
@@ -148,27 +150,31 @@ static void *do_fuzz(void *data)
 
 			t = time(NULL);
 			if (asprintf(&command2, "mv " OUTDIR "corrupt.%i " OUTDIR "failed/corrupt.%i-%i",
-				     thread, thread, t) <= 0)
+				     thread, thread, t) <= 0) {
 				assert(0);
+			}
 			ret = system(command2);
 			assert(ret == 0);
 			free(command2);
 			if (asprintf(&command2, "mv " OUTDIR "valgrind.log.%i " OUTDIR "failed/valgrind.%i-%i",
-				     thread, thread, t) <= 0)
+				     thread, thread, t) <= 0) {
 				assert(0);
+			}
 			ret = system(command2);
 			assert(ret == 0);
 			free(command2);
 			if (asprintf(&command2, "cp %s " OUTDIR "failed/original.%i-%i",
-				     from_files[thread], thread, t) <= 0)
+				     from_files[thread], thread, t) <= 0) {
 				assert(0);
+			}
 			ret = system(command2);
 			assert(ret == 0);
 			free(command2);
 			printf("x");
 			sleep(1); /* make sure no duplicates exist */
-		} else if (i % 10 == 0)
+		} else if (i % 10 == 0) {
 			printf(".");
+		}
 		fflush(stdout);
 	}
 	return NULL;
@@ -181,8 +187,9 @@ int main(int argc, char **argv)
 	int p;
 	int q;
 
-	if (argc < 2)
+	if (argc < 2) {
 		banner();
+	}
 
 	srand(time(NULL));
 

--- a/test/hash_test.c
+++ b/test/hash_test.c
@@ -28,16 +28,16 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <dirent.h> 
+#include <dirent.h>
 #include <errno.h>
 #include <unistd.h>
 #include <pthread.h>
 #include <openssl/hmac.h>
 #include <openssl/sha.h>
-#include <sys/types.h> 
+#include <sys/types.h>
 #include <sys/time.h>
 #include <sys/mman.h>
-#include <sys/stat.h> 
+#include <sys/stat.h>
 #include <sys/xattr.h>
 #include <errno.h>
 #include <assert.h>
@@ -47,9 +47,9 @@
 
 static void print_usage(void);
 
-#define HMAC_SHA1 	1
-#define HMAC_SHA256	4
-#define HMAC_SHA512	8
+#define HMAC_SHA1 1
+#define HMAC_SHA256 4
+#define HMAC_SHA512 8
 
 struct hmac_sha_stat {
 	uint64_t st_mode;
@@ -86,20 +86,20 @@ static char *hmac_sha_for_data(int method, const unsigned char *key, size_t key_
 	unsigned char digest[EVP_MAX_MD_SIZE];
 	unsigned int digest_len = 0;
 	char *digest_str;
-	const EVP_MD* evp_method;
+	const EVP_MD *evp_method;
 
 	switch (method) {
-		case HMAC_SHA1:
-			evp_method = EVP_sha1();
-			break;
-		case HMAC_SHA256:
-			evp_method = EVP_sha256();
-			break;
-		case HMAC_SHA512:
-			evp_method = EVP_sha512();
-			break;
-		default:
-			return NULL;
+	case HMAC_SHA1:
+		evp_method = EVP_sha1();
+		break;
+	case HMAC_SHA256:
+		evp_method = EVP_sha256();
+		break;
+	case HMAC_SHA512:
+		evp_method = EVP_sha512();
+		break;
+	default:
+		return NULL;
 	}
 
 	if ((data == NULL) || (data_len == 0))
@@ -128,7 +128,8 @@ static void print_xattr_list(const unsigned char *list, size_t len)
 	char *hexstr;
 
 	hexstr = bin2hex(list, len);
-	if (!hexstr) assert(0);
+	if (!hexstr)
+		assert(0);
 
 	printf("- X-Attribute-Blob: Length=[%lu], Value=[0x%s]\n", (long unsigned int)len, hexstr);
 	free(hexstr);
@@ -140,7 +141,7 @@ static void hmac_compute_key(int method, const char *file,
 {
 	char *xattrs_blob = NULL;
 	size_t len = 0;
-	char* key_str;
+	char *key_str;
 
 	*key_len = 0;
 
@@ -152,9 +153,9 @@ static void hmac_compute_key(int method, const char *file,
 					 (const unsigned char *)xattrs_blob,
 					 len);
 		if (*key != NULL) {
-			*key_len = strlen((const char*)*key);
+			*key_len = strlen((const char *)*key);
 			if (verbose) {
-				print_xattr_list((const unsigned char*)xattrs_blob, len);
+				print_xattr_list((const unsigned char *)xattrs_blob, len);
 				printf("- Hash Key: Length=[%lu], Value=[0x%s]\n", (long unsigned int)(*key_len), *key);
 			}
 		} else {
@@ -163,7 +164,6 @@ static void hmac_compute_key(int method, const char *file,
 			fprintf(stderr, "computing hash key: error while computing key for file %s: %s\n",
 				file, strerror(errno));
 		}
-
 
 		if (len != 0)
 			free(xattrs_blob);
@@ -174,8 +174,9 @@ static void hmac_compute_key(int method, const char *file,
 			memcpy(*key, updt_stat, *key_len);
 
 			if (verbose) {
-				key_str = bin2hex((const unsigned char*)key, *key_len);
-				if (!key_str) assert(0);
+				key_str = bin2hex((const unsigned char *)key, *key_len);
+				if (!key_str)
+					assert(0);
 				printf("- Stat Key: Length=[%lu], Value=[0x%s]\n", (long unsigned int)(*key_len), (const char *)key_str);
 				free(key_str);
 			}
@@ -188,7 +189,7 @@ static void hmac_compute_key(int method, const char *file,
 }
 
 static void compute_hmac_sha(int method, char *dirpath, int verbose, unsigned int *hashcount)
-{ 
+{
 	DIR *dir;
 	struct dirent *entry;
 	struct stat stat;
@@ -266,7 +267,8 @@ static void compute_hmac_sha(int method, char *dirpath, int verbose, unsigned in
 			fclose(fl);
 		}
 
-		if (!hash) assert(0);
+		if (!hash)
+			assert(0);
 		if (verbose)
 			printf("- Hash: 0x%s\n", hash);
 
@@ -283,14 +285,14 @@ on_exit:
 	free(hash);
 	free(statfile);
 	closedir(dir);
-} 
+}
 
 static void bench_compute_hmac_sha(int method, char *dirpath, int verbose)
 {
 	struct timeval start;
 	struct timeval end;
 	double diff_us;
-	
+
 	unsigned int hashcount = 0;
 
 	gettimeofday(&start, NULL);
@@ -312,13 +314,13 @@ static void bench_hmac_sha(int argc, char *argv[])
 			verbose = 1;
 
 		if (strcmp(argv[2], "hmac-sha1") == 0) {
-		  	printf("[bench hmac sha1]\n");
+			printf("[bench hmac sha1]\n");
 			return bench_compute_hmac_sha(HMAC_SHA1, argv[3], verbose);
 		} else if (strcmp(argv[2], "hmac-sha256") == 0) {
-		  	printf("[bench hmac sha256]\n");
+			printf("[bench hmac sha256]\n");
 			return bench_compute_hmac_sha(HMAC_SHA256, argv[3], verbose);
 		} else if (strcmp(argv[2], "hmac-sha512") == 0) {
-		  	printf("[bench hmac sha512]\n");
+			printf("[bench hmac sha512]\n");
 			return bench_compute_hmac_sha(HMAC_SHA512, argv[3], verbose);
 		}
 	}
@@ -333,7 +335,8 @@ static void *multithreads_do_hash(void *threadid)
 
 	tid = (long)threadid;
 	hash = hmac_sha_for_string(HMAC_SHA256, (const unsigned char *)&threadid, sizeof(threadid), "The quick brown fox jumps over the lazy dog");
-	if (!hash) assert(0);
+	if (!hash)
+		assert(0);
 
 	printf("multithreads: do_hash - Thread[#%ld] - hash = %s\n", tid, hash);
 
@@ -344,7 +347,7 @@ static void *multithreads_do_hash(void *threadid)
 	return NULL;
 }
 
-#define NUM_THREADS	4
+#define NUM_THREADS 4
 static void multithreads(void)
 {
 	pthread_t threads[NUM_THREADS];
@@ -359,7 +362,7 @@ static void multithreads(void)
 			exit(-1);
 		}
 	}
-	
+
 	pthread_exit(NULL);
 }
 
@@ -367,7 +370,7 @@ static void xattrs_set_cmd(char *file, char *attr_name, char *attr_value)
 {
 	int ret;
 
-	ret = setxattr(file, attr_name, (void*)&attr_value,
+	ret = setxattr(file, attr_name, (void *)&attr_value,
 		       strlen(attr_value) + 1, 0);
 	if (ret < 0)
 		printf("Set Extended attribute for file %s FAILED: %s\n", file,
@@ -385,7 +388,7 @@ static void xattrs_get_blob_cmd(char *file)
 
 	if ((xattrs_blob != NULL) && (len != 0)) {
 		printf("Extended attributes data blob for file %s:\n", file);
-		print_xattr_list((const unsigned char*)xattrs_blob, len);
+		print_xattr_list((const unsigned char *)xattrs_blob, len);
 	} else {
 		printf("Extended attributes data blob for file %s is EMPTY\n",
 		       file);
@@ -438,7 +441,7 @@ static void xattrs_test(char *dirpath)
 		fclose(file);
 	}
 
-	ret = setxattr(src, "user.xattr_test", (void*)"xattr_test_val",
+	ret = setxattr(src, "user.xattr_test", (void *)"xattr_test_val",
 		       strlen("xattr_test_val") + 1, 0);
 	if (ret < 0)
 		printf("Set Extended attribute for file %s FAILED: %s\n", src,
@@ -465,7 +468,7 @@ static void xattrs_test(char *dirpath)
 
 static void xattrs(int argc, char *argv[])
 {
-  printf("[xattrs argc %d]\n", argc);
+	printf("[xattrs argc %d]\n", argc);
 
 	if (argc > 3) {
 		if (strcmp(argv[2], "set") == 0) {
@@ -483,7 +486,7 @@ static void xattrs(int argc, char *argv[])
 				return print_usage();
 			printf("[copy]\n");
 			return xattrs_copy_cmd(argv[3], argv[4]);
-		}  else if (strcmp(argv[2], "test") == 0) {
+		} else if (strcmp(argv[2], "test") == 0) {
 			if (argc != 4)
 				return print_usage();
 			printf("[test]\n");

--- a/test/hash_test.c
+++ b/test/hash_test.c
@@ -102,23 +102,27 @@ static char *hmac_sha_for_data(int method, const unsigned char *key, size_t key_
 		return NULL;
 	}
 
-	if ((data == NULL) || (data_len == 0))
+	if ((data == NULL) || (data_len == 0)) {
 		return NULL;
+	}
 
-	if (HMAC(evp_method, (const void *)key, key_len, data, data_len, digest, &digest_len) == NULL)
+	if (HMAC(evp_method, (const void *)key, key_len, data, data_len, digest, &digest_len) == NULL) {
 		return NULL;
+	}
 
 	digest_str = bin2hex(digest, digest_len);
-	if (digest_str == NULL)
+	if (digest_str == NULL) {
 		return NULL;
+	}
 
 	return digest_str;
 }
 
 static char *hmac_sha_for_string(int method, const unsigned char *key, size_t key_len, const char *str)
 {
-	if (str == NULL)
+	if (str == NULL) {
 		return NULL;
+	}
 
 	return hmac_sha_for_data(method, key, key_len, (const unsigned char *)str, strlen(str));
 }
@@ -128,8 +132,9 @@ static void print_xattr_list(const unsigned char *list, size_t len)
 	char *hexstr;
 
 	hexstr = bin2hex(list, len);
-	if (!hexstr)
+	if (!hexstr) {
 		assert(0);
+	}
 
 	printf("- X-Attribute-Blob: Length=[%lu], Value=[0x%s]\n", (long unsigned int)len, hexstr);
 	free(hexstr);
@@ -165,8 +170,9 @@ static void hmac_compute_key(int method, const char *file,
 				file, strerror(errno));
 		}
 
-		if (len != 0)
+		if (len != 0) {
 			free(xattrs_blob);
+		}
 	} else {
 		*key = calloc(1, sizeof(*updt_stat));
 		if (*key != NULL) {
@@ -175,8 +181,9 @@ static void hmac_compute_key(int method, const char *file,
 
 			if (verbose) {
 				key_str = bin2hex((const unsigned char *)key, *key_len);
-				if (!key_str)
+				if (!key_str) {
 					assert(0);
+				}
 				printf("- Stat Key: Length=[%lu], Value=[0x%s]\n", (long unsigned int)(*key_len), (const char *)key_str);
 				free(key_str);
 			}
@@ -204,21 +211,26 @@ static void compute_hmac_sha(int method, char *dirpath, int verbose, unsigned in
 	size_t key_len;
 
 	dir = opendir(dirpath);
-	if (dir == NULL)
+	if (dir == NULL) {
 		return;
+	}
 
 	while ((entry = readdir(dir)) != NULL) {
-		if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+		if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
 			continue;
+		}
 
-		if (asprintf(&statfile, "%s/%s", dirpath, entry->d_name) <= 0)
+		if (asprintf(&statfile, "%s/%s", dirpath, entry->d_name) <= 0) {
 			assert(0);
+		}
 
-		if (entry->d_type == DT_DIR)
+		if (entry->d_type == DT_DIR) {
 			compute_hmac_sha(method, statfile, verbose, hashcount);
+		}
 
-		if (verbose)
+		if (verbose) {
 			printf("File: %s\n", statfile);
+		}
 
 		memset(&stat, 0, sizeof(stat));
 		ret = lstat(statfile, &stat);
@@ -267,10 +279,12 @@ static void compute_hmac_sha(int method, char *dirpath, int verbose, unsigned in
 			fclose(fl);
 		}
 
-		if (!hash)
+		if (!hash) {
 			assert(0);
-		if (verbose)
+		}
+		if (verbose) {
 			printf("- Hash: 0x%s\n", hash);
+		}
 
 		free(key);
 		key = NULL;
@@ -310,8 +324,9 @@ static void bench_hmac_sha(int argc, char *argv[])
 	int verbose = 0;
 
 	if (argc > 3) {
-		if ((argc > 4) && (strcmp(argv[4], "-v") == 0))
+		if ((argc > 4) && (strcmp(argv[4], "-v") == 0)) {
 			verbose = 1;
+		}
 
 		if (strcmp(argv[2], "hmac-sha1") == 0) {
 			printf("[bench hmac sha1]\n");
@@ -335,8 +350,9 @@ static void *multithreads_do_hash(void *threadid)
 
 	tid = (long)threadid;
 	hash = hmac_sha_for_string(HMAC_SHA256, (const unsigned char *)&threadid, sizeof(threadid), "The quick brown fox jumps over the lazy dog");
-	if (!hash)
+	if (!hash) {
 		assert(0);
+	}
 
 	printf("multithreads: do_hash - Thread[#%ld] - hash = %s\n", tid, hash);
 
@@ -372,11 +388,12 @@ static void xattrs_set_cmd(char *file, char *attr_name, char *attr_value)
 
 	ret = setxattr(file, attr_name, (void *)&attr_value,
 		       strlen(attr_value) + 1, 0);
-	if (ret < 0)
+	if (ret < 0) {
 		printf("Set Extended attribute for file %s FAILED: %s\n", file,
 		       strerror(errno));
-	else
+	} else {
 		printf("Set Extended attribute for file %s SUCCESS\n", file);
+	}
 }
 
 static void xattrs_get_blob_cmd(char *file)
@@ -394,8 +411,9 @@ static void xattrs_get_blob_cmd(char *file)
 		       file);
 	}
 
-	if (len != 0)
+	if (len != 0) {
 		free(xattrs_blob);
+	}
 }
 
 static void xattrs_copy_cmd(char *src, char *dst)
@@ -421,11 +439,13 @@ static void xattrs_test(char *dirpath)
 	printf("Extended attribute test working dir %s:\n", dirpath);
 
 	/* step 4: run valgrind on the patch program with the "corrupt" file */
-	if (asprintf(&src, "%s/testfile1.txt", dirpath) <= 0)
+	if (asprintf(&src, "%s/testfile1.txt", dirpath) <= 0) {
 		assert(0);
+	}
 
-	if (asprintf(&dst, "%s/testfile2.txt", dirpath) <= 0)
+	if (asprintf(&dst, "%s/testfile2.txt", dirpath) <= 0) {
 		assert(0);
+	}
 
 	file = fopen(src, "w+");
 	if (file != NULL) {
@@ -443,24 +463,28 @@ static void xattrs_test(char *dirpath)
 
 	ret = setxattr(src, "user.xattr_test", (void *)"xattr_test_val",
 		       strlen("xattr_test_val") + 1, 0);
-	if (ret < 0)
+	if (ret < 0) {
 		printf("Set Extended attribute for file %s FAILED: %s\n", src,
 		       strerror(errno));
-	else
+	} else {
 		printf("Set Extended attribute for file %s SUCCESS\n", src);
+	}
 
 	xattrs_copy(src, dst);
 
-	if (xattrs_compare(src, dst) != 0)
+	if (xattrs_compare(src, dst) != 0) {
 		printf("TEST FAILURE\n");
-	else
+	} else {
 		printf("TEST SUCCESS\n");
+	}
 
-	if (src != NULL)
+	if (src != NULL) {
 		unlink(src);
+	}
 
-	if (dst != NULL)
+	if (dst != NULL) {
 		unlink(dst);
+	}
 
 	free(src);
 	free(dst);
@@ -472,23 +496,27 @@ static void xattrs(int argc, char *argv[])
 
 	if (argc > 3) {
 		if (strcmp(argv[2], "set") == 0) {
-			if (argc != 6)
+			if (argc != 6) {
 				return print_usage();
+			}
 			printf("[set]\n");
 			return xattrs_set_cmd(argv[3], argv[4], argv[5]);
 		} else if (strcmp(argv[2], "get_blob") == 0) {
-			if (argc != 4)
+			if (argc != 4) {
 				return print_usage();
+			}
 			printf("[get_blob]\n");
 			return xattrs_get_blob_cmd(argv[3]);
 		} else if (strcmp(argv[2], "copy") == 0) {
-			if (argc != 5)
+			if (argc != 5) {
 				return print_usage();
+			}
 			printf("[copy]\n");
 			return xattrs_copy_cmd(argv[3], argv[4]);
 		} else if (strcmp(argv[2], "test") == 0) {
-			if (argc != 4)
+			if (argc != 4) {
 				return print_usage();
+			}
 			printf("[test]\n");
 			return xattrs_test(argv[3]);
 		}

--- a/test/listtest.c
+++ b/test/listtest.c
@@ -38,8 +38,8 @@ static int data_compare(const void *a, const void *b)
 {
 	unsigned int *A, *B;
 
-	A = (unsigned int*)a;
-	B = (unsigned int*)b;
+	A = (unsigned int *)a;
+	B = (unsigned int *)b;
 	// printf("comparing data %d > %d\n", *A, *B);
 	return (*A - *B);
 }
@@ -48,8 +48,8 @@ static int data_compare_reverse(const void *a, const void *b)
 {
 	unsigned int *A, *B;
 
-	A = (unsigned int*)a;
-	B = (unsigned int*)b;
+	A = (unsigned int *)a;
+	B = (unsigned int *)b;
 	// printf("comparing data %d > %d\n", *A, *B);
 	return (*B - *A);
 }
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
 
 	/* seed the random generator so that we get different lists each time */
 	gettimeofday(&tod, NULL);
-	seed = (unsigned int) tod.tv_sec;
+	seed = (unsigned int)tod.tv_sec;
 	srand(seed);
 
 	/* create a list with random data between 0 and len */
@@ -127,7 +127,7 @@ int main(int argc, char **argv)
 			printf("data allocation failed\n");
 			exit(-1);
 		}
-		*data = (unsigned int) rand() % len;
+		*data = (unsigned int)rand() % len;
 		list = list_append_data(list, data);
 	}
 	printf("List constructed, seed = %d, len = %d\n", seed, list_len(list));
@@ -138,7 +138,7 @@ int main(int argc, char **argv)
 
 	/* check list elements are in right order */
 	if (check_list_order(list, 1) != 0) {
-		printf ("Sorted (1) List is in wrong order\n");
+		printf("Sorted (1) List is in wrong order\n");
 		return EXIT_FAILURE;
 	}
 
@@ -148,7 +148,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 	// dump_list(list);
-	printf("List sorted in %f seconds\n", (float) t / CLOCKS_PER_SEC);
+	printf("List sorted in %f seconds\n", (float)t / CLOCKS_PER_SEC);
 
 	/* sort again on sorted list to check special case */
 
@@ -157,7 +157,7 @@ int main(int argc, char **argv)
 	t = clock() - t;
 
 	if (check_list_order(list, 1) != 0) {
-		printf ("Sorted (2) List is in wrong order\n");
+		printf("Sorted (2) List is in wrong order\n");
 		return EXIT_FAILURE;
 	}
 	if (list_len(list) != len) {
@@ -165,7 +165,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 	// dump_list(list);
-	printf("Sorted list sorted again in %f seconds\n", (float) t / CLOCKS_PER_SEC);
+	printf("Sorted list sorted again in %f seconds\n", (float)t / CLOCKS_PER_SEC);
 
 	/* reverse sort from sorted state */
 
@@ -174,7 +174,7 @@ int main(int argc, char **argv)
 	t = clock() - t;
 
 	if (check_list_order(list, -1) != 0) {
-		printf ("Sorted (3) List is in wrong order\n");
+		printf("Sorted (3) List is in wrong order\n");
 		return EXIT_FAILURE;
 	}
 	if (list_len(list) != len) {
@@ -182,7 +182,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 	// dump_list(list);
-	printf("Sorted list sorted reverse in %f seconds\n", (float) t / CLOCKS_PER_SEC);
+	printf("Sorted list sorted reverse in %f seconds\n", (float)t / CLOCKS_PER_SEC);
 
 	/* Check freeing the head item.
 	 * This must return the 2nd item, which must be the new head */
@@ -201,7 +201,7 @@ int main(int argc, char **argv)
 		printf("removing head item did not result in the right list len\n");
 		return EXIT_FAILURE;
 	}
-	printf ("Removing head correctly returned 2nd item as new head\n");
+	printf("Removing head correctly returned 2nd item as new head\n");
 
 	/* Check freeing middle item, must return previous item */
 	head = list_head(list);
@@ -221,7 +221,7 @@ int main(int argc, char **argv)
 		printf("removing 2nd item did not result in the right list len\n");
 		return EXIT_FAILURE;
 	}
-	printf ("Removing middle item correctly returned previous item\n");
+	printf("Removing middle item correctly returned previous item\n");
 
 	/* Check freeing tail, must return new tail */
 	tail = list_tail(list);
@@ -240,7 +240,7 @@ int main(int argc, char **argv)
 		printf("removing tail did not result in the right list len\n");
 		return EXIT_FAILURE;
 	}
-	printf ("Removing tail correctly returned previous item as new tail\n");
+	printf("Removing tail correctly returned previous item as new tail\n");
 
 	list_free_list_and_data(list, free);
 	list = NULL;
@@ -255,7 +255,7 @@ int main(int argc, char **argv)
 			printf("data allocation failed\n");
 			exit(-1);
 		}
-		*data = (unsigned int) i;
+		*data = (unsigned int)i;
 		list1 = list_prepend_data(list1, data);
 	}
 
@@ -265,7 +265,7 @@ int main(int argc, char **argv)
 			printf("data allocation failed\n");
 			exit(-1);
 		}
-		*data = (unsigned int) i;
+		*data = (unsigned int)i;
 		list2 = list_prepend_data(list2, data);
 	}
 
@@ -283,11 +283,11 @@ int main(int argc, char **argv)
 		printf("concat(list1, NULL) did not return list1 head\n");
 		return EXIT_FAILURE;
 	}
-	if (*((unsigned int*)(list->data)) != 1) {
+	if (*((unsigned int *)(list->data)) != 1) {
 		printf("concat(list1, NULL) head is wrong\n");
 		return EXIT_FAILURE;
 	}
-	printf ("concat(list1, NULL) is OK\n");
+	printf("concat(list1, NULL) is OK\n");
 	// dump_list(list);
 
 	/* Check concat empty list with one list*/
@@ -304,11 +304,11 @@ int main(int argc, char **argv)
 		printf("concat(NULL, list2) did not return list2 head\n");
 		return EXIT_FAILURE;
 	}
-	if (*((unsigned int*)(list->data)) != 4) {
+	if (*((unsigned int *)(list->data)) != 4) {
 		printf("concat(NULL, list2) head is wrong\n");
 		return EXIT_FAILURE;
 	}
-	printf ("concat(NULL, list2) is OK\n");
+	printf("concat(NULL, list2) is OK\n");
 	// dump_list(list);
 
 	/* Check concat two lists */
@@ -317,20 +317,20 @@ int main(int argc, char **argv)
 		printf("concat(list1, list2) did not result in a list len of 6\n");
 		return EXIT_FAILURE;
 	}
-	if (*((unsigned int*)(list->data)) != 1) {
+	if (*((unsigned int *)(list->data)) != 1) {
 		printf("concat(list1, list2) did not return list1 head\n");
 		return EXIT_FAILURE;
 	}
-	if (*((unsigned int*)(list->next->next->next->data)) != 4) {
+	if (*((unsigned int *)(list->next->next->next->data)) != 4) {
 		printf("concat(list1, list2) 4th item is not 4\n");
 		return EXIT_FAILURE;
 	}
-	printf ("concat(list1, list2) is OK\n");
+	printf("concat(list1, list2) is OK\n");
 	// dump_list(list);
 
 	list_free_list_and_data(list, free);
 
-	printf ("*** ALL LIST TESTS COMPLETED OK***\n");
+	printf("*** ALL LIST TESTS COMPLETED OK***\n");
 
-    return EXIT_SUCCESS;
+	return EXIT_SUCCESS;
 }

--- a/test/listtest.c
+++ b/test/listtest.c
@@ -40,7 +40,7 @@ static int data_compare(const void *a, const void *b)
 
 	A = (unsigned int*)a;
 	B = (unsigned int*)b;
-//	printf("comparing data %d > %d\n", *A, *B);
+	// printf("comparing data %d > %d\n", *A, *B);
 	return (*A - *B);
 }
 
@@ -50,7 +50,7 @@ static int data_compare_reverse(const void *a, const void *b)
 
 	A = (unsigned int*)a;
 	B = (unsigned int*)b;
-//	printf("comparing data %d > %d\n", *A, *B);
+	// printf("comparing data %d > %d\n", *A, *B);
 	return (*B - *A);
 }
 

--- a/test/locktest.c
+++ b/test/locktest.c
@@ -46,7 +46,7 @@ static void work(int id)
 	int lock_fd;
 	int successes = 0;
 
-	FILE * file;
+	FILE *file;
 	char buffer[LINE_MAX];
 
 	while (successes < NUM_ACCESS) {
@@ -70,7 +70,6 @@ static void work(int id)
 		printf("process %i acquired lock\n", id);
 
 		file = fopen(PROTECTED_FILE, "a+");
-
 
 		fseek(file, 0, SEEK_END);
 
@@ -149,7 +148,7 @@ int main(int UNUSED_PARAM argc, char UNUSED_PARAM **argv)
 	int ret = EXIT_FAILURE;
 	int t_cnt;
 	pid_t pid[NUM_THREADS];
-	FILE * file;
+	FILE *file;
 	int id, prev_id = -1;
 	char action, prev_action = ' ';
 	char buffer[LINE_MAX];

--- a/test/signature_verify_test.c
+++ b/test/signature_verify_test.c
@@ -20,7 +20,6 @@
  *
  */
 
-
 /*
  * Usage: thisprogram <data> <data-sig> <ca-cert>
  *
@@ -39,7 +38,7 @@
 
 #include "signature.h"
 
-static void usage(char*);
+static void usage(char *);
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
A user was running into issues installing the 'kernel-container' bundle
on Clear Linux. Namely, all missing files marked as boot were not
installed.

The root issue is that the bundle-add action does not set the "fix"
global variable before calling ignore(), so ignore() mistakenly returns
true when considering boot files that are missing, but not marked
deleted.

Since there are only three callers of ignore(), I have removed the
global variable and instead pass in the required values of "fix" to the
new second argument to ignore, "fix_missing". Passing "true" for the
bundle-add action corrects the return value of ignore() in this case.

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>