### PR TITLE
Add options to handle xattr at compile time.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -147,7 +147,7 @@ AC_ARG_ENABLE([tar-selinux],
 )
 AS_IF([test "x$enable_tar_selinux" = "xyes"],
 	    [AC_DEFINE(SWUPD_TAR_SELINUX,1,[give --selinux option to tar])
-	    AS_IF(test "x$enable_xattr" = "xyes",,
+	    AS_IF(test "x$XATTR" = "xno",
 	    echo "Must have --enable-xattr to have --enable-tar-selinux" >&2
 	    AS_EXIT(1))],
 	    [TARSELINUX=no]

--- a/configure.ac
+++ b/configure.ac
@@ -126,8 +126,31 @@ AC_ARG_ENABLE(
 	AS_HELP_STRING([--enable-bsdtar], [Use alternative bsdtar command (uses tar by default)])
 )
 AS_IF([test "x$enable_bsdtar" = "xyes" ],
-	[AC_DEFINE(SWUPD_WITH_BSDTAR, 1, [Use bsdtar])],
-	[AC_DEFINE(SWUPD_WITHOUT_BSDTAR, 1, [Use default tar])]
+	[AC_DEFINE(SWUPD_WITH_BSDTAR, 1, [Use bsdtar])]
+)
+dnl Enable extended attribute support
+XATTR="yes"
+AC_ARG_ENABLE(
+	[xattr],
+	AS_HELP_STRING([--enable-xattr],[Use extended file attributes (unused by default)])
+)
+AS_IF([test "x$enable_xattr" = "xyes"],
+	    [AC_DEFINE(SWUPD_WITH_XATTRS,1,[Use extended file attributes])
+	    AS_IF(test "x$enable_bsdtar" = "xyes",
+	    echo "Options --enable-bsdtar and --enable-xattr are incompatible" >&2
+	    AS_EXIT(1))],
+	    [XATTR=no]
+)
+TARSELINUX="yes"
+AC_ARG_ENABLE([tar-selinux],
+	AS_HELP_STRING([--enable-tar-selinux],[give --selinux option to tar])
+)
+AS_IF([test "x$enable_tar_selinux" = "xyes"],
+	    [AC_DEFINE(SWUPD_TAR_SELINUX,1,[give --selinux option to tar])
+	    AS_IF(test "x$enable_xattr" = "xyes",,
+	    echo "Must have --enable-xattr to have --enable-tar-selinux" >&2
+	    AS_EXIT(1))],
+	    [TARSELINUX=no]
 )
 
 AC_ARG_WITH([systemdsystemunitdir], AS_HELP_STRING([--with-systemdsystemunitdir=DIR],
@@ -165,7 +188,6 @@ certs_path="/usr/share/clear/update-ca"
 AH_TEMPLATE([SWUPD_LINUX_ROOTFS],[Enable Linux rootfs build variant])
 ## (2) variant features
 AH_TEMPLATE([SWUPD_WITH_BINDMNTS],[cope with bind mounts over rootfs])
-AH_TEMPLATE([SWUPD_WITH_SELINUX],[handle selinux attributes])
 ## (3) variant extra options
 AH_TEMPLATE([MOUNT_POINT],[The mount point])
 AH_TEMPLATE([STATE_DIR],[The state directory for swupd content])
@@ -209,4 +231,6 @@ Configuration to build swupd-client:
   SSL Certificate file:			${SWUPDCERT}
   Use bzip compression:			${BZIP}
   Run Tests:				${TESTS}
+  Use extended file attributes		${XATTR}
+  Use --selinux option for tar		${TARSELINUX}
 ])

--- a/include/swupd-build-variant.h
+++ b/include/swupd-build-variant.h
@@ -13,13 +13,18 @@
 #define TAR_XATTR_ARGS ""
 #else
 #define TAR_COMMAND "tar"
+/* configure.ac ensures a sensible configuration of bsdtar/selinux/xattr */
+#ifdef SWUPD_TAR_SELINUX
+#define TAR_XATTR_ARGS "--xattrs --xattrs-include='*' --selinux"
+#else
 #define TAR_XATTR_ARGS "--xattrs --xattrs-include='*'"
 #endif
+#endif
 
-#ifdef SWUPD_WITH_SELINUX
-#define TAR_PERM_ATTR_ARGS "--preserve-permissions --selinux " TAR_XATTR_ARGS
-#else /* SWUPD_WITHOUT_SELINUX */
+#ifdef SWUPD_WITH_XATTRS
 #define TAR_PERM_ATTR_ARGS "--preserve-permissions " TAR_XATTR_ARGS
+#else /* SWUPD_WITHOUT_XATTRS */
+#define TAR_PERM_ATTR_ARGS "--preserve-permissions "
 #endif
 
 #endif

--- a/include/xattrs.h
+++ b/include/xattrs.h
@@ -16,8 +16,10 @@ void xattrs_copy(const char *src_filename, const char *dst_filename);
 
 /*
  * Attempt to pack into a data blob the extended attributes of the given file.
- * The data blob will be allocated and possibly filled with first the list
- * of all the extended attributes names, and then their values.
+ * The data blob will be allocated and possibly filled with first the sorted
+ * list of all the extended attributes names, and then their values.
+ * The values will be NUL terminated, but the encoding is not reversable so
+ * is only suitable to use as input to a hashing function.
  * @param filename - The file from which the extended attributes will be
  * read and packed into the data blob.
  * @param blob - The data blob pointer into which the extended attributes will

--- a/src/xattrs.c
+++ b/src/xattrs.c
@@ -41,8 +41,15 @@ typedef enum xattrs_action_type_t_ xattrs_action_type_t;
  * glibc's interface to the system calls
  */
 #ifndef SWUPD_WITH_XATTRS
-#define lgetxattr(p,n,b,l) (-1)
+/* Return a length of zero attribute names, i.e. there are none.
+ * Not a perfect emulation, but good enough
+ */
 #define llistxattr(p,b,l) (0)
+/* If by some chance we have an attribute name and try and get its
+ * value then set errno and return an error.
+ */
+#define lgetxattr(p,n,b,l) ((errno = ENOTSUP, -1))
+
 #endif
 
 static int xattr_get_value(const char *path, const char *name, char **blob,

--- a/src/xattrs.c
+++ b/src/xattrs.c
@@ -37,6 +37,14 @@ enum xattrs_action_type_t_ {
 
 typedef enum xattrs_action_type_t_ xattrs_action_type_t;
 
+/* If SWUPD_WITH_XATTRS is not defined, create functions to override
+ * glibc's interface to the system calls
+ */
+#ifndef SWUPD_WITH_XATTRS
+#define lgetxattr(p,n,b,l) (-1)
+#define llistxattr(p,b,l) (0)
+#endif
+
 static int xattr_get_value(const char *path, const char *name, char **blob,
 			   size_t *blob_len, xattrs_action_type_t action)
 {


### PR DESCRIPTION
Swupd used to use a sorted blob of extended file attributes as part of
the data that was used to verify the contents. This caused problems if
extra attributes were added. In particular if a clearlinux system was
being run in a container that had selinux enabled in the base OS.

Add a configure option to allow the attributes to be considered or
not. Based on advice, the default is to ignore them, as this is what
everyone expects.

Tidied up passing a --selinux flag to tar, this is also handled by a new
config option.

Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>