### PR TITLE
Namespace cleanup: make functions/vars static.

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -157,8 +157,6 @@ extern int get_current_version(char *path_prefix);
 extern bool check_network(void);
 
 extern bool ignore(struct file *file);
-extern bool is_config(char *filename);
-extern bool is_state(char *filename);
 extern void apply_heuristics(struct file *file);
 
 extern int file_sort_filename(const void *a, const void *b);
@@ -231,9 +229,7 @@ extern int verify_bundle_hash(struct manifest *manifest, struct file *bundle);
 extern void unlink_all_staged_content(struct file *file);
 extern void link_renames(struct list *newfiles, struct manifest *from_manifest);
 extern void dump_file_descriptor_leaks(void);
-extern FILE *fopen_exclusive(const char *filename); /* no mode, opens for write only */
 extern int rm_staging_dir_contents(const char *rel_path);
-extern int create_required_dirs(void);
 extern void dump_file_info(struct file *file);
 void free_file_data(void *data);
 void remove_files_in_manifest_from_fs(struct manifest *m);
@@ -242,7 +238,6 @@ extern struct file *search_bundle_in_manifest(struct manifest *manifest, const c
 extern struct file *search_file_in_manifest(struct manifest *manifest, const char *filename);
 
 extern char *mounted_dirs;
-extern void get_mounted_directories(void);
 extern char *mk_full_filename(const char *prefix, const char *path);
 extern bool is_directory_mounted(const char *filename);
 extern bool is_under_mounted_directory(const char *filename);

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -173,7 +173,7 @@ static int unload_tracked_bundle(const char *bundle_name)
 }
 
 /* Check if bundle is included by any subscribed bundles */
-bool is_included(const char *bundle_name, struct manifest *mom)
+static bool is_included(const char *bundle_name, struct manifest *mom)
 {
 	bool ret = false;
 	struct list *b, *i;
@@ -393,7 +393,7 @@ out:
 	return ret;
 }
 
-int install_bundles(struct list *bundles, int current_version, struct manifest *mom)
+static int install_bundles(struct list *bundles, int current_version, struct manifest *mom)
 {
 	int ret;
 	struct file *file;

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -129,7 +129,7 @@ void unlink_all_staged_content(struct file *file)
 	}
 }
 
-FILE *fopen_exclusive(const char *filename) /* no mode, opens for write only */
+static FILE *fopen_exclusive(const char *filename) /* no mode, opens for write only */
 {
 	int fd;
 
@@ -140,7 +140,7 @@ FILE *fopen_exclusive(const char *filename) /* no mode, opens for write only */
 	return fdopen(fd, "w");
 }
 
-int create_required_dirs(void)
+static int create_required_dirs(void)
 {
 	int ret = 0;
 	int i;
@@ -202,7 +202,7 @@ int create_required_dirs(void)
  *
  * e.g: :/proc:/mnt/acct:
  */
-void get_mounted_directories(void)
+static void get_mounted_directories(void)
 {
 	FILE *file;
 	char *line = NULL;
@@ -717,7 +717,7 @@ out:
 	return ret;
 }
 
-void free_path_data(void *data)
+static void free_path_data(void *data)
 {
 	char *path = (char *)data;
 	free(path);

--- a/src/heuristics.c
+++ b/src/heuristics.c
@@ -31,7 +31,7 @@
 
 /* trailing slash is to indicate dir itself is expected to exist, but
  * contents are ignored */
-bool is_config(char *filename)
+static bool is_config(char *filename)
 {
 	if (strncmp(filename, "/etc/", 5) == 0) {
 		return true;
@@ -48,7 +48,7 @@ static void config_file_heuristics(struct file *file)
 
 /* trailing slash is to indicate dir itself is expected to exist, but
  * contents are ignored */
-bool is_state(char *filename)
+static bool is_state(char *filename)
 {
 	if (is_directory_mounted(filename)) {
 		return true;

--- a/src/search.c
+++ b/src/search.c
@@ -34,18 +34,19 @@
 #include "swupd.h"
 
 char *search_string;
-char search_type = '0';
 bool display_files = false; /* Just display all files found in Manifest set */
 bool init = false;
-char scope = '0';
+
+static char search_type = '0';
+static char scope = '0';
 
 /* Supported default search paths */
-char *lib_paths[] = {
+static char *lib_paths[] = {
 	"/usr/lib",
 	NULL
 };
 
-char *bin_paths[] = {
+static char *bin_paths[] = {
 	"/usr/bin/",
 	NULL
 };
@@ -222,7 +223,7 @@ err:
  * Attempt to match path and substring of filename. Base op for 'swupd search'
  * Path must match exact case, filename is case insensitive
  */
-bool file_search(char *filename, char *path, char *search_term)
+static bool file_search(char *filename, char *path, char *search_term)
 {
 	char *pos;
 
@@ -247,7 +248,7 @@ bool file_search(char *filename, char *path, char *search_term)
 /* report_find()
  * Report out, respecting verbosity
  */
-void report_find(char *bundle, char *file)
+static void report_find(char *bundle, char *file)
 {
 	printf("'%s'  :  '%s'\n", bundle, file);
 }
@@ -256,7 +257,7 @@ void report_find(char *bundle, char *file)
  * Description: Perform a lookup of the specified search string in all Clear manifests
  * for the current os release.
  */
-void do_search(struct manifest *MoM, char search_type, char *search_term)
+static void do_search(struct manifest *MoM, char search_type, char *search_term)
 {
 	struct list *list;
 	struct list *sublist;
@@ -388,7 +389,7 @@ static double query_total_download_size(struct list *list)
  * Description: To search Clear bundles for a particular entry, a complete set of
  *		manifests must be downloaded. This function does so, asynchronously, using
  *		the curl_multi interface */
-int download_manifests(struct manifest **MoM)
+static int download_manifests(struct manifest **MoM)
 {
 	struct list *list = NULL;
 	struct file *file = NULL;


### PR DESCRIPTION
Remaining hits by findstatic.pl are public API functions and
dangling statistic increments (but those last are fixed by the
PR cleaning up the stats, so they can be ignored for this PR).