### PR TITLE
fix error checking/retry handling on pack download

### DIFF
--- a/src/update.c
+++ b/src/update.c
@@ -356,7 +356,7 @@ load_server_manifests:
 download_packs:
 	/* Step 5: get the packs and untar */
 	ret = download_subscribed_packs(false);
-	if (ret == -ENONET) {
+	if (ret) {
 		// packs don't always exist, tolerate that but not ENONET
 		if (retries < MAX_TRIES) {
 			increment_retries(&retries, &timeout);


### PR DESCRIPTION
In the update loop when downloading packs a return
status is checked with an unreacheable error number
-ENONET, this is because the function is called
download_subscribed_packs() without forcing the
pack to download, so the only chance to this to
return an error is at checking network aviability
with a return code -ENOSWUPDSERVER so far. This
was causing the retry mechanism on this point to
be completely ignored and skipped right away.

Beyond checking for -ENOSWUPDSERVER, this fix
checks whether *any* error ocurred in the packs
download function, granting that if some code
changes inside the caller is checking accorrdingly.

Signed-off-by: Jaime A. Garcia <jaime.garcia.naranjo@intel.com>