### PR TITLE
Fix version to memory download

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -152,6 +152,7 @@ dist_check_SCRIPTS = \
 	test/functional/checkupdate/new-version/test.bats \
 	test/functional/checkupdate/no-server-content/test.bats \
 	test/functional/checkupdate/no-target-content/test.bats \
+	test/functional/checkupdate/slow-server/test.bats \
 	test/functional/checkupdate/version-match/test.bats \
 	test/functional/hashdump/file-hash/test.bats \
 	test/functional/hashdump/file-hash-no-path-prefix/test.bats \

--- a/src/version.c
+++ b/src/version.c
@@ -41,7 +41,7 @@ int get_latest_version(void)
 	int ret = 0;
 	char *tmp_version;
 
-	tmp_version = malloc(LINE_MAX);
+	tmp_version = calloc(LINE_MAX, 1);
 	if (tmp_version == NULL) {
 		abort();
 	}

--- a/test/functional/checkupdate/slow-server/server.py
+++ b/test/functional/checkupdate/slow-server/server.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import http.server as server
+import sys
+import time
+
+
+class SlowResponse(server.BaseHTTPRequestHandler):
+    """Handler that returns data with a set delay between writes"""
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        response = "99990"
+        delay = 0.00001 # seconds
+        for c in response:
+            self.wfile.write(str.encode(c))
+            time.sleep(delay)
+
+
+if __name__ == '__main__':
+    print(sys.argv)
+    addr = ('', int(sys.argv[1]))
+    httpd = server.HTTPServer(addr, SlowResponse)
+    httpd.serve_forever()

--- a/test/functional/checkupdate/slow-server/target-dir/usr/lib/os-release
+++ b/test/functional/checkupdate/slow-server/target-dir/usr/lib/os-release
@@ -1,0 +1,9 @@
+NAME="Clear Linux Software for Intel Architecture"
+VERSION=1
+ID=clear-linux-os
+VERSION_ID=10
+PRETTY_NAME="Clear Linux Software for Intel Architecture"
+ANSI_COLOR="1;35"
+HOME_URL="https://clearlinux.org"
+SUPPORT_URL="https://clearlinux.org"
+BUG_REPORT_URL="https://bugs.clearlinux.org/jira"

--- a/test/functional/checkupdate/slow-server/test.bats
+++ b/test/functional/checkupdate/slow-server/test.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+load "../../swupdlib"
+
+server_pid=""
+port=""
+
+setup() {
+  for i in $(seq 8080 8180); do
+    "$DIR/server.py" $i &
+    sleep .2
+    server_pid=$!
+    if [ -d /proc/$server_pid ]; then
+      port=$i
+      break
+    fi
+  done
+}
+
+teardown() {
+  kill $server_pid
+}
+
+@test "check-update with a slow server" {
+  slow_opts="-p $DIR/target-dir -F staging -u http://localhost:$port/"
+  run sudo sh -c "$SWUPD check-update $slow_opts"
+
+  echo "$output"
+  [ "${lines[2]}" = "Querying server version." ]
+  [ "${lines[3]}" = "Attempting to download version string to memory" ]
+  [ "${lines[4]}" = "There is a new OS version available: 99990" ]
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
Contains whites pace fix from #60.

In the case where the swupd_download_version_to_memory callback was run
multiple times, it would overwrite previous data instead of appending.

Correct this behavior by keeping track of data written so far in the
struct passed to the callback.

Resolves issue #45.