### PR TITLE
build: allow out of tree builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -126,7 +126,7 @@ distclean-local:
 	rm -rf aclocal.m4 ar-lib autom4te.cache config.guess config.h.in config.h.in~ config.sub configure depcomp install-sh ltmain.sh m4 Makefile.in missing compile
 
 install-exec-hook:
-	perl scripts/findstatic.pl */*.o | grep -v Checking ||:
+	perl $(top_srcdir)/scripts/findstatic.pl */*.o | grep -v Checking ||:
 
 
 TEST_EXTENSIONS = .bats


### PR DESCRIPTION
When doing out-of-tree builds, the distributed
scripts are in different directory than where
the build is happening. This doesn't work:

  make  install-exec-hook
  make[2]: Entering directory '<builddir>'
  perl scripts/findstatic.pl */*.o | grep -v Checking ||:
  Can't open perl script "scripts/findstatic.pl": No such file or directory
  make[2]: Leaving directory '<builddir>'

We therefore need to give perl the full path
of the perl-script to run using the standard
automake variable top_srcdir:

  make  install-exec-hook
  make[2]: Entering directory '<builddir>'
  perl ../../../../../../../../tmp/swupd-client.git/scripts/findstatic.pl */*.o | grep -v Checking ||:
    'bin_paths' is unique to src/search.o, should be static?  (initialised variable)
    'do_search' is unique to src/search.o, should be static?  (function)
    'download_manifests' is unique to src/search.o, should be static?  (function)
    'file_search' is unique to src/search.o, should be static?  (function)
    'lib_paths' is unique to src/search.o, should be static?  (initialised variable)
    'report_find' is unique to src/search.o, should be static?  (function)
    'scope' is unique to src/search.o, should be static?  (initialised variable)
    'search_type' is unique to src/search.o, should be static?  (initialised variable)
  make[2]: Leaving directory '<builddir>'

Signed-off-by: André Draszik <git@andred.net>