### PR TITLE
Consolidate initialization actions; store lock file in state directory

### DIFF
--- a/include/swupd-error.h
+++ b/include/swupd-error.h
@@ -19,5 +19,6 @@
 #define EFULLDOWNLOAD 17	/* full_download problem */
 #define ENET404 404		/* download 404'd */
 #define EBUNDLE_INSTALL 18      /* Cannot install bundles */
+#define EREQUIRED_DIRS 19	/* Cannot create required dirs */
 
 #endif

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -117,9 +117,6 @@ static bool parse_options(int argc, char **argv)
 		}
 	}
 
-	if (!init_globals()) {
-		return false;
-	}
 	return true;
 err:
 	print_help(argv[0]);
@@ -131,7 +128,9 @@ static int check_update()
 	int current_version, server_version;
 
 	check_root();
+	set_path_prefix(NULL);
 	swupd_curl_init();
+
 	read_versions(&current_version, &server_version, path_prefix);
 
 	if (server_version < 0) {
@@ -157,7 +156,6 @@ int check_update_main(int argc, char **argv)
 	copyright_header("software update checker");
 
 	if (!parse_options(argc, argv)) {
-		free_globals();
 		return EXIT_FAILURE;
 	}
 

--- a/src/hashdump.c
+++ b/src/hashdump.c
@@ -100,7 +100,6 @@ int hashdump_main(int argc, char **argv)
 
 	if (optind >= argc) {
 		usage(argv[0]);
-		free_globals();
 		exit(-1);
 	}
 

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -581,13 +581,24 @@ int swupd_init(int *lock_fd)
 	int ret = 0;
 
 	check_root();
+
+	if (!init_globals()) {
+		ret = EINIT_GLOBALS;
+		goto out_fds;
+	}
+
+	get_mounted_directories();
+
+	if (create_required_dirs()) {
+		ret = EREQUIRED_DIRS;
+		goto out_fds;
+	}
+
 	*lock_fd = p_lockfile();
 	if (*lock_fd < 0) {
 		ret = ELOCK_FILE;
 		goto out_fds;
 	}
-
-	get_mounted_directories();
 
 	if (swupd_curl_init() != 0) {
 		ret = ECURL_INIT;

--- a/src/main.c
+++ b/src/main.c
@@ -144,10 +144,6 @@ static bool parse_options(int argc, char **argv)
 		}
 	}
 
-	if (!init_globals()) {
-		return false;
-	}
-
 	return true;
 err:
 	print_help(argv[0]);
@@ -158,7 +154,10 @@ static void print_versions()
 {
 	int current_version, server_version;
 
+	check_root();
+	set_path_prefix(NULL);
 	swupd_curl_init();
+
 	read_versions(&current_version, &server_version, path_prefix);
 
 	if (current_version < 0) {
@@ -180,7 +179,6 @@ int update_main(int argc, char **argv)
 	copyright_header("software update");
 
 	if (!parse_options(argc, argv)) {
-		free_globals();
 		return EXIT_FAILURE;
 	}
 
@@ -189,6 +187,5 @@ int update_main(int argc, char **argv)
 	} else {
 		ret = main_update();
 	}
-	free_globals();
 	return ret;
 }

--- a/src/search.c
+++ b/src/search.c
@@ -476,17 +476,6 @@ int search_main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-	if (!init_globals()) {
-		ret = EINIT_GLOBALS;
-		goto clean_exit;
-	}
-
-	ret = create_required_dirs();
-	if (ret != 0) {
-		printf("State directory %s cannot be recreated\n", state_dir);
-		goto clean_exit;
-	}
-
 	ret = swupd_init(&lock_fd);
 	if (ret != 0) {
 		printf("Failed swupd initialization, exiting now.\n");

--- a/src/update.c
+++ b/src/update.c
@@ -263,10 +263,6 @@ int main_update()
 
 	/* Step 2: housekeeping */
 
-	if (create_required_dirs()) {
-		goto clean_curl;
-	}
-
 	if (rm_staging_dir_contents("download")) {
 		goto clean_curl;
 	}
@@ -410,6 +406,7 @@ clean_curl:
 	signature_terminate();
 	swupd_curl_cleanup();
 	free_subscriptions();
+	free_globals();
 
 	printf("Update exiting.\n");
 

--- a/src/verify.c
+++ b/src/verify.c
@@ -195,10 +195,6 @@ static bool parse_options(int argc, char **argv)
 		return false;
 	}
 
-	if (!init_globals()) {
-		return false;
-	}
-
 	return true;
 err:
 	print_help(argv[0]);
@@ -596,15 +592,19 @@ int verify_main(int argc, char **argv)
 
 	copyright_header("software verify");
 
-	if (!parse_options(argc, argv) ||
-	    create_required_dirs()) {
-		free_globals();
+	if (!parse_options(argc, argv)) {
 		return EXIT_FAILURE;
 	}
 
 	/* parse command line options */
 	assert(argc >= 0);
 	assert(argv != NULL);
+
+	ret = swupd_init(&lock_fd);
+	if (ret != 0) {
+		printf("Failed verify initialization, exiting now.\n");
+		return ret;
+	}
 
 	/* Gather current manifests */
 	if (!version) {
@@ -614,12 +614,6 @@ int verify_main(int argc, char **argv)
 			free_globals();
 			return EXIT_FAILURE;
 		}
-	}
-
-	ret = swupd_init(&lock_fd);
-	if (ret != 0) {
-		printf("Failed verify initialization, exiting now.\n");
-		return ret;
 	}
 
 	if (version == -1) {
@@ -640,7 +634,6 @@ int verify_main(int argc, char **argv)
 	}
 
 	read_subscriptions_alt();
-	get_mounted_directories();
 
 	/*
 	 * FIXME: We need a command line option to override this in case the


### PR DESCRIPTION
To ease maintenance of swupd initialization steps, call all necessary functions for common actions in swupd_init().

Also, store the lock file in the state directory, now that the state directory is guaranteed to exist before creating the file. This also prevents multiple readers/writers for a given state directory.