### PR TITLE
Fix typo in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -103,7 +103,7 @@ EXTRA_DIST += \
 	data/check-update.service \
 	data/check-update.timer \
 	data/swupd-update.service \
-	data/swupd-update.timer
+	data/swupd-update.timer \
 	$(SWUPD_CERTS)
 
 DISTCHECK_CONFIGURE_FLAGS = \


### PR DESCRIPTION
The backslash for the second-to-last entry in EXTRA_DIST was omitted,
leading to a dist issue.

Signed-off-by: Patrick McCarty <patrick.mccarty@intel.com>