### PR TITLE
Move sign/verify to abort on failure

### DIFF
--- a/include/swupd-error.h
+++ b/include/swupd-error.h
@@ -22,5 +22,6 @@
 #define EREQUIRED_DIRS 19       /* Cannot create required dirs */
 #define ECURRENT_VERSION 20     /* Cannot determine current OS version */
 #define ESIGNATURE 21           /* Cannot initialize signature verification */
+#define EHASH 22           /* Expected hash value does not match actual  */
 
 #endif

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -589,6 +589,7 @@ void swupd_deinit(int lock_fd)
 int swupd_init(int *lock_fd)
 {
 	int ret = 0;
+	char *log_cmd = NULL;
 
 	check_root();
 
@@ -736,6 +737,7 @@ int verify_fix_path(char *targetpath, struct manifest *target_MoM)
 	struct file *file;
 	char *tar_dotfile = NULL;
 	struct list *list1 = NULL;
+	char *log_cmd = NULL;
 
 	/* This shouldn't happen */
 	if (strcmp(targetpath, "/") == 0) {
@@ -786,8 +788,17 @@ int verify_fix_path(char *targetpath, struct manifest *target_MoM)
 		if (ret == 0) {
 			if (verify_file(file, target)) {
 				continue;
+			} else if (force) {
+				string_or_die(&log_cmd, "echo \"swupd security notice: "
+					"--force used to bypass hash verification\" | systemd-cat");
+				(void) system(log_cmd);
+				free(log_cmd);
+				continue;
+			} else {
+				printf("Expected hash did not match for path : %s\n", path);
+				ret = -EHASH;
+				goto end;
 			}
-			printf("Hash did not match for path : %s\n", path);
 		} else if (ret == -1 && errno == ENOENT) {
 			printf("Path %s is missing on the file system\n", path);
 		} else {

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -579,6 +579,7 @@ struct manifest *load_mom(int version)
 	int ret = 0;
 	char *filename;
 	char *url;
+	char *log_cmd = NULL;
 
 	ret = retrieve_manifests(version, version, "MoM", NULL);
 	if (ret != 0) {
@@ -589,8 +590,19 @@ struct manifest *load_mom(int version)
 	string_or_die(&filename, "%s/%i/Manifest.MoM", state_dir, version);
 	string_or_die(&url, "%s/%i/Manifest.MoM", content_url, version);
 	if (!download_and_verify_signature(url, filename)) {
-		printf("WARNING!!! FAILED TO VERIFY SIGNATURE OF Manifest.MoM\n");
+		if (!force) {
+			printf("FAILED TO VERIFY SIGNATURE OF Manifest.MoM\n");
+			return NULL;
+		} else {
+			printf("FAILED TO VERIFY SIGNATURE OF Manifest.MoM. Operation proceeding due to\n"
+				"  --force, but system security may be compromised\n");
+			string_or_die(&log_cmd, "echo \"swupd security notice:"
+				" --force used to bypass MoM signature verification failure\" | systemd-cat");
+			(void) system(log_cmd);
+			free(log_cmd);
+		}
 	}
+
 	free(filename);
 	free(url);
 
@@ -677,7 +689,8 @@ struct list *create_update_list(struct manifest *current, struct manifest *serve
 			if (verify_file(file, fullname)) {
 				free(fullname);
 				continue;
-			}
+			} /* A verify_file failure need not cause an operation abort, as this will
+				result in the file being updated, which should resolve the hash mismatch. */
 			free(fullname);
 		}
 

--- a/src/scripts.c
+++ b/src/scripts.c
@@ -130,6 +130,9 @@ void run_preupdate_scripts(struct manifest *manifest)
 		if (verify_file(file, script)) {
 			system(script);
 			break;
+		} else {
+			printf("Failed to run pre-update scripts. Hash check failure for : %s\n",
+					script);
 		}
 	}
 

--- a/src/update.c
+++ b/src/update.c
@@ -223,14 +223,27 @@ int main_update()
 	int lock_fd;
 	int retries = 0;
 	int timeout = 10;
+	char *log_cmd = NULL;
 
 	srand(time(NULL));
 
 	ret = swupd_init(&lock_fd);
 	if (ret != 0) {
-		/* being here means we already close log by a previously caught error */
-		printf("Updater failed to initialize, exiting now.\n");
-		return ret;
+		if (ret == ESIGNATURE) {
+			if (!force) {
+				printf("Failed to load a valid certificate. Aborting update\n");
+				return ret;
+			} else {
+				string_or_die(&log_cmd, "echo \"swupd security notice:"
+					" --force used to bypass signature verification failure\" | systemd-cat");
+				(void) system(log_cmd);
+				free(log_cmd);
+			}
+		} else {
+			/* being here means we already close log by a previously caught error */
+			printf("Updater failed to initialize, exiting now.\n");
+			return ret;
+		}
 	}
 
 	if (!check_network()) {

--- a/src/verify.c
+++ b/src/verify.c
@@ -595,8 +595,12 @@ int verify_main(int argc, char **argv)
 
 	ret = swupd_init(&lock_fd);
 	if (ret != 0) {
-		printf("Failed verify initialization, exiting now.\n");
-		return ret;
+		if (ret == ESIGNATURE) {
+			printf("Failed to load valid certificate. Attempting to proceed\n");
+		} else {
+			printf("Failed verify initialization, exiting now.\n");
+			return ret;
+		}
 	}
 
 	/* Gather current manifests */


### PR DESCRIPTION
Moves swupd signature verification to mandatory, though --force
is supported in some cases, described here:

The signed MoM serves as the top level chain
of trust as far as swupd is concerned, and it is used to extend
content trust down to the individual file level. When a client-side
files hash is found to differ from that expected given by the MoM,
we will abort or fix, as described:

 - During Update: Any sig or hash failure: Report and abort. Can be forced.
 - During Verify: Any sig or hash failure: Warn
 - During Verify fix: Any sig or hash failure: Autofix

Signed-off-by: Brad T. Peters <brad.t.peters@intel.com>