### PR TITLE
Cleanups for the configure.ac; make the certificate location configurable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -91,7 +91,7 @@ swupd_sig_verifytest_LDADD = $(SWUPD_CORE_LIBS)
 
 noinst_HEADERS = $(top_srcdir)/include/*
 
-swupdcertsdir = @update_ca_certs_path@
+swupdcertsdir = @cert_path@
 SWUPD_CERTS = certs/157753a5.0 \
 	certs/425b0f6b.0 \
 	certs/425b0f6b.key \

--- a/configure.ac
+++ b/configure.ac
@@ -80,21 +80,22 @@ AM_CONDITIONAL([ENABLE_TESTS], [test "$enable_tests" != "no"])
 
 have_coverage=no
 AC_ARG_ENABLE(coverage, AS_HELP_STRING([--enable-coverage], [enable test coverage]))
-if test "$enable_coverage" = "yes" ; then
-        AC_CHECK_PROG(lcov_found, [lcov], [yes], [no])
-        if test "$lcov_found" = "no" ; then
-                AC_MSG_ERROR([*** lcov support requested but the program was not found])
-        else
-                lcov_version_major="`lcov --version | cut -d ' ' -f 4 | cut -d '.' -f 1`"
-                lcov_version_minor="`lcov --version | cut -d ' ' -f 4 | cut -d '.' -f 2`"
-                if test "$lcov_version_major" -eq 1 -a "$lcov_version_minor" -lt 10; then
-                        AC_MSG_ERROR([*** lcov version is too old. 1.10 required])
-                else
-			have_coverage=yes
-			AC_DEFINE([COVERAGE], [1], [Coverage enabled])
-                fi
-        fi
-fi
+AS_IF(
+  [test "$enable_coverage" = "yes"],
+  [AC_CHECK_PROG(lcov_found, [lcov], [yes], [no])
+     AS_IF(
+       [test "$lcov_found" = "no"],
+       [AC_MSG_ERROR([*** lcov support requested but the program was not found])],
+       [lcov_version_major="`lcov --version | cut -d ' ' -f 4 | cut -d '.' -f 1`"
+          lcov_version_minor="`lcov --version | cut -d ' ' -f 4 | cut -d '.' -f 2`"
+          AS_IF(
+            [test "$lcov_version_major" -eq 1 -a "$lcov_version_minor" -lt 10],
+            [AC_MSG_ERROR([*** lcov version is too old. 1.10 required])],
+            [have_coverage=yes
+               AC_DEFINE([COVERAGE], [1], [Coverage enabled])]
+          )]
+     )]
+)
 AM_CONDITIONAL([COVERAGE], [test "$have_coverage" = "yes"])
 
 AC_ARG_ENABLE(
@@ -186,7 +187,10 @@ AS_IF([test -n "$with_formatid" -a "$with_formatid" != "no" -a "$with_formatid" 
 AC_ARG_WITH([systemdsystemunitdir], AS_HELP_STRING([--with-systemdsystemunitdir=DIR],
             [path to systemd system service dir @<:@default=/usr/lib/systemd/system@:>@]), [unitpath=${withval}],
             [unitpath="$($PKG_CONFIG --variable=systemdsystemunitdir systemd)"])
-test -z "${unitpath}" && unitpath=/usr/lib/systemd/system
+AS_IF(
+  [test -z "${unitpath}"],
+  [unitpath=/usr/lib/systemd/system]
+)
 AC_SUBST(SYSTEMD_UNITDIR, [${unitpath}])
 
 
@@ -209,18 +213,18 @@ AH_TEMPLATE([BUNDLES_DIR],[Directory to use for bundles])
 AH_TEMPLATE([UPDATE_CA_CERTS_PATH],[Location of CA certificates])
 AH_TEMPLATE([MOTD_FILE],[motd file path])
 
-if test "$enable_linux_rootfs_build" = "yes"; then
-	AC_DEFINE([SWUPD_LINUX_ROOTFS],1)
-	AC_DEFINE([MOUNT_POINT],["/"])
-	AC_DEFINE([STATE_DIR],["/var/lib/swupd"])
-	AC_DEFINE([LOG_DIR],["/var/log/swupd"])
-	AC_DEFINE([LOCK_DIR],["/run/lock"])
-	AC_DEFINE([BUNDLES_DIR],["/usr/share/clear/bundles"])
-	AC_DEFINE_UNQUOTED([UPDATE_CA_CERTS_PATH],["$certs_path"])
-	AC_DEFINE([MOTD_FILE],["/usr/lib/motd.d/001-new-release"])
-else
-	AC_MSG_ERROR([Unknown build variant])
-fi
+AS_IF(
+  [test "$enable_linux_rootfs_build" = "yes"],
+  [AC_DEFINE([SWUPD_LINUX_ROOTFS],1)
+     AC_DEFINE([MOUNT_POINT],["/"])
+     AC_DEFINE([STATE_DIR],["/var/lib/swupd"])
+     AC_DEFINE([LOG_DIR],["/var/log/swupd"])
+     AC_DEFINE([LOCK_DIR],["/run/lock"])
+     AC_DEFINE([BUNDLES_DIR],["/usr/share/clear/bundles"])
+     AC_DEFINE_UNQUOTED([UPDATE_CA_CERTS_PATH],["$certs_path"])
+     AC_DEFINE([MOTD_FILE],["/usr/lib/motd.d/001-new-release"])],
+  [AC_MSG_ERROR([Unknown build variant])]
+)
 
 AC_SUBST([update_ca_certs_path], ["$certs_path"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -13,9 +13,21 @@ AM_PROG_CC_C_O
 AC_LANG(C)
 
 AC_CONFIG_HEADERS([config.h])
+
+
+# Library checks
 PKG_CHECK_MODULES([bsdiff], [bsdiff])
 PKG_CHECK_MODULES([lzma], [liblzma])
 PKG_CHECK_MODULES([zlib], [zlib])
+PKG_CHECK_MODULES([curl], [libcurl])
+PKG_CHECK_MODULES([openssl], [libcrypto >= 1.0.1])
+AC_CHECK_LIB([pthread], [pthread_create])
+
+
+# Program checks
+AC_CHECK_PROGS(TAR, tar)
+
+
 AC_ARG_ENABLE(
 	[bzip2],
 	AS_HELP_STRING([--disable-bzip2],[Do not use bzip2 compression (uses bzip2 by default)]),
@@ -179,11 +191,6 @@ AS_IF([test "$enable_tests" != "no"], [
   TESTS="no"
 )
 AM_CONDITIONAL([ENABLE_TESTS], [test "$enable_tests" != "no"])
-
-PKG_CHECK_MODULES([curl], [libcurl])
-PKG_CHECK_MODULES([openssl], [libcrypto >= 1.0.1])
-AC_CHECK_LIB([pthread], [pthread_create])
-AC_CHECK_PROGS(TAR, tar)
 
 # default to Linux rootfs build
 enable_linux_rootfs_build="yes"

--- a/configure.ac
+++ b/configure.ac
@@ -30,19 +30,21 @@ AC_CHECK_PROGS(TAR, tar)
 
 # Enable/disable options
 AC_ARG_ENABLE(
-	[bzip2],
-	AS_HELP_STRING([--disable-bzip2],[Do not use bzip2 compression (uses bzip2 by default)]),
+  [bzip2],
+  [AS_HELP_STRING([--disable-bzip2], [Do not use bzip2 compression (uses bzip2 by default)])]
 )
 BZIP="yes"
-AS_IF([test -n "$enable_bzip2" -a "$enable_bzip2" = "yes"],
-		[BZIP="$enable_bzip2"]
+AS_IF(
+  [test -n "$enable_bzip2" -a "$enable_bzip2" = "yes"],
+  [BZIP="$enable_bzip2"]
 )
-AS_IF([test "x$enable_bzip2" != "xno" ],
-  [AC_DEFINE(SWUPD_WITH_BZIP2,1,[Use bzip2 compression])
-	 AC_CHECK_LIB([bz2], [BZ2_bzBuffToBuffCompress], [], [AC_MSG_ERROR([the libbz2 library is missing])])
-	 BZIP="yes"],
-  [AC_DEFINE(SWUPD_WITHOUT_BZIP2,1,[Do not use bzip2 compression])
-	 BZIP="no"]
+AS_IF(
+  [test "x$enable_bzip2" != "xno"],
+  [AC_DEFINE(SWUPD_WITH_BZIP2, 1, [Use bzip2 compression])
+     AC_CHECK_LIB([bz2], [BZ2_bzBuffToBuffCompress], [], [AC_MSG_ERROR([the libbz2 library is missing])])
+     BZIP="yes"],
+  [AC_DEFINE(SWUPD_WITHOUT_BZIP2, 1, [Do not use bzip2 compression])
+     BZIP="no"]
 )
 
 AC_ARG_ENABLE(
@@ -51,35 +53,43 @@ AC_ARG_ENABLE(
   [AC_DEFINE([SIGNATURES], 1, [Enable signature check as default])]
 )
 SIGVERIFICATION="no"
-AS_IF([test -n "$enable_signature_verification" -a "$enable_signature_verification" = "yes" ],
-		[SIGVERIFICATION="$enable_signature_verification"]
+AS_IF(
+  [test -n "$enable_signature_verification" -a "$enable_signature_verification" = "yes"],
+  [SIGVERIFICATION="$enable_signature_verification"]
 )
 
 AC_ARG_ENABLE(
   [tests],
-  [AS_HELP_STRING([--disable-tests], [Do not enable unit or functional test framework (enabled by default)])],
+  [AS_HELP_STRING([--disable-tests], [Do not enable unit or functional test framework (enabled by default)])]
 )
 TESTS="yes"
-AS_IF([test -n "$enable_tests" -a "$enable_tests" = "yes" ],
-		[TESTS="$enable_tests"]
+AS_IF(
+  [test -n "$enable_tests" -a "$enable_tests" = "yes"],
+  [TESTS="$enable_tests"]
 )
-AS_IF([test "$enable_tests" != "no"], [
-  PKG_CHECK_MODULES([check], [check >= 0.9.12])
-  AC_PATH_PROG([have_python3], [python3])
-  AS_IF([test -z "${have_python3}"], [
-    AC_MSG_ERROR([Must have Python 3 installed to run functional tests])
-  ])
-  AC_PATH_PROG([have_bats], [bats])
-  AS_IF([test -z "${have_bats}"], [
-    AC_MSG_ERROR([Must have the Bash Automated Testing System (bats) installed to run functional tests])
-  ])
-  TESTS="yes"],
-  TESTS="no"
+AS_IF(
+  [test "$enable_tests" != "no"],
+  [PKG_CHECK_MODULES([check], [check >= 0.9.12])
+     AC_PATH_PROG([have_python3], [python3])
+     AS_IF(
+       [test -z "${have_python3}"],
+       [AC_MSG_ERROR([Must have Python 3 installed to run functional tests])]
+     )
+     AC_PATH_PROG([have_bats], [bats])
+     AS_IF(
+       [test -z "${have_bats}"],
+       [AC_MSG_ERROR([Must have the Bash Automated Testing System (bats) installed to run functional tests])]
+     )
+     TESTS="yes"],
+  [TESTS="no"]
 )
 AM_CONDITIONAL([ENABLE_TESTS], [test "$enable_tests" != "no"])
 
 have_coverage=no
-AC_ARG_ENABLE(coverage, AS_HELP_STRING([--enable-coverage], [enable test coverage]))
+AC_ARG_ENABLE(
+  [coverage],
+  [AS_HELP_STRING([--enable-coverage], [enable test coverage])]
+)
 AS_IF(
   [test "$enable_coverage" = "yes"],
   [AC_CHECK_PROG(lcov_found, [lcov], [yes], [no])
@@ -99,43 +109,50 @@ AS_IF(
 AM_CONDITIONAL([COVERAGE], [test "$have_coverage" = "yes"])
 
 AC_ARG_ENABLE(
-	[bsdtar],
-	AS_HELP_STRING([--enable-bsdtar], [Use alternative bsdtar command (uses tar by default)])
+  [bsdtar],
+  [AS_HELP_STRING([--enable-bsdtar], [Use alternative bsdtar command (uses tar by default)])]
 )
-AS_IF([test "x$enable_bsdtar" = "xyes" ],
-	[AC_DEFINE(SWUPD_WITH_BSDTAR, 1, [Use bsdtar])]
+AS_IF(
+  [test "x$enable_bsdtar" = "xyes"],
+  [AC_DEFINE(SWUPD_WITH_BSDTAR, 1, [Use bsdtar])]
 )
 
 dnl Enable extended attribute support
 XATTR="yes"
 AC_ARG_ENABLE(
-	[xattr],
-	AS_HELP_STRING([--enable-xattr],[Use extended file attributes (unused by default)])
+  [xattr],
+  [AS_HELP_STRING([--enable-xattr], [Use extended file attributes (unused by default)])]
 )
-AS_IF([test "x$enable_xattr" = "xyes"],
-	    [AC_DEFINE(SWUPD_WITH_XATTRS,1,[Use extended file attributes])],
-	    [XATTR=no]
+AS_IF(
+  [test "x$enable_xattr" = "xyes"],
+  [AC_DEFINE(SWUPD_WITH_XATTRS, 1, [Use extended file attributes])],
+  [XATTR=no]
 )
 
 TARSELINUX="yes"
-AC_ARG_ENABLE([tar-selinux],
-	AS_HELP_STRING([--enable-tar-selinux],[give --selinux option to tar])
+AC_ARG_ENABLE(
+  [tar-selinux],
+  [AS_HELP_STRING([--enable-tar-selinux], [give --selinux option to tar])]
 )
-AS_IF([test "x$enable_tar_selinux" = "xyes"],
-	    [AC_DEFINE(SWUPD_TAR_SELINUX,1,[give --selinux option to tar])
-	    AS_IF(test "x$XATTR" = "xno",
-	    echo "Must have --enable-xattr to have --enable-tar-selinux" >&2
-	    AS_EXIT(1))],
-	    [TARSELINUX=no]
+AS_IF(
+  [test "x$enable_tar_selinux" = "xyes"],
+  [AC_DEFINE(SWUPD_TAR_SELINUX, 1, [give --selinux option to tar])
+    AS_IF(
+      [test "x$XATTR" = "xno"],
+      [echo "Must have --enable-xattr to have --enable-tar-selinux" >&2
+         AS_EXIT(1)]
+    )],
+  [TARSELINUX=no]
 )
 
 AC_ARG_ENABLE(
-        [stateless],
-        AS_HELP_STRING([--disable-stateless],[OS is not stateless, do not ignore configuration files (stateless by default)])
+  [stateless],
+  [AS_HELP_STRING([--disable-stateless], [OS is not stateless, do not ignore configuration files (stateless by default)])]
 )
-AS_IF([test "x$enable_stateless" = "xno"],
-            [AC_DEFINE(OS_IS_STATELESS,0,[OS is not stateless])],
-            [AC_DEFINE(OS_IS_STATELESS,1,[OS is stateless])]
+AS_IF(
+  [test "x$enable_stateless" = "xno"],
+  [AC_DEFINE(OS_IS_STATELESS, 0, [OS is not stateless])],
+  [AC_DEFINE(OS_IS_STATELESS, 1, [OS is stateless])]
 )
 
 
@@ -146,47 +163,63 @@ AC_ARG_WITH(
   [AC_DEFINE_UNQUOTED([SWUPDCERT], ["$withval"], [swupd verification cert])],
   [AC_DEFINE([SWUPDCERT], ["ClearLinuxRoot.pem"], [swupd verification cert])]
 )
-AS_IF([test -n "$with_swupdcert" -a "$with_swupdcert" != "no" -a "$with_swupdcert" != "yes"],
-		[SWUPDCERT="$with_swupdcert"],
-	[SWUPDCERT="ClearLinuxRoot.pem"]
+AS_IF(
+  [test -n "$with_swupdcert" -a "$with_swupdcert" != "no" -a "$with_swupdcert" != "yes"],
+  [SWUPDCERT="$with_swupdcert"],
+  [SWUPDCERT="ClearLinuxRoot.pem"]
 )
 
-AC_ARG_WITH([contenturl],
-	[AS_HELP_STRING([--with-contenturl=URL], [Default content url])],
-	  [AC_DEFINE_UNQUOTED([CONTENTURL], ["$withval"], [Default content url])]
+AC_ARG_WITH(
+  [contenturl],
+  [AS_HELP_STRING([--with-contenturl=URL], [Default content url])],
+  [AC_DEFINE_UNQUOTED([CONTENTURL], ["$withval"], [Default content url])]
 )
-AS_IF([test -n "$with_contenturl" -a "$with_contenturl" != "no" -a "$with_contenturl" != "yes"],
-		[CONTENTURL="$with_contenturl"],
-	[test "$with_contenturl" = "no"],	[CONTENTURL='!! Warning !! --with-contenturl not specified!'],
-	[test "$with_contenturl" = "yes"],	[CONTENTURL='!! Warning !! --with-contenturl not specified!'],
-	[CONTENTURL='!! Warning !! --with-contenturl not specified!']
-)
-
-AC_ARG_WITH([versionurl],
-	[AS_HELP_STRING([--with-versionurl=URL], [Default version url])],
-	[AC_DEFINE_UNQUOTED([VERSIONURL], ["$withval"], [Default version url])]
-)
-AS_IF([test -n "$with_versionurl" -a "$with_versionurl" != "no" -a "$with_versionurl" != "yes"],
-		[VERSIONURL="$with_versionurl"],
-	[test "$with_versionurl" = "no"],	[VERSIONURL='!! Warning !! --with-versionurl not specified!'],
-	[test "$with_versionurl" = "yes"],	[VERSIONURL='!! Warning !! --with-versionurl not specified!'],
-	[VERSIONURL='!! Warning !! --with-versionurl not specified!']
+AS_IF(
+  [test -n "$with_contenturl" -a "$with_contenturl" != "no" -a "$with_contenturl" != "yes"],
+  [CONTENTURL="$with_contenturl"],
+  [test "$with_contenturl" = "no"],
+  [CONTENTURL='!! Warning !! --with-contenturl not specified!'],
+  [test "$with_contenturl" = "yes"],
+  [CONTENTURL='!! Warning !! --with-contenturl not specified!'],
+  [CONTENTURL='!! Warning !! --with-contenturl not specified!']
 )
 
-AC_ARG_WITH([formatid],
-	[AS_HELP_STRING([--with-formatid=NUM], [Default format identifier])],
-	[AC_DEFINE_UNQUOTED([FORMATID], ["$withval"], [Default format identifier])]
+AC_ARG_WITH(
+  [versionurl],
+  [AS_HELP_STRING([--with-versionurl=URL], [Default version url])],
+  [AC_DEFINE_UNQUOTED([VERSIONURL], ["$withval"], [Default version url])]
 )
-AS_IF([test -n "$with_formatid" -a "$with_formatid" != "no" -a "$with_formatid" != "yes"],
-		[FORMATID="$with_formatid"],
-	[test "$with_formatid" = "no"],	[FORMATID='!! Warning !! --with-formatid not specified!'],
-	[test "$with_formatid" = "yes"],	[FORMATID='!! Warning !! --with-formatid not specified!'],
-	[FORMATID='!! Warning !! --with-formatid not specified!']
+AS_IF(
+  [test -n "$with_versionurl" -a "$with_versionurl" != "no" -a "$with_versionurl" != "yes"],
+  [VERSIONURL="$with_versionurl"],
+  [test "$with_versionurl" = "no"],
+  [VERSIONURL='!! Warning !! --with-versionurl not specified!'],
+  [test "$with_versionurl" = "yes"],
+  [VERSIONURL='!! Warning !! --with-versionurl not specified!'],
+  [VERSIONURL='!! Warning !! --with-versionurl not specified!']
 )
 
-AC_ARG_WITH([systemdsystemunitdir], AS_HELP_STRING([--with-systemdsystemunitdir=DIR],
-            [path to systemd system service dir @<:@default=/usr/lib/systemd/system@:>@]), [unitpath=${withval}],
-            [unitpath="$($PKG_CONFIG --variable=systemdsystemunitdir systemd)"])
+AC_ARG_WITH(
+  [formatid],
+  [AS_HELP_STRING([--with-formatid=NUM], [Default format identifier])],
+  [AC_DEFINE_UNQUOTED([FORMATID], ["$withval"], [Default format identifier])]
+)
+AS_IF(
+  [test -n "$with_formatid" -a "$with_formatid" != "no" -a "$with_formatid" != "yes"],
+  [FORMATID="$with_formatid"],
+  [test "$with_formatid" = "no"],
+  [FORMATID='!! Warning !! --with-formatid not specified!'],
+  [test "$with_formatid" = "yes"],
+  [FORMATID='!! Warning !! --with-formatid not specified!'],
+  [FORMATID='!! Warning !! --with-formatid not specified!']
+)
+
+AC_ARG_WITH(
+  [systemdsystemunitdir],
+  [AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [path to systemd system service dir @<:@default=/usr/lib/systemd/system@:>@])],
+  [unitpath=${withval}],
+  [unitpath="$($PKG_CONFIG --variable=systemdsystemunitdir systemd)"]
+)
 AS_IF(
   [test -z "${unitpath}"],
   [unitpath=/usr/lib/systemd/system]
@@ -201,28 +234,28 @@ certs_path="/usr/share/clear/update-ca"
 
 # document all options for build variants
 ## (1) build variants
-AH_TEMPLATE([SWUPD_LINUX_ROOTFS],[Enable Linux rootfs build variant])
+AH_TEMPLATE([SWUPD_LINUX_ROOTFS], [Enable Linux rootfs build variant])
 ## (2) variant features
-AH_TEMPLATE([SWUPD_WITH_BINDMNTS],[cope with bind mounts over rootfs])
+AH_TEMPLATE([SWUPD_WITH_BINDMNTS], [cope with bind mounts over rootfs])
 ## (3) variant extra options
-AH_TEMPLATE([MOUNT_POINT],[The mount point])
-AH_TEMPLATE([STATE_DIR],[The state directory for swupd content])
-AH_TEMPLATE([LOG_DIR],[Directory for swupd log files])
-AH_TEMPLATE([LOCK_DIR],[Directory for lock file])
-AH_TEMPLATE([BUNDLES_DIR],[Directory to use for bundles])
-AH_TEMPLATE([UPDATE_CA_CERTS_PATH],[Location of CA certificates])
-AH_TEMPLATE([MOTD_FILE],[motd file path])
+AH_TEMPLATE([MOUNT_POINT], [The mount point])
+AH_TEMPLATE([STATE_DIR], [The state directory for swupd content])
+AH_TEMPLATE([LOG_DIR], [Directory for swupd log files])
+AH_TEMPLATE([LOCK_DIR], [Directory for lock file])
+AH_TEMPLATE([BUNDLES_DIR], [Directory to use for bundles])
+AH_TEMPLATE([UPDATE_CA_CERTS_PATH], [Location of CA certificates])
+AH_TEMPLATE([MOTD_FILE], [motd file path])
 
 AS_IF(
   [test "$enable_linux_rootfs_build" = "yes"],
-  [AC_DEFINE([SWUPD_LINUX_ROOTFS],1)
-     AC_DEFINE([MOUNT_POINT],["/"])
-     AC_DEFINE([STATE_DIR],["/var/lib/swupd"])
-     AC_DEFINE([LOG_DIR],["/var/log/swupd"])
-     AC_DEFINE([LOCK_DIR],["/run/lock"])
-     AC_DEFINE([BUNDLES_DIR],["/usr/share/clear/bundles"])
-     AC_DEFINE_UNQUOTED([UPDATE_CA_CERTS_PATH],["$certs_path"])
-     AC_DEFINE([MOTD_FILE],["/usr/lib/motd.d/001-new-release"])],
+  [AC_DEFINE([SWUPD_LINUX_ROOTFS], 1)
+     AC_DEFINE([MOUNT_POINT], ["/"])
+     AC_DEFINE([STATE_DIR], ["/var/lib/swupd"])
+     AC_DEFINE([LOG_DIR], ["/var/log/swupd"])
+     AC_DEFINE([LOCK_DIR], ["/run/lock"])
+     AC_DEFINE([BUNDLES_DIR], ["/usr/share/clear/bundles"])
+     AC_DEFINE_UNQUOTED([UPDATE_CA_CERTS_PATH], ["$certs_path"])
+     AC_DEFINE([MOTD_FILE], ["/usr/lib/motd.d/001-new-release"])],
   [AC_MSG_ERROR([Unknown build variant])]
 )
 

--- a/configure.ac
+++ b/configure.ac
@@ -140,12 +140,12 @@ AS_IF([test "x$enable_stateless" = "xno"],
 
 
 # With/without options
-if test "$enable_signature_verification" = "yes" ; then
-	AC_ARG_WITH([swupdcert],
-		[AS_HELP_STRING([--with-swupdcert=FILE], [swupd verification cert])],
-		[AC_DEFINE_UNQUOTED([SWUPDCERT], ["$withval"], [swupd verification cert])],
-		[AC_DEFINE([SWUPDCERT], ["ClearLinuxRoot.pem"], [swupd verification cert])])
-fi
+AC_ARG_WITH(
+  [swupdcert],
+  [AS_HELP_STRING([--with-swupdcert=FILE], [swupd verification cert])],
+  [AC_DEFINE_UNQUOTED([SWUPDCERT], ["$withval"], [swupd verification cert])],
+  [AC_DEFINE([SWUPDCERT], ["ClearLinuxRoot.pem"], [swupd verification cert])]
+)
 AS_IF([test -n "$with_swupdcert" -a "$with_swupdcert" != "no" -a "$with_swupdcert" != "yes"],
 		[SWUPDCERT="$with_swupdcert"],
 	[SWUPDCERT="ClearLinuxRoot.pem"]

--- a/configure.ac
+++ b/configure.ac
@@ -28,16 +28,15 @@ AC_CHECK_LIB([pthread], [pthread_create])
 AC_CHECK_PROGS(TAR, tar)
 
 
+# Enable/disable options
 AC_ARG_ENABLE(
 	[bzip2],
 	AS_HELP_STRING([--disable-bzip2],[Do not use bzip2 compression (uses bzip2 by default)]),
 )
-
 BZIP="yes"
 AS_IF([test -n "$enable_bzip2" -a "$enable_bzip2" = "yes"],
 		[BZIP="$enable_bzip2"]
 )
-
 AS_IF([test "x$enable_bzip2" != "xno" ],
   [AC_DEFINE(SWUPD_WITH_BZIP2,1,[Use bzip2 compression])
 	 AC_CHECK_LIB([bz2], [BZ2_bzBuffToBuffCompress], [], [AC_MSG_ERROR([the libbz2 library is missing])])
@@ -45,74 +44,39 @@ AS_IF([test "x$enable_bzip2" != "xno" ],
   [AC_DEFINE(SWUPD_WITHOUT_BZIP2,1,[Do not use bzip2 compression])
 	 BZIP="no"]
 )
+
 AC_ARG_ENABLE(
   [signature-verification],
   [AS_HELP_STRING([--enable-signature-verification], [Enable signature check (disabled by default)])],
   [AC_DEFINE([SIGNATURES], 1, [Enable signature check as default])]
 )
-
 SIGVERIFICATION="no"
 AS_IF([test -n "$enable_signature_verification" -a "$enable_signature_verification" = "yes" ],
 		[SIGVERIFICATION="$enable_signature_verification"]
-)
-
-if test "$enable_signature_verification" = "yes" ; then
-	AC_ARG_WITH([swupdcert],
-		[AS_HELP_STRING([--with-swupdcert=FILE], [swupd verification cert])],
-		[AC_DEFINE_UNQUOTED([SWUPDCERT], ["$withval"], [swupd verification cert])],
-		[AC_DEFINE([SWUPDCERT], ["ClearLinuxRoot.pem"], [swupd verification cert])])
-fi
-
-AS_IF([test -n "$with_swupdcert" -a "$with_swupdcert" != "no" -a "$with_swupdcert" != "yes"],
-		[SWUPDCERT="$with_swupdcert"],
-	[SWUPDCERT="ClearLinuxRoot.pem"]
-)
-
-AC_ARG_WITH([contenturl],
-	[AS_HELP_STRING([--with-contenturl=URL], [Default content url])],
-	  [AC_DEFINE_UNQUOTED([CONTENTURL], ["$withval"], [Default content url])]
-)
-
-AS_IF([test -n "$with_contenturl" -a "$with_contenturl" != "no" -a "$with_contenturl" != "yes"],
-		[CONTENTURL="$with_contenturl"],
-	[test "$with_contenturl" = "no"],	[CONTENTURL='!! Warning !! --with-contenturl not specified!'],
-	[test "$with_contenturl" = "yes"],	[CONTENTURL='!! Warning !! --with-contenturl not specified!'],
-	[CONTENTURL='!! Warning !! --with-contenturl not specified!']
-)
-
-AC_ARG_WITH([versionurl],
-	[AS_HELP_STRING([--with-versionurl=URL], [Default version url])],
-	[AC_DEFINE_UNQUOTED([VERSIONURL], ["$withval"], [Default version url])]
-)
-
-AS_IF([test -n "$with_versionurl" -a "$with_versionurl" != "no" -a "$with_versionurl" != "yes"],
-		[VERSIONURL="$with_versionurl"],
-	[test "$with_versionurl" = "no"],	[VERSIONURL='!! Warning !! --with-versionurl not specified!'],
-	[test "$with_versionurl" = "yes"],	[VERSIONURL='!! Warning !! --with-versionurl not specified!'],
-	[VERSIONURL='!! Warning !! --with-versionurl not specified!']
-)
-
-AC_ARG_WITH([formatid],
-	[AS_HELP_STRING([--with-formatid=NUM], [Default format identifier])],
-	[AC_DEFINE_UNQUOTED([FORMATID], ["$withval"], [Default format identifier])]
-)
-
-AS_IF([test -n "$with_formatid" -a "$with_formatid" != "no" -a "$with_formatid" != "yes"],
-		[FORMATID="$with_formatid"],
-	[test "$with_formatid" = "no"],	[FORMATID='!! Warning !! --with-formatid not specified!'],
-	[test "$with_formatid" = "yes"],	[FORMATID='!! Warning !! --with-formatid not specified!'],
-	[FORMATID='!! Warning !! --with-formatid not specified!']
 )
 
 AC_ARG_ENABLE(
   [tests],
   [AS_HELP_STRING([--disable-tests], [Do not enable unit or functional test framework (enabled by default)])],
 )
-
 TESTS="yes"
 AS_IF([test -n "$enable_tests" -a "$enable_tests" = "yes" ],
 		[TESTS="$enable_tests"]
 )
+AS_IF([test "$enable_tests" != "no"], [
+  PKG_CHECK_MODULES([check], [check >= 0.9.12])
+  AC_PATH_PROG([have_python3], [python3])
+  AS_IF([test -z "${have_python3}"], [
+    AC_MSG_ERROR([Must have Python 3 installed to run functional tests])
+  ])
+  AC_PATH_PROG([have_bats], [bats])
+  AS_IF([test -z "${have_bats}"], [
+    AC_MSG_ERROR([Must have the Bash Automated Testing System (bats) installed to run functional tests])
+  ])
+  TESTS="yes"],
+  TESTS="no"
+)
+AM_CONDITIONAL([ENABLE_TESTS], [test "$enable_tests" != "no"])
 
 have_coverage=no
 AC_ARG_ENABLE(coverage, AS_HELP_STRING([--enable-coverage], [enable test coverage]))
@@ -140,6 +104,7 @@ AC_ARG_ENABLE(
 AS_IF([test "x$enable_bsdtar" = "xyes" ],
 	[AC_DEFINE(SWUPD_WITH_BSDTAR, 1, [Use bsdtar])]
 )
+
 dnl Enable extended attribute support
 XATTR="yes"
 AC_ARG_ENABLE(
@@ -150,6 +115,7 @@ AS_IF([test "x$enable_xattr" = "xyes"],
 	    [AC_DEFINE(SWUPD_WITH_XATTRS,1,[Use extended file attributes])],
 	    [XATTR=no]
 )
+
 TARSELINUX="yes"
 AC_ARG_ENABLE([tar-selinux],
 	AS_HELP_STRING([--enable-tar-selinux],[give --selinux option to tar])
@@ -171,27 +137,60 @@ AS_IF([test "x$enable_stateless" = "xno"],
             [AC_DEFINE(OS_IS_STATELESS,1,[OS is stateless])]
 )
 
+
+# With/without options
+if test "$enable_signature_verification" = "yes" ; then
+	AC_ARG_WITH([swupdcert],
+		[AS_HELP_STRING([--with-swupdcert=FILE], [swupd verification cert])],
+		[AC_DEFINE_UNQUOTED([SWUPDCERT], ["$withval"], [swupd verification cert])],
+		[AC_DEFINE([SWUPDCERT], ["ClearLinuxRoot.pem"], [swupd verification cert])])
+fi
+AS_IF([test -n "$with_swupdcert" -a "$with_swupdcert" != "no" -a "$with_swupdcert" != "yes"],
+		[SWUPDCERT="$with_swupdcert"],
+	[SWUPDCERT="ClearLinuxRoot.pem"]
+)
+
+AC_ARG_WITH([contenturl],
+	[AS_HELP_STRING([--with-contenturl=URL], [Default content url])],
+	  [AC_DEFINE_UNQUOTED([CONTENTURL], ["$withval"], [Default content url])]
+)
+AS_IF([test -n "$with_contenturl" -a "$with_contenturl" != "no" -a "$with_contenturl" != "yes"],
+		[CONTENTURL="$with_contenturl"],
+	[test "$with_contenturl" = "no"],	[CONTENTURL='!! Warning !! --with-contenturl not specified!'],
+	[test "$with_contenturl" = "yes"],	[CONTENTURL='!! Warning !! --with-contenturl not specified!'],
+	[CONTENTURL='!! Warning !! --with-contenturl not specified!']
+)
+
+AC_ARG_WITH([versionurl],
+	[AS_HELP_STRING([--with-versionurl=URL], [Default version url])],
+	[AC_DEFINE_UNQUOTED([VERSIONURL], ["$withval"], [Default version url])]
+)
+AS_IF([test -n "$with_versionurl" -a "$with_versionurl" != "no" -a "$with_versionurl" != "yes"],
+		[VERSIONURL="$with_versionurl"],
+	[test "$with_versionurl" = "no"],	[VERSIONURL='!! Warning !! --with-versionurl not specified!'],
+	[test "$with_versionurl" = "yes"],	[VERSIONURL='!! Warning !! --with-versionurl not specified!'],
+	[VERSIONURL='!! Warning !! --with-versionurl not specified!']
+)
+
+AC_ARG_WITH([formatid],
+	[AS_HELP_STRING([--with-formatid=NUM], [Default format identifier])],
+	[AC_DEFINE_UNQUOTED([FORMATID], ["$withval"], [Default format identifier])]
+)
+AS_IF([test -n "$with_formatid" -a "$with_formatid" != "no" -a "$with_formatid" != "yes"],
+		[FORMATID="$with_formatid"],
+	[test "$with_formatid" = "no"],	[FORMATID='!! Warning !! --with-formatid not specified!'],
+	[test "$with_formatid" = "yes"],	[FORMATID='!! Warning !! --with-formatid not specified!'],
+	[FORMATID='!! Warning !! --with-formatid not specified!']
+)
+
 AC_ARG_WITH([systemdsystemunitdir], AS_HELP_STRING([--with-systemdsystemunitdir=DIR],
             [path to systemd system service dir @<:@default=/usr/lib/systemd/system@:>@]), [unitpath=${withval}],
             [unitpath="$($PKG_CONFIG --variable=systemdsystemunitdir systemd)"])
 test -z "${unitpath}" && unitpath=/usr/lib/systemd/system
 AC_SUBST(SYSTEMD_UNITDIR, [${unitpath}])
 
-AS_IF([test "$enable_tests" != "no"], [
-  PKG_CHECK_MODULES([check], [check >= 0.9.12])
-  AC_PATH_PROG([have_python3], [python3])
-  AS_IF([test -z "${have_python3}"], [
-    AC_MSG_ERROR([Must have Python 3 installed to run functional tests])
-  ])
-  AC_PATH_PROG([have_bats], [bats])
-  AS_IF([test -z "${have_bats}"], [
-    AC_MSG_ERROR([Must have the Bash Automated Testing System (bats) installed to run functional tests])
-  ])
-  TESTS="yes"],
-  TESTS="no"
-)
-AM_CONDITIONAL([ENABLE_TESTS], [test "$enable_tests" != "no"])
 
+# Build variants
 # default to Linux rootfs build
 enable_linux_rootfs_build="yes"
 certs_path="/usr/share/clear/update-ca"

--- a/configure.ac
+++ b/configure.ac
@@ -158,6 +158,27 @@ AS_IF(
 
 # With/without options
 AC_ARG_WITH(
+  [certpath],
+  [AS_HELP_STRING([--with-certpath=PATH], [Location of CA certificates])]
+)
+default_cert_path="/usr/share/clear/update-ca"
+cert_path=
+# Makes sure --with-certpath receives an argument that is not "yes" or "no",
+# and uses the default path if only --enable-signature-verification is passed.
+AS_IF(
+  [test "$enable_signature_verification" = "yes" && test "$with_certpath" = "no"],
+  [AC_MSG_ERROR(['--with-certpath=no' or '--without-certpath' not supported. Specify a PATH.])],
+  [test "$enable_signature_verification" = "yes" && test "$with_certpath" = "yes"],
+  [AC_MSG_ERROR(['--with-certpath=yes' or '--with-certpath' not supported. Specify a PATH.])],
+  [test "$enable_signature_verification" != "yes" && test -n "$with_certpath"],
+  [AC_MSG_WARN([--with-certpath=PATH requires --enable-signature-verification])],
+  [test "$enable_signature_verification" = "yes" && test -n "$with_certpath"],
+  [cert_path="$with_certpath"],
+  [test "$enable_signature_verification" = "yes"],
+  [cert_path="$default_cert_path"]
+)
+
+AC_ARG_WITH(
   [swupdcert],
   [AS_HELP_STRING([--with-swupdcert=FILE], [swupd verification cert])],
   [AC_DEFINE_UNQUOTED([SWUPDCERT], ["$withval"], [swupd verification cert])],
@@ -230,7 +251,6 @@ AC_SUBST(SYSTEMD_UNITDIR, [${unitpath}])
 # Build variants
 # default to Linux rootfs build
 enable_linux_rootfs_build="yes"
-certs_path="/usr/share/clear/update-ca"
 
 # document all options for build variants
 ## (1) build variants
@@ -243,7 +263,7 @@ AH_TEMPLATE([STATE_DIR], [The state directory for swupd content])
 AH_TEMPLATE([LOG_DIR], [Directory for swupd log files])
 AH_TEMPLATE([LOCK_DIR], [Directory for lock file])
 AH_TEMPLATE([BUNDLES_DIR], [Directory to use for bundles])
-AH_TEMPLATE([UPDATE_CA_CERTS_PATH], [Location of CA certificates])
+AH_TEMPLATE([CERT_PATH], [Location of CA certificates])
 AH_TEMPLATE([MOTD_FILE], [motd file path])
 
 AS_IF(
@@ -254,12 +274,12 @@ AS_IF(
      AC_DEFINE([LOG_DIR], ["/var/log/swupd"])
      AC_DEFINE([LOCK_DIR], ["/run/lock"])
      AC_DEFINE([BUNDLES_DIR], ["/usr/share/clear/bundles"])
-     AC_DEFINE_UNQUOTED([UPDATE_CA_CERTS_PATH], ["$certs_path"])
+     AC_DEFINE_UNQUOTED([CERT_PATH], ["$cert_path"])
      AC_DEFINE([MOTD_FILE], ["/usr/lib/motd.d/001-new-release"])],
   [AC_MSG_ERROR([Unknown build variant])]
 )
 
-AC_SUBST([update_ca_certs_path], ["$certs_path"])
+AC_SUBST([cert_path], ["$cert_path"])
 
 AC_CONFIG_FILES([Makefile data/check-update.service data/swupd-update.service])
 AC_REQUIRE_AUX_FILE([tap-driver.sh])
@@ -277,6 +297,7 @@ Configuration to build swupd-client:
   Version URL:				${VERSIONURL}
   Format Identifier:			${FORMATID}
   Signature verification:		${SIGVERIFICATION}
+  CA certificate path:			${cert_path}
   SSL Certificate file:			${SWUPDCERT}
   Use bzip compression:			${BZIP}
   Run Tests:				${TESTS}

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -134,10 +134,12 @@ extern char *state_dir;
 
 extern char *version_url;
 extern char *content_url;
+extern char *cert_path;
 extern long update_server_port;
 extern bool set_path_prefix(char *path);
 extern int set_content_url(char *url);
 extern int set_version_url(char *url);
+extern void set_cert_path(char *path);
 extern bool set_state_dir(char *path);
 
 extern void check_root(void);

--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -53,6 +53,7 @@ static void print_help(const char *name)
 	printf("   -l, --list              List all available bundles for the current version of Clear Linux\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
+	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
 	printf("\n");
 }
 
@@ -67,6 +68,7 @@ static const struct option prog_opts[] = {
 	{ "format", required_argument, 0, 'F' },
 	{ "force", no_argument, 0, 'x' },
 	{ "statedir", required_argument, 0, 'S' },
+	{ "certpath", required_argument, 0, 'C' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -74,7 +76,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxu:c:v:P:p:F:lS:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxu:c:v:P:p:F:lS:C:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -131,6 +133,13 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'x':
 			force = true;
+			break;
+		case 'C':
+			if (!optarg) {
+				printf("Invalid --certpath argument\n\n");
+				goto err;
+			}
+			set_cert_path(optarg);
 			break;
 		default:
 			printf("error: unrecognized option\n\n");

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -52,6 +52,7 @@ static void print_help(const char *name)
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
+	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
 	printf("\n");
 }
 
@@ -65,6 +66,7 @@ static const struct option prog_opts[] = {
 	{ "format", required_argument, 0, 'F' },
 	{ "force", no_argument, 0, 'x' },
 	{ "statedir", required_argument, 0, 'S' },
+	{ "certpath", required_argument, 0, 'C' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -72,7 +74,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxp:u:c:v:P:F:S:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxp:u:c:v:P:F:S:C:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -126,6 +128,13 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'x':
 			force = true;
+			break;
+		case 'C':
+			if (!optarg) {
+				printf("Invalid --certpath argument\n\n");
+				goto err;
+			}
+			set_cert_path(optarg);
 			break;
 		default:
 			printf("error: unrecognized option\n\n");

--- a/src/globals.c
+++ b/src/globals.c
@@ -63,6 +63,7 @@ bool have_manifest_diskspace = false; /* assume no until checked */
 bool have_network = false;	    /* assume no access until proved */
 char *version_url = NULL;
 char *content_url = NULL;
+char *cert_path = NULL;
 long update_server_port = -1;
 
 static const char *default_version_url_path = "/usr/share/defaults/swupd/versionurl";
@@ -312,6 +313,31 @@ bool set_path_prefix(char *path)
 	return true;
 }
 
+/* Initializes the cert_path global variable. If the path parameter is not
+ * NULL, cert_path will be set to its value. Otherwise, the default build-time
+ * value is used (CERT_PATH). Note that only the first call to this function
+ * sets the variable.
+ */
+#ifdef SIGNATURES
+void set_cert_path(char *path) {
+	// Early exit if the function was called previously.
+	if (cert_path) {
+		return;
+	}
+
+	if (path) {
+		string_or_die(&cert_path, "%s", path);
+	} else {
+		// CERT_PATH is guaranteed to be valid at this point.
+		string_or_die(&cert_path, "%s", CERT_PATH);
+	}
+}
+#else
+void set_cert_path(char UNUSED_PARAM *path) {
+	return;
+}
+#endif
+
 bool init_globals(void)
 {
 	int ret;
@@ -378,6 +404,10 @@ bool init_globals(void)
 
 	/* must set this global after version_url and content_url */
 	set_local_download();
+
+#ifdef SIGNATURES
+	set_cert_path(NULL);
+#endif
 
 	return true;
 }

--- a/src/globals.c
+++ b/src/globals.c
@@ -133,6 +133,10 @@ static int set_url(char **global, char *url, const char *path)
 	return ret;
 }
 
+/* Initializes the content_url global variable. If the url parameter is not
+ * NULL, content_url will be set to its value. Otherwise, the value is read
+ * from the 'contenturl' configuration file.
+ */
 int set_content_url(char *url)
 {
 	if (content_url) {
@@ -143,6 +147,10 @@ int set_content_url(char *url)
 	return set_url(&content_url, url, default_content_url_path);
 }
 
+/* Initializes the version_url global variable. If the url parameter is not
+ * NULL, version_url will be set to its value. Otherwise, the value is read
+ * from the 'versionurl' configuration file.
+ */
 int set_version_url(char *url)
 {
 	if (version_url) {
@@ -166,6 +174,10 @@ static bool is_valid_integer_format(char *str)
 	return true;
 }
 
+/* Initializes the state_dir global variable. If the path parameter is not
+ * NULL, state_dir will be set to its value. Otherwise, the value is the
+ * build-time default (STATE_DIR).
+ */
 bool set_state_dir(char *path)
 {
 	if (path) {
@@ -189,6 +201,11 @@ bool set_state_dir(char *path)
 	return true;
 }
 
+/* Initializes the format_string global variable. If the userinput parameter is
+ * not NULL, format_string will be set to its value, but only if it is a
+ * positive integer or the special value "staging". Otherwise, the value is
+ * read from the 'format' configuration file.
+ */
 bool set_format_string(char *userinput)
 {
 	int ret;
@@ -229,8 +246,10 @@ bool set_format_string(char *userinput)
 	return true;
 }
 
-/* Passing NULL for PATH will either use the last --path argument given on the command
- * line, or sets the default value ("/").
+/* Initializes the path_prefix global variable. If the path parameter is not
+ * NULL, path_prefix will be set to its value, but only if it is a positive
+ * integer or the special value "staging". Otherwise, the default value of '/'
+ * is used. Note that the given path must exist.
  */
 bool set_path_prefix(char *path)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -47,6 +47,7 @@ static const struct option prog_opts[] = {
 	{ "path", required_argument, 0, 'p' },
 	{ "force", no_argument, 0, 'x' },
 	{ "statedir", required_argument, 0, 'S' },
+	{ "certpath", required_argument, 0, 'C' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -70,6 +71,7 @@ static void print_help(const char *name)
 	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
+	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
 	printf("\n");
 }
 
@@ -77,7 +79,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxdu:P:c:v:sF:p:S:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxdu:P:c:v:sF:p:S:C:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -137,6 +139,13 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'x':
 			force = true;
+			break;
+		case 'C':
+			if (!optarg) {
+				printf("Invalid --certpath argument\n\n");
+				goto err;
+			}
+			set_cert_path(optarg);
 			break;
 		default:
 			printf("Unrecognized option\n\n");

--- a/src/search.c
+++ b/src/search.c
@@ -72,6 +72,7 @@ static void print_help(const char *name)
 	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
+	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
 
 	printf("\nResults format:\n");
 	printf(" 'Bundle Name'  :  'File matching search term'\n\n");
@@ -92,6 +93,7 @@ static const struct option prog_opts[] = {
 	{ "init", no_argument, 0, 'i' },
 	{ "display-files", no_argument, 0, 'd' },
 	{ "statedir", required_argument, 0, 'S' },
+	{ "certpath", required_argument, 0, 'C' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -99,7 +101,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hu:c:v:P:p:F:s:lbidS:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hu:c:v:P:p:F:s:lbidS:C:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -187,6 +189,13 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'd':
 			display_files = true;
+			break;
+		case 'C':
+			if (!optarg) {
+				printf("Invalid --certpath argument\n\n");
+				goto err;
+			}
+			set_cert_path(optarg);
 			break;
 		default:
 			printf("Error: unrecognized option: -'%c',\n\n", opt);

--- a/src/signature.c
+++ b/src/signature.c
@@ -42,7 +42,7 @@
 
 #ifdef SIGNATURES
 
-#define CERTNAME UPDATE_CA_CERTS_PATH "/" SWUPDCERT
+#define CERTNAME CERT_PATH "/" SWUPDCERT
 
 static bool validate_certificate(void);
 static int verify_callback(int, X509_STORE_CTX *);

--- a/src/signature.c
+++ b/src/signature.c
@@ -42,7 +42,7 @@
 
 #ifdef SIGNATURES
 
-#define CERTNAME CERT_PATH "/" SWUPDCERT
+static char *CERTNAME;
 
 static bool validate_certificate(void);
 static int verify_callback(int, X509_STORE_CTX *);
@@ -64,6 +64,8 @@ static char *crl = NULL;
  * returns: true if can initialize and validate certificates, otherwise false */
 bool initialize_signature(void)
 {
+	string_or_die(&CERTNAME, "%s/%s", cert_path, SWUPDCERT);
+
 	ERR_load_crypto_strings();
 	ERR_load_PKCS7_strings();
 	EVP_add_digest(EVP_sha256());

--- a/src/verify.c
+++ b/src/verify.c
@@ -68,6 +68,7 @@ static const struct option prog_opts[] = {
 	{ "quick", no_argument, 0, 'q' },
 	{ "force", no_argument, 0, 'x' },
 	{ "statedir", required_argument, 0, 'S' },
+	{ "certpath", required_argument, 0, 'C' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -90,6 +91,7 @@ static void print_help(const char *name)
 	printf("   -q, --quick             Don't compare hashes, only fix missing files\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
+	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
 	printf("\n");
 }
 
@@ -97,7 +99,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxm:p:u:P:c:v:fiF:qS:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxm:p:u:P:c:v:fiF:qS:C:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -169,6 +171,13 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'x':
 			force = true;
+			break;
+		case 'C':
+			if (!optarg) {
+				printf("Invalid --certpath argument\n\n");
+				goto err;
+			}
+			set_cert_path(optarg);
 			break;
 		default:
 			printf("Unrecognized option\n\n");


### PR DESCRIPTION
To better support running the functional test suite with signature
verification enabled, make the certificate location configurable. Note
that the basename of the certificate used for verification can be
configured separately with the --with-swupdcert=NAME option.