### PR TITLE
Fix a memory leak

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -359,6 +359,10 @@ static bool validate_certificate(void)
 error:
 	ERR_print_errors_fp(stderr);
 
+	if (verify_ctx) {
+		X509_STORE_CTX_free(verify_ctx);
+	}
+
 	return false;
 }
 


### PR DESCRIPTION
X509_STORE_CTX_free() is being called in the "verify success" path, but
not in the error path.

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>