### PR TITLE
Improve output for miscellaneous curl errors

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -346,7 +346,7 @@ exit:
 			err = -1;
 			break;
 		default:
-			printf("Curl error: %d - see curl.h for details\n", curl_ret);
+			printf("Curl error: %s\n", curl_easy_strerror(curl_ret));
 			err = -1;
 			break;
 		}


### PR DESCRIPTION
Because libcurl has many different error codes, referring the end user
to curl.h is not ideal for the errors swupd does not handle explicitly.
Instead, call curl_easy_strerror() to print a generic error string as
indicated by the error code.

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>