### PR TITLE
Add support for libcurl's FILE protocol

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -104,6 +104,7 @@ struct file {
 };
 
 extern bool download_only;
+extern bool local_download;
 extern bool verify_esp_only;
 extern bool have_manifest_diskspace;
 extern bool have_network;
@@ -246,6 +247,7 @@ void update_motd(int new_release);
 void delete_motd(void);
 extern int is_dirname_link(const char *fullname);
 extern int verify_fix_path(char* targetpath, struct manifest *manifest);
+extern void set_local_download(char *url);
 
 /* subscription.c */
 struct list *free_list_file(struct list *item);

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -71,6 +71,7 @@ static bool parse_options(int argc, char **argv)
 				printf("error: invalid --url argument\n\n");
 				goto err;
 			}
+			set_local_download(optarg);
 			if (version_server_urls[0]) {
 				free(version_server_urls[0]);
 			}

--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -81,6 +81,7 @@ static bool parse_options(int argc, char **argv)
 				printf("error: invalid --url argument\n\n");
 				goto err;
 			}
+			set_local_download(optarg);
 			if (version_server_urls[0]) {
 				free(version_server_urls[0]);
 			}

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -85,6 +85,7 @@ static bool parse_options(int argc, char **argv)
 				printf("error: invalid --url argument\n\n");
 				goto err;
 			}
+			set_local_download(optarg);
 			if (version_server_urls[0]) {
 				free(version_server_urls[0]);
 			}

--- a/src/curl.c
+++ b/src/curl.c
@@ -285,6 +285,16 @@ exit:
 		case 206:
 			err = 0;
 			break;
+		case 0:
+			/* When using the FILE:// protocol, 0 indicates success.
+			 * Otherwise, it means the web server hasn't responded yet.
+			 */
+			if (local_download) {
+				err = 0;
+			} else {
+				err = -ETIMEDOUT;
+			}
+			break;
 		case 403:
 			err = -EACCES;
 			break;
@@ -307,6 +317,9 @@ exit:
 			break;
 		case CURLE_COULDNT_CONNECT:
 			err = -ENONET;
+			break;
+		case CURLE_FILE_COULDNT_READ_FILE:
+			err = -1;
 			break;
 		case CURLE_PARTIAL_FILE:
 			printf("Curl: File incompletely downloaded from '%s' to '%s'\n",

--- a/src/download.c
+++ b/src/download.c
@@ -374,13 +374,16 @@ static int perform_curl_io_and_complete(int *left)
 			 * proceed to uncompress. */
 			untar_full_download(file);
 		} else if (ret == 0) {
-			/* For this case, the CURLINFO_RESPONSE_CODE(3) man page states:
-			 * "The stored value will be zero if no server response has been received."
-			 * This seems to indicate misuse of libcurl, so report this condition.
+			/* When using the FILE:// protocol, 0 indicates success.
+			 * Otherwise, it means the web server hasn't responded yet.
 			 */
-			printf("error: received http \"0\" response for %s download\n",
-			       file->hash);
-			failed = list_prepend_data(failed, file);
+			if (local_download) {
+				untar_full_download(file);
+			} else {
+				printf("error: received http \"0\" response for %s download\n",
+				       file->hash);
+				failed = list_prepend_data(failed, file);
+			}
 		} else {
 			char *url = NULL;
 

--- a/src/globals.c
+++ b/src/globals.c
@@ -57,6 +57,7 @@ struct timeval start_time;
  * different quality of server and control of the servers
  */
 bool download_only;
+bool local_download = false;
 bool have_manifest_diskspace = false; /* assume no until checked */
 bool have_network = false;	    /* assume no access until proved */
 #define URL_COUNT 2

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -782,3 +782,15 @@ end:
 	list_free_list_and_data(path_list, free_path_data);
 	return ret;
 }
+
+/* In case URL has the file:// prefix, use libcurl's file protocol to copy
+ * files from the local filesystem instead of downloading from a web server.
+ * The local_download global variable defaults to false and is used to
+ * determine how to handle libcurl results after a *_perform.
+ */
+void set_local_download(char *url)
+{
+	if (strncmp(url, "file://", 7) == 0) {
+		local_download = true;
+	}
+}

--- a/src/main.c
+++ b/src/main.c
@@ -91,6 +91,7 @@ static bool parse_options(int argc, char **argv)
 				printf("Invalid --url argument\n\n");
 				goto err;
 			}
+			set_local_download(optarg);
 			if (version_server_urls[0]) {
 				free(version_server_urls[0]);
 			}

--- a/src/search.c
+++ b/src/search.c
@@ -102,6 +102,7 @@ static bool parse_options(int argc, char **argv)
 				printf("error: invalid --url argument\n\n");
 				goto err;
 			}
+			set_local_download(optarg);
 			if (version_server_urls[0]) {
 				free(version_server_urls[0]);
 			}

--- a/src/verify.c
+++ b/src/verify.c
@@ -125,6 +125,7 @@ static bool parse_options(int argc, char **argv)
 				printf("Invalid --url argument\n\n");
 				goto err;
 			}
+			set_local_download(optarg);
 			if (version_server_urls[0]) {
 				free(version_server_urls[0]);
 			}


### PR DESCRIPTION
To support swupd-client testing without connecting to a web server, it's
convenient to use libcurl's FILE protocol, which will query files on the
local filesystem instead.

Because the libcurl-multi download path for fullfiles has treated the
"0" response code as an error, but it has the opposite meaning when
using the FILE protocol, only set the error when connecting to a web
server.

Also, the libcurl-easy code for synchronous downloads didn't treat "0"
specially, so this commit ensures the proper handling, as well as
setting a generic download error for the FILE protocol specific
CURLE_FILE_COULDNT_READ_FILE.

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>