### PR TITLE
Print some build-time options in --version output

### DIFF
--- a/include/swupd-build-opts.h
+++ b/include/swupd-build-opts.h
@@ -1,0 +1,56 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2016 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef __INCLUDE_GUARD_SWUPD_BUILD_OPTS_H
+#define __INCLUDE_GUARD_SWUPD_BUILD_OPTS_H
+
+#include "config.h"
+
+#ifdef SWUPD_WITH_BZIP2
+#define OPT_BZIP2 "+BZIP2"
+#else
+#define OPT_BZIP2 "-BZIP2"
+#endif
+
+#ifdef SIGNATURES
+#define OPT_SIGNATURES "+SIGVERIFY"
+#else
+#define OPT_SIGNATURES "-SIGVERIFY"
+#endif
+
+#ifdef COVERAGE
+#define OPT_COVERAGE "+COVERAGE"
+#else
+#define OPT_COVERAGE "-COVERAGE"
+#endif
+
+#ifdef SWUPD_WITH_BSDTAR
+#define OPT_BSDTAR "+BSDTAR"
+#else
+#define OPT_BSDTAR "-BSDTAR"
+#endif
+
+#define BUILD_OPTS \
+	OPT_BZIP2 " " \
+	OPT_SIGNATURES " " \
+	OPT_COVERAGE " " \
+	OPT_BSDTAR
+
+
+#endif

--- a/src/swupd.c
+++ b/src/swupd.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "swupd-build-opts.h"
 #include "swupd-internal.h"
 #include "swupd.h"
 
@@ -101,6 +102,7 @@ static int parse_options(int argc, char **argv, int *index)
 			exit(EXIT_SUCCESS);
 		case 'v':
 			copyright_header("swupd");
+			printf("Compile-time options: %s\n", BUILD_OPTS);
 			exit(EXIT_SUCCESS);
 		case '\01':
 			/* found a subcommand, or a random non-option argument */


### PR DESCRIPTION
To make compile-time options more easily discoverable at runtime, make
the --version output more verbose by printing a few of them. Other
options can be easily added in the future by adding an appropriate
AC_DEFINE call in configure.ac, and updating the new header added in
this commit (swupd-build-opts.h).

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>