### PR TITLE
Set O_CLOEXEC when opening the certificate file

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -250,7 +250,7 @@ error:
  * returns: true if it can get the public key, false otherwise */
 static bool get_pubkey(void)
 {
-	fp_pubkey = fopen(CERTNAME, "r");
+	fp_pubkey = fopen(CERTNAME, "re");
 	if (!fp_pubkey) {
 		fprintf(stderr, "Failed fopen %s\n", CERTNAME);
 		goto error;


### PR DESCRIPTION
Because swupd-client on Clear Linux may fork/exec clr-boot-manager near
the end of its operation, which itself checks for file descriptor leaks
before exiting, it will report leaks for files it did not open (i.e.
inherited from the parent process, swupd).

To resolve this, set O_CLOEXEC when opening the cert file using the "e"
flag (glibc extension).

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>