### PR TITLE
TLS comment clarification

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -436,7 +436,7 @@ static CURLcode swupd_curl_set_security_opts(CURL *curl)
 		goto exit;
 	}
 
-	// TODO: change this to to use tlsv1.2 when it is supported and enabled
+	// TODO: change this to to use tlsv1.2 when it is supported and enabled on hosting web server
 	curl_ret = curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_0);
 	if (curl_ret != CURLE_OK) {
 		goto exit;

--- a/src/hash.c
+++ b/src/hash.c
@@ -276,8 +276,8 @@ int verify_bundle_hash(struct manifest *manifest, struct file *bundle)
 			      current->last_change, current->filename);
 
 		if (!verify_file(bundle, local)) {
-			printf("Warning: hash check failed for Manifest.%s\n",
-			       current->filename);
+			printf("Warning: hash check failed for Manifest.%s for version %i\n",
+			       current->filename, manifest->version);
 			ret = 0;
 		}
 		break;


### PR DESCRIPTION
The issue with TLS versions is on the server side.  The client
must specify which version to use, but that version must be
supported by the server.  And sadly the server world is often
running old OS's with old libraries and daemons.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>