### PR TITLE
Move sign/verify to abort on failure

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -62,6 +62,7 @@ struct version_container {
 
 struct header;
 
+extern bool force_ignore_unverified_signature;
 extern bool force;
 extern int verbose;
 extern int update_count;

--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -52,6 +52,7 @@ static void print_help(const char *name)
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	printf("   -l, --list              List all available bundles for the current version of Clear Linux\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
+	printf("   -y, --force-continue-with-unverified-signature    Attempt to proceed despite MoM signature verification failure\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 	printf("\n");
 }
@@ -66,6 +67,7 @@ static const struct option prog_opts[] = {
 	{ "path", required_argument, 0, 'p' },
 	{ "format", required_argument, 0, 'F' },
 	{ "force", no_argument, 0, 'x' },
+	{ "force-continue-with-unverified-signature", no_argument, 0, 'y' },
 	{ "statedir", required_argument, 0, 'S' },
 	{ 0, 0, 0, 0 }
 };
@@ -74,7 +76,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxu:c:v:P:p:F:lS:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxu:c:v:P:p:F:lS:y", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -131,6 +133,9 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'x':
 			force = true;
+			break;
+		case 'y':
+			force_ignore_unverified_signature = true;
 			break;
 		default:
 			printf("error: unrecognized option\n\n");

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -51,6 +51,7 @@ static void print_help(const char *name)
 	printf("   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
+	printf("   -y, --force-continue-with-unverified-signature    Attempt to proceed despite MoM signature verification failure\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 	printf("\n");
 }
@@ -64,6 +65,7 @@ static const struct option prog_opts[] = {
 	{ "port", required_argument, 0, 'P' },
 	{ "format", required_argument, 0, 'F' },
 	{ "force", no_argument, 0, 'x' },
+	{ "force-continue-with-unverified-signature", no_argument, 0, 'y' },
 	{ "statedir", required_argument, 0, 'S' },
 	{ 0, 0, 0, 0 }
 };
@@ -72,7 +74,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxp:u:c:v:P:F:S:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxp:u:c:v:P:F:S:y", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -126,6 +128,9 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'x':
 			force = true;
+			break;
+		case 'y':
+			force_ignore_unverified_signature = true;
 			break;
 		default:
 			printf("error: unrecognized option\n\n");

--- a/src/globals.c
+++ b/src/globals.c
@@ -32,6 +32,7 @@
 #include "swupd.h"
 
 bool force = false;
+bool force_ignore_unverified_signature = false;
 bool verify_esp_only;
 bool verify_bundles_only = false;
 int update_count = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -45,6 +45,7 @@ static const struct option prog_opts[] = {
 	{ "format", required_argument, 0, 'F' },
 	{ "path", required_argument, 0, 'p' },
 	{ "force", no_argument, 0, 'x' },
+	{ "force-continue-with-unverified-signature", no_argument, 0, 'y' },
 	{ "statedir", required_argument, 0, 'S' },
 	{ 0, 0, 0, 0 }
 };
@@ -68,6 +69,7 @@ static void print_help(const char *name)
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
+	printf("   -y, --force-continue-with-unverified-signature    Attempt to proceed despite MoM signature verification failure\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 	printf("\n");
 }
@@ -76,7 +78,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxdu:P:c:v:sF:p:S:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxdu:P:c:v:sF:p:S:y", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -136,6 +138,9 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'x':
 			force = true;
+			break;
+		case 'y':
+			force_ignore_unverified_signature = true;
 			break;
 		default:
 			printf("Unrecognized option\n\n");

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -589,8 +589,18 @@ struct manifest *load_mom(int version)
 	string_or_die(&filename, "%s/%i/Manifest.MoM", state_dir, version);
 	string_or_die(&url, "%s/%i/Manifest.MoM", content_url, version);
 	if (!download_and_verify_signature(url, filename)) {
-		printf("WARNING!!! FAILED TO VERIFY SIGNATURE OF Manifest.MoM\n");
+		if (!force_ignore_unverified_signature) {
+			printf("FAILED TO VERIFY SIGNATURE OF Manifest.MoM. Can proceed if"
+				"  --force-continue-with-unverified-signature used, but system"
+				" security WILL BE COMPROMISED\n");
+			return NULL;
+		} else {
+			printf("FAILED TO VERIFY SIGNATURE OF Manifest.MoM. Operation proceeding due to"
+				"  --force-continue-with-unverified-signature, but system security WILL BE"
+				" COMPROMISED\n");
+		}
 	}
+
 	free(filename);
 	free(url);
 

--- a/src/search.c
+++ b/src/search.c
@@ -71,6 +71,7 @@ static void print_help(const char *name)
 	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
+	printf("   -y, --force-continue-with-unverified-signature    Attempt to proceed despite MoM signature verification failure\n");
 
 	printf("\nResults format:\n");
 	printf(" 'Bundle Name'  :  'File matching search term'\n\n");
@@ -91,6 +92,7 @@ static const struct option prog_opts[] = {
 	{ "init", no_argument, 0, 'i' },
 	{ "display-files", no_argument, 0, 'd' },
 	{ "statedir", required_argument, 0, 'S' },
+	{ "force-continue-with-unverified-signature", no_argument, 0, 'y' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -98,7 +100,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hu:c:v:P:p:F:s:lbidS:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hu:c:v:P:p:F:s:lbidS:y", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -186,6 +188,9 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'd':
 			display_files = true;
+			break;
+		case 'y':
+			force_ignore_unverified_signature = true;
 			break;
 		default:
 			printf("Error: unrecognized option: -'%c',\n\n", opt);

--- a/src/verify.c
+++ b/src/verify.c
@@ -67,6 +67,7 @@ static const struct option prog_opts[] = {
 	{ "format", required_argument, 0, 'F' },
 	{ "quick", no_argument, 0, 'q' },
 	{ "force", no_argument, 0, 'x' },
+	{ "force-continue-with-unverified-signature", no_argument, 0, 'y' },
 	{ "statedir", required_argument, 0, 'S' },
 	{ 0, 0, 0, 0 }
 };
@@ -89,6 +90,7 @@ static void print_help(const char *name)
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	printf("   -q, --quick             Don't compare hashes, only fix missing files\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
+	printf("   -y, --force-continue-with-unverified-signature    Attempt to proceed despite MoM signature verification failure\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 	printf("\n");
 }
@@ -97,7 +99,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxm:p:u:P:c:v:fiF:qS:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxm:p:u:P:c:v:fiF:qS:y", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -169,6 +171,9 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'x':
 			force = true;
+			break;
+		case 'y':
+			force_ignore_unverified_signature = true;
 			break;
 		default:
 			printf("Unrecognized option\n\n");


### PR DESCRIPTION
Moves swupd signature verification to mandatory, where
the operation will not proceed unless the following flag
is passed in:

  --force-continue-with-unverified-signature

The signed MoM serves as the top level chain of trust as
far as swupd is concerned, and it is used to extend content
trust down to the individual file level.

Signed-off-by: Brad T. Peters <brad.t.peters@intel.com>