### PR TITLE
Cleanups for certificate verification failure path

### DIFF
--- a/include/swupd-error.h
+++ b/include/swupd-error.h
@@ -21,5 +21,6 @@
 #define EBUNDLE_INSTALL 18      /* Cannot install bundles */
 #define EREQUIRED_DIRS 19       /* Cannot create required dirs */
 #define ECURRENT_VERSION 20     /* Cannot determine current OS version */
+#define ESIGNATURE 21           /* Cannot initialize signature verification */
 
 #endif

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -620,8 +620,9 @@ int swupd_init(int *lock_fd)
 	}
 
 	if (!initialize_signature()) {
+		ret = ESIGNATURE;
 		terminate_signature();
-		return false;
+		goto out_close_lock;
 	}
 
 	return ret;

--- a/src/signature.c
+++ b/src/signature.c
@@ -371,7 +371,7 @@ error:
 int verify_callback(int ok, X509_STORE_CTX *stor)
 {
 	if (!ok) {
-		fprintf(stderr, "Error: %s\n",
+		fprintf(stderr, "Certificate verification error: %s\n",
 			X509_verify_cert_error_string(stor->error));
 	}
 	return ok;

--- a/src/signature.c
+++ b/src/signature.c
@@ -359,12 +359,6 @@ static bool validate_certificate(void)
 error:
 	ERR_print_errors_fp(stderr);
 
-	if (store) {
-		X509_STORE_free(store);
-	}
-	if (lookup) {
-		X509_LOOKUP_free(lookup);
-	}
 	return false;
 }
 

--- a/src/signature.c
+++ b/src/signature.c
@@ -112,6 +112,7 @@ void terminate_signature(void)
 		fclose(fp_pubkey);
 	}
 	if (cert) {
+		X509_free(cert);
 		cert = NULL;
 	}
 	ERR_remove_thread_state(NULL);
@@ -358,6 +359,10 @@ static bool validate_certificate(void)
 
 error:
 	ERR_print_errors_fp(stderr);
+
+	if (verify_ctx) {
+		X509_STORE_CTX_free(verify_ctx);
+	}
 
 	return false;
 }


### PR DESCRIPTION
This path series addresses several issues: two double free issues that lead to segfaults, two memory leaks, and an issue with error handling in swupd_init().