### PR TITLE
Remove unused function

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -125,17 +125,6 @@ void unlink_all_staged_content(struct file *file)
 	}
 }
 
-static FILE *fopen_exclusive(const char *filename) /* no mode, opens for write only */
-{
-	int fd;
-
-	fd = open(filename, O_CREAT | O_EXCL | O_RDWR, 00600);
-	if (fd < 0) {
-		return NULL;
-	}
-	return fdopen(fd, "w");
-}
-
 static int create_required_dirs(void)
 {
 	int ret = 0;


### PR DESCRIPTION
A recent commit removed the declaration for this function in swupd.h,
and now the compiler warns about it being unused, so the function can be
removed entirely now.

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>