### PR TITLE
fix to check whether resume download is supported

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -198,6 +198,7 @@ extern int swupd_curl_get_file(const char *url, char *filename, struct file *fil
 #define SWUPD_CURL_CONNECT_TIMEOUT 30
 #define SWUPD_CURL_RCV_TIMEOUT 120
 extern CURLcode swupd_curl_set_basic_options(CURL *curl, const char *url);
+void swupd_curl_test_resume(void);
 
 extern struct list *subs;
 extern void free_subscriptions(void);

--- a/src/curl.c
+++ b/src/curl.c
@@ -50,6 +50,7 @@ static CURL *curl = NULL;
 
 static int curr_version = -1;
 static int req_version = -1;
+static bool resume_download_enabled = true;
 
 int swupd_curl_init(void)
 {
@@ -231,7 +232,7 @@ int swupd_curl_get_file(const char *url, char *filename, struct file *file,
 		local->staging = filename;
 
 		if (lstat(filename, &stat) == 0) {
-			if (pack) {
+			if (pack && resume_download_enabled) {
 				curl_ret = curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE, (curl_off_t)stat.st_size);
 			} else {
 				unlink(filename);
@@ -361,6 +362,62 @@ exit:
 	}
 
 	return err;
+}
+
+void swupd_curl_test_resume(void)
+{
+#define RESUME_BYTE_RANGE 2
+
+	CURLcode curl_ret;
+	char *version_string = NULL;
+	char *url = NULL;
+
+	if (!curl) {
+		abort();
+	}
+
+	curl_easy_reset(curl);
+	version_string = malloc(LINE_MAX);
+	if (version_string == NULL) {
+		abort();
+	}
+
+	string_or_die(&url, "%s/version/format%s/latest", version_url, format_string);
+
+	curl_ret = curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE, (curl_off_t)RESUME_BYTE_RANGE);
+	if (curl_ret != CURLE_OK) {
+		goto exit;
+	}
+
+	curl_ret = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, swupd_download_version_to_memory);
+	if (curl_ret != CURLE_OK) {
+		goto exit;
+	}
+	curl_ret = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)version_string);
+	if (curl_ret != CURLE_OK) {
+		goto exit;
+	}
+	curl_ret = curl_easy_setopt(curl, CURLOPT_COOKIE, "request=uncached");
+	if (curl_ret != CURLE_OK) {
+		goto exit;
+	}
+
+	curl_ret = swupd_curl_set_basic_options(curl, url);
+	if (curl_ret != CURLE_OK) {
+		goto exit;
+	}
+
+	curl_ret = curl_easy_perform(curl);
+
+	if (curl_ret == CURLE_RANGE_ERROR) {
+		printf("Range command not supported by server, download resume disabled.\n");
+		resume_download_enabled = false;
+	}
+exit:
+	free(version_string);
+	free(url);
+
+	return;
 }
 
 static CURLcode swupd_curl_set_security_opts(CURL *curl)

--- a/src/version.c
+++ b/src/version.c
@@ -76,6 +76,8 @@ bool check_network(void)
 			have_network = false;
 		} else {
 			have_network = true;
+			/* check if server supports Range command (resume) */
+			swupd_curl_test_resume();
 		}
 	}
 


### PR DESCRIPTION
When pack is going to be downloaded an option for
curl called resume is activated no matter what,
however although major http server support 'Range'
command that enables this functionality, not all
complies with this, when swupd client tries to
re-download a partial file from one of the server
that does not support 'Range' it will just throw
an error and stop to work until partial download
is deleted by hand.

This patch address that issue by checking first
whether server supports 'Range' command and if not
then disable 'resume' of packs.

Signed-off-by: Jaime A. Garcia <jaime.garcia.naranjo@intel.com>