### PR TITLE
downloads: minimize syscalls to improve performance

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -84,6 +84,7 @@ struct file {
 	int last_change;
 	struct update_stat stat;
 
+	unsigned int fd_valid : 1;
 	unsigned int is_dir : 1;
 	unsigned int is_file : 1;
 	unsigned int is_link : 1;
@@ -104,6 +105,7 @@ struct file {
 
 	char *staging; /* output name used during download & staging */
 	CURL *curl;    /* curl handle if downloading */
+	int fd;        /* file written into during downloading, unset when fd_valid is false */
 };
 
 extern bool download_only;
@@ -192,6 +194,7 @@ extern void swupd_curl_set_current_version(int v);
 extern void swupd_curl_set_requested_version(int v);
 extern double swupd_query_url_content_size(char *url);
 extern size_t swupd_download_file(void *ptr, size_t size, size_t nmemb, void *userdata);
+extern CURLcode swupd_download_file_complete(CURLcode curl_ret, struct file *file);
 extern int swupd_curl_get_file(const char *url, char *filename, struct file *file,
 			       char *tmp_version, bool pack);
 #define SWUPD_CURL_LOW_SPEED_LIMIT 1

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -84,7 +84,6 @@ struct file {
 	int last_change;
 	struct update_stat stat;
 
-	unsigned int fd_valid : 1;
 	unsigned int is_dir : 1;
 	unsigned int is_file : 1;
 	unsigned int is_link : 1;
@@ -105,7 +104,7 @@ struct file {
 
 	char *staging; /* output name used during download & staging */
 	CURL *curl;    /* curl handle if downloading */
-	int fd;        /* file written into during downloading, unset when fd_valid is false */
+	FILE *fh;      /* file written into during downloading */
 };
 
 extern bool download_only;
@@ -193,7 +192,7 @@ extern void swupd_curl_cleanup(void);
 extern void swupd_curl_set_current_version(int v);
 extern void swupd_curl_set_requested_version(int v);
 extern double swupd_query_url_content_size(char *url);
-extern size_t swupd_download_file(void *ptr, size_t size, size_t nmemb, void *userdata);
+extern CURLcode swupd_download_file_start(struct file *file);
 extern CURLcode swupd_download_file_complete(CURLcode curl_ret, struct file *file);
 extern int swupd_curl_get_file(const char *url, char *filename, struct file *file,
 			       char *tmp_version, bool pack);

--- a/src/curl.c
+++ b/src/curl.c
@@ -169,35 +169,57 @@ size_t swupd_download_file(void *ptr, size_t size, size_t nmemb, void *userdata)
 	const char *outfile;
 	int fd;
 	FILE *f;
-	size_t written;
+	size_t written, remaining;
 
 	outfile = file->staging;
+	if (file->fd_valid) {
+		fd = file->fd;
+	} else {
+		fd = open(outfile, O_CREAT | O_RDWR | O_CLOEXEC | O_APPEND, 00600);
+		if (fd < 0) {
+			fprintf(stderr, "Cannot open file for write \\*outfile=\"%s\",strerror=\"%s\"*\\\n",
+				outfile, strerror(errno));
+			return -1;
+		}
+		file->fd = fd;
+		file->fd_valid = 1;
+	}
 
-	fd = open(outfile, O_CREAT | O_RDWR, 00600);
-	if (fd < 0) {
-		printf("Error: Cannot open %s for write: %s\n",
-		       outfile, strerror(errno));
+	/* handle short writes with repeated write() calls */
+	for (remaining = size * nmemb; remaining; remaining -= written) {
+		written = write(fd, ptr, size*nmemb);
+		if (written < 0) {
+			if (errno == EINTR) {
+				written = 0;
+				continue;
+			}
+			fprintf(stderr, "write error \\*outfile=\"%s\",strerror=\"%s\"*\\\n",
+				outfile, strerror(errno));
+			return -1;
+		}
+	}
+
+	if (fdatasync(fd)) {
+		fprintf(stderr, "fdatasync \\*outfile=\"%s\",strerror=\"%s\"*\\\n", outfile, strerror(errno));
 		return -1;
 	}
 
-	f = fdopen(fd, "a");
-	if (!f) {
-		printf("Error: Cannot fdopen %s for write: %s\n",
-		       outfile, strerror(errno));
-		close(fd);
-		return -1;
+	return size*nmemb;
+}
+
+CURLcode swupd_download_file_complete(CURLcode curl_ret, struct file *file)
+{
+	if (file->fd_valid) {
+		if (close(file->fd)) {
+			fprintf(stderr, "Cannot close file after write \\*outfile=\"%s\",strerror=\"%s\"*\\\n",
+				file->staging, strerror(errno));
+			if (curl_ret == CURLE_OK) {
+				curl_ret = CURLE_WRITE_ERROR;
+			}
+		}
+		file->fd_valid = 0;
 	}
-
-	written = fwrite(ptr, size * nmemb, 1, f);
-
-	fflush(f);
-	fclose(f);
-
-	if (written != 1) {
-		return -1;
-	}
-
-	return size * nmemb;
+	return curl_ret;
 }
 
 /* Download a single file SYNCHRONOUSLY
@@ -288,6 +310,9 @@ int swupd_curl_get_file(const char *url, char *filename, struct file *file,
 	}
 
 exit:
+	if (local) {
+		curl_ret = swupd_download_file_complete(curl_ret, local);
+	}
 	if (curl_ret == CURLE_OK) {
 		/* curl command succeeded, download might've failed, let our caller handle */
 		switch (ret) {

--- a/src/curl.c
+++ b/src/curl.c
@@ -162,62 +162,28 @@ static size_t swupd_download_version_to_memory(void *ptr, size_t size, size_t nm
 	return data_len;
 }
 
-/* curl easy CURLOPT_WRITEFUNCTION callback */
-size_t swupd_download_file(void *ptr, size_t size, size_t nmemb, void *userdata)
+CURLcode swupd_download_file_start(struct file *file)
 {
-	struct file *file = (struct file *)userdata;
-	const char *outfile;
-	int fd;
-	FILE *f;
-	size_t written, remaining;
-
-	outfile = file->staging;
-	if (file->fd_valid) {
-		fd = file->fd;
-	} else {
-		fd = open(outfile, O_CREAT | O_RDWR | O_CLOEXEC | O_APPEND, 00600);
-		if (fd < 0) {
-			fprintf(stderr, "Cannot open file for write \\*outfile=\"%s\",strerror=\"%s\"*\\\n",
-				outfile, strerror(errno));
-			return -1;
-		}
-		file->fd = fd;
-		file->fd_valid = 1;
+	file->fh = fopen(file->staging, "w");
+	if (!file->fh) {
+		fprintf(stderr, "Cannot open file for write \\*outfile=\"%s\",strerror=\"%s\"*\\\n",
+			file->staging, strerror(errno));
+		return CURLE_WRITE_ERROR;
 	}
-
-	/* handle short writes with repeated write() calls */
-	for (remaining = size * nmemb; remaining; remaining -= written) {
-		written = write(fd, ptr, size*nmemb);
-		if (written < 0) {
-			if (errno == EINTR) {
-				written = 0;
-				continue;
-			}
-			fprintf(stderr, "write error \\*outfile=\"%s\",strerror=\"%s\"*\\\n",
-				outfile, strerror(errno));
-			return -1;
-		}
-	}
-
-	if (fdatasync(fd)) {
-		fprintf(stderr, "fdatasync \\*outfile=\"%s\",strerror=\"%s\"*\\\n", outfile, strerror(errno));
-		return -1;
-	}
-
-	return size*nmemb;
+	return CURLE_OK;
 }
 
 CURLcode swupd_download_file_complete(CURLcode curl_ret, struct file *file)
 {
-	if (file->fd_valid) {
-		if (close(file->fd)) {
+	if (file->fh) {
+		if (fclose(file->fh)) {
 			fprintf(stderr, "Cannot close file after write \\*outfile=\"%s\",strerror=\"%s\"*\\\n",
 				file->staging, strerror(errno));
 			if (curl_ret == CURLE_OK) {
 				curl_ret = CURLE_WRITE_ERROR;
 			}
 		}
-		file->fd_valid = 0;
+		file->fh = NULL;
 	}
 	return curl_ret;
 }
@@ -250,6 +216,7 @@ int swupd_curl_get_file(const char *url, char *filename, struct file *file,
 
 		if (file) {
 			local = file;
+			local->fh = NULL;
 		} else {
 			local = calloc(1, sizeof(struct file));
 			if (!local) {
@@ -270,11 +237,11 @@ int swupd_curl_get_file(const char *url, char *filename, struct file *file,
 		if (curl_ret != CURLE_OK) {
 			goto exit;
 		}
-		curl_ret = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, swupd_download_file);
+		curl_ret = swupd_download_file_start(local);
 		if (curl_ret != CURLE_OK) {
 			goto exit;
 		}
-		curl_ret = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)local);
+		curl_ret = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)local->fh);
 		if (curl_ret != CURLE_OK) {
 			goto exit;
 		}


### PR DESCRIPTION
This fixes https://github.com/clearlinux/swupd-client/issues/41

Beware that I have only tested a slightly different patch against
2.87. Porting it to the current master code required some manual
conflict resolution and I haven't had the time to try the result.
