### PR TITLE
Change delta's name from FROM-TO-HASH2 to FROM-TO-HASH1-HASH2 format.

### DIFF
--- a/src/delta.c
+++ b/src/delta.c
@@ -81,8 +81,8 @@ static void do_delta(struct file *file)
 	int ret;
 	struct stat stat;
 
-	string_or_die(&deltafile, "%s/delta/%i-%i-%s", state_dir,
-		      file->deltapeer->last_change, file->last_change, file->hash);
+	string_or_die(&deltafile, "%s/delta/%i-%i-%s-%s", state_dir,
+		      file->deltapeer->last_change, file->last_change, file->deltapeer->hash, file->hash);
 
 	/* check if the full file is there already, because if it is, don't do the delta */
 	string_or_die(&filename, "%s/staged/%s", state_dir, file->hash);


### PR DESCRIPTION
There is an issue when two different files in a newer release have same hash:
This is, when swupd updates a file by applying a delta, it takes the HASH2 to
know the file where delta must be applyed. If files are different in current
release (before updating), there must be 2 deltas, one for each file but as
the two files have same hash in new release delta's name are the same:
FROM-TO-HASH2 and it is when issue arises due to just the last delta file is
kept when swupd server creates files and packs. So when swupd client tries to
apply the delta to one of the file that does not corresponds it will fail and
generates an error. At the first look it will seem like delta file is corrupted
however the issue is that delta file was created for another file.
To solve this issue we include the hash for the original file in the delta's
name so that swupd client can take the correct delta and apply it:
FROM-TO-HASH1-HASH2.

Warning: A corresponding patch to swupd server must be applied in order to
sync both sides and understand the new delta's name format.

->
Refer to https://github.com/jrguzman-intel/swupd-server/commit/6b98c2a2b7fe56b1a12dd782d73bd772fe8da27f
<-


Signed-off-by: Jose R Guzman <jose.r.guzman.mosqueda@intel.com>