### PR TITLE
Fix deletion of directory trees with 'verify --fix'

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -155,6 +155,7 @@ extern bool is_state(char *filename);
 extern void apply_heuristics(struct file *file);
 
 extern int file_sort_filename(const void *a, const void *b);
+extern int file_sort_filename_reverse(const void *a, const void *b);
 extern int load_manifests(int current, int version, char *component, struct file *file, struct manifest **manifest);
 extern struct list *create_update_list(struct manifest *current, struct manifest *server);
 extern void link_manifests(struct manifest *m1, struct manifest *m2);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -76,6 +76,21 @@ int file_sort_filename(const void *a, const void *b)
 	return 0;
 }
 
+int file_sort_filename_reverse(const void *a, const void *b)
+{
+	struct file *A, *B;
+	int ret;
+	A = (struct file *)a;
+	B = (struct file *)b;
+
+	ret = strcmp(A->filename, B->filename);
+	if (ret) {
+		return -ret;
+	}
+
+	return 0;
+}
+
 static int file_sort_version(const void *a, const void *b)
 {
 	struct file *A, *B;

--- a/src/verify.c
+++ b/src/verify.c
@@ -500,6 +500,8 @@ static void remove_orphaned_files(struct manifest *official_manifest)
 	int ret;
 	struct list *iter;
 
+	official_manifest->files = list_sort(official_manifest->files, file_sort_filename_reverse);
+
 	iter = list_head(official_manifest->files);
 	while (iter) {
 		struct file *file;


### PR DESCRIPTION
For safety, 'verify --fix' does not use swupd_rm() (like 'update') when
deleting files, etc. Instead, each deleted entry is considered
individually.

So for the deletion step to work correctly with 'verify --fix', files
contained within directories must be listed before the directories
themselves. A simple solution is to make the manifest reverse filename
sorted (opposite of the current filename sorted order).

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>