### PR TITLE
Always handle errors from recurse_manifest()

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -281,13 +281,21 @@ int remove_bundle(const char *bundle_name)
 	}
 
 	subscription_versions_from_MoM(current_mom, 0);
+
 	/* load all submanifest minus the one to be removed */
-	recurse_manifest(current_mom, NULL);
+	ret = recurse_manifest(current_mom, NULL);
+	if (ret != 0) {
+		printf("Error: Cannot load MoM sub-manifests (ret = %d)\n", ret);
+		ret = ERECURSE_MANIFEST;
+		goto out_free_mom;
+	}
+
 	consolidate_submanifests(current_mom);
 
 	/* Now that we have the consolidated list of all files, load bundle to be removed submanifest*/
 	ret = load_bundle_manifest(bundle_name, current_version, &bundle_manifest);
 	if (ret != 0) {
+		printf("Error: Cannot load %s sub-manifest (ret = %d)\n", bundle_name, ret);
 		goto out_free_mom;
 	}
 
@@ -412,7 +420,14 @@ int install_bundles(struct list *bundles, int current_version, struct manifest *
 	}
 
 	subscription_versions_from_MoM(mom, 0);
-	recurse_manifest(mom, NULL);
+
+	ret = recurse_manifest(mom, NULL);
+	if (ret != 0) {
+		printf("Error: Cannot load MoM sub-manifests (ret = %d)\n", ret);
+		ret = ERECURSE_MANIFEST;
+		goto out;
+	}
+
 	consolidate_submanifests(mom);
 
 	/* step 2: download neccessary packs */

--- a/src/verify.c
+++ b/src/verify.c
@@ -650,7 +650,14 @@ int verify_main(int argc, char **argv)
 	}
 
 	subscription_versions_from_MoM(official_manifest, 0);
-	recurse_manifest(official_manifest, NULL);
+
+	ret = recurse_manifest(official_manifest, NULL);
+	if (ret != 0) {
+		printf("Error: Cannot load MoM sub-manifests (ret = %d)\n", ret);
+		ret = ERECURSE_MANIFEST;
+		goto clean_and_exit;
+	}
+
 	consolidate_submanifests(official_manifest);
 
 	/* preparation work complete. */

--- a/test/functional/bundleremove/boot-file/setup.sh
+++ b/test/functional/bundleremove/boot-file/setup.sh
@@ -3,6 +3,7 @@
 set -e
 
 tar -C web-dir/10 -cf web-dir/10/Manifest.MoM.tar Manifest.MoM Manifest.MoM.signed
+tar -C web-dir/10 -cf web-dir/10/Manifest.os-core.tar Manifest.os-core Manifest.os-core.signed
 tar -C web-dir/10 -cf web-dir/10/Manifest.test-bundle.tar Manifest.test-bundle Manifest.test-bundle.signed
 
 sudo chown root:root target-dir/usr/lib/kernel/testfile


### PR DESCRIPTION
Some call sites of recurse_manifest() did not handle return codes. Add handling for those, and also fix a functional test that was broken after adding the proper error handling.