### PR TITLE
Unconditionally remove file after download if errors.

### DIFF
--- a/src/packs.c
+++ b/src/packs.c
@@ -59,9 +59,7 @@ static int download_pack(int oldversion, int newversion, char *module)
 	err = swupd_curl_get_file(url, filename, NULL, NULL, true);
 	if (err) {
 		free(url);
-		if ((lstat(filename, &stat) == 0) && (stat.st_size == 0)) {
-			unlink(filename);
-		}
+		unlink(filename);
 		free(filename);
 		return err;
 	}


### PR DESCRIPTION
We've created the convention that zero-sized packs are "already
processed" earlier and don't need to be re-downloaded. However,
if we have an unlikely failure that Curl created a zero-length
file, but was unable to write any bytes output to it (due to
e.g. network connection failure), then we'd leave a zero-sized
pack file on the system, potentially causing a redownload attempt
to skip all further re-downloads.

Ergo, we should always remove zero-sized pack files if any error
happened.