### PR TITLE
add --statedir option to alternate state directory

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -124,6 +124,7 @@ extern bool has_telemetry;
 extern void *tm_dlhandle;
 extern char *bundle_to_add;
 extern struct timeval start_time;
+extern char *state_dir;
 
 extern char *version_url;
 extern char *content_url;
@@ -131,6 +132,7 @@ extern long update_server_port;
 extern bool set_path_prefix(char *path);
 extern void set_content_url(char *url);
 extern void set_version_url(char *url);
+extern bool set_state_dir(char *path);
 
 extern void check_root(void);
 extern void clean_curl_multi_queue(void);

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -62,7 +62,7 @@ int list_installable_bundles()
 
 	ret = create_required_dirs();
 	if (ret != 0) {
-		printf("State directory %s cannot be recreated, aborting removal\n", STATE_DIR);
+		printf("State directory %s cannot be recreated, aborting removal\n", state_dir);
 		v_lockfile(lock_fd);
 		return EXIT_FAILURE;
 	}
@@ -260,10 +260,10 @@ int remove_bundle(const char *bundle_name)
 	current_version = read_version_from_subvol_file(path_prefix);
 	swupd_curl_set_current_version(current_version);
 
-	/* first of all, make sure STATE_DIR is there, recreate if necessary*/
+	/* first of all, make sure state_dir is there, recreate if necessary*/
 	ret = create_required_dirs();
 	if (ret != 0) {
-		printf("State directory %s cannot be recreated, aborting removal\n", STATE_DIR);
+		printf("State directory %s cannot be recreated, aborting removal\n", state_dir);
 		goto out_free_curl;
 	}
 
@@ -524,7 +524,7 @@ int install_bundles_frontend(char **bundles)
 
 	ret = create_required_dirs();
 	if (ret != 0) {
-		printf("State directory %s cannot be recreated, aborting installation\n", STATE_DIR);
+		printf("State directory %s cannot be recreated, aborting installation\n", state_dir);
 		goto clean_and_exit;
 	}
 

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -42,6 +42,7 @@ static void print_help(const char *name)
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
+	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 	printf("\n");
 }
 
@@ -53,6 +54,7 @@ static const struct option prog_opts[] = {
 	{ "format", required_argument, 0, 'F' },
 	{ "force", no_argument, 0, 'x' },
 	{ "path", required_argument, 0, 'p' },
+	{ "statedir", required_argument, 0, 'S' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -60,7 +62,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxu:v:P:F:p:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxu:v:P:F:p:S:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -90,6 +92,12 @@ static bool parse_options(int argc, char **argv)
 		case 'F':
 			if (!optarg || !set_format_string(optarg)) {
 				printf("Invalid --format argument\n\n");
+				goto err;
+			}
+			break;
+		case 'S':
+			if (!optarg || !set_state_dir(optarg)) {
+				printf("Invalid --statedir argument\n\n");
 				goto err;
 			}
 			break;

--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -52,6 +52,7 @@ static void print_help(const char *name)
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	printf("   -l, --list              List all available bundles for the current version of Clear Linux\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
+	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 	printf("\n");
 }
 
@@ -65,6 +66,7 @@ static const struct option prog_opts[] = {
 	{ "path", required_argument, 0, 'p' },
 	{ "format", required_argument, 0, 'F' },
 	{ "force", no_argument, 0, 'x' },
+	{ "statedir", required_argument, 0, 'S' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -72,7 +74,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxu:c:v:P:p:F:l", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxu:c:v:P:p:F:lS:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -116,6 +118,12 @@ static bool parse_options(int argc, char **argv)
 		case 'F':
 			if (!optarg || !set_format_string(optarg)) {
 				printf("Invalid --format argument\n\n");
+				goto err;
+			}
+			break;
+		case 'S':
+			if (!optarg || !set_state_dir(optarg)) {
+				printf("Invalid --statedir argument\n\n");
 				goto err;
 			}
 			break;

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -51,6 +51,7 @@ static void print_help(const char *name)
 	printf("   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
+	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 	printf("\n");
 }
 
@@ -63,6 +64,7 @@ static const struct option prog_opts[] = {
 	{ "port", required_argument, 0, 'P' },
 	{ "format", required_argument, 0, 'F' },
 	{ "force", no_argument, 0, 'x' },
+	{ "statedir", required_argument, 0, 'S' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -70,7 +72,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxp:u:c:v:P:F:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxp:u:c:v:P:F:S:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -114,6 +116,12 @@ static bool parse_options(int argc, char **argv)
 		case 'F':
 			if (!optarg || !set_format_string(optarg)) {
 				printf("Invalid --format argument\n\n");
+				goto err;
+			}
+			break;
+		case 'S':
+			if (!optarg || !set_state_dir(optarg)) {
+				printf("Invalid --statedir argument\n\n");
 				goto err;
 			}
 			break;

--- a/src/delta.c
+++ b/src/delta.c
@@ -62,7 +62,7 @@ void try_delta(struct file *file)
 	}
 
 	/* check if the full file is there already, because if it is, don't do the delta */
-	string_or_die(&filename, "%s/staged/%s", STATE_DIR, file->hash);
+	string_or_die(&filename, "%s/staged/%s", state_dir, file->hash);
 	if (lstat(filename, &stat) == 0) {
 		free(filename);
 		return;
@@ -81,11 +81,11 @@ static void do_delta(struct file *file)
 	int ret;
 	struct stat stat;
 
-	string_or_die(&deltafile, "%s/delta/%i-%i-%s", STATE_DIR,
+	string_or_die(&deltafile, "%s/delta/%i-%i-%s", state_dir,
 		      file->deltapeer->last_change, file->last_change, file->hash);
 
 	/* check if the full file is there already, because if it is, don't do the delta */
-	string_or_die(&filename, "%s/staged/%s", STATE_DIR, file->hash);
+	string_or_die(&filename, "%s/staged/%s", state_dir, file->hash);
 	ret = lstat(filename, &stat);
 	if (ret == 0) {
 		unlink(deltafile);

--- a/src/download.c
+++ b/src/download.c
@@ -95,7 +95,7 @@ static int swupd_curl_hashmap_insert(struct file *file)
 	}
 
 	// if valid target file is already here, no need to download
-	string_or_die(&targetfile, "%s/staged/%s", STATE_DIR, file->hash);
+	string_or_die(&targetfile, "%s/staged/%s", state_dir, file->hash);
 
 	if (lstat(targetfile, &stat) == 0) {
 		if (verify_file(file, targetfile)) {
@@ -109,7 +109,7 @@ static int swupd_curl_hashmap_insert(struct file *file)
 	// hash not in queue and not present in staged
 
 	// clean up in case any prior download failed in a partial state
-	string_or_die(&tar_dotfile, "%s/download/.%s.tar", STATE_DIR, file->hash);
+	string_or_die(&tar_dotfile, "%s/download/.%s.tar", state_dir, file->hash);
 	unlink(tar_dotfile);
 	free(tar_dotfile);
 
@@ -194,7 +194,7 @@ static int check_tarfile_content(struct file *file, const char *tarfilename)
 	FILE *tar;
 	int count = 0;
 
-	string_or_die(&tarcommand, TAR_COMMAND " -tf %s/download/%s.tar 2> /dev/null", STATE_DIR, file->hash);
+	string_or_die(&tarcommand, TAR_COMMAND " -tf %s/download/%s.tar 2> /dev/null", state_dir, file->hash);
 
 	err = access(tarfilename, R_OK);
 	if (err) {
@@ -252,9 +252,9 @@ int untar_full_download(void *data)
 	int err;
 	char *tarcommand;
 
-	string_or_die(&tar_dotfile, "%s/download/.%s.tar", STATE_DIR, file->hash);
-	string_or_die(&tarfile, "%s/download/%s.tar", STATE_DIR, file->hash);
-	string_or_die(&targetfile, "%s/staged/%s", STATE_DIR, file->hash);
+	string_or_die(&tar_dotfile, "%s/download/.%s.tar", state_dir, file->hash);
+	string_or_die(&tarfile, "%s/download/%s.tar", state_dir, file->hash);
+	string_or_die(&targetfile, "%s/staged/%s", state_dir, file->hash);
 
 	/* If valid target file already exists, we're done.
 	 * NOTE: this should NEVER happen given the checking that happens
@@ -290,7 +290,7 @@ int untar_full_download(void *data)
 
 	/* modern tar will automatically determine the compression type used */
 	string_or_die(&tarcommand, TAR_COMMAND " -C %s/staged/ " TAR_PERM_ATTR_ARGS " -xf %s 2> /dev/null",
-		      STATE_DIR, tarfile);
+		      state_dir, tarfile);
 
 	err = system(tarcommand);
 	if (WIFEXITED(err)) {
@@ -481,7 +481,7 @@ void full_download(struct file *file)
 
 	string_or_die(&url, "%s/%i/files/%s.tar", content_url, file->last_change, file->hash);
 
-	string_or_die(&filename, "%s/download/.%s.tar", STATE_DIR, file->hash);
+	string_or_die(&filename, "%s/download/.%s.tar", state_dir, file->hash);
 	file->staging = filename;
 
 	curl_ret = curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1);

--- a/src/globals.c
+++ b/src/globals.c
@@ -50,6 +50,7 @@ char *path_prefix = NULL; /* must always end in '/' */
 char *mounted_dirs = NULL;
 char *bundle_to_add = NULL;
 struct timeval start_time;
+char *state_dir = NULL;
 
 /* NOTE: Today the content and version server urls are the same in
  * all cases.  It is highly likely these will eventually differ, eg:
@@ -169,6 +170,29 @@ static bool is_valid_integer_format(char *str)
 	return true;
 }
 
+bool set_state_dir(char *path)
+{
+	if (path) {
+		if (path[0] != '/') {
+			printf("statepath must be a full path starting with '/', not '%c'\n", path[0]);
+			return false;
+		}
+
+		if (state_dir) {
+			free(state_dir);
+		}
+
+		string_or_die(&state_dir, "%s", path);
+	} else {
+		if (state_dir) {
+			return true;
+		}
+		string_or_die(&state_dir, "%s", STATE_DIR);
+	}
+
+	return true;
+}
+
 bool set_format_string(char *userinput)
 {
 	int ret;
@@ -282,6 +306,11 @@ bool init_globals(void)
 
 	gettimeofday(&start_time, NULL);
 
+	ret = set_state_dir(NULL);
+	if (!ret) {
+		return false;
+	}
+
 	ret = set_path_prefix(NULL);
 	/* a valid path prefix must be set to continue */
 	if (!ret) {
@@ -306,6 +335,7 @@ void free_globals(void)
 	free(path_prefix);
 	free(format_string);
 	free(mounted_dirs);
+	free(state_dir);
 	if (bundle_to_add != NULL) {
 		free(bundle_to_add);
 	}

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -63,7 +63,7 @@ int rm_staging_dir_contents(const char *rel_path)
 	char *abs_path;
 	int ret;
 
-	string_or_die(&abs_path, "%s/%s", STATE_DIR, rel_path);
+	string_or_die(&abs_path, "%s/%s", state_dir, rel_path);
 
 	dir = opendir(abs_path);
 	if (dir == NULL) {
@@ -103,15 +103,15 @@ void unlink_all_staged_content(struct file *file)
 	char *filename;
 
 	/* downloaded tar file */
-	string_or_die(&filename, "%s/download/%s.tar", STATE_DIR, file->hash);
+	string_or_die(&filename, "%s/download/%s.tar", state_dir, file->hash);
 	unlink(filename);
 	free(filename);
-	string_or_die(&filename, "%s/download/.%s.tar", STATE_DIR, file->hash);
+	string_or_die(&filename, "%s/download/.%s.tar", state_dir, file->hash);
 	unlink(filename);
 	free(filename);
 
 	/* downloaded and un-tar'd file */
-	string_or_die(&filename, "%s/staged/%s", STATE_DIR, file->hash);
+	string_or_die(&filename, "%s/staged/%s", state_dir, file->hash);
 	if (file->is_dir) {
 		rmdir(filename);
 	} else {
@@ -121,7 +121,7 @@ void unlink_all_staged_content(struct file *file)
 
 	/* delta file */
 	if (file->peer) {
-		string_or_die(&filename, "%s/delta/%i-%i-%s", STATE_DIR,
+		string_or_die(&filename, "%s/delta/%i-%i-%s", state_dir,
 			      file->peer->last_change, file->last_change, file->hash);
 		unlink(filename);
 		free(filename);
@@ -150,12 +150,12 @@ int create_required_dirs(void)
 	bool missing = false;
 
 	// check for existance
-	ret = stat(STATE_DIR, &buf);
+	ret = stat(state_dir, &buf);
 	if (ret && (errno == ENOENT)) {
 		missing = true;
 	}
 	for (i = 0; i < STATE_DIR_COUNT; i++) {
-		string_or_die(&dir, "%s/%s", STATE_DIR, dirs[i]);
+		string_or_die(&dir, "%s/%s", state_dir, dirs[i]);
 		ret = stat(dir, &buf);
 		if (ret) {
 			missing = true;
@@ -167,14 +167,14 @@ int create_required_dirs(void)
 		char *cmd;
 
 		for (i = 0; i < STATE_DIR_COUNT; i++) {
-			string_or_die(&cmd, "mkdir -p %s/%s", STATE_DIR, dirs[i]);
+			string_or_die(&cmd, "mkdir -p %s/%s", state_dir, dirs[i]);
 			ret = system(cmd);
 			if (ret) {
 				return -1;
 			}
 			free(cmd);
 
-			string_or_die(&dir, "%s/%s", STATE_DIR, dirs[i]);
+			string_or_die(&dir, "%s/%s", state_dir, dirs[i]);
 			ret = chmod(dir, S_IRWXU);
 			if (ret) {
 				return -1;
@@ -183,7 +183,7 @@ int create_required_dirs(void)
 		}
 
 		// chmod 700
-		ret = chmod(STATE_DIR, S_IRWXU);
+		ret = chmod(state_dir, S_IRWXU);
 		if (ret) {
 			return -1;
 		}
@@ -767,7 +767,7 @@ int verify_fix_path(char *targetpath, struct manifest *target_MoM)
 			goto end;
 		}
 
-		string_or_die(&tar_dotfile, "%s/download/.%s.tar", STATE_DIR, file->hash);
+		string_or_die(&tar_dotfile, "%s/download/.%s.tar", state_dir, file->hash);
 
 		// clean up in case any prior download failed in a partial state
 		unlink(tar_dotfile);

--- a/src/main.c
+++ b/src/main.c
@@ -45,6 +45,7 @@ static const struct option prog_opts[] = {
 	{ "format", required_argument, 0, 'F' },
 	{ "path", required_argument, 0, 'p' },
 	{ "force", no_argument, 0, 'x' },
+	{ "statedir", required_argument, 0, 'S' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -67,6 +68,7 @@ static void print_help(const char *name)
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
+	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 	printf("\n");
 }
 
@@ -74,7 +76,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxdu:P:c:v:sF:p:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxdu:P:c:v:sF:p:S:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -117,6 +119,11 @@ static bool parse_options(int argc, char **argv)
 		case 'F':
 			if (!optarg || !set_format_string(optarg)) {
 				printf("Invalid --format argument\n\n");
+				goto err;
+			}
+		case 'S':
+			if (!optarg || !set_state_dir(optarg)) {
+				printf("Invalid --statedir argument\n\n");
 				goto err;
 			}
 			break;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -163,7 +163,7 @@ static struct manifest *manifest_from_file(int version, char *component)
 	int manifest_hdr_version;
 	int manifest_enc_version;
 
-	string_or_die(&filename, "%s/%i/Manifest.%s", STATE_DIR, version, component);
+	string_or_die(&filename, "%s/%i/Manifest.%s", state_dir, version, component);
 
 	infile = fopen(filename, "rb");
 	if (infile == NULL) {
@@ -422,7 +422,7 @@ static int try_delta_manifest_download(int current, int new, char *component, st
 		goto out;
 	}
 
-	string_or_die(&original, "%s/%i/Manifest.%s", STATE_DIR, current, component);
+	string_or_die(&original, "%s/%i/Manifest.%s", state_dir, current, component);
 
 	populate_file_struct(file, original);
 	ret = compute_hash(file, original);
@@ -433,7 +433,7 @@ static int try_delta_manifest_download(int current, int new, char *component, st
 		goto out;
 	}
 
-	string_or_die(&deltafile, "%s/Manifest-%s-delta-from-%i-to-%i", STATE_DIR, component, current, new);
+	string_or_die(&deltafile, "%s/Manifest-%s-delta-from-%i-to-%i", state_dir, component, current, new);
 
 	memset(&buf, 0, sizeof(struct stat));
 	ret = stat(deltafile, &buf);
@@ -455,7 +455,7 @@ static int try_delta_manifest_download(int current, int new, char *component, st
 
 	/* Now apply the manifest delta */
 
-	string_or_die(&newfile, "%s/%i/Manifest.%s", STATE_DIR, new, component);
+	string_or_die(&newfile, "%s/%i/Manifest.%s", state_dir, new, component);
 
 	ret = apply_bsdiff_delta(original, newfile, deltafile);
 	xattrs_copy(original, newfile);
@@ -492,7 +492,7 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 		return -ENOSWUPDSERVER;
 	}
 
-	string_or_die(&dir, "%s/%i", STATE_DIR, version);
+	string_or_die(&dir, "%s/%i", state_dir, version);
 	ret = mkdir(dir, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 	if ((ret != 0) && (errno != EEXIST)) {
 		return ret;
@@ -508,7 +508,7 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 		}
 	}
 
-	string_or_die(&filename, "%s/%i/Manifest.%s.tar", STATE_DIR, version, component);
+	string_or_die(&filename, "%s/%i/Manifest.%s.tar", state_dir, version, component);
 
 	string_or_die(&url, "%s/%i/Manifest.%s.tar", content_url, version, component);
 
@@ -524,7 +524,7 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 	}
 
 	string_or_die(&tar, TAR_COMMAND " -C %s/%i -xf %s/%i/Manifest.%s.tar 2> /dev/null",
-		      STATE_DIR, version, STATE_DIR, version, component);
+		      state_dir, version, state_dir, version, component);
 
 	/* this is is historically a point of odd errors */
 	ret = system(tar);
@@ -938,7 +938,7 @@ void debug_write_manifest(struct manifest *manifest, char *filename)
 	FILE *out;
 	char *fullfile = NULL;
 
-	string_or_die(&fullfile, "%s/%s", STATE_DIR, filename);
+	string_or_die(&fullfile, "%s/%s", state_dir, filename);
 
 	out = fopen(fullfile, "w");
 	if (out == NULL) {

--- a/src/packs.c
+++ b/src/packs.c
@@ -44,7 +44,7 @@ static int download_pack(int oldversion, int newversion, char *module)
 	char *filename;
 	struct stat stat;
 
-	string_or_die(&filename, "%s/pack-%s-from-%i-to-%i.tar", STATE_DIR, module, oldversion, newversion);
+	string_or_die(&filename, "%s/pack-%s-from-%i-to-%i.tar", state_dir, module, oldversion, newversion);
 
 	err = lstat(filename, &stat);
 	if (err == 0 && stat.st_size == 0) {
@@ -77,7 +77,7 @@ static int download_pack(int oldversion, int newversion, char *module)
 
 	printf("Extracting pack.\n");
 	string_or_die(&tar, TAR_COMMAND " -C %s " TAR_PERM_ATTR_ARGS " -xf %s/pack-%s-from-%i-to-%i.tar 2> /dev/null",
-		      STATE_DIR, STATE_DIR, module, oldversion, newversion);
+		      state_dir, state_dir, module, oldversion, newversion);
 
 	err = system(tar);
 	if (WIFEXITED(err)) {

--- a/src/search.c
+++ b/src/search.c
@@ -70,6 +70,7 @@ static void print_help(const char *name)
 	printf("   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
 	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
+	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 
 	printf("\nResults format:\n");
 	printf(" 'Bundle Name'  :  'File matching search term'\n\n");
@@ -89,6 +90,7 @@ static const struct option prog_opts[] = {
 	{ "format", required_argument, 0, 'F' },
 	{ "init", no_argument, 0, 'i' },
 	{ "display-files", no_argument, 0, 'd' },
+	{ "statedir", required_argument, 0, 'S' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -96,7 +98,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hu:c:v:P:p:F:s:lbid", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hu:c:v:P:p:F:s:lbidS:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -154,6 +156,12 @@ static bool parse_options(int argc, char **argv)
 		case 'F':
 			if (!optarg || !set_format_string(optarg)) {
 				printf("Invalid --format argument\n\n");
+				goto err;
+			}
+			break;
+		case 'S':
+			if (!optarg || !set_state_dir(optarg)) {
+				printf("Invalid --statedir argument\n\n");
 				goto err;
 			}
 			break;
@@ -354,7 +362,7 @@ static double query_total_download_size(struct list *list)
 		file = list->data;
 		list = list->next;
 
-		string_or_die(&untard_file, "%s/%i/Manifest.%s", STATE_DIR, file->last_change,
+		string_or_die(&untard_file, "%s/%i/Manifest.%s", state_dir, file->last_change,
 			      file->filename);
 
 		if (access(untard_file, F_OK) == -1) {
@@ -418,10 +426,10 @@ int download_manifests(struct manifest **MoM)
 
 		create_and_append_subscription(file->filename);
 
-		string_or_die(&untard_file, "%s/%i/Manifest.%s", STATE_DIR, file->last_change,
+		string_or_die(&untard_file, "%s/%i/Manifest.%s", state_dir, file->last_change,
 			      file->filename);
 
-		string_or_die(&tarfile, "%s/%i/Manifest.%s.tar", STATE_DIR, file->last_change,
+		string_or_die(&tarfile, "%s/%i/Manifest.%s.tar", state_dir, file->last_change,
 			      file->filename);
 
 		if (access(untard_file, F_OK) == -1) {

--- a/src/staging.c
+++ b/src/staging.c
@@ -89,7 +89,7 @@ int do_staging(struct file *file, struct manifest *MoM)
 		rel_dir = dir + 1;
 	}
 
-	string_or_die(&original, "%s/staged/%s", STATE_DIR, file->hash);
+	string_or_die(&original, "%s/staged/%s", state_dir, file->hash);
 
 	string_or_die(&targetpath, "%s%s", path_prefix, rel_dir);
 	ret = stat(targetpath, &s);
@@ -138,7 +138,7 @@ int do_staging(struct file *file, struct manifest *MoM)
 		 * pre-existing: */
 		/* In order to avoid tar transforms with directories, rename
 		 * the directory before and after the tar command */
-		string_or_die(&rename_tmpdir, "%s/tmprenamedir", STATE_DIR);
+		string_or_die(&rename_tmpdir, "%s/tmprenamedir", state_dir);
 		ret = create_staging_renamedir(rename_tmpdir);
 		if (ret) {
 			goto out;
@@ -180,7 +180,7 @@ int do_staging(struct file *file, struct manifest *MoM)
 			/* either the hardlink failed, or it was undesirable (config), do a tar-tar dance */
 			/* In order to avoid tar transforms, rename the file
 			 * before and after the tar command */
-			string_or_die(&rename_target, "%s/staged/.update.%s", STATE_DIR, base);
+			string_or_die(&rename_target, "%s/staged/.update.%s", state_dir, base);
 			ret = rename(original, rename_target);
 			if (ret) {
 				ret = -errno;
@@ -188,7 +188,7 @@ int do_staging(struct file *file, struct manifest *MoM)
 			}
 			string_or_die(&tarcommand, TAR_COMMAND " -C %s/staged " TAR_PERM_ATTR_ARGS " -cf - '.update.%s' 2> /dev/null | "
 				      TAR_COMMAND " -C %s%s " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
-				      STATE_DIR, base, path_prefix, rel_dir);
+				      state_dir, base, path_prefix, rel_dir);
 			ret = system(tarcommand);
 			if (WIFEXITED(ret)) {
 				ret = WEXITSTATUS(ret);

--- a/src/verify.c
+++ b/src/verify.c
@@ -67,6 +67,7 @@ static const struct option prog_opts[] = {
 	{ "format", required_argument, 0, 'F' },
 	{ "quick", no_argument, 0, 'q' },
 	{ "force", no_argument, 0, 'x' },
+	{ "statedir", required_argument, 0, 'S' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -88,6 +89,7 @@ static void print_help(const char *name)
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	printf("   -q, --quick             Don't compare hashes, only fix missing files\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
+	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 	printf("\n");
 }
 
@@ -95,7 +97,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxm:p:u:P:c:v:fiF:q", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxm:p:u:P:c:v:fiF:qS:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -152,6 +154,12 @@ static bool parse_options(int argc, char **argv)
 		case 'F':
 			if (!optarg || !set_format_string(optarg)) {
 				printf("Invalid --format argument\n\n");
+				goto err;
+			}
+			break;
+		case 'S':
+			if (!optarg || !set_state_dir(optarg)) {
+				printf("Invalid --statedir argument\n\n");
 				goto err;
 			}
 			break;

--- a/src/version.c
+++ b/src/version.c
@@ -48,7 +48,7 @@ static int try_version_download(void)
 
 	string_or_die(&url, "%s/version/format%s/latest", version_url, format_string);
 
-	string_or_die(&path, "%s/server_version", STATE_DIR);
+	string_or_die(&path, "%s/server_version", state_dir);
 
 	unlink(path);
 
@@ -183,7 +183,7 @@ int update_device_latest_version(int version)
 	FILE *file = NULL;
 	char *path = NULL;
 
-	string_or_die(&path, "%s/version", STATE_DIR);
+	string_or_die(&path, "%s/version", state_dir);
 	file = fopen(path, "w");
 	if (!file) {
 		free(path);


### PR DESCRIPTION
This option overrides the global setup for state_dir
variable that is now used to find out where swupd
is going to do work (state dir).

If not --statedir option is passed along, the global
STATE_DIR definition value is going to be used instead,
this last one can also be changed at compilation time.

Signed-off-by: Jaime A. Garcia <jaime.garcia.naranjo@intel.com>