### PR TITLE
staging: better handle file type change from directory

### DIFF
--- a/src/staging.c
+++ b/src/staging.c
@@ -122,6 +122,13 @@ int do_staging(struct file *file, struct manifest *MoM)
 				ret = -ETYPE_CHANGED_FILE_RM;
 				goto out;
 			}
+			/* Since we have removed the old file, it doesn't
+			 * matter what type it used to be. This is in
+			 * particular important if file has changed from
+			 * directory to non-directory, as otherwise we'd end
+			 * up in the directory clause below, which we really
+			 * only want for new directories. */
+			s.st_mode &= ~S_IFMT;
 		}
 	}
 	free(statfile);


### PR DESCRIPTION
If the file type changes from directory to something else,
we have to make sure to end up in the right place when
extracting it.

So far, we end up the directory case, but of course we
need to get into the case of non-directory.

Note that at least bsdtar handles extracting a new non-
directory over an existing directory with the same name
fine, i.e. the existing directory is correctly removed,
and the new file (or symlink) created instead.

Signed-off-by: André Draszik <git@andred.net>