### PR TITLE
Print error message for CURLE_COULDNT_CONNECT

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -319,6 +319,7 @@ exit:
 			err = -1;
 			break;
 		case CURLE_COULDNT_CONNECT:
+			printf("Curl: Could not connect to host or proxy\n");
 			err = -ENONET;
 			break;
 		case CURLE_FILE_COULDNT_READ_FILE:


### PR DESCRIPTION
Certain types of network-connectivity problems hit this curl error, so
print a diagnostic message when it occurs.