### PR TITLE
staging.c: Protect tar command against special characters

### DIFF
--- a/src/staging.c
+++ b/src/staging.c
@@ -148,8 +148,8 @@ int do_staging(struct file *file, struct manifest *MoM)
 			ret = -errno;
 			goto out;
 		}
-		string_or_die(&tarcommand, TAR_COMMAND " -C %s " TAR_PERM_ATTR_ARGS " -cf - '%s' 2> /dev/null | "
-			      TAR_COMMAND " -C %s%s " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
+		string_or_die(&tarcommand, TAR_COMMAND " -C '%s' " TAR_PERM_ATTR_ARGS " -cf - './%s' 2> /dev/null | "
+			      TAR_COMMAND " -C '%s%s' " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
 			      rename_tmpdir, base, path_prefix, rel_dir);
 		ret = system(tarcommand);
 		if (WIFEXITED(ret)) {
@@ -186,8 +186,8 @@ int do_staging(struct file *file, struct manifest *MoM)
 				ret = -errno;
 				goto out;
 			}
-			string_or_die(&tarcommand, TAR_COMMAND " -C %s/staged " TAR_PERM_ATTR_ARGS " -cf - '.update.%s' 2> /dev/null | "
-				      TAR_COMMAND " -C %s%s " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
+			string_or_die(&tarcommand, TAR_COMMAND " -C '%s/staged' " TAR_PERM_ATTR_ARGS " -cf - '.update.%s' 2> /dev/null | "
+				      TAR_COMMAND " -C '%s%s' " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
 				      state_dir, base, path_prefix, rel_dir);
 			ret = system(tarcommand);
 			if (WIFEXITED(ret)) {


### PR DESCRIPTION
It may happen that a bundle contains a directory named '#' and
other files under this directory, thus not only target files
need to be escaped in tar commands, but also target directories
where the files get installed.

Also a target file may have a name with '@' as its first symbol.
Since the symbol has a special meaning in case of bsdtar the
name needs to escaped in tar commands with the prefix './'.

Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>

The problem was found in the version 2.87, but 3.x is still affected. Here's the typical log for the NodeJS bundle that triggers the issue:

```
   DEBUG   44.733 0.008 src/staging.c                :408	| /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array	| directory overwrite	| bsdtar -C /var/lib/swupd/tmprenamedir --preserve-permissions  -cf - array 2> /dev/null | bsdtar -C /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext --preserve-permissions  -xf - 2> /dev/null
   DEBUG   44.753 0.020 src/staging.c                :408	| /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array/#	| directory overwrite	| bsdtar -C /var/lib/swupd/tmprenamedir --preserve-permissions  -cf - # 2> /dev/null | bsdtar -C /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array --preserve-permissions  -xf - 2> /dev/null
   DEBUG   44.778 0.025 src/staging.c                :408	| /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array/#/@@iterator	| directory overwrite	| bsdtar -C /var/lib/swupd/tmprenamedir --preserve-permissions  -cf - @@iterator 2> /dev/null | bsdtar -C /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array/# --preserve-permissions  -xf - 2> /dev/null
   DEBUG   44.795 0.017 src/staging.c                :431	| /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array/#/@@iterator/implement.js	| dotfile hardlink	| /var/lib/swupd/staged/f4dd7645d7dd327b351c08760e3e66170d75cbf518f385b66d76ae396fa02bdb -> /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array/#/@@iterator/.update.implement.js  -1
   DEBUG   44.796       src/staging.c                :446	| /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array/#/@@iterator/implement.js	| dotfile install	| bsdtar -C /var/lib/swupd/staged --preserve-permissions  -cf - .update.implement.js 2> /dev/null | bsdtar -C /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array/#/@@iterator --preserve-permissions  -xf - 2> /dev/null
   DEBUG   44.808 0.012 src/staging.c                :475	| /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array/#/@@iterator/implement.js	| Installed dotfile not present	| /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array/#/@@iterator/.update.implement.js
   DEBUG   44.813 0.005 src/staging.c                :431	| /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array/#/@@iterator/index.js	| dotfile hardlink	| /var/lib/swupd/staged/1c7e7a0ffe86b0cdbe7081fe45f42f2a9b28f1f8fd4a2734a778ac0ee9e3efa7 -> /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array/#/@@iterator/.update.index.js  -1
   DEBUG   44.813       src/staging.c                :446	| /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array/#/@@iterator/index.js	| dotfile install	| bsdtar -C /var/lib/swupd/staged --preserve-permissions  -cf - .update.index.js 2> /dev/null | bsdtar -C /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array/#/@@iterator --preserve-permissions  -xf - 2> /dev/null
   DEBUG   44.825 0.011 src/staging.c                :475	| /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array/#/@@iterator/index.js	| Installed dotfile not present	| /usr/lib/node_modules/npm/node_modules/node-gyp/node_modules/path-array/node_modules/array-index/node_modules/es6-symbol/node_modules/es5-ext/array/#/@@iterator/.update.index.js
```