### PR TITLE
Update gitignore for gtags metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 .libs/
 .project
 DEADJOE
+GPATH
+GRTAGS
+GTAGS
 Makefile
 Makefile.in
 aclocal.m4


### PR DESCRIPTION
Ignore GPATH, GRTAGS and GTAGS files created by the gtags tool.