### PR TITLE
Ignore sigverify errors in existing tests

### DIFF
--- a/test/functional/bundleadd/add-directory/test.bats
+++ b/test/functional/bundleadd/add-directory/test.bats
@@ -24,6 +24,7 @@ teardown() {
 
   echo "$output"
   [ "${lines[2]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 3
   [ "${lines[3]}" = "Downloading packs..." ]
   [ "${lines[4]}" = "Downloading test-bundle pack for version 10" ]
   [ "${lines[5]}" = "Extracting pack." ]

--- a/test/functional/bundleadd/add-existing/test.bats
+++ b/test/functional/bundleadd/add-existing/test.bats
@@ -17,6 +17,7 @@ teardown() {
 
   echo "$output"
   [ "${lines[2]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 3
   [ "${lines[3]}" = "bundle(s) already installed, exiting now" ]
 }
 

--- a/test/functional/bundleadd/add-multiple/test.bats
+++ b/test/functional/bundleadd/add-multiple/test.bats
@@ -33,6 +33,7 @@ teardown() {
 
   echo "$output"
   [ "${lines[2]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 3
   [ "${lines[3]}" = "Downloading packs..." ]
   [ "${lines[4]}" = "Downloading test-bundle1 pack for version 10" ]
   [ "${lines[5]}" = "Extracting pack." ]

--- a/test/functional/bundleadd/boot-file/test.bats
+++ b/test/functional/bundleadd/boot-file/test.bats
@@ -24,6 +24,7 @@ teardown() {
 
   echo "$output"
   [ "${lines[2]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 3
   [ "${lines[3]}" = "Downloading packs..." ]
   [ "${lines[4]}" = "Downloading test-bundle pack for version 10" ]
   [ "${lines[5]}" = "Extracting pack." ]

--- a/test/functional/bundleadd/fix-missing-file/test.bats
+++ b/test/functional/bundleadd/fix-missing-file/test.bats
@@ -24,6 +24,7 @@ teardown() {
 
   echo "$output"
   [ "${lines[2]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 3
   [ "${lines[3]}" = "Downloading packs..." ]
   [ "${lines[4]}" = "Downloading test-bundle pack for version 10" ]
   [ "${lines[5]}" = "Installing bundle(s) files..." ]

--- a/test/functional/bundleadd/include/test.bats
+++ b/test/functional/bundleadd/include/test.bats
@@ -29,6 +29,7 @@ teardown() {
 
   echo "$output"
   [ "${lines[2]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 3
   [ "${lines[3]}" = "Downloading packs..." ]
   [ "${lines[4]}" = "Downloading test-bundle pack for version 10" ]
   [ "${lines[5]}" = "Extracting pack." ]

--- a/test/functional/bundleadd/list/test.bats
+++ b/test/functional/bundleadd/list/test.bats
@@ -17,6 +17,7 @@ teardown() {
 
   echo "$output"
   [ "${lines[2]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 3
   [ "${lines[3]}" = "os-core" ]
 }
 

--- a/test/functional/bundleadd/verify-fix-path/test.bats
+++ b/test/functional/bundleadd/verify-fix-path/test.bats
@@ -32,6 +32,7 @@ teardown() {
 
   echo "$output"
   [ "${lines[2]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 3
   [ "${lines[3]}" = "Downloading packs..." ]
   [ "${lines[4]}" = "Downloading test-bundle pack for version 10" ]
   [ "${lines[5]}" = "Extracting pack." ]

--- a/test/functional/bundleremove/boot-file/test.bats
+++ b/test/functional/bundleremove/boot-file/test.bats
@@ -22,6 +22,8 @@ teardown() {
 
   echo "$output"
   [ "${lines[2]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 3
+  ignore_sigverify_error 3
   [ "${lines[3]}" = "Deleting bundle files..." ]
   [ "${lines[4]}" = "Total deleted files: 1" ]
   [ "${lines[5]}" = "Untracking bundle from system..." ]

--- a/test/functional/bundleremove/include/test.bats
+++ b/test/functional/bundleremove/include/test.bats
@@ -19,6 +19,7 @@ teardown() {
 
   echo "$output"
   [ "${lines[2]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 3
   [ "${lines[3]}" = "Error: bundle requested to be removed is required by other installed bundles" ]
   [ "${lines[4]}" = "Error: Bundle remove failed" ]
   [ -f "$DIR/target-dir/test-file" ]

--- a/test/functional/bundleremove/remove-file/test.bats
+++ b/test/functional/bundleremove/remove-file/test.bats
@@ -21,6 +21,8 @@ teardown() {
 
   echo "$output"
   [ "${lines[2]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 3
+  ignore_sigverify_error 3
   [ "${lines[3]}" = "Deleting bundle files..." ]
   [ "${lines[4]}" = "Total deleted files: 1" ]
   [ "${lines[5]}" = "Untracking bundle from system..." ]

--- a/test/functional/swupdlib.bash
+++ b/test/functional/swupdlib.bash
@@ -67,4 +67,14 @@ create_fullfile_tar() {
 #   return
 # }
 
+ignore_sigverify_error() {
+  local index="$1"
+  if [[ "${lines[$index]}" =~ ^WARNING!!!\ FAILED\ TO\ VERIFY\ SIGNATURE\ OF\ Manifest.MoM ]]; then
+    # remove element from array
+    unset lines[$index]
+    # reassign indices
+    lines=("${lines[@]}")
+  fi
+}
+
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/test/functional/update/apply-full-file-delta/test.bats
+++ b/test/functional/update/apply-full-file-delta/test.bats
@@ -35,7 +35,9 @@ teardown() {
   [ "${lines[5]}" = "Attempting to download version string to memory" ]
   [ "${lines[6]}" = "Preparing to update from 10 to 100" ]
   [ "${lines[7]}" = "Querying current manifest." ]
+  ignore_sigverify_error 8
   [ "${lines[8]}" = "Querying server manifest." ]
+  ignore_sigverify_error 9
   [ "${lines[9]}" = "Downloading os-core pack for version 100" ]
   [ "${lines[10]}" = "Extracting pack." ]
   [ "${lines[11]}" = "Statistics for going from version 10 to version 100:" ]

--- a/test/functional/update/boot-file/test.bats
+++ b/test/functional/update/boot-file/test.bats
@@ -31,7 +31,9 @@ teardown() {
   [ "${lines[6]}" = "Attempting to download version string to memory" ]
   [ "${lines[7]}" = "Preparing to update from 10 to 100" ]
   [ "${lines[8]}" = "Querying current manifest." ]
+  ignore_sigverify_error 9
   [ "${lines[9]}" = "Querying server manifest." ]
+  ignore_sigverify_error 10
   [ "${lines[10]}" = "Downloading os-core pack for version 100" ]
   [ "${lines[11]}" = "Statistics for going from version 10 to version 100:" ]
   [ "${lines[12]}" = "    changed manifests : 1" ]

--- a/test/functional/update/download/test.bats
+++ b/test/functional/update/download/test.bats
@@ -31,7 +31,9 @@ teardown() {
   [ "${lines[5]}" = "Attempting to download version string to memory" ]
   [ "${lines[6]}" = "Preparing to update from 10 to 100" ]
   [ "${lines[7]}" = "Querying current manifest." ]
+  ignore_sigverify_error 8
   [ "${lines[8]}" = "Querying server manifest." ]
+  ignore_sigverify_error 9
   [ "${lines[9]}" = "Downloading os-core pack for version 100" ]
   [ "${lines[10]}" = "Extracting pack." ]
   [ "${lines[11]}" = "Statistics for going from version 10 to version 100:" ]

--- a/test/functional/update/include-old-bundle/test.bats
+++ b/test/functional/update/include-old-bundle/test.bats
@@ -47,7 +47,9 @@ teardown() {
   [ "${lines[5]}" = "Attempting to download version string to memory" ]
   [ "${lines[6]}" = "Preparing to update from 10 to 100" ]
   [ "${lines[7]}" = "Querying current manifest." ]
+  ignore_sigverify_error 8
   [ "${lines[8]}" = "Querying server manifest." ]
+  ignore_sigverify_error 9
   [ "${lines[9]}" = "Downloading os-core pack for version 100" ]
   [ "${lines[10]}" = "Downloading test-bundle1 pack for version 100" ]
   [ "${lines[11]}" = "Statistics for going from version 10 to version 100:" ]

--- a/test/functional/update/include/test.bats
+++ b/test/functional/update/include/test.bats
@@ -68,7 +68,9 @@ teardown() {
   [ "${lines[5]}" = "Attempting to download version string to memory" ]
   [ "${lines[6]}" = "Preparing to update from 10 to 100" ]
   [ "${lines[7]}" = "Querying current manifest." ]
+  ignore_sigverify_error 8
   [ "${lines[8]}" = "Querying server manifest." ]
+  ignore_sigverify_error 9
   [ "${lines[9]}" = "Downloading test-bundle3 pack for version 100" ]
   [ "${lines[10]}" = "Downloading test-bundle4 pack for version 100" ]
   [ "${lines[11]}" = "Downloading test-bundle5 pack for version 100" ]

--- a/test/functional/update/missing-os-core/test.bats
+++ b/test/functional/update/missing-os-core/test.bats
@@ -35,7 +35,9 @@ teardown() {
   [ "${lines[5]}" = "Attempting to download version string to memory" ]
   [ "${lines[6]}" = "Preparing to update from 10 to 100" ]
   [ "${lines[7]}" = "Querying current manifest." ]
+  ignore_sigverify_error 8
   [ "${lines[8]}" = "Querying server manifest." ]
+  ignore_sigverify_error 9
   [ "${lines[9]}" = "Downloading os-core pack for version 100" ]
   [ "${lines[10]}" = "Downloading test-bundle1 pack for version 100" ]
   [ "${lines[11]}" = "Statistics for going from version 10 to version 100:" ]

--- a/test/functional/update/newest-deleted/test.bats
+++ b/test/functional/update/newest-deleted/test.bats
@@ -39,7 +39,9 @@ teardown() {
   [ "${lines[5]}" = "Attempting to download version string to memory" ]
   [ "${lines[6]}" = "Preparing to update from 20 to 30" ]
   [ "${lines[7]}" = "Querying current manifest." ]
+  ignore_sigverify_error 8
   [ "${lines[8]}" = "Querying server manifest." ]
+  ignore_sigverify_error 9
   [ "${lines[9]}" = "Downloading os-core pack for version 30" ]
   [ "${lines[10]}" = "Extracting pack." ]
   [ "${lines[11]}" = "Downloading test-bundle2 pack for version 30" ]

--- a/test/functional/update/skip-verified-fullfiles/test.bats
+++ b/test/functional/update/skip-verified-fullfiles/test.bats
@@ -28,7 +28,9 @@ teardown() {
   [ "${lines[5]}" = "Attempting to download version string to memory" ]
   [ "${lines[6]}" = "Preparing to update from 10 to 100" ]
   [ "${lines[7]}" = "Querying current manifest." ]
+  ignore_sigverify_error 8
   [ "${lines[8]}" = "Querying server manifest." ]
+  ignore_sigverify_error 9
   [ "${lines[9]}" = "Downloading test-bundle pack for version 100" ]
   [ "${lines[10]}" = "Statistics for going from version 10 to version 100:" ]
   [ "${lines[11]}" = "    changed manifests : 1" ]

--- a/test/functional/update/use-full-file/test.bats
+++ b/test/functional/update/use-full-file/test.bats
@@ -31,7 +31,9 @@ teardown() {
   [ "${lines[5]}" = "Attempting to download version string to memory" ]
   [ "${lines[6]}" = "Preparing to update from 10 to 100" ]
   [ "${lines[7]}" = "Querying current manifest." ]
+  ignore_sigverify_error 8
   [ "${lines[8]}" = "Querying server manifest." ]
+  ignore_sigverify_error 9
   [ "${lines[9]}" = "Downloading os-core pack for version 100" ]
   [ "${lines[10]}" = "Statistics for going from version 10 to version 100:" ]
   [ "${lines[11]}" = "    changed manifests : 1" ]

--- a/test/functional/update/use-pack/test.bats
+++ b/test/functional/update/use-pack/test.bats
@@ -32,7 +32,9 @@ teardown() {
   [ "${lines[5]}" = "Attempting to download version string to memory" ]
   [ "${lines[6]}" = "Preparing to update from 10 to 100" ]
   [ "${lines[7]}" = "Querying current manifest." ]
+  ignore_sigverify_error 8
   [ "${lines[8]}" = "Querying server manifest." ]
+  ignore_sigverify_error 9
   [ "${lines[9]}" = "Downloading os-core pack for version 100" ]
   [ "${lines[10]}" = "Extracting pack." ]
   [ "${lines[11]}" = "Statistics for going from version 10 to version 100:" ]

--- a/test/functional/update/verify-fix-path-hash-mismatch/test.bats
+++ b/test/functional/update/verify-fix-path-hash-mismatch/test.bats
@@ -41,7 +41,9 @@ teardown() {
   [ "${lines[5]}" = "Attempting to download version string to memory" ]
   [ "${lines[6]}" = "Preparing to update from 10 to 100" ]
   [ "${lines[7]}" = "Querying current manifest." ]
+  ignore_sigverify_error 8
   [ "${lines[8]}" = "Querying server manifest." ]
+  ignore_sigverify_error 9
   [ "${lines[9]}" = "Downloading test-bundle pack for version 100" ]
   [ "${lines[10]}" = "Statistics for going from version 10 to version 100:" ]
   [ "${lines[11]}" = "    changed manifests : 1" ]

--- a/test/functional/update/verify-fix-path-missing-dir/test.bats
+++ b/test/functional/update/verify-fix-path-missing-dir/test.bats
@@ -43,7 +43,9 @@ teardown() {
   [ "${lines[5]}" = "Attempting to download version string to memory" ]
   [ "${lines[6]}" = "Preparing to update from 10 to 100" ]
   [ "${lines[7]}" = "Querying current manifest." ]
+  ignore_sigverify_error 8
   [ "${lines[8]}" = "Querying server manifest." ]
+  ignore_sigverify_error 9
   [ "${lines[9]}" = "Downloading test-bundle pack for version 100" ]
   [ "${lines[10]}" = "Statistics for going from version 10 to version 100:" ]
   [ "${lines[11]}" = "    changed manifests : 1" ]

--- a/test/functional/update/verify-fullfile-hash/test.bats
+++ b/test/functional/update/verify-fullfile-hash/test.bats
@@ -31,7 +31,9 @@ teardown() {
   [ "${lines[5]}" = "Attempting to download version string to memory" ]
   [ "${lines[6]}" = "Preparing to update from 10 to 100" ]
   [ "${lines[7]}" = "Querying current manifest." ]
+  ignore_sigverify_error 8
   [ "${lines[8]}" = "Querying server manifest." ]
+  ignore_sigverify_error 9
   [ "${lines[9]}" = "Downloading test-bundle pack for version 100" ]
   [ "${lines[10]}" = "Statistics for going from version 10 to version 100:" ]
   [ "${lines[11]}" = "    changed manifests : 1" ]

--- a/test/functional/verify/add-missing-directory/test.bats
+++ b/test/functional/verify/add-missing-directory/test.bats
@@ -24,6 +24,7 @@ teardown() {
   echo "$output"
   [ "${lines[5]}" = "Verifying version 10" ]
   [ "${lines[6]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 7
   [ "${lines[7]}" = "Starting download of remaining update content. This may take a while..." ]
   [ "${lines[8]}" = "Finishing download of update content..." ]
   [ "${lines[9]}" = "Adding any missing files" ]

--- a/test/functional/verify/add-missing-include-old/test.bats
+++ b/test/functional/verify/add-missing-include-old/test.bats
@@ -40,6 +40,7 @@ teardown() {
   echo "$output"
   [ "${lines[5]}" = "Verifying version 100" ]
   [ "${lines[6]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 7
   [ "${lines[7]}" = "Starting download of remaining update content. This may take a while..." ]
   [ "${lines[8]}" = "Finishing download of update content..." ]
   [ "${lines[9]}" = "Adding any missing files" ]

--- a/test/functional/verify/add-missing-include/test.bats
+++ b/test/functional/verify/add-missing-include/test.bats
@@ -34,6 +34,7 @@ teardown() {
   echo "$output"
   [ "${lines[5]}" = "Verifying version 10" ]
   [ "${lines[6]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 7
   [ "${lines[7]}" = "Starting download of remaining update content. This may take a while..." ]
   [ "${lines[8]}" = "Finishing download of update content..." ]
   [ "${lines[9]}" = "Adding any missing files" ]

--- a/test/functional/verify/boot-file-deleted/test.bats
+++ b/test/functional/verify/boot-file-deleted/test.bats
@@ -26,6 +26,7 @@ teardown() {
   echo "$output"
   [ "${lines[5]}" = "Verifying version 10" ]
   [ "${lines[6]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 7
   [ "${lines[7]}" = "Starting download of remaining update content. This may take a while..." ]
   [ "${lines[8]}" = "Finishing download of update content..." ]
   [ "${lines[9]}" = "Adding any missing files" ]

--- a/test/functional/verify/boot-file-mismatch-fix/test.bats
+++ b/test/functional/verify/boot-file-mismatch-fix/test.bats
@@ -27,6 +27,7 @@ teardown() {
   echo "$output"
   [ "${lines[5]}" = "Verifying version 10" ]
   [ "${lines[6]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 7
   [ "${lines[7]}" = "Starting download of remaining update content. This may take a while..." ]
   [ "${lines[8]}" = "Finishing download of update content..." ]
   [ "${lines[9]}" = "Adding any missing files" ]

--- a/test/functional/verify/boot-file-mismatch/test.bats
+++ b/test/functional/verify/boot-file-mismatch/test.bats
@@ -20,6 +20,7 @@ teardown() {
   echo "$output"
   [ "${lines[2]}" = "Verifying version 10" ]
   [ "${lines[3]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 4
   [ "${lines[4]}" = "Verifying files" ]
   [ "${lines[6]}" = "Inspected 1 files" ]
   [ "${lines[7]}" = "  1 files did not match" ]

--- a/test/functional/verify/check-missing-directory/test.bats
+++ b/test/functional/verify/check-missing-directory/test.bats
@@ -18,6 +18,7 @@ teardown() {
   echo "$output"
   [ "${lines[2]}" = "Verifying version 10" ]
   [ "${lines[3]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 4
   [ "${lines[4]}" = "Verifying files" ]
   [ "${lines[6]}" = "Inspected 1 files" ]
   [ "${lines[7]}" = "  1 files did not match" ]

--- a/test/functional/verify/directory-tree-deleted/test.bats
+++ b/test/functional/verify/directory-tree-deleted/test.bats
@@ -20,6 +20,7 @@ teardown() {
   echo "$output"
   [ "${lines[5]}" = "Verifying version 10" ]
   [ "${lines[6]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 7
   [ "${lines[7]}" = "Starting download of remaining update content. This may take a while..." ]
   [ "${lines[8]}" = "Finishing download of update content..." ]
   [ "${lines[9]}" = "Adding any missing files" ]

--- a/test/functional/verify/directory-tree-deleted/test.bats
+++ b/test/functional/verify/directory-tree-deleted/test.bats
@@ -18,6 +18,12 @@ teardown() {
   run sudo sh -c "$SWUPD verify --fix $SWUPD_OPTS"
 
   echo "$output"
+  [ "${lines[5]}" = "Verifying version 10" ]
+  [ "${lines[6]}" = "Attempting to download version string to memory" ]
+  [ "${lines[7]}" = "Starting download of remaining update content. This may take a while..." ]
+  [ "${lines[8]}" = "Finishing download of update content..." ]
+  [ "${lines[9]}" = "Adding any missing files" ]
+  [ "${lines[10]}" = "Fixing modified files" ]
   [ "${lines[11]}" = "Deleted $DIR/target-dir/testdir1/testdir2/testfile" ]
   [ "${lines[12]}" = "Deleted $DIR/target-dir/testdir1/testdir2" ]
   [ "${lines[13]}" = "Deleted $DIR/target-dir/testdir1" ]

--- a/test/functional/verify/empty-dir-deleted/test.bats
+++ b/test/functional/verify/empty-dir-deleted/test.bats
@@ -21,6 +21,7 @@ teardown() {
   echo "$output"
   [ "${lines[5]}" = "Verifying version 10" ]
   [ "${lines[6]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 7
   [ "${lines[7]}" = "Starting download of remaining update content. This may take a while..." ]
   [ "${lines[8]}" = "Finishing download of update content..." ]
   [ "${lines[9]}" = "Adding any missing files" ]

--- a/test/functional/verify/install-directory/test.bats
+++ b/test/functional/verify/install-directory/test.bats
@@ -24,6 +24,7 @@ teardown() {
   echo "$output"
   [ "${lines[5]}" = "Verifying version 10" ]
   [ "${lines[6]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 7
   [ "${lines[7]}" = "Downloading os-core pack for version 10" ]
   [ "${lines[8]}" = "Extracting pack." ]
   [ "${lines[9]}" = "Adding any missing files" ]

--- a/test/functional/verify/install-latest-directory/test.bats
+++ b/test/functional/verify/install-latest-directory/test.bats
@@ -25,6 +25,7 @@ teardown() {
   [ "${lines[5]}" = "Attempting to download version string to memory" ]
   [ "${lines[6]}" = "Verifying version 100" ]
   [ "${lines[7]}" = "Attempting to download version string to memory" ]
+  ignore_sigverify_error 8
   [ "${lines[8]}" = "Downloading os-core pack for version 100" ]
   [ "${lines[9]}" = "Extracting pack." ]
   [ "${lines[10]}" = "Adding any missing files" ]


### PR DESCRIPTION
Because signature verification is a feature that we need separate testing for, and swupd's output may print a verification error (or not) depending on how swupd was built, add a helper function to remove the verification error message when swupd is built with verification enabled. If verification is not enabled, swupd will not print any message, and the function is a no-op.
