### PR TITLE
Fix check for symlinks in a dirname path

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -248,7 +248,7 @@ extern void copyright_header(const char *name);
 extern void string_or_die(char **strp, const char *fmt, ...);
 void update_motd(int new_release);
 void delete_motd(void);
-extern int is_dirname_link(const char *fullname);
+extern int get_dirfd_path(const char *fullname);
 extern int verify_fix_path(char *targetpath, struct manifest *manifest);
 extern void set_local_download(void);
 

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -652,7 +652,7 @@ int get_dirfd_path(const char *fullname)
 	char *dir;
 	char *real_path = NULL;
 
-	tmp = strdup(fullname);
+	string_or_die(&tmp, "%s", fullname);
 	dir = dirname(tmp);
 
 	fd = open(dir, O_RDONLY);

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -644,23 +644,46 @@ void delete_motd(void)
 	}
 }
 
-int is_dirname_link(const char *fullname)
+int get_dirfd_path(const char *fullname)
 {
 	int ret = -1;
+	int fd;
+	char *tmp = NULL;
+	char *dir;
 	char *real_path = NULL;
-	real_path = realpath(fullname, NULL);
-	if (!real_path) {
-		printf("Failed to get real path of %s\n", fullname);
-		return -1;
+
+	tmp = strdup(fullname);
+	dir = dirname(tmp);
+
+	fd = open(dir, O_RDONLY);
+	if (fd < 0) {
+		printf("Failed to open dir %s (%s)\n", dir, strerror(errno));
+		goto out;
 	}
 
-	if (strcmp(real_path, fullname) != 0) {
-		ret = 1;
+	real_path = realpath(dir, NULL);
+	if (!real_path) {
+		printf("Failed to get real path of %s (%s)\n", dir, strerror(errno));
+		close(fd);
+		goto out;
+	}
+
+	if (strcmp(real_path, dir) != 0) {
+		/* FIXME: Should instead check to see if real_path is marked
+		 * non-deleted in the consolidated manifest. If it is
+		 * non-deleted, then we must not delete the file (and also not
+		 * flag an error); otherwise, it can be safely deleted. Until
+		 * that check is implemented, always skip the file, because we
+		 * cannot safely determine if it can be deleted. */
+		ret = -1;
+		close(fd);
 	} else {
-		ret = 0;
+		ret = fd;
 	}
 
 	free(real_path);
+out:
+	free(tmp);
 	return ret;
 }
 


### PR DESCRIPTION
The intended behavior here is to check if the directory path for the
current file contains any symlinks, not the full path itself. By not
checking the directory path only, verify --fix would not delete any
symlinks that were marked deleted.

Also, because the directory path is being examined now, we can obtain
the directory file descriptor (dirfd) and use unlinkat(2) to delete
files and directories instead of unlink/rmdir; doing so avoids race
conditions in that paths may change between calling realpath() and
unlink().

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>