### PR TITLE
Add check for do_staging return code

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -444,7 +444,8 @@ int install_bundles(struct list *bundles, int current_version, struct manifest *
 		if (ret == 0) {
 			rename_staged_file_to_final(file);
 		} else {
-			printf("Failed to stage file(s) (ret = %d). Cannot proceed with bundle-add \n", ret);
+			printf("Failed to stage file: %s (ret = %d). Aborting bundle-add\n",
+                    file->filename, ret);
 			goto out;
 		}
 	}

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -443,6 +443,9 @@ int install_bundles(struct list *bundles, int current_version, struct manifest *
 		ret = do_staging(file, mom);
 		if (ret == 0) {
 			rename_staged_file_to_final(file);
+		} else {
+			printf("Failed to stage file(s) (ret = %d). Cannot proceed with bundle-add \n", ret);
+			goto out;
 		}
 	}
 


### PR DESCRIPTION
Add check for do_staging return code, aborting bundle-add
operation when any file or directory fails to stage. This
addresses file system corruption seen when client runs out
of disk space

Signed-off-by: Brad T. Peters <brad.t.peters@intel.com>