### PR TITLE
Warn about bundle not installed when running bundle-remove

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -239,6 +239,7 @@ int remove_bundle(const char *bundle_name)
 
 	if (!is_tracked_bundle(bundle_name)) {
 		ret = EBUNDLE_NOT_TRACKED;
+		printf("Warning: Bundle \"%s\" does not seem to be installed\n", bundle_name);
 		goto out_free_curl;
 	}
 


### PR DESCRIPTION
In the case when trying to remove the non existing bundle
first warn about that fact, then fail with an error.

Signed-off-by: Jaime A. Garcia <jaime.garcia.naranjo@intel.com>