### PR TITLE
Enospace

### DIFF
--- a/include/swupd-error.h
+++ b/include/swupd-error.h
@@ -21,5 +21,6 @@
 #define EBUNDLE_INSTALL 18      /* Cannot install bundles */
 #define EREQUIRED_DIRS 19       /* Cannot create required dirs */
 #define ECURRENT_VERSION 20     /* Cannot determine current OS version */
+#define EINSUFFICIENT_SPACE 21  /* Insufficient space on target device */
 
 #endif

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -207,6 +207,7 @@ extern CURLcode swupd_curl_set_basic_options(CURL *curl, const char *url);
 void swupd_curl_test_resume(void);
 
 extern struct list *subs;
+extern void free_subscription_data(void *data);
 extern void free_subscriptions(void);
 extern void read_subscriptions(void);
 extern void read_subscriptions_alt(void);

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -434,7 +434,10 @@ int install_bundles(struct list *bundles, int current_version, struct manifest *
 	(void)rm_staging_dir_contents("download");
 
 	printf("Downloading packs...\n");
-	(void)download_subscribed_packs(true);
+	ret = download_subscribed_packs(true);
+	if (ret) {
+		goto out;
+	}
 
 	/* step 3: Add tracked bundles */
 	read_subscriptions_alt();

--- a/src/packs.c
+++ b/src/packs.c
@@ -44,16 +44,9 @@ static int download_pack(int oldversion, int newversion, char *module)
 	char *filename;
 	struct stat stat;
 
-	string_or_die(&filename, "%s/pack-%s-from-%i-to-%i.tar", state_dir, module, oldversion, newversion);
-
-	err = lstat(filename, &stat);
-	if (err == 0 && stat.st_size == 0) {
-		free(filename);
-		return 0;
-	}
-
 	printf("Downloading %s pack for version %i\n", module, newversion);
 
+	string_or_die(&filename, "%s/pack-%s-from-%i-to-%i.tar", state_dir, module, oldversion, newversion);
 	string_or_die(&url, "%s/%i/pack-%s-from-%i.tar", content_url, newversion, module, oldversion);
 
 	err = swupd_curl_get_file(url, filename, NULL, NULL, true);
@@ -88,34 +81,80 @@ static int download_pack(int oldversion, int newversion, char *module)
 	return err;
 }
 
+/* strip out bundles from download list which have been prev installed,
+	or which have not changed since oldversion */
+struct list *get_min_bundle_list(struct list *full_list)
+{
+	struct list *min_list = list_clone(full_list);
+	struct sub *bundle = NULL;
+	char *file = NULL;
+	struct list *list;
+	struct list *next;
+	int err = -1;
+	struct stat stat;
+
+	list = list_head(full_list);
+	while (list) {
+		bundle = list->data;
+		next = list->next;
+
+		/* bundle has not changed, no pack download needed */
+		if (bundle->oldversion == bundle->version) {
+			list_free_item(list, NULL);
+			list = next;
+			continue;
+		}
+
+		/* now check if the appropriate bundle update has been previously installed. Once installed,
+			pack contents are truncated to 0 but the file left on fs as a hint */
+		string_or_die(&file, "%s/pack-%s-from-%i-to-%i.tar", state_dir, bundle->component,
+						bundle->oldversion, bundle->version);
+		err = lstat(file, &stat);
+
+		if (err == 0 && stat.st_size == 0) {
+			list_free_item(list, NULL);
+			list = next;
+			free(file);
+		}
+		list = next;
+	}
+
+	return min_list;
+}
+
 /* pull in packs for base and any subscription */
 int download_subscribed_packs(bool required)
 {
 	struct list *iter;
-	struct sub *sub = NULL;
-	int err;
+	struct list *req_bundles; /* bundles requiring download */;
+	struct sub *bundle = NULL;
+	int err, ret = 0;
 
 	if (!check_network()) {
 		return -ENOSWUPDSERVER;
 	}
 
-	iter = list_head(subs);
+	req_bundles = get_min_bundle_list(subs);
+
+	iter = list_head(req_bundles);
 	while (iter) {
-		sub = iter->data;
+		bundle = iter->data;
 		iter = iter->next;
 
-		if (sub->oldversion == sub->version) { // pack didn't change in this release
-			continue;
-		}
-
-		err = download_pack(sub->oldversion, sub->version, sub->component);
+		err = download_pack(bundle->oldversion, bundle->version, bundle->component);
 		if (err < 0) {
 			if (required) {
-				return err;
+				ret = err;
+				break;
 			} else {
 				continue;
 			}
 		}
+	}
+
+	if (req_bundles) {
+		list_free_list_and_data(req_bundles, free_subscription_data);
+		req_bundles = NULL;
 	}
 
 	return 0;

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -34,7 +34,7 @@
 
 struct list *subs;
 
-static void free_subscription_data(void *data)
+void free_subscription_data(void *data)
 {
 	struct sub *sub = (struct sub *)data;
 


### PR DESCRIPTION
Series of 3 patches which 1) refactor a minimalist download list prior to acting, 2) add a pre-bundle(s)-add test for sufficient space, and 3) pay attention to download return codes to ensure a bundle-add does not proceed if download fails
