### PR TITLE
Initialize tmprenamedir in the state directory

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -130,8 +130,8 @@ static int create_required_dirs(void)
 	int ret = 0;
 	int i;
 	char *dir;
-#define STATE_DIR_COUNT 3
-	const char *dirs[] = { "delta", "staged", "download" };
+#define STATE_DIR_COUNT 4
+	const char *dirs[] = { "delta", "staged", "download", "tmprenamedir" };
 	struct stat buf;
 	bool missing = false;
 


### PR DESCRIPTION
Initializing this directory here fixes an issue with creating custom
Clear Linux Docker images with swupd; when "tmprenamedir" doesn't exist
in the image layer and is later created in the container layer, a
rename() call will fail with EXDEV, due to the layers existing on
different overlayed filesystems. Ensuring that "tmprenamedir" is always
present in the state directory resolves the issue.

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>