### PR TITLE
tar: extract failure handling

### DIFF
--- a/src/download.c
+++ b/src/download.c
@@ -290,7 +290,7 @@ int untar_full_download(void *data)
 	}
 
 	/* modern tar will automatically determine the compression type used */
-	string_or_die(&tarcommand, TAR_COMMAND " -C %s/staged/ " TAR_PERM_ATTR_ARGS " -xf %s 2> /dev/null",
+	string_or_die(&tarcommand, TAR_COMMAND " -C %s/staged/ " TAR_PERM_ATTR_ARGS " -xf %s",
 		      state_dir, tarfile);
 
 	err = system(tarcommand);
@@ -301,6 +301,7 @@ int untar_full_download(void *data)
 	if (err) {
 		printf("ignoring tar extract failure for fullfile %s.tar (ret %d)\n",
 		       file->hash, err);
+		err = 0;
 		goto exit;
 		/* FIXME: can we respond meaningfully to tar error codes?
 		 * symlink untars may have perm/xattr complaints and non-zero

--- a/src/packs.c
+++ b/src/packs.c
@@ -69,12 +69,17 @@ static int download_pack(int oldversion, int newversion, char *module)
 	free(url);
 
 	printf("Extracting pack.\n");
-	string_or_die(&tar, TAR_COMMAND " -C %s " TAR_PERM_ATTR_ARGS " -xf %s/pack-%s-from-%i-to-%i.tar 2> /dev/null",
+	string_or_die(&tar, TAR_COMMAND " -C %s " TAR_PERM_ATTR_ARGS " -xf %s/pack-%s-from-%i-to-%i.tar",
 		      state_dir, state_dir, module, oldversion, newversion);
 
 	err = system(tar);
 	if (WIFEXITED(err)) {
 		err = WEXITSTATUS(err);
+	}
+	if (err) {
+		printf("ignoring tar extract failure for '%s' (ret %d)\n",
+		       tar, err);
+		err = 0;
 	}
 	free(tar);
 	unlink(filename);


### PR DESCRIPTION
tar errors when unpacking individual files used to be ignored in swupd
client < 3.0 and current 3.6.0 still prints a message about "ignoring
tar extract failure for fullfile ..." but the error is not really
getting ignored. Instead, downloading is tried again a few times
before swupd gives up.

This is relevant in Ostro OS where IMA prevents bsdtar from setting a
security.ima xattr when the value is redundant (see "[Linux-ima-user]
copying files with security.ima xattr" - the consensus is that the
kernel is too strict and needs to be fixed), leading to errors that
can be ignored.

The same can happen when extracting a pack file, and there errors also
should be ignored.

In both cases it is useful to see the actual error messages from the
tar command, so the redirection to /dev/null gets removed.