### PR TITLE
Fix the swupd resume when set_path_prefix returns false 

### DIFF
--- a/src/check_update.c
+++ b/src/check_update.c
@@ -103,11 +103,10 @@ static bool parse_options(int argc, char **argv)
 			}
 			break;
 		case 'p': /* default empty path_prefix checks the running OS */
-			if (!optarg) {
+			if (!optarg || !set_path_prefix(optarg)) {
 				printf("Invalid --path argument\n\n");
 				goto err;
 			}
-			set_path_prefix(optarg);
 			break;
 		case 'x':
 			force = true;

--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -103,11 +103,10 @@ static bool parse_options(int argc, char **argv)
 			set_version_url(optarg);
 			break;
 		case 'p': /* default empty path_prefix verifies the running OS */
-			if (!optarg) {
+			if (!optarg || !set_path_prefix(optarg)) {
 				printf("Invalid --path argument\n\n");
 				goto err;
 			}
-			set_path_prefix(optarg);
 			break;
 		case 'P':
 			if (sscanf(optarg, "%ld", &update_server_port) != 1) {

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -79,11 +79,10 @@ static bool parse_options(int argc, char **argv)
 			print_help(argv[0]);
 			exit(EXIT_SUCCESS);
 		case 'p': /* default empty path_prefix removes on the running OS */
-			if (!optarg) {
+			if (!optarg || !set_path_prefix(optarg)) {
 				printf("Invalid --path argument\n\n");
 				goto err;
 			}
-			set_path_prefix(optarg);
 			break;
 		case 'u':
 			if (!optarg) {

--- a/src/main.c
+++ b/src/main.c
@@ -129,11 +129,10 @@ static bool parse_options(int argc, char **argv)
 			}
 			break;
 		case 'p': /* default empty path_prefix updates the running OS */
-			if (!optarg) {
+			if (!optarg || !set_path_prefix(optarg)) {
 				printf("Invalid --path argument\n\n");
 				goto err;
 			}
-			set_path_prefix(optarg);
 			break;
 		case 'x':
 			force = true;

--- a/src/search.c
+++ b/src/search.c
@@ -133,11 +133,10 @@ static bool parse_options(int argc, char **argv)
 			}
 			break;
 		case 'p': /* default empty path_prefix verifies the running OS */
-			if (!optarg) {
+			if (!optarg || !set_path_prefix(optarg)) {
 				printf("Invalid --path argument\n\n");
 				goto err;
 			}
-			set_path_prefix(optarg);
 			break;
 		case 's':
 			if (!optarg || (strcmp(optarg, "b") && (strcmp(optarg, "o")))) {

--- a/src/verify.c
+++ b/src/verify.c
@@ -112,11 +112,10 @@ static bool parse_options(int argc, char **argv)
 			}
 			break;
 		case 'p': /* default empty path_prefix verifies the running OS */
-			if (!optarg) {
+			if (!optarg || !set_path_prefix(optarg)) {
 				printf("Invalid --path argument\n\n");
 				goto err;
 			}
-			set_path_prefix(optarg);
 			break;
 		case 'u':
 			if (!optarg) {


### PR DESCRIPTION
When set_path_prefix returns false, a message "cannot continue"
appears but swupd continues its execution, this patch goes to
err when a false is returned by set_path_prefix.

Signed-off-by: Jesus Ornelas Aguayo <jesus.ornelas.aguayo@intel.com>