### PR TITLE
Add symlink match to Search

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -294,7 +294,7 @@ void do_search(struct manifest *MoM, char search_type, char *search_term)
 			subfile = sublist->data;
 			sublist = sublist->next;
 
-			if (!subfile->is_file) {
+			if ((!subfile->is_file) && (!subfile->is_link)) {
 				continue;
 			}
 


### PR DESCRIPTION
Match search term against symlinks as well as files. This is
necessary in order to find hits for perfectly valid searches