### PR TITLE
fix --enable-xattr

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -135,10 +135,7 @@ AC_ARG_ENABLE(
 	AS_HELP_STRING([--enable-xattr],[Use extended file attributes (unused by default)])
 )
 AS_IF([test "x$enable_xattr" = "xyes"],
-	    [AC_DEFINE(SWUPD_WITH_XATTRS,1,[Use extended file attributes])
-	    AS_IF(test "x$enable_bsdtar" = "xyes",
-	    echo "Options --enable-bsdtar and --enable-xattr are incompatible" >&2
-	    AS_EXIT(1))],
+	    [AC_DEFINE(SWUPD_WITH_XATTRS,1,[Use extended file attributes])],
 	    [XATTR=no]
 )
 TARSELINUX="yes"

--- a/include/swupd-build-variant.h
+++ b/include/swupd-build-variant.h
@@ -9,17 +9,27 @@
 #include "swupd.h"
 
 #ifdef SWUPD_WITH_BSDTAR
+
+/* bsdtar always includes xattrs, without needing special parameters
+ * for it. This has been tested in Ostro OS in combination with IMA
+ * and Smack, but not with SELinux.
+ */
 #define TAR_COMMAND "bsdtar"
 #define TAR_XATTR_ARGS ""
-#else
+
+#else /* SWUPD_WITH_BSDTAR */
+
+/* GNU tar requires special options, depending on how the OS uses xattrs.
+ * This has been tested in Clear Linux OS in combination with SELinux.
+ */
 #define TAR_COMMAND "tar"
-/* configure.ac ensures a sensible configuration of bsdtar/selinux/xattr */
 #ifdef SWUPD_TAR_SELINUX
 #define TAR_XATTR_ARGS "--xattrs --xattrs-include='*' --selinux"
 #else
 #define TAR_XATTR_ARGS "--xattrs --xattrs-include='*'"
 #endif
-#endif
+
+#endif /* SWUPD_WITH_BSDTAR */
 
 #ifdef SWUPD_WITH_XATTRS
 #define TAR_PERM_ATTR_ARGS "--preserve-permissions " TAR_XATTR_ARGS

--- a/src/xattrs.c
+++ b/src/xattrs.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <sys/xattr.h>
 
+#include "config.h"
 #include "swupd.h"
 #include "xattrs.h"
 


### PR DESCRIPTION
Commit fc0f570d added a check that prevents using --enable-xattr
together with --enable-bsdtar, perhaps because it was assumed that this
wouldn't work because there is no special tar option as in the GNU tar
case.

But bsdtar worked fined in combination with IMA and Smack xattrs in
Ostro OS. Xattrs are set accordingly there on the server side, so the
check needs to be removed to allow the combination.

Besides that, enabling xattrs also had no effect because xattrs.c
never got to see the SWUPD_WITH_XATTRS define due to not including
config.h.

@icarus-sparry this is the fix I mentioned on IRC.