### PR TITLE
Stop using out of scope stack memory

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -55,6 +55,11 @@ struct manifest {
 	char *component;
 };
 
+struct version_container {
+	size_t offset;
+	char *version;
+};
+
 struct header;
 
 extern bool force;
@@ -193,7 +198,7 @@ extern void swupd_curl_set_requested_version(int v);
 extern double swupd_query_url_content_size(char *url);
 extern size_t swupd_download_file(void *ptr, size_t size, size_t nmemb, void *userdata);
 extern int swupd_curl_get_file(const char *url, char *filename, struct file *file,
-			       char *tmp_version, bool pack);
+			       struct version_container *tmp_version, bool pack);
 #define SWUPD_CURL_LOW_SPEED_LIMIT 1
 #define SWUPD_CURL_CONNECT_TIMEOUT 30
 #define SWUPD_CURL_RCV_TIMEOUT 120

--- a/src/curl.c
+++ b/src/curl.c
@@ -52,11 +52,6 @@ static int curr_version = -1;
 static int req_version = -1;
 static bool resume_download_enabled = true;
 
-struct version_container {
-	size_t offset;
-	char *version;
-};
-
 int swupd_curl_init(void)
 {
 	CURLcode curl_ret;
@@ -211,7 +206,7 @@ size_t swupd_download_file(void *ptr, size_t size, size_t nmemb, void *userdata)
  * - NOTE: See full_download() for multi/asynchronous downloading of fullfiles.
  */
 int swupd_curl_get_file(const char *url, char *filename, struct file *file,
-			char *in_memory_version_string, bool pack)
+			struct version_container *in_memory_version_string, bool pack)
 {
 	CURLcode curl_ret;
 	long ret = 0;
@@ -258,9 +253,6 @@ int swupd_curl_get_file(const char *url, char *filename, struct file *file,
 			goto exit;
 		}
 	} else {
-		struct version_container vc = { 0 };
-		vc.version = in_memory_version_string;
-
 		// only download latest version number, storing in the provided pointer
 		printf("Attempting to download version string to memory\n");
 
@@ -268,7 +260,7 @@ int swupd_curl_get_file(const char *url, char *filename, struct file *file,
 		if (curl_ret != CURLE_OK) {
 			goto exit;
 		}
-		curl_ret = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&vc);
+		curl_ret = curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)in_memory_version_string);
 		if (curl_ret != CURLE_OK) {
 			goto exit;
 		}

--- a/src/version.c
+++ b/src/version.c
@@ -39,10 +39,10 @@ int get_latest_version(void)
 	char *url = NULL;
 	char *path = NULL;
 	int ret = 0;
-	char *tmp_version;
+	struct version_container tmp_version = { 0 };
 
-	tmp_version = calloc(LINE_MAX, 1);
-	if (tmp_version == NULL) {
+	tmp_version.version = calloc(LINE_MAX, 1);
+	if (tmp_version.version == NULL) {
 		abort();
 	}
 
@@ -52,17 +52,17 @@ int get_latest_version(void)
 
 	unlink(path);
 
-	ret = swupd_curl_get_file(url, path, NULL, tmp_version, false);
+	ret = swupd_curl_get_file(url, path, NULL, &tmp_version, false);
 	if (ret) {
 		goto out;
 	} else {
-		ret = strtol(tmp_version, NULL, 10);
+		ret = strtol(tmp_version.version, NULL, 10);
 	}
 
 out:
 	free(path);
 	free(url);
-	free(tmp_version);
+	free(tmp_version.version);
 	return ret;
 }
 


### PR DESCRIPTION
When running get_latest_version, the swupd_curl_get_file would allocate
a version_container struct on the stack that would then be used by the
curl callback to keep track of the buffer offset. This use was invalid
however because the callback was run after the stack had been popped
which lead to undefined behavior.

Instead change the swupd_curl_get_file function to take the struct
itself so it will refer to memory valid for the entire length of the
call.

The swupd_curl_get_file function should likely be restructured at some
point so that in memory downloads are less of a hack (only able to
download a LINE_MAX worth of data) at some point however and this will
need to be updated again.