### PR TITLE
build: track m4 directory to avoid aclocal warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ kw*
 libswupd*
 libtool
 ltmain.sh
-m4/
+m4/*.m4
 missing
 regression/*.out
 src/*.gcda


### PR DESCRIPTION
When running 'autoreconf', aclocal warns that the "m4" directory does
not exist, even though AC_CONFIG_MACRO_DIR in configure.ac declares that
it should exist.

To avoid the warning, track the directory in the git tree.

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>