### PR TITLE
Make remove() error messages correct and useful.

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -102,6 +102,7 @@ int rm_staging_dir_contents(const char *rel_path)
 void unlink_all_staged_content(struct file *file)
 {
 	char *filename;
+	int ret;
 
 	/* downloaded tar file */
 	string_or_die(&filename, "%s/download/%s.tar", state_dir, file->hash);
@@ -113,8 +114,10 @@ void unlink_all_staged_content(struct file *file)
 
 	/* downloaded and un-tar'd file */
 	string_or_die(&filename, "%s/staged/%s", state_dir, file->hash);
-	if (remove(filename) != 0) {
-		fprintf(stderr, "ERROR:%d, failed to remove %s...\nconsider running swupd verify --fix\n",errno, file->filename);
+	ret = remove(filename);
+	if (ret && (errno != ENOENT)) {
+		fprintf(stderr, "ERROR: %s, failed to remove %s...\nconsider running swupd verify --fix\n",
+			strerror(errno), filename);
 	}
 	free(filename);
 


### PR DESCRIPTION
We do not want to print this message if there was no file to begin
with, so check that errno isn't ENOENT.

We also want to print strerror(errno) instead of a code, and last,
we want to print the right filename here as well.

This is due to commit f06bcdba6d5b994a426cf23c76b97c79989f6427.

We should seriously consider also reverting that commit, as there
is almost no value in these error messages.