### PR TITLE
Make directory hashes independent on filename

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -31,6 +31,8 @@ extern "C" {
 
 #define MAX_TRIES 3
 
+#define SWUPD_HASH_DIRNAME "DIRECTORY"
+
 struct sub {
 	/* name of bundle/component/subscription */
 	char *component;

--- a/src/hash.c
+++ b/src/hash.c
@@ -201,7 +201,7 @@ int compute_hash(struct file *file, char *filename)
 		hmac_sha256_for_string(file->hash,
 				       (const unsigned char *)key,
 				       key_len,
-				       file->filename); //file->filename not filename
+				       SWUPD_HASH_DIRNAME); //Make independent of dirname
 		return 0;
 	}
 


### PR DESCRIPTION
Calculate the hash for directories is desiderable to be independent
on the dirname due to the subsequent calculation on the staged/HASH
file. Here is used const "DIRECTORY" string for input name for
all folders.

->
There is a patch for server side that must be applied at same time than this
jrguzman-intel/swupd-server#23
<-


Signed-off-by: Jose R Guzman <jose.r.guzman.mosqueda@intel.com>

