### PR TITLE
Move signature verification to Mandatory

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -64,6 +64,7 @@ struct version_container {
 
 struct header;
 
+extern bool badcert;
 extern bool force;
 extern int verbose;
 extern int update_count;

--- a/src/globals.c
+++ b/src/globals.c
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "swupd.h"
 
+bool badcert = false;
 bool force = false;
 bool verify_esp_only;
 bool verify_bundles_only = false;

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -617,7 +617,8 @@ int swupd_init(int *lock_fd)
 		goto out_close_lock;
 	}
 
-	if (!initialize_signature()) {
+	if (!initialize_signature() && !force) {
+		badcert = true;
 		ret = ESIGNATURE;
 		terminate_signature();
 		goto out_close_lock;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -579,6 +579,7 @@ struct manifest *load_mom(int version)
 	int ret = 0;
 	char *filename;
 	char *url;
+	char *log_cmd = NULL;
 
 	ret = retrieve_manifests(version, version, "MoM", NULL);
 	if (ret != 0) {
@@ -589,7 +590,19 @@ struct manifest *load_mom(int version)
 	string_or_die(&filename, "%s/%i/Manifest.MoM", state_dir, version);
 	string_or_die(&url, "%s/%i/Manifest.MoM", content_url, version);
 	if (!download_and_verify_signature(url, filename)) {
-		printf("WARNING!!! FAILED TO VERIFY SIGNATURE OF Manifest.MoM\n");
+		if (!force) {
+			printf("WARNING!!! FAILED TO VERIFY SIGNATURE OF Manifest.MoM\n");
+			free(filename);
+			free(url);
+			return NULL;
+		} else {
+			printf("FAILED TO VERIFY SIGNATURE OF Manifest.MoM. Operation proceeding due to\n"
+				"  --force, but system security may be compromised\n");
+			string_or_die(&log_cmd, "echo \"swupd security notice:"
+				" --force used to bypass MoM signature verification failure\" | systemd-cat");
+			(void)system(log_cmd);
+			free(log_cmd);
+		}
 	}
 	free(filename);
 	free(url);

--- a/src/signature.c
+++ b/src/signature.c
@@ -260,12 +260,14 @@ static bool get_pubkey(void)
 	cert = PEM_read_X509(fp_pubkey, NULL, NULL, NULL);
 	if (!cert) {
 		fprintf(stderr, "Failed PEM_read_X509() for %s\n", CERTNAME);
+		fp_pubkey = NULL;
 		goto error;
 	}
 
 	pkey = X509_get_pubkey(cert);
 	if (!pkey) {
 		fprintf(stderr, "Failed X509_get_pubkey() for %s\n", CERTNAME);
+		fp_pubkey = NULL;
 		X509_free(cert);
 		goto error;
 	}
@@ -385,6 +387,10 @@ bool download_and_verify_signature(const char *data_url, const char *data_filena
 	char *sig_filename;
 	int ret;
 	bool result;
+
+	if (badcert) {
+		return false;
+	}
 
 	string_or_die(&sig_url, "%s.sig", data_url);
 


### PR DESCRIPTION
Moves swupd signature verification to mandatory, though --force
is supported in some cases, described here:

The signed MoM serves as the top level chain
of trust as far as swupd is concerned, and it is used to extend
content trust down to the individual file level. When the signature
of the top-level MoM is invalid or cannot be verified for any reason,
we warn and abort the operation.
  --force will allow this to proceed, explicitly accepting the
	unverified MoM and outputting a log entry to the Journal to this
	effect. This may introduce a security hole

For files being downloaded from a Clear server, the downloaded file
must match the MoM hash, or a warning is emitted and the operation is
aborted.
  --force has no effect

Signed-off-by: Brad T. Peters <brad.t.peters@intel.com>