### PR TITLE
Replace system calls by local system_argv functions.

### DIFF
--- a/include/swupd-build-variant.h
+++ b/include/swupd-build-variant.h
@@ -15,7 +15,7 @@
  * and Smack, but not with SELinux.
  */
 #define TAR_COMMAND "bsdtar"
-#define TAR_XATTR_ARGS ""
+#define TAR_XATTR_ARGS
 
 #else /* SWUPD_WITH_BSDTAR */
 
@@ -24,17 +24,17 @@
  */
 #define TAR_COMMAND "tar"
 #ifdef SWUPD_TAR_SELINUX
-#define TAR_XATTR_ARGS "--xattrs --xattrs-include='*' --selinux"
+#define TAR_XATTR_ARGS "--xattrs", "--xattrs-include='*'", "--selinux",
 #else
-#define TAR_XATTR_ARGS "--xattrs --xattrs-include='*'"
+#define TAR_XATTR_ARGS "--xattrs", "--xattrs-include='*'",
 #endif
 
 #endif /* SWUPD_WITH_BSDTAR */
 
 #ifdef SWUPD_WITH_XATTRS
-#define TAR_PERM_ATTR_ARGS "--preserve-permissions " TAR_XATTR_ARGS
+#define TAR_PERM_ATTR_ARGS TAR_XATTR_ARGS "--preserve-permissions"
 #else /* SWUPD_WITHOUT_XATTRS */
-#define TAR_PERM_ATTR_ARGS "--preserve-permissions "
+#define TAR_PERM_ATTR_ARGS "--preserve-permissions"
 #endif
 
 #endif

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -296,6 +296,10 @@ extern int get_dirfd_path(const char *fullname);
 extern int verify_fix_path(char *targetpath, struct manifest *manifest);
 extern void set_local_download(void);
 extern struct list *files_from_bundles(struct list *bundles);
+extern int system_argv(char *const argv[]);
+extern int system_argv_fd(char *const argv[], int newstdin, int newstdout, int newstderr);
+extern int system_argv_pipe(char *const argvp1[], int stdinp1, int stderrp1,
+							char *const argvp2[], int stdoutp2, int stderrp2);
 
 /* subscription.c */
 struct list *free_list_file(struct list *item);

--- a/src/download.c
+++ b/src/download.c
@@ -252,7 +252,7 @@ int untar_full_download(void *data)
 	char *targetfile;
 	struct stat stat;
 	int err;
-	char *tarcommand;
+	char *tardir;
 
 	string_or_die(&tar_dotfile, "%s/download/.%s.tar", state_dir, file->hash);
 	string_or_die(&tarfile, "%s/download/%s.tar", state_dir, file->hash);
@@ -291,14 +291,10 @@ int untar_full_download(void *data)
 	}
 
 	/* modern tar will automatically determine the compression type used */
-	string_or_die(&tarcommand, TAR_COMMAND " -C %s/staged/ " TAR_PERM_ATTR_ARGS " -xf %s 2> /dev/null",
-		      state_dir, tarfile);
-
-	err = system(tarcommand);
-	if (WIFEXITED(err)) {
-		err = WEXITSTATUS(err);
-	}
-	free(tarcommand);
+	string_or_die(&tardir, "%s/staged/", state_dir);
+	char *const tarcmd[] = { TAR_COMMAND, "-C", tardir, TAR_PERM_ATTR_ARGS, "-xf", tarfile, NULL };
+	err = system_argv_fd(tarcmd, -1, -1, -2);
+	free(tardir);
 	if (err) {
 		printf("ignoring tar extract failure for fullfile %s.tar (ret %d)\n",
 		       file->hash, err);

--- a/src/hash.c
+++ b/src/hash.c
@@ -299,7 +299,6 @@ int verify_bundle_hash(struct manifest *manifest, struct file *bundle)
 			/* missing bundle manifest - attempt to download it */
 			char *filename;
 			char *url;
-			char *tar;
 
 			printf("Warning: Downloading missing manifest for bundle %s version %d.\n",
 					current->filename, current->last_change);
@@ -319,15 +318,15 @@ int verify_bundle_hash(struct manifest *manifest, struct file *bundle)
 			}
 			free(filename);
 
-			string_or_die(&tar, TAR_COMMAND " -C %s/%i -xf %s/%i/Manifest.%s.tar 2> /dev/null",
-					state_dir, current->last_change, state_dir,
-					current->last_change, current->filename);
+			char *param1, *param2;
+			string_or_die(&param1, "%s/%i", state_dir, current->last_change);
+			string_or_die(&param2, "%s/%i/Manifest.%s.tar",
+				      state_dir, current->last_change, current->filename);
+			char *const tarcmd[] = { TAR_COMMAND, "-C", param1, "-xf", param2, NULL };
+			ret = system_argv_fd(tarcmd, -1, -1, -2);
+			free(param1);
+			free(param2);
 
-			ret = system(tar);
-			free(tar);
-			if (WIFEXITED(ret)) {
-				ret = WEXITSTATUS(ret);
-			}
 			if (ret != 0) {
 				break;
 			}

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -495,8 +495,8 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 	char *filename;
 	char *dir;
 	int ret = 0;
-	char *tar;
 	struct stat sb;
+	char *param1, *param2;
 
 	string_or_die(&filename, "%s/%i/Manifest.%s.tar", state_dir, version, component);
 	if (stat(filename, &sb) == 0) {
@@ -531,15 +531,13 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 		goto out;
 	}
 
-	string_or_die(&tar, TAR_COMMAND " -C %s/%i -xf %s/%i/Manifest.%s.tar 2> /dev/null",
-		      state_dir, version, state_dir, version, component);
-
+	string_or_die(&param1, "%s/%i",  state_dir, version);
+	string_or_die(&param2, "%s/%i/Manifest.%s.tar", state_dir, version, component);
+	char *const tarcmd[] = { TAR_COMMAND, "-C", param1, "-xf", param2, NULL };
 	/* this is is historically a point of odd errors */
-	ret = system(tar);
-	if (WIFEXITED(ret)) {
-		ret = WEXITSTATUS(ret);
-	}
-	free(tar);
+	ret = system_argv_fd(tarcmd, -1, -1, -2);
+	free(param1);
+	free(param2);
 	if (ret != 0) {
 		goto out;
 	}

--- a/src/packs.c
+++ b/src/packs.c
@@ -29,6 +29,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 #include "config.h"
 #include "signature.h"
@@ -38,7 +39,7 @@
 static int download_pack(int oldversion, int newversion, char *module)
 {
 	FILE *tarfile = NULL;
-	char *tar = NULL;
+	char *param = NULL;
 	char *url = NULL;
 	int err = -1;
 	char *filename;
@@ -69,14 +70,10 @@ static int download_pack(int oldversion, int newversion, char *module)
 	free(url);
 
 	printf("Extracting pack.\n");
-	string_or_die(&tar, TAR_COMMAND " -C %s " TAR_PERM_ATTR_ARGS " -xf %s/pack-%s-from-%i-to-%i.tar 2> /dev/null",
-		      state_dir, state_dir, module, oldversion, newversion);
-
-	err = system(tar);
-	if (WIFEXITED(err)) {
-		err = WEXITSTATUS(err);
-	}
-	free(tar);
+	string_or_die(&param, "%s/pack-%s-from-%i-to-%i.tar", state_dir, module, oldversion, newversion);
+	char *const tarcmd[] = { TAR_COMMAND, "-C", state_dir, TAR_PERM_ATTR_ARGS, "-xf", param, NULL };
+	err = system_argv_fd(tarcmd, -1, -1, -2);
+	free(param);
 	unlink(filename);
 	/* make a zero sized file to prevent redownload */
 	tarfile = fopen(filename, "w");

--- a/src/scripts.c
+++ b/src/scripts.c
@@ -34,45 +34,59 @@
 
 static void update_kernel(void)
 {
-	char *kernel_update_cmd = NULL;
-
 	if (strcmp("/", path_prefix) == 0) {
-		string_or_die(&kernel_update_cmd, "/usr/bin/kernel_updater.sh");
-	} else {
-		string_or_die(&kernel_update_cmd, "%s/usr/bin/kernel_updater.sh --path %s", path_prefix, path_prefix);
-	}
+		char *const kernel_update_cmd[] = { "/usr/bin/kernel_updater.sh", NULL } ;
 
-	system(kernel_update_cmd);
-	free(kernel_update_cmd);
+		(void)system_argv(kernel_update_cmd);
+	} else {
+		char *pathupdater;
+
+		string_or_die(&pathupdater, "%s/usr/bin/kernel_updater.sh", path_prefix);
+		char *const kernel_update_cmd[] = { pathupdater, "--path", path_prefix,  NULL } ;
+
+		(void)system_argv(kernel_update_cmd);
+		free(pathupdater);
+	}
 }
 
 static void update_bootloader(void)
 {
-	char *bootloader_update_cmd = NULL;
-
 	if (strcmp("/", path_prefix) == 0) {
-		string_or_die(&bootloader_update_cmd, "/usr/bin/gummiboot_updaters.sh");
+		char *const bootloader_update_cmd[] = { "/usr/bin/gummiboot_updaters.sh", NULL };
+
+		(void)system_argv(bootloader_update_cmd);
 	} else {
-		string_or_die(&bootloader_update_cmd, "%s/usr/bin/gummiboot_updaters.sh --path %s", path_prefix, path_prefix);
+		char *pathupdater;
+
+		string_or_die(&pathupdater, "%s/usr/bin/gummiboot_updaters.sh", path_prefix);
+		char *const bootloader_update_cmd[] = { pathupdater, "--path", path_prefix, NULL };
+
+		(void)system_argv(bootloader_update_cmd);
+		free(pathupdater);
 	}
 
-	system(bootloader_update_cmd);
-	free(bootloader_update_cmd);
-
 	if (strcmp("/", path_prefix) == 0) {
-		string_or_die(&bootloader_update_cmd, "/usr/bin/systemdboot_updater.sh");
-	} else {
-		string_or_die(&bootloader_update_cmd, "%s/usr/bin/systemdboot_updater.sh --path %s", path_prefix, path_prefix);
-	}
+		char *const bootloader_update_cmd[] = { "/usr/bin/systemdboot_updater.sh", NULL };
 
-	system(bootloader_update_cmd);
-	free(bootloader_update_cmd);
+		(void)system_argv(bootloader_update_cmd);
+	} else {
+		char *pathupdater;
+
+		string_or_die(&pathupdater, "%s/usr/bin/systemdboot_updater.sh", path_prefix);
+		char *const bootloader_update_cmd[] = { pathupdater, "--path", path_prefix, NULL };
+
+		(void)system_argv(bootloader_update_cmd);
+		free(pathupdater);
+	}
 }
 
 static void update_triggers(void)
 {
-	system("/usr/bin/systemctl --no-block daemon-reload");
-	system("/usr/bin/systemctl --no-block restart update-triggers.target");
+	char *const reloadcmd[] = { "/usr/bin/systemctl", "--no-block", "daemon-reload", NULL };
+	char *const restartcmd[] = { "/usr/bin/systemctl", "--no-block", "restart", "update-triggers.target", NULL };
+
+	(void)system_argv(reloadcmd);
+	(void)system_argv(restartcmd);
 }
 
 void run_scripts(void)
@@ -108,6 +122,7 @@ void run_preupdate_scripts(struct manifest *manifest)
 	char *script;
 
 	string_or_die(&script, "/usr/bin/clr_pre_update.sh");
+	char *const scriptcmd[] = { script, NULL };
 
 	if (stat(script, &sb) == -1) {
 		free(script);
@@ -124,7 +139,7 @@ void run_preupdate_scripts(struct manifest *manifest)
 
 		/* Check that system file matches file in manifest */
 		if (verify_file(file, script)) {
-			system(script);
+			(void)system_argv(scriptcmd);
 			break;
 		}
 	}

--- a/src/staging.c
+++ b/src/staging.c
@@ -31,6 +31,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 #include "config.h"
 #include "swupd-build-variant.h"
@@ -40,16 +41,14 @@
 static int create_staging_renamedir(char *rename_tmpdir)
 {
 	int ret;
-	char *rmcommand = NULL;
+	char *const rmcommand[] = { "rm", "-fr", rename_tmpdir, NULL };
 
-	string_or_die(&rmcommand, "rm -fr %s", rename_tmpdir);
-	if (!system(rmcommand)) {
+	if (!system_argv(rmcommand)) {
 		/* Not fatal but pretty scary, likely to really fail at the
 		 * next command too. Pass for now as printing may just cause
 		 * confusion */
 		;
 	}
-	free(rmcommand);
 
 	ret = mkdir(rename_tmpdir, S_IRWXU);
 	if (ret == -1 && errno != EEXIST) {
@@ -69,7 +68,7 @@ int do_staging(struct file *file, struct manifest *MoM)
 {
 	char *statfile = NULL, *tmp = NULL, *tmp2 = NULL;
 	char *dir, *base, *rel_dir;
-	char *tarcommand = NULL;
+	char *param1 = NULL, *param2 = NULL, *param3 = NULL;
 	char *original = NULL;
 	char *target = NULL;
 	char *targetpath = NULL;
@@ -148,13 +147,14 @@ int do_staging(struct file *file, struct manifest *MoM)
 			ret = -errno;
 			goto out;
 		}
-		string_or_die(&tarcommand, TAR_COMMAND " -C '%s' " TAR_PERM_ATTR_ARGS " -cf - './%s' 2> /dev/null | " TAR_COMMAND " -C '%s%s' " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
-			      rename_tmpdir, base, path_prefix, rel_dir);
-		ret = system(tarcommand);
-		if (WIFEXITED(ret)) {
-			ret = WEXITSTATUS(ret);
-		}
-		free(tarcommand);
+		string_or_die(&param1, "./%s", base);
+		string_or_die(&param2, "%s%s", path_prefix, rel_dir);
+		char *const tarcfcmd[] = { TAR_COMMAND, "-C", rename_tmpdir, TAR_PERM_ATTR_ARGS, "-cf", "-", param1, NULL };
+		char *const tarxfcmd[] = { TAR_COMMAND, "-C", param2, TAR_PERM_ATTR_ARGS, "-xf", "-", NULL };
+		ret = system_argv_pipe(tarcfcmd, -1, -2, tarxfcmd, -1, -2);
+		free(param1);
+		free(param2);
+
 		if (rename(rename_target, original)) {
 			ret = -errno;
 			goto out;
@@ -185,13 +185,15 @@ int do_staging(struct file *file, struct manifest *MoM)
 				ret = -errno;
 				goto out;
 			}
-			string_or_die(&tarcommand, TAR_COMMAND " -C '%s/staged' " TAR_PERM_ATTR_ARGS " -cf - '.update.%s' 2> /dev/null | " TAR_COMMAND " -C '%s%s' " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
-				      state_dir, base, path_prefix, rel_dir);
-			ret = system(tarcommand);
-			if (WIFEXITED(ret)) {
-				ret = WEXITSTATUS(ret);
-			}
-			free(tarcommand);
+			string_or_die(&param1, "%s/staged", state_dir);
+			string_or_die(&param2, ".update.%s", base);
+			string_or_die(&param3, "%s%s", path_prefix, rel_dir);
+			char *const tarcfcmd[] = { TAR_COMMAND, "-C", param1, TAR_PERM_ATTR_ARGS, "-cf", "-", param2, NULL };
+			char *const tarxfcmd[] = { TAR_COMMAND, "-C", param3, TAR_PERM_ATTR_ARGS, "-xf", "-", NULL };
+			ret = system_argv_pipe(tarcfcmd, -1, -2, tarxfcmd, -1, -2);
+			free(param1);
+			free(param2);
+			free(param3);
 			ret = rename(rename_target, original);
 			if (ret) {
 				ret = -errno;

--- a/test/functional/ignore-list
+++ b/test/functional/ignore-list
@@ -9,11 +9,8 @@
 ^No kernel update needed, skipping helper call out.$
 ^No bootloader update needed, skipping helper call out.$
 ^Update took .* seconds$
-^sh: .*/usr/bin/kernel_updater.sh: No such file or directory$
-^sh: .*/usr/bin/gummiboot_updaters.sh: No such file or directory$
-^sh: .*/usr/bin/systemdboot_updater.sh: No such file or directory$
-^sh: .*/usr/bin/kernel_updater.sh: not found$
-^sh: .*/usr/bin/gummiboot_updaters.sh: not found$
-^sh: .*/usr/bin/systemdboot_updater.sh: not found$
+^Error: Failed to exec.*/usr/bin/kernel_updater.sh.*No such file or directory$
+^Error: Failed to exec.*/usr/bin/gummiboot_updaters.sh.*No such file or directory$
+^Error: Failed to exec.*/usr/bin/systemdboot_updater.sh.*No such file or directory$
 ^Possible filedescriptor leak: .*$
 ^WARNING!!! FAILED TO VERIFY SIGNATURE OF Manifest.MoM$


### PR DESCRIPTION
There are new functions that replace system() calls: system_argv()
and system_argv_pipe(). They are based on execvp() function and they
can manage any argument including filenames with characters that could
be interpreted as meta-characters in a regular system() function.
So no escape for the arguments needed and is less prone to errors.

Signed-off-by: Jose R Guzman jose.r.guzman.mosqueda@intel.com
Signed-off-by: Patrick McCarty patrick.mccarty@intel.com
