### PR TITLE
Update fallback preference for global configuration

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -137,8 +137,8 @@ extern char *version_url;
 extern char *content_url;
 extern long update_server_port;
 extern bool set_path_prefix(char *path);
-extern void set_content_url(char *url);
-extern void set_version_url(char *url);
+extern int set_content_url(char *url);
+extern int set_version_url(char *url);
 extern bool set_state_dir(char *path);
 
 extern void check_root(void);


### PR DESCRIPTION
Updates the order of preference for content_url, version_url
and formate_string, from:
  1. Runtime flags
  2. Configure time options
  3. State dir files

to:
  1. Runtime flags
  2. State dir files
  3. Configure time options

This patch also changes the logic of the setter functions to allow
multiple calls. Once the respective global is set, that function will
return true or 0, ie "success", (depending on the function).

Signed-off-by: Brad T. Peters <brad.t.peters@intel.com>