### PR TITLE
Do not report leaks in sockets.

### DIFF
--- a/src/filedesc.c
+++ b/src/filedesc.c
@@ -74,7 +74,7 @@ void dump_file_descriptor_leaks(void)
 		string_or_die(&filename, "/proc/self/fd/%s", entry->d_name);
 		memset(&buffer, 0, sizeof(buffer));
 		size = readlink(filename, buffer, PATH_MAXLEN);
-		if (size) {
+		if (size && !strstr(buffer, "socket")) {
 			printf("Possible filedescriptor leak: fd_number=\"%s\",fd_details=\"%s\"\n", entry->d_name, buffer);
 		}
 		free(filename);


### PR DESCRIPTION
The only sockets held are irrelevant for our file descriptor
leak check, which focuses on leaks in opening/closing regular
files. Some of the sockets are things like pacrunner that
curl opens, and we should just ignore leaks in them.