### PR TITLE
Statistics: inline counter increments.

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -170,14 +170,47 @@ extern void link_manifests(struct manifest *m1, struct manifest *m2);
 extern void link_submanifests(struct manifest *m1, struct manifest *m2);
 extern void free_manifest(struct manifest *manifest);
 
-extern void account_new_file(void);
-extern void account_deleted_file(void);
-extern void account_changed_file(void);
-extern void account_new_manifest(void);
-extern void account_deleted_manifest(void);
-extern void account_changed_manifest(void);
-extern void account_delta_hit(void);
-extern void account_delta_miss(void);
+extern int swupd_stats[];
+static inline void account_new_file(void)
+{
+	swupd_stats[0]++;
+}
+
+static inline void account_deleted_file(void)
+{
+	swupd_stats[1]++;
+}
+
+static inline void account_changed_file(void)
+{
+	swupd_stats[2]++;
+};
+
+static inline void account_new_manifest(void)
+{
+	swupd_stats[3]++;
+};
+
+static inline void account_deleted_manifest(void)
+{
+	swupd_stats[4]++;
+};
+
+static inline void account_changed_manifest(void)
+{
+	swupd_stats[5]++;
+};
+
+static inline void account_delta_hit(void)
+{
+	swupd_stats[6]++;
+};
+
+static inline void account_delta_miss(void)
+{
+	swupd_stats[7]++;
+};
+
 extern void print_statistics(int version1, int version2);
 
 extern int download_subscribed_packs(bool required);

--- a/src/stats.c
+++ b/src/stats.c
@@ -28,64 +28,17 @@
 
 #include "swupd.h"
 
-static int new_files;
-static int deleted_files;
-static int changed_files;
-static int new_manifests;
-static int deleted_manifests;
-static int changed_manifests;
-static int delta_miss;
-static int delta_hit;
-
-void account_new_file(void)
-{
-	new_files++;
-}
-
-void account_deleted_file(void)
-{
-	deleted_files++;
-}
-
-void account_changed_file(void)
-{
-	changed_files++;
-}
-
-void account_new_manifest(void)
-{
-	new_manifests++;
-}
-
-void account_deleted_manifest(void)
-{
-	deleted_manifests++;
-}
-
-void account_changed_manifest(void)
-{
-	changed_manifests++;
-}
-
-void account_delta_hit(void)
-{
-	delta_hit++;
-}
-
-void account_delta_miss(void)
-{
-	delta_miss++;
-}
+int swupd_stats[8];
 
 void print_statistics(int version1, int version2)
 {
 	printf("\n");
 	printf("Statistics for going from version %i to version %i:\n\n", version1, version2);
-	printf("    changed manifests : %i\n", changed_manifests);
-	printf("    new manifests     : %i\n", new_manifests);
-	printf("    deleted manifests : %i\n\n", deleted_manifests);
-	printf("    changed files     : %i\n", changed_files);
-	printf("    new files         : %i\n", new_files);
-	printf("    deleted files     : %i\n", deleted_files);
+	printf("    changed manifests : %i\n", swupd_stats[5]);
+	printf("    new manifests     : %i\n", swupd_stats[3]);
+	printf("    deleted manifests : %i\n\n", swupd_stats[4]);
+	printf("    changed files     : %i\n", swupd_stats[2]);
+	printf("    new files         : %i\n", swupd_stats[0]);
+	printf("    deleted files     : %i\n", swupd_stats[1]);
 	printf("\n");
 }


### PR DESCRIPTION
This is a negligable performance increase and more of a cleanup
of symbol space. In order for these to inline, we need the stats
to be exported instead, so we go from 8+1 exports to 1+1.