### PR TITLE
Add configure option to re-enable updating of config files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,6 +153,15 @@ AS_IF([test "x$enable_tar_selinux" = "xyes"],
 	    [TARSELINUX=no]
 )
 
+AC_ARG_ENABLE(
+        [stateless],
+        AS_HELP_STRING([--disable-stateless],[OS is not stateless, do not ignore configuration files (stateless by default)])
+)
+AS_IF([test "x$enable_stateless" = "xno"],
+            [AC_DEFINE(OS_IS_STATELESS,0,[OS is not stateless])],
+            [AC_DEFINE(OS_IS_STATELESS,1,[OS is stateless])]
+)
+
 AC_ARG_WITH([systemdsystemunitdir], AS_HELP_STRING([--with-systemdsystemunitdir=DIR],
             [path to systemd system service dir @<:@default=/usr/lib/systemd/system@:>@]), [unitpath=${withval}],
             [unitpath="$($PKG_CONFIG --variable=systemdsystemunitdir systemd)"])

--- a/src/heuristics.c
+++ b/src/heuristics.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "config.h"
 #include "swupd.h"
 
 /* trailing slash is to indicate dir itself is expected to exist, but
@@ -121,8 +122,8 @@ void apply_heuristics(struct file *file)
  */
 bool ignore(struct file *file)
 {
-	if ((file->is_config) ||
-	    is_config(file->filename) || // ideally we trust the manifest but short term reapply check here
+	if ((OS_IS_STATELESS && file->is_config) ||
+	    (OS_IS_STATELESS && is_config(file->filename)) || // ideally we trust the manifest but short term reapply check here
 	    (file->is_state) ||
 	    is_state(file->filename) || // ideally we trust the manifest but short term reapply check here
 	    (file->is_boot && file->is_deleted) ||


### PR DESCRIPTION
This is required by distros which ship configuration files under
/etc. Those files then are considered read-only and must be updated as
part of OS updates.