### PR TITLE
Improvements for update list creation

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -616,16 +616,20 @@ struct list *create_update_list(struct manifest *current, struct manifest *serve
 		file = list->data;
 		list = list->next;
 
-		/* Skip files that aren't updated */
-		fullname = mk_full_filename(path_prefix, file->filename);
-		if (fullname == NULL) {
-			abort();
-		}
-		if (verify_file(file, fullname)) {
+		if (file->peer && hash_equal(file->hash, file->peer->hash)) {
+			/* Skip new/changed files if they are already installed
+			 * and the hash check passes. This makes minversion
+			 * bumps cheaper. */
+			fullname = mk_full_filename(path_prefix, file->filename);
+			if (fullname == NULL) {
+				abort();
+			}
+			if (verify_file(file, fullname)) {
+				free(fullname);
+				continue;
+			}
 			free(fullname);
-			continue;
 		}
-		free(fullname);
 
 		if ((file->last_change > current->version) ||
 		    (file->is_rename && file_has_different_hash_in_manifest(current, file)) ||


### PR DESCRIPTION
The recently added call to verify_file(), used to skip files that are
already installed and have correct hashes, is a nice optimization for
the case when an update crosses a build where a new minversion was
applied to the server content.

However, I ran into a case where calling verify_file() like this results
in an incomplete update: If the corresponding hash calculation of a file
in the latest version *follows a symlink" for the path in the current
version, the hashes will match (assuming the same file content).

This issue is avoidable by checking for the file's presence in the
current version's manifest first, because manifests only contain real
paths (no non-leaf path components are symlinks).

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>