### PR TITLE
Do not block on systemctl post-update triggers

### DIFF
--- a/src/scripts.c
+++ b/src/scripts.c
@@ -71,8 +71,8 @@ static void update_bootloader(void)
 
 static void update_triggers(void)
 {
-	system("/usr/bin/systemctl daemon-reload");
-	system("/usr/bin/systemctl restart update-triggers.target");
+	system("/usr/bin/systemctl --no-block daemon-reload");
+	system("/usr/bin/systemctl --no-block restart update-triggers.target");
 }
 
 void run_scripts(void)


### PR DESCRIPTION
We call systemctl to update triggers once an update finishes, which enqueues a
task and then waits to finish by default thus blocking the system() call. This
adds unnecessary time to the update, so set --no-block and move on since we
already reached the end of the update.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>