### PR TITLE
Replace system calls by local system_argv functions.

### DIFF
--- a/include/swupd-build-variant.h
+++ b/include/swupd-build-variant.h
@@ -10,19 +10,15 @@
 
 #ifdef SWUPD_WITH_BSDTAR
 #define TAR_COMMAND "bsdtar"
-#define TAR_XATTR_ARGS ""
 #define TAR_XATTR_ARGS_STRLIST
 #else
 #define TAR_COMMAND "tar"
-#define TAR_XATTR_ARGS "--xattrs --xattrs-include='*'"
 #define TAR_XATTR_ARGS_STRLIST "--xattrs", "--xattrs-include='*'",
 #endif
 
 #ifdef SWUPD_WITH_SELINUX
-#define TAR_PERM_ATTR_ARGS "--preserve-permissions --selinux " TAR_XATTR_ARGS
 #define TAR_PERM_ATTR_ARGS_STRLIST TAR_XATTR_ARGS_STRLIST "--preserve-permissions", "--selinux"
 #else /* SWUPD_WITHOUT_SELINUX */
-#define TAR_PERM_ATTR_ARGS "--preserve-permissions " TAR_XATTR_ARGS
 #define TAR_PERM_ATTR_ARGS_STRLIST TAR_XATTR_ARGS_STRLIST "--preserve-permissions"
 #endif
 

--- a/include/swupd-build-variant.h
+++ b/include/swupd-build-variant.h
@@ -11,15 +11,19 @@
 #ifdef SWUPD_WITH_BSDTAR
 #define TAR_COMMAND "bsdtar"
 #define TAR_XATTR_ARGS ""
+#define TAR_XATTR_ARGS_STRLIST
 #else
 #define TAR_COMMAND "tar"
 #define TAR_XATTR_ARGS "--xattrs --xattrs-include='*'"
+#define TAR_XATTR_ARGS_STRLIST "--xattrs", "--xattrs-include='*'",
 #endif
 
 #ifdef SWUPD_WITH_SELINUX
 #define TAR_PERM_ATTR_ARGS "--preserve-permissions --selinux " TAR_XATTR_ARGS
+#define TAR_PERM_ATTR_ARGS_STRLIST TAR_XATTR_ARGS_STRLIST "--preserve-permissions", "--selinux"
 #else /* SWUPD_WITHOUT_SELINUX */
 #define TAR_PERM_ATTR_ARGS "--preserve-permissions " TAR_XATTR_ARGS
+#define TAR_PERM_ATTR_ARGS_STRLIST TAR_XATTR_ARGS_STRLIST "--preserve-permissions"
 #endif
 
 #endif

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -263,6 +263,10 @@ extern int get_dirfd_path(const char *fullname);
 extern int verify_fix_path(char *targetpath, struct manifest *manifest);
 extern void set_local_download(void);
 extern struct list *files_from_bundles(struct list *bundles);
+extern int system_argv(char *const argv[]);
+extern int system_argv_fd(char *const argv[], int newstdin, int newstdout, int newstderr);
+extern int system_argv_pipe(char *const argvp1[], int stdinp1, int stderrp1,
+							char *const argvp2[], int stdoutp2, int stderrp2);
 
 /* subscription.c */
 struct list *free_list_file(struct list *item);

--- a/src/download.c
+++ b/src/download.c
@@ -250,7 +250,7 @@ int untar_full_download(void *data)
 	char *tar_dotfile;
 	char *targetfile;
 	struct stat stat;
-	int err, stderrfd;
+	int err;
 	char *tardir;
 
 	string_or_die(&tar_dotfile, "%s/download/.%s.tar", state_dir, file->hash);
@@ -292,14 +292,8 @@ int untar_full_download(void *data)
 	/* modern tar will automatically determine the compression type used */
 	string_or_die(&tardir, "%s/staged/", state_dir);
 	char *const tarcmd[] = { TAR_COMMAND, "-C", tardir, TAR_PERM_ATTR_ARGS_STRLIST, "-xf", tarfile, NULL };
-	stderrfd = open("/dev/null", O_WRONLY);
-	if (stderrfd == -1) {
-		fprintf(stderr, "Failed to open /dev/null\n");
-		assert(0);
-	}
-	err = system_argv_fd(tarcmd, -1, -1, stderrfd);
+	err = system_argv_fd(tarcmd, -1, -1, -2);
 	free(tardir);
-	close(stderrfd);
 	if (err) {
 		printf("ignoring tar extract failure for fullfile %s.tar (ret %d)\n",
 		       file->hash, err);

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -947,21 +947,21 @@ int system_argv_fd(char *const argv[], int newstdin, int newstdout, int newstder
 	pid = fork();
 
 	if (pid == 0) { /* child */
-		if (newstdin >= 0) {
+		if (newstdin >= 0 && newstdin != STDIN_FILENO) {
 			if (dup2(newstdin, STDIN_FILENO) == -1) {
 				fprintf(stderr, "Could not redirect stdin\n");
 				assert(0);
 			}
 			close(newstdin);
 		}
-		if (newstdout >= 0) {
+		if (newstdout >= 0 && newstdout != STDOUT_FILENO) {
 			if (dup2(newstdout, STDOUT_FILENO) == -1) {
 				fprintf(stderr, "Could not redirect stdout\n");
 				assert(0);
 			}
 			close(newstdout);
 		}
-		if (newstderr >= 0) {
+		if (newstderr >= 0 && newstderr != STDERR_FILENO) {
 			if (dup2(newstderr, STDERR_FILENO) == -1) {
 				fprintf(stderr, "Could not redirect stderr\n");
 				assert(0);

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -35,6 +35,8 @@
 #include <sys/statvfs.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <assert.h>
+#include <sys/wait.h>
 
 #include "config.h"
 #include "swupd.h"
@@ -164,16 +166,17 @@ int create_required_dirs(void)
 	}
 
 	if (missing) { // (re)create dirs
-		char *cmd;
+		char *param;
 
 		for (i = 0; i < STATE_DIR_COUNT; i++) {
-			string_or_die(&cmd, "mkdir -p %s/%s", state_dir, dirs[i]);
-			ret = system(cmd);
+			string_or_die(&param, "%s/%s", state_dir, dirs[i]);
+			char *const cmd[] = { "mkdir", "-p", param, NULL };
+			ret = system_argv(cmd);
 			if (ret) {
 				printf("Error: failed to create %s/%s\n", state_dir, dirs[i]);
 				return -1;
 			}
-			free(cmd);
+			free(param);
 
 			string_or_die(&dir, "%s/%s", state_dir, dirs[i]);
 			ret = chmod(dir, S_IRWXU);
@@ -871,4 +874,148 @@ struct list *files_from_bundles(struct list *bundles)
 	}
 
 	return files;
+}
+
+void concat_str_array(char **output, char *const argv[])
+{
+	int size = 0;
+
+	for (int i = 0; argv[i]; i++) {
+		size += strlen(argv[i]) + 1;
+	}
+
+	*output = malloc(size + 1);
+	if (!*output) {
+		fprintf(stderr, "Failed to allocate %i bytes", size);
+		assert(0);
+	}
+	strcpy(*output, "");
+	for (int i = 0; argv[i]; i++) {
+		strcat(*output, argv[i]);
+		strcat(*output, " ");
+	}
+}
+
+int system_argv(char *const argv[])
+{
+	int child_exit_status;
+	pid_t pid;
+	int status = -1;
+
+	pid = fork();
+
+	if (pid == 0) { /* child */
+		execvp(*argv, argv);
+		/* Next line must not be reached */
+		assert(0);
+	} else if (pid < 0) {
+		fprintf(stderr, "Failed to fork a child process\n");
+		assert(0);
+	} else {
+		pid_t ws = waitpid(pid, &child_exit_status, 0);
+
+		if (ws == -1) {
+			fprintf(stderr, "Failed to wait for child process\n");
+			assert(0);
+		}
+
+		if (WIFEXITED(child_exit_status)) {
+			status = WEXITSTATUS(child_exit_status);
+		} else {
+			fprintf(stderr, "Child process didn't exit\n");
+			assert(0);
+		}
+
+		if (status != 0) {
+			char *cmdline = NULL;
+
+			concat_str_array(&cmdline, argv);
+			fprintf(stderr, "Failed to run command: %s\n", cmdline);
+			free(cmdline);
+		}
+	}
+
+	return status;
+}
+
+int system_argv_fd(char *const argv[], int newstdin, int newstdout, int newstderr)
+{
+	int child_exit_status;
+	pid_t pid;
+	int status = -1;
+
+	pid = fork();
+
+	if (pid == 0) { /* child */
+		if (newstdin >= 0) {
+			if (dup2(newstdin, STDIN_FILENO) == -1) {
+				fprintf(stderr, "Could not redirect stdin\n");
+				assert(0);
+			}
+			close(newstdin);
+		}
+		if (newstdout >= 0) {
+			if (dup2(newstdout, STDOUT_FILENO) == -1) {
+				fprintf(stderr, "Could not redirect stdout\n");
+				assert(0);
+			}
+			close(newstdout);
+		}
+		if (newstderr >= 0) {
+			if (dup2(newstderr, STDERR_FILENO) == -1) {
+				fprintf(stderr, "Could not redirect stderr\n");
+				assert(0);
+			}
+			close(newstderr);
+		}
+
+		execvp(*argv, argv);
+		/* Next line must not be reached */
+		assert(0);
+	} else if (pid < 0) {
+	    fprintf(stderr, "Failed to fork a child process\n");
+		assert(0);
+	} else {
+		pid_t ws = waitpid(pid, &child_exit_status, 0);
+
+		if (ws == -1) {
+			fprintf(stderr, "Failed to wait for child process\n");
+			assert(0);
+		}
+
+		if (WIFEXITED(child_exit_status)) {
+			status = WEXITSTATUS(child_exit_status);
+		} else {
+			fprintf(stderr, "Child process didn't exit\n");
+			assert(0);
+		}
+
+		if (status != 0) {
+			char *cmdline = NULL;
+
+			concat_str_array(&cmdline, argv);
+			fprintf(stderr, "Failed to run command: %s\n", cmdline);
+			free(cmdline);
+		}
+	}
+
+	return status;
+}
+
+int system_argv_pipe(char *const argvp1[], int stdinp1, int stderrp1,
+					 char *const argvp2[], int stdoutp2, int stderrp2)
+{
+	int statusp2;
+	int pipefd[2];
+
+	if (pipe(pipefd)) {
+		fprintf(stderr, "Failed to create a pipe\n");
+		return -1;
+	}
+	system_argv_fd(argvp1, stdinp1, pipefd[1], stderrp1);
+	close(pipefd[1]);
+	statusp2 = system_argv_fd(argvp2, pipefd[0], stdoutp2, stderrp2);
+	close(pipefd[0]);
+
+	return statusp2;
 }

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -498,7 +498,7 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 	char *url;
 	char *filename;
 	char *dir;
-	int ret = 0, stderrfd = -1;
+	int ret = 0;
 	char *param1, *param2;
 
 	*manifest = NULL;
@@ -541,15 +541,10 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 	string_or_die(&param1, "%s/%i",  state_dir, version);
 	string_or_die(&param2, "%s/%i/Manifest.%s.tar", state_dir, version, component);
 	char *const tarcmd[] = { TAR_COMMAND, "-C", param1, "-xf", param2, NULL };
-	stderrfd = open("/dev/null", O_WRONLY);
-	if (stderrfd == -1) {
-		fprintf(stderr, "Failed to open /dev/null\n");
-		assert(0);
-	}
-	ret = system_argv_fd(tarcmd, -1, -1, stderrfd);
+	/* this is is historically a point of odd errors */
+	ret = system_argv_fd(tarcmd, -1, -1, -2);
 	free(param1);
 	free(param2);
-	close(stderrfd);
 	if (ret != 0) {
 		goto out;
 	}

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -33,6 +33,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <assert.h>
 
 #include "config.h"
 #include "signature.h"
@@ -497,8 +498,8 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 	char *url;
 	char *filename;
 	char *dir;
-	int ret = 0;
-	char *tar;
+	int ret = 0, stderrfd = -1;
+	char *param1, *param2;
 
 	*manifest = NULL;
 
@@ -537,15 +538,18 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 		goto out;
 	}
 
-	string_or_die(&tar, TAR_COMMAND " -C %s/%i -xf %s/%i/Manifest.%s.tar 2> /dev/null",
-		      state_dir, version, state_dir, version, component);
-
-	/* this is is historically a point of odd errors */
-	ret = system(tar);
-	if (WIFEXITED(ret)) {
-		ret = WEXITSTATUS(ret);
+	string_or_die(&param1, "%s/%i",  state_dir, version);
+	string_or_die(&param2, "%s/%i/Manifest.%s.tar", state_dir, version, component);
+	char *const tarcmd[] = { TAR_COMMAND, "-C", param1, "-xf", param2, NULL };
+	stderrfd = open("/dev/null", O_WRONLY);
+	if (stderrfd == -1) {
+		fprintf(stderr, "Failed to open /dev/null\n");
+		assert(0);
 	}
-	free(tar);
+	ret = system_argv_fd(tarcmd, -1, -1, stderrfd);
+	free(param1);
+	free(param2);
+	close(stderrfd);
 	if (ret != 0) {
 		goto out;
 	}

--- a/src/packs.c
+++ b/src/packs.c
@@ -42,7 +42,7 @@ static int download_pack(int oldversion, int newversion, char *module)
 	FILE *tarfile = NULL;
 	char *param = NULL;
 	char *url = NULL;
-	int err = -1, stderrfd;
+	int err = -1;
 	char *filename;
 	struct stat stat;
 
@@ -80,14 +80,8 @@ static int download_pack(int oldversion, int newversion, char *module)
 	printf("Extracting pack.\n");
 	string_or_die(&param, "%s/pack-%s-from-%i-to-%i.tar", state_dir, module, oldversion, newversion);
 	char *const tarcmd[] = { TAR_COMMAND, "-C", state_dir, TAR_PERM_ATTR_ARGS_STRLIST, "-xf", param, NULL };
-	stderrfd = open("/dev/null", O_WRONLY);
-	if (stderrfd == -1) {
-		fprintf(stderr, "Failed to open /dev/null\n");
-		assert(0);
-	}
-	err = system_argv_fd(tarcmd, -1, -1, stderrfd);
+	err = system_argv_fd(tarcmd, -1, -1, -2);
 	free(param);
-	close(stderrfd);
 	unlink(filename);
 	/* make a zero sized file to prevent redownload */
 	tarfile = fopen(filename, "w");

--- a/src/packs.c
+++ b/src/packs.c
@@ -29,6 +29,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <fcntl.h>
+#include <assert.h>
 
 #include "config.h"
 #include "signature.h"
@@ -38,9 +40,9 @@
 static int download_pack(int oldversion, int newversion, char *module)
 {
 	FILE *tarfile = NULL;
-	char *tar = NULL;
+	char *param = NULL;
 	char *url = NULL;
-	int err = -1;
+	int err = -1, stderrfd;
 	char *filename;
 	struct stat stat;
 
@@ -76,14 +78,16 @@ static int download_pack(int oldversion, int newversion, char *module)
 	free(url);
 
 	printf("Extracting pack.\n");
-	string_or_die(&tar, TAR_COMMAND " -C %s " TAR_PERM_ATTR_ARGS " -xf %s/pack-%s-from-%i-to-%i.tar 2> /dev/null",
-		      state_dir, state_dir, module, oldversion, newversion);
-
-	err = system(tar);
-	if (WIFEXITED(err)) {
-		err = WEXITSTATUS(err);
+	string_or_die(&param, "%s/pack-%s-from-%i-to-%i.tar", state_dir, module, oldversion, newversion);
+	char *const tarcmd[] = { TAR_COMMAND, "-C", state_dir, TAR_PERM_ATTR_ARGS_STRLIST, "-xf", param, NULL };
+	stderrfd = open("/dev/null", O_WRONLY);
+	if (stderrfd == -1) {
+		fprintf(stderr, "Failed to open /dev/null\n");
+		assert(0);
 	}
-	free(tar);
+	err = system_argv_fd(tarcmd, -1, -1, stderrfd);
+	free(param);
+	close(stderrfd);
 	unlink(filename);
 	/* make a zero sized file to prevent redownload */
 	tarfile = fopen(filename, "w");

--- a/src/scripts.c
+++ b/src/scripts.c
@@ -37,14 +37,14 @@ static void update_kernel(void)
 	if (strcmp("/", path_prefix) == 0) {
 		char *const kernel_update_cmd[] = { "/usr/bin/kernel_updater.sh", NULL } ;
 
-		system_argv(kernel_update_cmd);
+		(void)system_argv(kernel_update_cmd);
 	} else {
 		char *pathupdater;
 
 		string_or_die(&pathupdater, "%s/usr/bin/kernel_updater.sh", path_prefix);
 		char *const kernel_update_cmd[] = { pathupdater, "--path", path_prefix,  NULL } ;
 
-		system_argv(kernel_update_cmd);
+		(void)system_argv(kernel_update_cmd);
 		free(pathupdater);
 	}
 }
@@ -54,28 +54,28 @@ static void update_bootloader(void)
 	if (strcmp("/", path_prefix) == 0) {
 		char *const bootloader_update_cmd[] = { "/usr/bin/gummiboot_updaters.sh", NULL };
 
-		system_argv(bootloader_update_cmd);
+		(void)system_argv(bootloader_update_cmd);
 	} else {
 		char *pathupdater;
 
 		string_or_die(&pathupdater, "%s/usr/bin/gummiboot_updaters.sh", path_prefix);
 		char *const bootloader_update_cmd[] = { pathupdater, "--path", path_prefix, NULL };
 
-		system_argv(bootloader_update_cmd);
+		(void)system_argv(bootloader_update_cmd);
 		free(pathupdater);
 	}
 
 	if (strcmp("/", path_prefix) == 0) {
 		char *const bootloader_update_cmd[] = { "/usr/bin/systemdboot_updater.sh", NULL };
 
-		system_argv(bootloader_update_cmd);
+		(void)system_argv(bootloader_update_cmd);
 	} else {
 		char *pathupdater;
 
 		string_or_die(&pathupdater, "%s/usr/bin/systemdboot_updater.sh", path_prefix);
 		char *const bootloader_update_cmd[] = { pathupdater, "--path", path_prefix, NULL };
 
-		system_argv(bootloader_update_cmd);
+		(void)system_argv(bootloader_update_cmd);
 		free(pathupdater);
 	}
 }
@@ -85,8 +85,8 @@ static void update_triggers(void)
 	char *const reloadcmd[] = { "/usr/bin/systemctl", "daemon-reload", NULL };
 	char *const restartcmd[] = { "/usr/bin/systemctl", "restart", "update-triggers.target", NULL };
 
-	system_argv(reloadcmd);
-	system_argv(restartcmd);
+	(void)system_argv(reloadcmd);
+	(void)system_argv(restartcmd);
 }
 
 void run_scripts(void)
@@ -143,7 +143,7 @@ void run_preupdate_scripts(struct manifest *manifest)
 
 		/* Check that system file matches file in manifest */
 		if (verify_file(file, script)) {
-			system_argv(scriptcmd);
+			(void)system_argv(scriptcmd);
 			break;
 		}
 	}

--- a/src/scripts.c
+++ b/src/scripts.c
@@ -34,45 +34,59 @@
 
 static void update_kernel(void)
 {
-	char *kernel_update_cmd = NULL;
-
 	if (strcmp("/", path_prefix) == 0) {
-		string_or_die(&kernel_update_cmd, "/usr/bin/kernel_updater.sh");
-	} else {
-		string_or_die(&kernel_update_cmd, "%s/usr/bin/kernel_updater.sh --path %s", path_prefix, path_prefix);
-	}
+		char *const kernel_update_cmd[] = { "/usr/bin/kernel_updater.sh", NULL } ;
 
-	system(kernel_update_cmd);
-	free(kernel_update_cmd);
+		system_argv(kernel_update_cmd);
+	} else {
+		char *pathupdater;
+
+		string_or_die(&pathupdater, "%s/usr/bin/kernel_updater.sh", path_prefix);
+		char *const kernel_update_cmd[] = { pathupdater, "--path", path_prefix,  NULL } ;
+
+		system_argv(kernel_update_cmd);
+		free(pathupdater);
+	}
 }
 
 static void update_bootloader(void)
 {
-	char *bootloader_update_cmd = NULL;
-
 	if (strcmp("/", path_prefix) == 0) {
-		string_or_die(&bootloader_update_cmd, "/usr/bin/gummiboot_updaters.sh");
+		char *const bootloader_update_cmd[] = { "/usr/bin/gummiboot_updaters.sh", NULL };
+
+		system_argv(bootloader_update_cmd);
 	} else {
-		string_or_die(&bootloader_update_cmd, "%s/usr/bin/gummiboot_updaters.sh --path %s", path_prefix, path_prefix);
+		char *pathupdater;
+
+		string_or_die(&pathupdater, "%s/usr/bin/gummiboot_updaters.sh", path_prefix);
+		char *const bootloader_update_cmd[] = { pathupdater, "--path", path_prefix, NULL };
+
+		system_argv(bootloader_update_cmd);
+		free(pathupdater);
 	}
 
-	system(bootloader_update_cmd);
-	free(bootloader_update_cmd);
-
 	if (strcmp("/", path_prefix) == 0) {
-		string_or_die(&bootloader_update_cmd, "/usr/bin/systemdboot_updater.sh");
-	} else {
-		string_or_die(&bootloader_update_cmd, "%s/usr/bin/systemdboot_updater.sh --path %s", path_prefix, path_prefix);
-	}
+		char *const bootloader_update_cmd[] = { "/usr/bin/systemdboot_updater.sh", NULL };
 
-	system(bootloader_update_cmd);
-	free(bootloader_update_cmd);
+		system_argv(bootloader_update_cmd);
+	} else {
+		char *pathupdater;
+
+		string_or_die(&pathupdater, "%s/usr/bin/systemdboot_updater.sh", path_prefix);
+		char *const bootloader_update_cmd[] = { pathupdater, "--path", path_prefix, NULL };
+
+		system_argv(bootloader_update_cmd);
+		free(pathupdater);
+	}
 }
 
 static void update_triggers(void)
 {
-	system("/usr/bin/systemctl daemon-reload");
-	system("/usr/bin/systemctl restart update-triggers.target");
+	char *const reloadcmd[] = { "/usr/bin/systemctl", "daemon-reload", NULL };
+	char *const restartcmd[] = { "/usr/bin/systemctl", "restart", "update-triggers.target", NULL };
+
+	system_argv(reloadcmd);
+	system_argv(restartcmd);
 }
 
 void run_scripts(void)
@@ -112,6 +126,7 @@ void run_preupdate_scripts(struct manifest *manifest)
 	char *script;
 
 	string_or_die(&script, "/usr/bin/clr_pre_update.sh");
+	char *const scriptcmd = { script, NULL };
 
 	if (stat(script, &sb) == -1) {
 		free(script);
@@ -128,7 +143,7 @@ void run_preupdate_scripts(struct manifest *manifest)
 
 		/* Check that system file matches file in manifest */
 		if (verify_file(file, script)) {
-			system(script);
+			system_argv(scriptcmd);
 			break;
 		}
 	}

--- a/src/scripts.c
+++ b/src/scripts.c
@@ -126,7 +126,7 @@ void run_preupdate_scripts(struct manifest *manifest)
 	char *script;
 
 	string_or_die(&script, "/usr/bin/clr_pre_update.sh");
-	char *const scriptcmd = { script, NULL };
+	char *const scriptcmd[] = { script, NULL };
 
 	if (stat(script, &sb) == -1) {
 		free(script);

--- a/src/staging.c
+++ b/src/staging.c
@@ -31,6 +31,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 #include "config.h"
 #include "swupd-build-variant.h"
@@ -40,16 +41,14 @@
 static int create_staging_renamedir(char *rename_tmpdir)
 {
 	int ret;
-	char *rmcommand = NULL;
+	char *const rmcommand[] = { "rm", "-fr", rename_tmpdir, NULL };
 
-	string_or_die(&rmcommand, "rm -fr %s", rename_tmpdir);
-	if (!system(rmcommand)) {
+	if (!system_argv(rmcommand)) {
 		/* Not fatal but pretty scary, likely to really fail at the
 		 * next command too. Pass for now as printing may just cause
 		 * confusion */
 		;
 	}
-	free(rmcommand);
 
 	ret = mkdir(rename_tmpdir, S_IRWXU);
 	if (ret == -1 && errno != EEXIST) {
@@ -69,13 +68,13 @@ int do_staging(struct file *file, struct manifest *MoM)
 {
 	char *statfile = NULL, *tmp = NULL, *tmp2 = NULL;
 	char *dir, *base, *rel_dir;
-	char *tarcommand = NULL;
+	char *param1 = NULL, *param2 = NULL, *param3 = NULL;
 	char *original = NULL;
 	char *target = NULL;
 	char *targetpath = NULL;
 	char *rename_target = NULL;
 	char *rename_tmpdir = NULL;
-	int ret;
+	int ret, stderrfd;
 	struct stat s;
 
 	tmp = strdup(file->filename);
@@ -148,13 +147,20 @@ int do_staging(struct file *file, struct manifest *MoM)
 			ret = -errno;
 			goto out;
 		}
-		string_or_die(&tarcommand, TAR_COMMAND " -C '%s' " TAR_PERM_ATTR_ARGS " -cf - './%s' 2> /dev/null | " TAR_COMMAND " -C '%s%s' " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
-			      rename_tmpdir, base, path_prefix, rel_dir);
-		ret = system(tarcommand);
-		if (WIFEXITED(ret)) {
-			ret = WEXITSTATUS(ret);
+		string_or_die(&param1, "./%s", base);
+		string_or_die(&param2, "%s%s", path_prefix, rel_dir);
+		char *const tarcfcmd[] = { TAR_COMMAND, "-C", rename_tmpdir, TAR_PERM_ATTR_ARGS_STRLIST, "-cf", "-", param1, NULL };
+		char *const tarxfcmd[] = { TAR_COMMAND, "-C", param2, TAR_PERM_ATTR_ARGS_STRLIST, "-xf", "-", NULL };
+		stderrfd = open("/dev/null", O_WRONLY);
+		if (stderrfd == -1) {
+			fprintf(stderr, "Failed to open /dev/null\n");
+			assert(0);
 		}
-		free(tarcommand);
+		ret = system_argv_pipe(tarcfcmd, -1, stderrfd, tarxfcmd, -1, stderrfd);
+		free(param1);
+		free(param2);
+		close(stderrfd);
+
 		if (rename(rename_target, original)) {
 			ret = -errno;
 			goto out;
@@ -185,13 +191,21 @@ int do_staging(struct file *file, struct manifest *MoM)
 				ret = -errno;
 				goto out;
 			}
-			string_or_die(&tarcommand, TAR_COMMAND " -C '%s/staged' " TAR_PERM_ATTR_ARGS " -cf - '.update.%s' 2> /dev/null | " TAR_COMMAND " -C '%s%s' " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
-				      state_dir, base, path_prefix, rel_dir);
-			ret = system(tarcommand);
-			if (WIFEXITED(ret)) {
-				ret = WEXITSTATUS(ret);
+			string_or_die(&param1, "%s/staged", state_dir);
+			string_or_die(&param2, ".update.%s", base);
+			string_or_die(&param3, "%s%s", path_prefix, rel_dir);
+			char *const tarcfcmd[] = { TAR_COMMAND, "-C", param1, TAR_PERM_ATTR_ARGS_STRLIST, "-cf", "-", param2, NULL };
+			char *const tarxfcmd[] = { TAR_COMMAND, "-C", param3, TAR_PERM_ATTR_ARGS_STRLIST, "-xf", "-", NULL };
+			stderrfd = open("/dev/null", O_WRONLY);
+			if (stderrfd == -1) {
+				fprintf(stderr, "Failed to open /dev/null\n");
+				assert(0);
 			}
-			free(tarcommand);
+			ret = system_argv_pipe(tarcfcmd, -1, stderrfd, tarxfcmd, -1, stderrfd);
+			free(param1);
+			free(param2);
+			free(param3);
+			close(stderrfd);
 			ret = rename(rename_target, original);
 			if (ret) {
 				ret = -errno;

--- a/src/staging.c
+++ b/src/staging.c
@@ -74,7 +74,7 @@ int do_staging(struct file *file, struct manifest *MoM)
 	char *targetpath = NULL;
 	char *rename_target = NULL;
 	char *rename_tmpdir = NULL;
-	int ret, stderrfd;
+	int ret;
 	struct stat s;
 
 	tmp = strdup(file->filename);
@@ -151,15 +151,9 @@ int do_staging(struct file *file, struct manifest *MoM)
 		string_or_die(&param2, "%s%s", path_prefix, rel_dir);
 		char *const tarcfcmd[] = { TAR_COMMAND, "-C", rename_tmpdir, TAR_PERM_ATTR_ARGS_STRLIST, "-cf", "-", param1, NULL };
 		char *const tarxfcmd[] = { TAR_COMMAND, "-C", param2, TAR_PERM_ATTR_ARGS_STRLIST, "-xf", "-", NULL };
-		stderrfd = open("/dev/null", O_WRONLY);
-		if (stderrfd == -1) {
-			fprintf(stderr, "Failed to open /dev/null\n");
-			assert(0);
-		}
-		ret = system_argv_pipe(tarcfcmd, -1, stderrfd, tarxfcmd, -1, stderrfd);
+		ret = system_argv_pipe(tarcfcmd, -1, -2, tarxfcmd, -1, -2);
 		free(param1);
 		free(param2);
-		close(stderrfd);
 
 		if (rename(rename_target, original)) {
 			ret = -errno;
@@ -196,16 +190,10 @@ int do_staging(struct file *file, struct manifest *MoM)
 			string_or_die(&param3, "%s%s", path_prefix, rel_dir);
 			char *const tarcfcmd[] = { TAR_COMMAND, "-C", param1, TAR_PERM_ATTR_ARGS_STRLIST, "-cf", "-", param2, NULL };
 			char *const tarxfcmd[] = { TAR_COMMAND, "-C", param3, TAR_PERM_ATTR_ARGS_STRLIST, "-xf", "-", NULL };
-			stderrfd = open("/dev/null", O_WRONLY);
-			if (stderrfd == -1) {
-				fprintf(stderr, "Failed to open /dev/null\n");
-				assert(0);
-			}
-			ret = system_argv_pipe(tarcfcmd, -1, stderrfd, tarxfcmd, -1, stderrfd);
+			ret = system_argv_pipe(tarcfcmd, -1, -2, tarxfcmd, -1, -2);
 			free(param1);
 			free(param2);
 			free(param3);
-			close(stderrfd);
 			ret = rename(rename_target, original);
 			if (ret) {
 				ret = -errno;


### PR DESCRIPTION
There are new functions that replace system() calls: system_argv()
and system_argv_pipe(). They are based on execvp() function and they
can manage any argument including filenames with characters that could
be interpreted as meta-characters in a regular system() function.
So no escape for the arguments needed and is less prone to errors.

Signed-off-by: Jose R Guzman <jose.r.guzman.mosqueda@intel.com>