### PR TITLE
Telemetry - re-introduce telemetry.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,7 +44,8 @@ SWUPD_COMMON_SOURCES = \
 	src/xattrs.c \
 	src/globals.c \
 	src/scripts.c \
-	src/bundle.c
+	src/bundle.c \
+	src/telemetry.c
 
 lib_LTLIBRARIES = libswupd.la
 libswupd_la_SOURCES = $(SWUPD_COMMON_SOURCES)

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -309,6 +309,15 @@ extern int list_installable_bundles();
 extern int install_bundles_frontend(char **bundles);
 extern int add_subscriptions(struct list *bundles, struct list **subs, int current_version, struct manifest *mom, int recursion);
 
+/* telemetry.c */
+typedef enum telem_prio_t {
+	TELEMETRY_DEBG = 1,
+	TELEMETRY_INFO,
+	TELEMETRY_WARN,
+	TELEMETRY_CRIT
+} telem_prio_t;
+extern void telemetry(telem_prio_t level, const char *fmt, ...);
+
 /* some disk sizes constants for the various features:
  *   ...consider adding build automation to catch at build time
  *      if the build's artifacts are larger than these thresholds */

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -128,8 +128,6 @@ extern char *path_prefix;
 extern bool set_format_string(char *userinput);
 extern bool init_globals(void);
 extern void free_globals(void);
-extern bool has_telemetry;
-extern void *tm_dlhandle;
 extern char *bundle_to_add;
 extern struct timeval start_time;
 extern char *state_dir;

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -135,8 +135,8 @@ static int create_required_dirs(void)
 	int ret = 0;
 	int i;
 	char *dir;
-#define STATE_DIR_COUNT 3
-	const char *state_dirs[] = { "delta", "staged", "download" };
+#define STATE_DIR_COUNT 4
+	const char *state_dirs[] = { "delta", "staged", "download", "telemetry" };
 	struct stat buf;
 	bool missing = false;
 

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -136,7 +136,7 @@ static int create_required_dirs(void)
 	int i;
 	char *dir;
 #define STATE_DIR_COUNT 3
-	const char *dirs[] = { "delta", "staged", "download" };
+	const char *state_dirs[] = { "delta", "staged", "download" };
 	struct stat buf;
 	bool missing = false;
 
@@ -146,7 +146,7 @@ static int create_required_dirs(void)
 		missing = true;
 	}
 	for (i = 0; i < STATE_DIR_COUNT; i++) {
-		string_or_die(&dir, "%s/%s", state_dir, dirs[i]);
+		string_or_die(&dir, "%s/%s", state_dir, state_dirs[i]);
 		ret = stat(dir, &buf);
 		if (ret) {
 			missing = true;
@@ -154,22 +154,22 @@ static int create_required_dirs(void)
 		free(dir);
 	}
 
-	if (missing) { // (re)create dirs
+	if (missing) { // (re)create state dirs
 		char *cmd;
 
 		for (i = 0; i < STATE_DIR_COUNT; i++) {
-			string_or_die(&cmd, "mkdir -p %s/%s", state_dir, dirs[i]);
+			string_or_die(&cmd, "mkdir -p %s/%s", state_dir, state_dirs[i]);
 			ret = system(cmd);
 			if (ret) {
-				printf("Error: failed to create %s/%s\n", state_dir, dirs[i]);
+				printf("Error: failed to create %s/%s\n", state_dir, state_dirs[i]);
 				return -1;
 			}
 			free(cmd);
 
-			string_or_die(&dir, "%s/%s", state_dir, dirs[i]);
+			string_or_die(&dir, "%s/%s", state_dir, state_dirs[i]);
 			ret = chmod(dir, S_IRWXU);
 			if (ret) {
-				printf("Error: failed to set mode for %s/%s\n", state_dir, dirs[i]);
+				printf("Error: failed to set mode for %s/%s\n", state_dir, state_dirs[i]);
 				return -1;
 			}
 			free(dir);

--- a/src/main.c
+++ b/src/main.c
@@ -180,6 +180,16 @@ static int print_versions()
 	if ((ret == 0) && (server_version <= current_version)) {
 		ret = 1;
 	}
+
+	telemetry(ret ? TELEMETRY_WARN : TELEMETRY_INFO,
+		"action=check\n"
+		"result=%d\n"
+		"version_current=%d\n"
+		"version_server=%d\n",
+		ret,
+		current_version,
+		server_version);
+
 	return ret;
 }
 
@@ -195,16 +205,7 @@ int update_main(int argc, char **argv)
 	if (cmd_line_status) {
 		ret = print_versions();
 	} else {
-		struct timespec ts_start, ts_stop;
-		double delta;
-
-		clock_gettime(CLOCK_MONOTONIC_RAW, &ts_start);
 		ret = main_update();
-		clock_gettime(CLOCK_MONOTONIC_RAW, &ts_stop);
-
-		delta = ts_stop.tv_sec - ts_start.tv_sec + ts_stop.tv_nsec / 1000000000.0 - ts_start.tv_nsec / 1000000000.0;
-
-		printf("Update took %5.1f seconds\n", delta);
 	}
 	return ret;
 }

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -1,0 +1,57 @@
+
+/*
+ *   Software Updater - telemetry collection
+ *
+ *      Copyright © 2016 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Authors:
+ *         Auke Kok <auke-jan.h.kok@intel.com>
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdarg.h>
+
+#include "config.h"
+#include "swupd.h"
+
+#define RECORD_VERSION 1
+
+void telemetry(telem_prio_t level, const char *fmt, ...)
+{
+	va_list args;
+	char *filename;
+	int fd;
+
+	string_or_die(&filename, "%s/telemetry/%d.%d.XXXXXX", state_dir, RECORD_VERSION, level);
+
+	fd = mkstemp(filename);
+	free(filename);
+
+	if (fd < 0) {
+		return;
+	}
+
+	dprintf(fd, "PACKAGE_NAME=%s\nPACKAGE_VERSION=%s\n",
+		PACKAGE_NAME, PACKAGE_VERSION);
+
+	va_start(args, fmt);
+	vdprintf(fd, fmt, args);
+	va_end(args);
+
+	close(fd);
+}

--- a/src/verify.c
+++ b/src/verify.c
@@ -783,8 +783,30 @@ brick_the_system_and_clean_curl:
 /* this concludes the critical section, after this point it's clean up time, the disk content is finished and final */
 
 clean_and_exit:
-	swupd_deinit(lock_fd, &subs);
-
+	telemetry(ret ? TELEMETRY_CRIT : TELEMETRY_INFO,
+		"action=verify\nfix=%d\nret=%d\n"
+		"current_version=%d\n"
+		"file_replaced_count=%d\n"
+		"file_not_replaced_count=%d\n"
+		"file_missing_count=%d\n"
+		"file_fixed_count=%d\n"
+		"file_not_fixed_count=%d\n"
+		"file_deleted_count=%d\n"
+		"file_not_deleted_count=%d\n"
+		"file_mismatch_count=%d\n"
+		"file_extraneous_count=%d\n",
+		cmdline_option_fix || cmdline_option_install,
+		ret,
+		version,
+		file_replaced_count,
+		file_not_replaced_count,
+		file_missing_count,
+		file_fixed_count,
+		file_not_fixed_count,
+		file_deleted_count,
+		file_not_deleted_count,
+		file_mismatch_count,
+		file_extraneous_count);
 	if (ret == EXIT_SUCCESS) {
 		if (cmdline_option_fix || cmdline_option_install) {
 			printf("Fix successful\n");
@@ -800,6 +822,8 @@ clean_and_exit:
 			printf("Error: Verify did not fully succeed\n");
 		}
 	}
+
+	swupd_deinit(lock_fd, &subs);
 
 	return ret;
 }


### PR DESCRIPTION
This is a new telemetry framework for swupd-client. The patch is split up in a few changes:

- clean out some old telemetry stuff that was left around and is unused.
- Separate patch to always create new telemetry drop folder
- introduce new telemetry() function and use it in 3 locations (check, update, and verify paths) to create a telemetry record at completion of those actions.

This won't actually deliver records to the telemetry service. For that, a separate telemetry agent will be created that runs as a separate process and does not affect swupd operation. That "probe" will have its own repository.