### PR TITLE
don't segfault on not found MoM

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -410,7 +410,7 @@ int download_manifests(struct manifest **MoM)
 	*MoM = load_mom(current_version);
 	if (!(*MoM)) {
 		printf("Cannot load official manifest MoM for version %i\n", current_version);
-		return ret;
+		return EMOM_NOTFOUND;
 	}
 
 	subscription_versions_from_MoM(*MoM, 0);


### PR DESCRIPTION
If the MoM is not found on the server to match the os version on which
you're running, swupd search's MoM downloader returns 0 instead of an
error.  EMOM_NOTFOUND is a natural value to return.

When 0 is returned, the null MoM pointer is later derferenced leading to a
segfault.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>