### PR TITLE
ignore xattrs when verifying Manifest files

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -236,7 +236,14 @@ bool verify_file(struct file *file, char *filename)
 	}
 
 	local->filename = file->filename;
-	local->use_xattrs = true;
+	/*
+	 * xattrs are currently not supported for manifest files.
+	 * They are data files produced by the swupd-server and
+	 * therefore do not have any of the xattrs normally
+	 * set for the actual system files (like security.ima
+	 * when using IMA or security.SMACK64 when using Smack).
+	 */
+	local->use_xattrs = !file->is_manifest;
 
 	populate_file_struct(local, filename);
 	if (compute_hash(local, filename) != 0) {


### PR DESCRIPTION
When IMA or Smack are active on the client, the downloaded Manifest
files will be assigned certain xattrs (security.ima
resp. security.SMACK64). Those xattrs did not exist on the server side
(because it is most likely not having those kernel features enabled)
and besides, the swupd-server code wouldn't include them in the
Manifest hashes even if they existed (see write_manifest_plain() in
src/manifest.c).

Therefore the client must ignore xattrs when verifying Manifest files.
This is the only place where verification gets relaxed. All other locations
still use xattrs, just as before.

This is the solution that was agree upon when discussing https://github.com/clearlinux/swupd-server/pull/34