### PR TITLE
Enable HTTP/2 protocol as option

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -480,6 +480,8 @@ CURLcode swupd_curl_set_basic_options(CURL *curl, const char *url)
 		goto exit;
 	}
 
+	curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
+
 	if (update_server_port > 0) {
 		curl_ret = curl_easy_setopt(curl, CURLOPT_PORT, update_server_port);
 		if (curl_ret != CURLE_OK) {


### PR DESCRIPTION
Allow curl to use the HTTP/2 protocol, with an automatic fallback to
HTTP/1.1.
Because of the optional nature, there's also no strict error handling
performed, if requesting HTTP/2 fails it fails.... and we get HTTP/1.1.