### PR TITLE
Make pinned pubkey configurable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,6 +114,7 @@ AH_TEMPLATE([LOCK_DIR],[Directory for lock file])
 AH_TEMPLATE([BUNDLES_DIR],[Directory to use for bundles])
 AH_TEMPLATE([UPDATE_CA_CERTS_PATH],[Location of CA certificates])
 AH_TEMPLATE([MOTD_FILE],[motd file path])
+AH_TEMPLATE([PINNED_PUBKEY_PATH],[Path to pinned public key])
 
 if test "$enable_linux_rootfs_build" = "yes"; then
 	AC_DEFINE([SWUPD_LINUX_ROOTFS],1)
@@ -124,6 +125,7 @@ if test "$enable_linux_rootfs_build" = "yes"; then
 	AC_DEFINE([BUNDLES_DIR],["/usr/share/clear/bundles"])
 	AC_DEFINE_UNQUOTED([UPDATE_CA_CERTS_PATH],["$certs_path"])
 	AC_DEFINE([MOTD_FILE],["/usr/lib/motd.d/001-new-release"])
+	AC_DEFINE_UNQUOTED([PINNED_PUBKEY_PATH],["${certs_path}/425b0f6b.key"])
 else
 	AC_MSG_ERROR([Unknown build variant])
 fi

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -132,6 +132,7 @@ extern void *tm_dlhandle;
 extern char *bundle_to_add;
 extern struct timeval start_time;
 extern char *state_dir;
+extern char *pinned_pubkey_path;
 
 extern char *version_url;
 extern char *content_url;

--- a/src/curl.c
+++ b/src/curl.c
@@ -447,7 +447,7 @@ static CURLcode swupd_curl_set_security_opts(CURL *curl)
 		goto exit;
 	}
 
-	curl_ret = curl_easy_setopt(curl, CURLOPT_PINNEDPUBLICKEY, UPDATE_CA_CERTS_PATH "/425b0f6b.key");
+	curl_ret = curl_easy_setopt(curl, CURLOPT_PINNEDPUBLICKEY, pinned_pubkey_path);
 	if (curl_ret != CURLE_OK) {
 		goto exit;
 	}

--- a/src/globals.c
+++ b/src/globals.c
@@ -51,6 +51,7 @@ char *mounted_dirs = NULL;
 char *bundle_to_add = NULL;
 struct timeval start_time;
 char *state_dir = NULL;
+char *pinned_pubkey_path = NULL;
 
 /* NOTE: Today the content and version server urls are the same in
  * all cases.  It is highly likely these will eventually differ, eg:
@@ -68,6 +69,7 @@ long update_server_port = -1;
 static const char *default_version_url_path = "/usr/share/defaults/swupd/versionurl";
 static const char *default_content_url_path = "/usr/share/defaults/swupd/contenturl";
 static const char *default_format_path = "/usr/share/defaults/swupd/format";
+static const char *default_pinnedpubkey_path = "/usr/share/defaults/swupd/pinnedpubkey";
 
 static int set_default_value(char **global, const char *path)
 {
@@ -192,6 +194,16 @@ bool set_state_dir(char *path)
 	}
 
 	return true;
+}
+
+void set_pinned_pubkey_path()
+{
+	int ret;
+
+	ret = set_default_value(&pinned_pubkey_path, default_pinnedpubkey_path);
+	if (ret < 0) {
+		string_or_die(&pinned_pubkey_path, "%s", PINNED_PUBKEY_PATH);
+	}
 }
 
 bool set_format_string(char *userinput)
@@ -322,6 +334,7 @@ bool init_globals(void)
 	(void)set_format_string(NULL);
 	set_version_url(NULL);
 	set_content_url(NULL);
+	set_pinned_pubkey_path();
 
 	/* must set this global after version_url and content_url */
 	set_local_download();
@@ -337,6 +350,7 @@ void free_globals(void)
 	free(format_string);
 	free(mounted_dirs);
 	free(state_dir);
+	free(pinned_pubkey_path);
 	if (bundle_to_add != NULL) {
 		free(bundle_to_add);
 	}


### PR DESCRIPTION
The server may move to a new location where a different pubkey
needs to be used.

Signed-off-by: Dmitry Rozhkov dmitry.rozhkov@linux.intel.com
