### PR TITLE
Fix update failure during new bundle include

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -724,7 +724,12 @@ void link_manifests(struct manifest *m1, struct manifest *m2)
 				file2->deltapeer = file1;
 			}
 
-			if (!file1->is_deleted && !file2->is_deleted && hash_equal(file1->hash, file2->hash)) {
+			/* When new bundle is added to the include list of an installed bundle,
+				we must use the more recent, tracked last_change to ensure new files
+				are not assumed already present */
+			if (!file1->is_deleted && !file2->is_deleted
+					&& hash_equal(file1->hash, file2->hash)
+					&& file1->is_tracked) {
 				file2->last_change = file1->last_change;
 			}
 


### PR DESCRIPTION
When a new bundle was added as an included bundle from a previously installed
bundle, files in the new bundle were not getting properly installed. This was due to last_change
pointing at to old an entry, and swupd assuming the file was already installed.

This patch ensures last_change points at the more recent, tracked last_changed
entry, and the new file(s) gets installed

Signed-off-by: Brad T. Peters <brad.t.peters@intel.com>