### PR TITLE
Correct return check of get_latest_version

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -190,7 +190,8 @@ dist_check_SCRIPTS = \
 	test/functional/verify/directory-tree-deleted/test.bats \
 	test/functional/verify/empty-dir-deleted/test.bats \
 	test/functional/verify/install-directory/test.bats \
-	test/functional/verify/install-latest-directory/test.bats
+	test/functional/verify/install-latest-directory/test.bats \
+	test/functional/verify/latest-missing/test.bats
 endif
 
 if COVERAGE

--- a/src/verify.c
+++ b/src/verify.c
@@ -620,7 +620,7 @@ int verify_main(int argc, char **argv)
 
 	if (version == -1) {
 		version = get_latest_version();
-		if (version == -1) {
+		if (version < 0) {
 			printf("Unable to get latest version for install\n");
 			v_lockfile(lock_fd);
 			return EXIT_FAILURE;

--- a/test/functional/verify/latest-missing/target-dir/usr/lib/os-release
+++ b/test/functional/verify/latest-missing/target-dir/usr/lib/os-release
@@ -1,0 +1,9 @@
+NAME="Clear Linux Software for Intel Architecture"
+VERSION=1
+ID=clear-linux-os
+VERSION_ID=100
+PRETTY_NAME="Clear Linux Software for Intel Architecture"
+ANSI_COLOR="1;35"
+HOME_URL="https://clearlinux.org"
+SUPPORT_URL="https://clearlinux.org"
+BUG_REPORT_URL="https://bugs.clearlinux.org/jira"

--- a/test/functional/verify/latest-missing/test.bats
+++ b/test/functional/verify/latest-missing/test.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+
+load "../../swupdlib"
+
+@test "verify install using latest with missing version file on server" {
+  run sudo sh -c "$SWUPD verify $SWUPD_OPTS --install -m latest"
+
+  echo "$output"
+  [ "${lines[2]}" = "Attempting to download version string to memory" ]
+  [ "${lines[3]}" = "Unable to get latest version for install" ]
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
Update verify to correctly check the return value of get_latest_version
for errors. Since get_latest_version could return a variety of negative
error codes to signify errors compare against that range instead of -1
to determine success of the operation.