### PR TITLE
Fix check-update content url message

### DIFF
--- a/src/check_update.c
+++ b/src/check_update.c
@@ -81,6 +81,7 @@ static bool parse_options(int argc, char **argv)
 				printf("Invalid --versionurl argument\n\n");
 				goto err;
 			}
+			set_content_url(optarg);
 			set_version_url(optarg);
 			break;
 		case 'P':


### PR DESCRIPTION
Fix "Use the -c option instead" message in check-update since it does
not require the -c option, this occurs when the default contenturl
can not be foud in the config files, this patch sets the content url
with the version url value in check-update.

Signed-off-by: Jesus Ornelas Aguayo <jesus.ornelas.aguayo@intel.com>