### PR TITLE
Do not mark a pack file as "downloaded and extracted" on tar error.

### DIFF
--- a/src/packs.c
+++ b/src/packs.c
@@ -78,11 +78,14 @@ static int download_pack(int oldversion, int newversion, char *module)
 	}
 	free(tar);
 	unlink(filename);
-	/* make a zero sized file to prevent redownload */
-	tarfile = fopen(filename, "w");
-	free(filename);
-	if (tarfile) {
-		fclose(tarfile);
+
+	if (err == 0) {
+		/* make a zero sized file to prevent redownload */
+		tarfile = fopen(filename, "w");
+		free(filename);
+		if (tarfile) {
+			fclose(tarfile);
+		}
 	}
 
 	return err;


### PR DESCRIPTION
Because this code did not ever look at the return value of
`tar`, it is possible that a download succeeded to download
something (possibly a bad file on the server, etc.) properly,
and tar then failed to extract it (possible local problems
with disk space, a random memory failure, etc.).

When this condition happens, we should never leave an empty
pack file on the system, since we're sure that there was an
error extracting it, and the best course of action is to
either re-download it or download individual files. Of course,
the latter is likely going to happen anyway.