### PR TITLE
Hashdump cleanups

### DIFF
--- a/src/hashdump.c
+++ b/src/hashdump.c
@@ -34,7 +34,7 @@
 
 static struct option opts[] = {
 	{ "no-xattrs", 0, NULL, 'n' },
-	{ "basepath", 1, NULL, 'b' },
+	{ "path", 1, NULL, 'p' },
 	{ "help", 0, NULL, 'h' },
 	{ 0, 0, NULL, 0 }
 };
@@ -47,7 +47,7 @@ static void usage(const char *name)
 	printf("   -h, --help              Show help options\n\n");
 	printf("Application Options:\n");
 	printf("   -n, --no-xattrs         Ignore extended attributes\n");
-	printf("   -b, --basepath          Optional argument for leading path to filename\n");
+	printf("   -p, --path=[PATH...]    Use [PATH...] for leading path to filename\n");
 	printf("\n");
 	printf("The filename is the name as it would appear in a Manifest file.\n");
 	printf("\n");
@@ -70,7 +70,7 @@ int hashdump_main(int argc, char **argv)
 		int c;
 		int i;
 
-		c = getopt_long(argc, argv, "nb:h", opts, &i);
+		c = getopt_long(argc, argv, "np:h", opts, &i);
 		if (c == -1) {
 			break;
 		}
@@ -79,7 +79,7 @@ int hashdump_main(int argc, char **argv)
 		case 'n':
 			file->use_xattrs = false;
 			break;
-		case 'b':
+		case 'p':
 			if (!optarg || !set_path_prefix(optarg)) {
 				printf("Invalid --basepath argument\n\n");
 				free(file);

--- a/test/functional/hashdump/file-hash-no-path-prefix/test.bats
+++ b/test/functional/hashdump/file-hash-no-path-prefix/test.bats
@@ -14,7 +14,7 @@ teardown() {
   run sudo sh -c "$SWUPD hashdump $DIR/target-dir/test-hash"
 
   echo "$output"
-  [ "${lines[2]}" = "b03e11e3307de4d4f3f545c8a955c2208507dbc1927e9434d1da42917712c15b" ]
+  [ "${lines[1]}" = "b03e11e3307de4d4f3f545c8a955c2208507dbc1927e9434d1da42917712c15b" ]
 }
 
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/test/functional/hashdump/file-hash/test.bats
+++ b/test/functional/hashdump/file-hash/test.bats
@@ -11,10 +11,10 @@ teardown() {
 }
 
 @test "hashdump with prefix" {
-  run sudo sh -c "$SWUPD hashdump --basepath=$DIR/target-dir /test-hash"
+  run sudo sh -c "$SWUPD hashdump --path=$DIR/target-dir /test-hash"
 
   echo "$output"
-  [ "${lines[2]}" = "b03e11e3307de4d4f3f545c8a955c2208507dbc1927e9434d1da42917712c15b" ]
+  [ "${lines[1]}" = "b03e11e3307de4d4f3f545c8a955c2208507dbc1927e9434d1da42917712c15b" ]
 }
 
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/test/functional/update/apply-full-file-delta/test.bats
+++ b/test/functional/update/apply-full-file-delta/test.bats
@@ -56,7 +56,7 @@ teardown() {
   run sudo sh -c "$SWUPD hashdump $DIR/target-dir/testfile"
 
   echo "$output"
-  [ "${lines[2]}" = "9f83d713da9df6cabd2abc9d9061f9b611a207e1e0dd22ed7a071ddb1cc1537a" ]
+  [ "${lines[1]}" = "9f83d713da9df6cabd2abc9d9061f9b611a207e1e0dd22ed7a071ddb1cc1537a" ]
 }
 
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
This patch series includes some changes to the 'hashdump' subcommand. Namely, I renamed its -b option to -p for consistency with the other subcommands, and I reworked the tool to allow relative pathnames.