### PR TITLE
Correctly free manifest data

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -377,7 +377,7 @@ int add_subscriptions(struct list *bundles, int current_version, struct manifest
 				new_bundles = true;
 			}
 		}
-		free(manifest);
+		free_manifest(manifest);
 
 		if (is_tracked_bundle(bundle)) {
 			continue;


### PR DESCRIPTION
Call free_manifest instead of plain free on allocated manifests.