### PR TITLE
Fix swupd operations when curl is not HTTP2-enabled

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -480,7 +480,7 @@ CURLcode swupd_curl_set_basic_options(CURL *curl, const char *url)
 	}
 
 	curl_ret = curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
-	if (curl_ret != CURLE_OK) {
+	if (curl_ret != CURLE_OK && curl_ret != CURLE_UNSUPPORTED_PROTOCOL) {
 		goto exit;
 	}
 


### PR DESCRIPTION
To support running swupd on distros without an HTTP2-enabled curl
package, explicitly check for the "unsupported protocol" error, returned
by libcurl in this event.

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>