### PR TITLE
Fix a hashdump crash

### DIFF
--- a/functional-tests.py
+++ b/functional-tests.py
@@ -309,6 +309,15 @@ class hashdump_file_hash(unittest.TestCase):
         test_output = process.stdout.splitlines()
         self.assertIn('b03e11e3307de4d4f3f545c8a955c2208507dbc1927e9434d1da42917712c15b', test_output)
 
+class hashdump_file_hash_no_path_prefix(unittest.TestCase):
+    def runTest(self):
+        target_path = path_from_name(self.__class__.__name__, 'target')
+        subcommand = COMMAND_MAP[self.__class__.__name__.split('_')[0]]
+        command = ['./swupd', subcommand, "{0}/{1}/test-hash".format(os.getcwd(), target_path)]
+        process = subprocess.run(command, stdout=subprocess.PIPE,
+                                 universal_newlines=True)
+        test_output = process.stdout.splitlines()
+        self.assertIn('b03e11e3307de4d4f3f545c8a955c2208507dbc1927e9434d1da42917712c15b', test_output)
 
 @http_command(option="")
 class update_apply_full_file_delta(unittest.TestCase):

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -128,6 +128,7 @@ extern struct timeval start_time;
 extern char *version_url;
 extern char *content_url;
 extern long update_server_port;
+extern bool set_path_prefix(char *path);
 extern void set_content_url(char *url);
 extern void set_version_url(char *url);
 

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -98,10 +98,7 @@ static bool parse_options(int argc, char **argv)
 				printf("Invalid --path argument\n\n");
 				goto err;
 			}
-			if (path_prefix) { /* multiple -p options */
-				free(path_prefix);
-			}
-			string_or_die(&path_prefix, "%s", optarg);
+			set_path_prefix(optarg);
 			break;
 		case 'x':
 			force = true;

--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -105,10 +105,7 @@ static bool parse_options(int argc, char **argv)
 				printf("Invalid --path argument\n\n");
 				goto err;
 			}
-			if (path_prefix) { /* multiple -p options */
-				free(path_prefix);
-			}
-			string_or_die(&path_prefix, "%s", optarg);
+			set_path_prefix(optarg);
 			break;
 		case 'P':
 			if (sscanf(optarg, "%ld", &update_server_port) != 1) {

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -81,10 +81,7 @@ static bool parse_options(int argc, char **argv)
 				printf("Invalid --path argument\n\n");
 				goto err;
 			}
-			if (path_prefix) { /* multiple -p options */
-				free(path_prefix);
-			}
-			string_or_die(&path_prefix, "%s", optarg);
+			set_path_prefix(optarg);
 			break;
 		case 'u':
 			if (!optarg) {

--- a/src/globals.c
+++ b/src/globals.c
@@ -212,20 +212,28 @@ bool set_format_string(char *userinput)
 	return true;
 }
 
-bool init_globals(void)
+/* Passing NULL for PATH will either use the last --path argument given on the command
+ * line, or sets the default value ("/").
+ */
+bool set_path_prefix(char *path)
 {
 	struct stat statbuf;
 	int ret;
 
-	gettimeofday(&start_time, NULL);
-
-	/* insure path_prefix is absolute, at least '/', ends in '/',
-	 * and is a valid dir */
-	if (path_prefix != NULL) {
+	if (path != NULL) {
 		int len;
 		char *tmp;
 
-		if (path_prefix[0] != '/') {
+		/* in case multiple -p options are passed */
+		if (path_prefix) {
+			free(path_prefix);
+		}
+
+		string_or_die(&tmp, "%s", path);
+
+		/* ensure path_prefix is absolute, at least '/', ends in '/',
+		 * and is a valid dir */
+		if (tmp[0] != '/') {
 			char *cwd;
 
 			cwd = get_current_dir_name();
@@ -233,26 +241,49 @@ bool init_globals(void)
 				printf("Unable to getwd() (%s)\n", strerror(errno));
 				return false;
 			}
-			string_or_die(&tmp, "%s/%s", cwd, path_prefix);
 
-			free(path_prefix);
-			path_prefix = tmp;
+			free(tmp);
+			string_or_die(&tmp, "%s/%s", cwd, path);
+
 			free(cwd);
 		}
 
-		len = strlen(path_prefix);
-		if (!len || (path_prefix[len - 1] != '/')) {
-			string_or_die(&tmp, "%s/", path_prefix);
-			free(path_prefix);
-			path_prefix = tmp;
+		len = strlen(tmp);
+		if (!len || (tmp[len - 1] != '/')) {
+			char *tmp_old = tmp;
+			string_or_die(&tmp, "%s/", tmp_old);
+			free(tmp_old);
 		}
+
+		path_prefix = tmp;
+
 	} else {
-		string_or_die(&path_prefix, "/");
+		if (path_prefix) {
+			/* option passed on command line previously */
+			return true;
+		} else {
+			string_or_die(&path_prefix, "/");
+		}
 	}
 	ret = stat(path_prefix, &statbuf);
 	if (ret != 0 || !S_ISDIR(statbuf.st_mode)) {
 		printf("Bad path_prefix %s (%s), cannot continue.\n",
 		       path_prefix, strerror(errno));
+		return false;
+	}
+
+	return true;
+}
+
+bool init_globals(void)
+{
+	int ret;
+
+	gettimeofday(&start_time, NULL);
+
+	ret = set_path_prefix(NULL);
+	/* a valid path prefix must be set to continue */
+	if (!ret) {
 		return false;
 	}
 

--- a/src/globals.c
+++ b/src/globals.c
@@ -239,6 +239,7 @@ bool set_path_prefix(char *path)
 			cwd = get_current_dir_name();
 			if (cwd == NULL) {
 				printf("Unable to getwd() (%s)\n", strerror(errno));
+				free(tmp);
 				return false;
 			}
 

--- a/src/hashdump.c
+++ b/src/hashdump.c
@@ -85,10 +85,7 @@ int hashdump_main(int argc, char **argv)
 				free(file);
 				return EXIT_FAILURE;
 			}
-			if (path_prefix) { /* multiple -p options */
-				free(path_prefix);
-			}
-			string_or_die(&path_prefix, "%s", optarg);
+			set_path_prefix(optarg);
 			break;
 		case 'h':
 			usage(argv[0]);

--- a/src/hashdump.c
+++ b/src/hashdump.c
@@ -114,6 +114,8 @@ int hashdump_main(int argc, char **argv)
 		string_or_die(&file->filename, "/%s", argv[optind]);
 	}
 
+	set_path_prefix(NULL);
+
 	printf("Calculating hash %s xattrs for: (%s) ... %s\n",
 	       (file->use_xattrs ? "with" : "without"), path_prefix, file->filename);
 	fullname = mk_full_filename(path_prefix, file->filename);

--- a/src/main.c
+++ b/src/main.c
@@ -125,10 +125,7 @@ static bool parse_options(int argc, char **argv)
 				printf("Invalid --path argument\n\n");
 				goto err;
 			}
-			if (path_prefix) { /* multiple -p options */
-				free(path_prefix);
-			}
-			string_or_die(&path_prefix, "%s", optarg);
+			set_path_prefix(optarg);
 			break;
 		case 'x':
 			force = true;

--- a/src/search.c
+++ b/src/search.c
@@ -135,12 +135,7 @@ static bool parse_options(int argc, char **argv)
 				printf("Invalid --path argument\n\n");
 				goto err;
 			}
-			if (path_prefix) {
-				/* multiple -p options */
-				free(path_prefix);
-			}
-			string_or_die(&path_prefix, "%s", optarg);
-
+			set_path_prefix(optarg);
 			break;
 		case 's':
 			if (!optarg || (strcmp(optarg, "b") && (strcmp(optarg, "o")))) {

--- a/src/verify.c
+++ b/src/verify.c
@@ -112,10 +112,7 @@ static bool parse_options(int argc, char **argv)
 				printf("Invalid --path argument\n\n");
 				goto err;
 			}
-			if (path_prefix) { /* multiple -p options */
-				free(path_prefix);
-			}
-			string_or_die(&path_prefix, "%s", optarg);
+			set_path_prefix(optarg);
 			break;
 		case 'u':
 			if (!optarg) {

--- a/test/functional/hashdump/file-hash-no-path-prefix/setup.sh
+++ b/test/functional/hashdump/file-hash-no-path-prefix/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+sudo chown root:root target-dir/test-hash

--- a/test/functional/hashdump/file-hash-no-path-prefix/target-dir/test-hash
+++ b/test/functional/hashdump/file-hash-no-path-prefix/target-dir/test-hash
@@ -1,0 +1,1 @@
+test-data

--- a/test/functional/hashdump/file-hash-no-path-prefix/teardown.sh
+++ b/test/functional/hashdump/file-hash-no-path-prefix/teardown.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+sudo chown $(ls -l setup.sh | awk '{ print $3 ":" $4 }') target-dir/test-hash


### PR DESCRIPTION
My recent change that removed the init_globals() call from the hashdump code led to a crash if --basepath was not passed on the command line.

To fix, refactor the path_prefix init code to a new function, and explicitly call this function for hashdump.