### PR TITLE
Signature verification

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -90,7 +90,7 @@ swupd_sig_verifytest_LDADD = $(SWUPD_CORE_LIBS)
 
 noinst_HEADERS = $(top_srcdir)/include/*
 
-swupdcertsdir = @swupdcertsdir@
+swupdcertsdir = @update_ca_certs_path@
 SWUPD_CERTS = certs/157753a5.0 \
 	certs/425b0f6b.0 \
 	certs/425b0f6b.key \

--- a/configure.ac
+++ b/configure.ac
@@ -11,11 +11,7 @@ AM_SILENT_RULES([yes])
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_LANG(C)
-AC_ARG_WITH([swupdcertsdir],
-  [AS_HELP_STRING([--with-swupdcertsdir=DIR], [swupdcertsdir files])],
-  [swupdcertsdir=$withval],
-  [swupdcertsdir="/usr/share/clear/update-ca"])
-AC_SUBST([swupdcertsdir], [$swupdcertsdir])
+
 AC_CONFIG_HEADERS([config.h])
 PKG_CHECK_MODULES([bsdiff], [bsdiff])
 PKG_CHECK_MODULES([lzma], [liblzma])
@@ -29,6 +25,19 @@ AS_IF([test "x$enable_bzip2" != "xno" ],
 	 AC_CHECK_LIB([bz2], [BZ2_bzBuffToBuffCompress], [], [AC_MSG_ERROR([the libbz2 library is missing])])],
   [AC_DEFINE(SWUPD_WITHOUT_BZIP2,1,[Do not use bzip2 compression])]
 )
+AC_ARG_ENABLE(
+  [signature-verification],
+  [AS_HELP_STRING([--enable-signature-verification], [Enable signature check (disabled by default)])],
+  [AC_DEFINE([SIGNATURES], [], [Enable signature check as default])]
+
+)
+
+if test "$enable_signature_verification" = "yes" ; then
+	AC_ARG_WITH([swupdcert],
+		[AS_HELP_STRING([--with-swupdcert=FILE], [swupd verification cert])],
+		[AC_DEFINE_UNQUOTED([SWUPDCERT], ["$withval"], [swupd verification cert])],
+		[AC_DEFINE([SWUPDCERT], ["ClearLinuxRoot.pem"], [swupd verification cert])])
+fi
 
 AC_ARG_ENABLE(
   [tests],
@@ -83,12 +92,13 @@ AS_IF([test "$enable_tests" != "no"], [
 AM_CONDITIONAL([ENABLE_TESTS], [test "$enable_tests" != "no"])
 
 PKG_CHECK_MODULES([curl], [libcurl])
-PKG_CHECK_MODULES([openssl], [libcrypto >= 0.9.8])
+PKG_CHECK_MODULES([openssl], [libcrypto >= 1.0.2])
 AC_CHECK_LIB([pthread], [pthread_create])
 AC_CHECK_PROGS(TAR, tar)
 
 # default to Linux rootfs build
 enable_linux_rootfs_build="yes"
+certs_path="/usr/share/clear/update-ca"
 
 # document all options for build variants
 ## (1) build variants
@@ -103,7 +113,6 @@ AH_TEMPLATE([LOG_DIR],[Directory for swupd log files])
 AH_TEMPLATE([LOCK_DIR],[Directory for lock file])
 AH_TEMPLATE([BUNDLES_DIR],[Directory to use for bundles])
 AH_TEMPLATE([UPDATE_CA_CERTS_PATH],[Location of CA certificates])
-AH_TEMPLATE([SIGNATURE_CA_CERT],[CA certificate to use])
 AH_TEMPLATE([MOTD_FILE],[motd file path])
 
 if test "$enable_linux_rootfs_build" = "yes"; then
@@ -113,12 +122,13 @@ if test "$enable_linux_rootfs_build" = "yes"; then
 	AC_DEFINE([LOG_DIR],["/var/log/swupd"])
 	AC_DEFINE([LOCK_DIR],["/run/lock"])
 	AC_DEFINE([BUNDLES_DIR],["/usr/share/clear/bundles"])
-	AC_DEFINE([UPDATE_CA_CERTS_PATH],["/usr/share/clear/update-ca"])
-	AC_DEFINE([SIGNATURE_CA_CERT],["test-do-not-ship-R0-0.pem"])
+	AC_DEFINE_UNQUOTED([UPDATE_CA_CERTS_PATH],["$certs_path"])
 	AC_DEFINE([MOTD_FILE],["/usr/lib/motd.d/001-new-release"])
 else
 	AC_MSG_ERROR([Unknown build variant])
 fi
+
+AC_SUBST([update_ca_certs_path], ["$certs_path"])
 
 AC_CONFIG_FILES([Makefile data/check-update.service data/check-update.timer])
 AC_REQUIRE_AUX_FILE([tap-driver.sh])

--- a/include/signature.h
+++ b/include/signature.h
@@ -4,38 +4,12 @@
 #include <stdbool.h>
 
 /*
- * Initialize this module.
- * @param ca_cert_filename - the file containing the CA certificate
- * @return true <=> no error
- */
-bool signature_initialize(const char *ca_cert_filename);
-
-/*
- * Terminate usage of this module, free resources.
- */
-void signature_terminate(void);
-
-/*
- * Verify data file contents against a purported signature.
- * @param data_filename - the file containing the data
- * @param sig_filename - the file containing the signature
- * @return true <=> no error
- */
-bool signature_verify(const char *data_filename, const char *sig_filename);
-
-/*
  * The given data file has already been downloaded from the given URL.
  * Download the corresponding signature file, and verify the data against the signature.
  * Delete the signature file if and only if the verification fails.
  * @param data_url - the URL from which the data came
  * @param data_filename - the file containing the data
  */
-bool signature_download_and_verify(const char *data_url, const char *data_filename);
-
-/*
- * Delete the signature file corresponding to given data file.
- * @param data_filename - the file containing the data
- */
-void signature_delete(const char *data_filename);
+bool download_and_verify_signature(const char *data_url, const char *data_filename);
 
 #endif /* SIGNATURE_H_ */

--- a/include/signature.h
+++ b/include/signature.h
@@ -3,6 +3,17 @@
 
 #include <stdbool.h>
 
+ /*
+ * Initialize this module.
+ * @return true <=> no error
+ */
+bool initialize_signature(void);
+
+/*
+ * Terminate usage of this module, free resources.
+ */
+void terminate_signature(void);
+
 /*
  * The given data file has already been downloaded from the given URL.
  * Download the corresponding signature file, and verify the data against the signature.

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -256,6 +256,7 @@ void v_lockfile(int fd);
 extern int swupd_rm(const char *path);
 extern int rm_bundle_file(const char *bundle);
 extern void print_manifest_files(struct manifest *m);
+extern void swupd_deinit(int lock_fd);
 extern int swupd_init(int *lock_fd);
 extern void copyright_header(const char *name);
 extern void string_or_die(char **strp, const char *fmt, ...);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -428,7 +428,7 @@ static int try_delta_manifest_download(int current, int new, char *component, st
 	struct stat buf;
 
 	if (strcmp(component, "MoM") == 0) {
-#warning "need to crypto validate MoM and allow delta"
+		// We don't do MoM deltas.
 		return -1;
 	}
 
@@ -459,16 +459,9 @@ static int try_delta_manifest_download(int current, int new, char *component, st
 			unlink(deltafile);
 			goto out;
 		}
-
-		if (!signature_download_and_verify(url, deltafile)) {
-			ret = -1;
-			unlink(deltafile);
-			goto out;
-		}
 	}
 
 	/* Now apply the manifest delta */
-
 	string_or_die(&newfile, "%s/%i/Manifest.%s", state_dir, new, component);
 
 	ret = apply_bsdiff_delta(original, newfile, deltafile);
@@ -480,7 +473,6 @@ static int try_delta_manifest_download(int current, int new, char *component, st
 	}
 
 	unlink(deltafile);
-	signature_delete(deltafile);
 
 out:
 	free(original);
@@ -494,7 +486,7 @@ out:
 /* TODO: This should deal with nested manifests better */
 static int retrieve_manifests(int current, int version, char *component, struct file *file)
 {
-	char *url;
+	char *url = NULL;
 	char *filename;
 	char *dir;
 	int ret = 0;
@@ -503,17 +495,19 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 
 	string_or_die(&filename, "%s/%i/Manifest.%s.tar", state_dir, version, component);
 	if (stat(filename, &sb) == 0) {
-		return 0;
+		ret = 0;
+		goto out;
 	}
 
 	if (!check_network()) {
-		return -ENOSWUPDSERVER;
+		ret = -ENOSWUPDSERVER;
+		goto out;
 	}
 
 	string_or_die(&dir, "%s/%i", state_dir, version);
 	ret = mkdir(dir, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 	if ((ret != 0) && (errno != EEXIST)) {
-		return ret;
+		goto out;
 	}
 	free(dir);
 
@@ -528,11 +522,6 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 
 	ret = swupd_curl_get_file(url, filename, NULL, NULL, false);
 	if (ret) {
-		unlink(filename);
-		goto out;
-	}
-
-	if (!signature_download_and_verify(url, filename)) {
 		unlink(filename);
 		goto out;
 	}
@@ -588,6 +577,8 @@ struct manifest *load_mom(int version)
 {
 	struct manifest *manifest = NULL;
 	int ret = 0;
+	char *filename;
+	char *url;
 
 	ret = retrieve_manifests(version, version, "MoM", NULL);
 	if (ret != 0) {
@@ -595,14 +586,25 @@ struct manifest *load_mom(int version)
 		return NULL;
 	}
 
+	string_or_die(&filename, "%s/%i/Manifest.MoM", state_dir, version);
+	string_or_die(&url, "%s/%i/Manifest.MoM", content_url, version);
+	if (!download_and_verify_signature(url, filename)) {
+		printf("WARNING!!! FAILED TO VERIFY SIGNATURE OF Manifest.MoM\n");
+	}
+	free(filename);
+	free(url);
+
 	manifest = manifest_from_file(version, "MoM");
 
 	if (manifest == NULL) {
 		printf("Failed to load %d MoM manifest\n", version);
-		return NULL;
+		goto out;
 	}
 
 	return manifest;
+
+out:
+	return NULL;
 }
 
 /* Loads the MANIFEST for bundle associated with FILE at VERSION, referenced by

--- a/src/packs.c
+++ b/src/packs.c
@@ -66,13 +66,6 @@ static int download_pack(int oldversion, int newversion, char *module)
 		return err;
 	}
 
-	if (!signature_download_and_verify(url, filename)) {
-		free(url);
-		unlink(filename);
-		free(filename);
-		return -1;
-	}
-
 	free(url);
 
 	printf("Extracting pack.\n");

--- a/src/search.c
+++ b/src/search.c
@@ -483,7 +483,7 @@ int search_main(int argc, char **argv)
 	ret = swupd_init(&lock_fd);
 	if (ret != 0) {
 		printf("Failed swupd initialization, exiting now.\n");
-		goto clean_exit;
+		return ret;
 	}
 
 	if (!check_network()) {
@@ -519,10 +519,7 @@ int search_main(int argc, char **argv)
 	do_search(MoM, search_type, search_string);
 
 clean_exit:
-	free_manifest(MoM);
-	free_globals();
-	swupd_curl_cleanup();
-	v_lockfile(lock_fd);
+	swupd_deinit(lock_fd);
 
 	return ret;
 }

--- a/src/update.c
+++ b/src/update.c
@@ -260,6 +260,8 @@ int main_update()
 	/* Step 2: housekeeping */
 
 	if (rm_staging_dir_contents("download")) {
+		printf("Error cleaning download directory\n");
+		ret = EXIT_FAILURE;
 		goto clean_curl;
 	}
 
@@ -398,11 +400,7 @@ clean_exit:
 	free_manifest(server_manifest);
 
 clean_curl:
-	swupd_curl_cleanup();
-	free_subscriptions();
-	free_globals();
-	v_lockfile(lock_fd);
-	dump_file_descriptor_leaks();
+	swupd_deinit(lock_fd);
 
 	if ((current_version < server_version) && (ret == 0)) {
 		printf("Update successful. System updated from version %d to version %d\n",

--- a/src/update.c
+++ b/src/update.c
@@ -242,10 +242,6 @@ int main_update()
 	printf("Update started.\n");
 	read_subscriptions_alt();
 
-	if (!signature_initialize(UPDATE_CA_CERTS_PATH "/" SIGNATURE_CA_CERT)) {
-		goto clean_curl;
-	}
-
 	/* Step 1: get versions */
 
 	ret = check_versions(&current_version, &server_version, path_prefix);
@@ -402,7 +398,6 @@ clean_exit:
 	free_manifest(server_manifest);
 
 clean_curl:
-	signature_terminate();
 	swupd_curl_cleanup();
 	free_subscriptions();
 	free_globals();

--- a/src/verify.c
+++ b/src/verify.c
@@ -641,10 +641,6 @@ int verify_main(int argc, char **argv)
 	 * FIXME: We need a command line option to override this in case the
 	 * certificate is hosed and the admin knows it and wants to recover.
 	 */
-	if (!signature_initialize(UPDATE_CA_CERTS_PATH "/" SIGNATURE_CA_CERT)) {
-		printf("Can't initialize the SSL certificates\n");
-		goto brick_the_system_and_clean_curl;
-	}
 
 	ret = rm_staging_dir_contents("download");
 	if (ret != 0) {
@@ -658,7 +654,7 @@ int verify_main(int argc, char **argv)
 		 * is not available, or if there is a server error and a manifest is
 		 * not provided.
 		 */
-		printf("Unable to download %d Manifest.MoM\n", version);
+		printf("Unable to download/verify %d Manifest.MoM\n", version);
 		ret = EXIT_FAILURE;
 
 		/* No repair is possible without a manifest, nor is accurate reporting

--- a/test/signature_verify_test.c
+++ b/test/signature_verify_test.c
@@ -46,18 +46,11 @@ int main(int argc, char **argv)
 		usage(argv[0]);
 	}
 
-	if (!signature_initialize(argv[3])) {
-		fprintf(stderr, "Can't initialize!\n");
-		exit(-1);
-	}
-
-	if (signature_verify(argv[1], argv[2])) {
+	if (download_and_verify_signature(argv[1], argv[2])) {
 		fprintf(stderr, "Verification successful!\n");
 	} else {
 		fprintf(stderr, "Verification failed!\n");
 	}
-
-	signature_terminate();
 
 	return 0;
 }


### PR DESCRIPTION
This PR represents the final working state of Tudor and I as we went through OpenSSL's poor documentation and addressed review comments from PR #85 .  The src/signature.c:verify_signature() function is an abomination, but we think we doesn't leak openssl state and valgrind is agreeing.  The code is focused now on just the MoM signature verification flow, which means some functions are now static.  The cert and cert path are now autoconf configurable.