### PR TITLE
swupd-client check-update return 1 if none available

### DIFF
--- a/src/check_update.c
+++ b/src/check_update.c
@@ -123,6 +123,7 @@ err:
 	return false;
 }
 
+/* Return 0 if there is an update available, nonzero if not */
 static int check_update()
 {
 	int current_version, server_version;
@@ -142,16 +143,19 @@ static int check_update()
 		printf("Unable to determine current OS version\n");
 		return ECURRENT_VERSION;
 	} else {
-		if (current_version != -1 && current_version < server_version) {
+		printf("Current OS version: %d\n", current_version);
+		if (current_version < server_version) {
 			printf("There is a new OS version available: %d\n", server_version);
 			update_motd(server_version);
+			return 0; /* update available */
 		} else if (current_version >= server_version) {
 			printf("There are no updates available\n");
 		}
-		return 0;
+		return 1;	/* No update available */
 	}
 }
 
+/* return 0 if update available, non-zero if not */
 int check_update_main(int argc, char **argv)
 {
 	int ret;

--- a/src/main.c
+++ b/src/main.c
@@ -150,9 +150,13 @@ err:
 	return false;
 }
 
-static void print_versions()
+/* return 0 if server_version is ahead of current_version,
+ * 1 if the current_version is current or ahead
+ * 2 if one or more versions can't be found
+ */
+static int print_versions()
 {
-	int current_version, server_version;
+	int current_version, server_version, ret=0;
 
 	check_root();
 	(void)init_globals();
@@ -162,15 +166,21 @@ static void print_versions()
 
 	if (current_version < 0) {
 		printf("Cannot determine current OS version\n");
+		ret = 2;
 	} else {
 		printf("Current OS version: %d\n", current_version);
 	}
 
 	if (server_version < 0) {
 		printf("Cannot get latest the server version.Could not reach server\n");
+		ret = 2;
 	} else {
 		printf("Latest server version: %d\n", server_version);
 	}
+	if ((ret == 0) && (server_version <= current_version)) {
+		ret = 1;
+	}
+	return ret;
 }
 
 int update_main(int argc, char **argv)
@@ -183,7 +193,7 @@ int update_main(int argc, char **argv)
 	}
 
 	if (cmd_line_status) {
-		print_versions();
+		ret = print_versions();
 	} else {
 		struct timespec ts_start, ts_stop;
 		double delta;

--- a/test/functional/checkupdate/new-version/lines-checked
+++ b/test/functional/checkupdate/new-version/lines-checked
@@ -1,2 +1,3 @@
 Attempting to download version string to memory
+Current OS version: 10
 There is a new OS version available: 100

--- a/test/functional/checkupdate/new-version/test.bats
+++ b/test/functional/checkupdate/new-version/test.bats
@@ -5,6 +5,7 @@ load "../../swupdlib"
 @test "check-update with a new version available" {
   run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
 }
 

--- a/test/functional/checkupdate/no-server-content/test.bats
+++ b/test/functional/checkupdate/no-server-content/test.bats
@@ -5,6 +5,7 @@ load "../../swupdlib"
 @test "check-update with no server version file available" {
   run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"
 
+[ "$status" -ne 0 ]
   check_lines "$output"
 }
 

--- a/test/functional/checkupdate/no-target-content/test.bats
+++ b/test/functional/checkupdate/no-target-content/test.bats
@@ -5,6 +5,7 @@ load "../../swupdlib"
 @test "check-update with no target version file available" {
   run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"
 
+  [ "$status" -ne 0 ]
   check_lines "$output"
 }
 

--- a/test/functional/checkupdate/slow-server/lines-checked
+++ b/test/functional/checkupdate/slow-server/lines-checked
@@ -1,2 +1,3 @@
 Attempting to download version string to memory
+Current OS version: 10
 There is a new OS version available: 99990

--- a/test/functional/checkupdate/slow-server/test.bats
+++ b/test/functional/checkupdate/slow-server/test.bats
@@ -25,6 +25,7 @@ teardown() {
   slow_opts="-p $DIR/target-dir -F staging -u http://localhost:$port/"
   run sudo sh -c "$SWUPD check-update $slow_opts"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
 }
 

--- a/test/functional/checkupdate/version-match/lines-checked
+++ b/test/functional/checkupdate/version-match/lines-checked
@@ -1,2 +1,3 @@
 Attempting to download version string to memory
+Current OS version: 10
 There are no updates available

--- a/test/functional/checkupdate/version-match/test.bats
+++ b/test/functional/checkupdate/version-match/test.bats
@@ -5,6 +5,7 @@ load "../../swupdlib"
 @test "check-update with no new version available" {
   run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"
 
+  [ "$status" -eq 1 ]
   check_lines "$output"
 }
 


### PR DESCRIPTION
make the return code for swupd-client be 1 if there is no update
available. This follows in the tradition of grep, which returns 0 if
there are matches, 1 if there are not, and 2 for errors.

Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>