### PR TITLE
Ensure bundle-remove gets one bundle argument

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -148,6 +148,7 @@ dist_check_SCRIPTS = \
 	test/functional/bundleadd/include/test.bats \
 	test/functional/bundleadd/list/test.bats \
 	test/functional/bundleremove/boot-file/test.bats \
+	test/functional/bundleremove/parse-args/test.bats \
 	test/functional/bundleremove/remove-file/test.bats \
 	test/functional/checkupdate/new-version/test.bats \
 	test/functional/checkupdate/no-server-content/test.bats \

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -134,8 +134,8 @@ static bool parse_options(int argc, char **argv)
 		}
 	}
 
-	if (argc == optind) {
-		printf("error: bundle name missing\n\n");
+	if (argc != optind + 1) {
+		printf("error: invalid arguments\n\n");
 		goto err;
 	}
 	string_or_die(&bundle_name, "%s", argv[optind]);

--- a/test/functional/bundleremove/parse-args/target-dir/usr/lib/os-release
+++ b/test/functional/bundleremove/parse-args/target-dir/usr/lib/os-release
@@ -1,0 +1,9 @@
+NAME="Clear Linux Software for Intel Architecture"
+VERSION=1
+ID=clear-linux-os
+VERSION_ID=10
+PRETTY_NAME="Clear Linux Software for Intel Architecture"
+ANSI_COLOR="1;35"
+HOME_URL="https://clearlinux.org"
+SUPPORT_URL="https://clearlinux.org"
+BUG_REPORT_URL="https://bugs.clearlinux.org/jira"

--- a/test/functional/bundleremove/parse-args/test.bats
+++ b/test/functional/bundleremove/parse-args/test.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+load "../../swupdlib"
+
+@test "bundle-remove ensure bundle name is passed as an option" {
+  run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS"
+
+  echo "$output"
+  [ "${lines[2]}" = "error: invalid arguments" ]
+}
+
+@test "bundle-remove ensure only 1 bundle can be removed at a time" {
+  run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle test-bundle2"
+
+  echo "$output"
+  [ "${lines[2]}" = "error: invalid arguments" ]
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
Instead of only checking if bundle-remove has at least one bundle
argument and ignoring additional ones, check that there is exactly one
argument passed to bundle-remove instead.