### PR TITLE
Some error handling improvements; miscellaneous cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,9 +45,13 @@ swupd_*
 tap-driver.sh
 test-suite.log
 test/*.gcno
+test/functional/ClearLinuxRoot.pem
+test/functional/private.pem
+test/functional/*.log
 test/functional/*/*/web-dir/*/*.tar
 test/functional/*/*/web-dir/*/staged/*.tar
 test/functional/*/*/web-dir/*/files/*.tar
+test/functional/*/*/web-dir/*/Manifest.MoM.sig
 test/functional/*/*/test.log
 test/functional/*/*/state
 test/functional/*/*/lines-output

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ swupd
 swupd-client*tar.gz
 swupd_*
 tap-driver.sh
+test-driver
 test-suite.log
 test/*.gcno
 test/functional/ClearLinuxRoot.pem

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -73,7 +73,7 @@ int list_installable_bundles()
 	MoM = load_mom(current_version);
 	if (!MoM) {
 		v_lockfile(lock_fd);
-		return ret;
+		return EMOM_NOTFOUND;
 	}
 
 	list = MoM->manifests;

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -58,7 +58,7 @@ int list_installable_bundles()
 	if (!check_network()) {
 		printf("Error: Network issue, unable to download manifest\n");
 		v_lockfile(lock_fd);
-		return EXIT_FAILURE;
+		return ENOSWUPDSERVER;
 	}
 
 	current_version = get_current_version(path_prefix);

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -162,7 +162,7 @@ int check_update_main(int argc, char **argv)
 	copyright_header("software update checker");
 
 	if (!parse_options(argc, argv)) {
-		return EXIT_FAILURE;
+		return EINVALID_OPTION;
 	}
 
 	ret = check_update();

--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -167,7 +167,7 @@ int bundle_add_main(int argc, char **argv)
 	copyright_header("bundle adder");
 
 	if (!parse_options(argc, argv)) {
-		return EXIT_FAILURE;
+		return EINVALID_OPTION;
 	}
 
 	if (list) {

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -71,8 +71,8 @@ int rm_staging_dir_contents(const char *rel_path)
 		return -1;
 	}
 
-	errno = 0;
 	while(true) {
+		errno = 0;
 		entry = readdir(dir);
 		if (!entry) {
 			/* readdir returns NULL on the end of a directory stream, we only
@@ -394,8 +394,8 @@ static int swupd_rm_dir(const char *path)
 		}
 	}
 
-	errno = 0;
 	while (true) {
+		errno = 0;
 		entry = readdir(dir);
 		if (!entry) {
 			if (!errno) {

--- a/src/main.c
+++ b/src/main.c
@@ -208,7 +208,7 @@ int update_main(int argc, char **argv)
 	copyright_header("software update");
 
 	if (!parse_options(argc, argv)) {
-		return EXIT_FAILURE;
+		return EINVALID_OPTION;
 	}
 
 	if (cmd_line_status) {

--- a/src/packs.c
+++ b/src/packs.c
@@ -85,7 +85,12 @@ static int download_pack(int oldversion, int newversion, char *module)
 		fclose(tarfile);
 	}
 
-	return err;
+	// Only negative return values should indicate errors
+	if (err > 0) {
+		return -err;
+	} else {
+		return err;
+	}
 }
 
 /* pull in packs for base and any subscription */

--- a/src/search.c
+++ b/src/search.c
@@ -486,7 +486,7 @@ int search_main(int argc, char **argv)
 	struct list *subs = NULL;
 
 	if (!parse_options(argc, argv)) {
-		return EXIT_FAILURE;
+		return EINVALID_OPTION;
 	}
 
 	ret = swupd_init(&lock_fd);

--- a/src/search.c
+++ b/src/search.c
@@ -497,7 +497,7 @@ int search_main(int argc, char **argv)
 
 	if (!check_network()) {
 		printf("Error: Network issue, unable to proceed with update\n");
-		ret = EXIT_FAILURE;
+		ret = ENOSWUPDSERVER;
 		goto clean_exit;
 	}
 

--- a/src/swupd.c
+++ b/src/swupd.c
@@ -139,7 +139,7 @@ int main(int argc, char **argv)
 	int ret;
 
 	if (parse_options(argc, argv, &index) < 0) {
-		return EXIT_FAILURE;
+		return EINVALID_OPTION;
 	}
 
 	/* Reset optind to 0 (instead of the default value, 1) at this point,

--- a/src/update.c
+++ b/src/update.c
@@ -393,7 +393,9 @@ download_packs:
 
 	ret = update_loop(updates, server_manifest);
 	if (ret == 0) {
-		ret = update_device_latest_version(server_version);
+		/* Failure to write the version file in the state directory
+		 * should not affect exit status. */
+		(void)update_device_latest_version(server_version);
 		printf("Update was applied.\n");
 	}
 

--- a/src/update.c
+++ b/src/update.c
@@ -325,8 +325,8 @@ load_server_manifests:
 	/* read the current collective of manifests that we are subscribed to */
 	current_manifest->submanifests = recurse_manifest(current_manifest, current_subs, NULL);
 	if (!current_manifest->submanifests) {
-		ret = -1;
-		printf("Cannot load current MoM sub-manifests, (%s), exiting\n", strerror(errno));
+		ret = ERECURSE_MANIFEST;
+		printf("Cannot load current MoM sub-manifests, exiting\n");
 		goto clean_exit;
 	}
 	/* consolidate the current collective manifests down into one in memory */
@@ -337,8 +337,8 @@ load_server_manifests:
 	/* read the new collective of manifests that we are subscribed to */
 	server_manifest->submanifests = recurse_manifest(server_manifest, latest_subs, NULL);
 	if (!server_manifest->submanifests) {
-		ret = -1;
-		printf("Error: Cannot load server MoM sub-manifests, (%s), exiting\n", strerror(errno));
+		ret = ERECURSE_MANIFEST;
+		printf("Error: Cannot load server MoM sub-manifests, exiting\n");
 		goto clean_exit;
 	}
 

--- a/src/update.c
+++ b/src/update.c
@@ -284,6 +284,7 @@ load_current_manifests:
 			goto load_current_manifests;
 		}
 		printf("Failure retrieving manifest from server\n");
+		ret = EMOM_NOTFOUND;
 		goto clean_exit;
 	}
 
@@ -301,6 +302,7 @@ load_server_manifests:
 		}
 		printf("Failure retrieving manifest from server\n");
 		printf("Unable to load manifest after retrying (config or network problem?)\n");
+		ret = EMOM_NOTFOUND;
 		goto clean_exit;
 	}
 

--- a/src/update.c
+++ b/src/update.c
@@ -240,7 +240,7 @@ int main_update()
 
 	if (!check_network()) {
 		printf("Error: Network issue, unable to proceed with update\n");
-		ret = EXIT_FAILURE;
+		ret = ENOSWUPDSERVER;
 		goto clean_curl;
 	}
 

--- a/src/update.c
+++ b/src/update.c
@@ -368,6 +368,7 @@ download_packs:
 			goto download_packs;
 		}
 		printf("No network, or server unavailable for pack downloads\n");
+		ret = ENOSWUPDSERVER;
 		goto clean_exit;
 	}
 

--- a/src/update.c
+++ b/src/update.c
@@ -313,6 +313,7 @@ load_server_manifests:
 	latest_subs = list_clone(current_subs);
 	ret = add_included_manifests(server_manifest, &latest_subs);
 	if (ret) {
+		ret = EMANIFEST_LOAD;
 		goto clean_exit;
 	}
 

--- a/src/update.c
+++ b/src/update.c
@@ -252,6 +252,7 @@ int main_update()
 	ret = check_versions(&current_version, &server_version, path_prefix);
 
 	if (ret < 0) {
+		ret = EXIT_FAILURE;
 		goto clean_curl;
 	}
 	if (server_version <= current_version) {

--- a/src/update.c
+++ b/src/update.c
@@ -398,6 +398,9 @@ download_packs:
 		 * should not affect exit status. */
 		(void)update_device_latest_version(server_version);
 		printf("Update was applied.\n");
+	} else if (ret < 0) {
+		// Ensure a positive exit status for the main program.
+		ret = -ret;
 	}
 
 	delete_motd();

--- a/src/verify.c
+++ b/src/verify.c
@@ -656,7 +656,7 @@ int verify_main(int argc, char **argv)
 		 * not provided.
 		 */
 		printf("Unable to download/verify %d Manifest.MoM\n", version);
-		ret = EXIT_FAILURE;
+		ret = EMOM_NOTFOUND;
 
 		/* No repair is possible without a manifest, nor is accurate reporting
 		 * of the state of the system. Therefore cleanup, report failure and exit

--- a/src/verify.c
+++ b/src/verify.c
@@ -596,7 +596,7 @@ int verify_main(int argc, char **argv)
 	copyright_header("software verify");
 
 	if (!parse_options(argc, argv)) {
-		return EXIT_FAILURE;
+		return EINVALID_OPTION;
 	}
 
 	/* parse command line options */

--- a/src/verify.c
+++ b/src/verify.c
@@ -318,7 +318,7 @@ RETRY_DOWNLOADS:
 		 * 	unable to download the needed files. This is a terminal error
 		 * 	and we need good logging */
 		printf("Error: Unable to download neccessary files for this OS release\n");
-		return ret;
+		return -EFULLDOWNLOAD;
 	}
 
 	if (failed != NULL) {
@@ -339,7 +339,7 @@ RETRY_DOWNLOADS:
 	if (retries >= MAX_TRIES) {
 		printf("ERROR: Could not download all files, aborting update\n");
 		list_free_list(failed);
-		return -1;
+		return -EFULLDOWNLOAD;
 	}
 
 	return 0;

--- a/src/verify.c
+++ b/src/verify.c
@@ -632,7 +632,7 @@ int verify_main(int argc, char **argv)
 
 	if (!check_network()) {
 		printf("Error: Network issue, unable to download manifest\n");
-		ret = EXIT_FAILURE;
+		ret = ENOSWUPDSERVER;
 		goto clean_and_exit;
 	}
 

--- a/src/verify.c
+++ b/src/verify.c
@@ -666,6 +666,7 @@ int verify_main(int argc, char **argv)
 
 	ret = add_included_manifests(official_manifest, &subs);
 	if (ret) {
+		ret = EMANIFEST_LOAD;
 		goto clean_and_exit;
 	}
 

--- a/src/verify.c
+++ b/src/verify.c
@@ -231,7 +231,7 @@ static int get_all_files(struct manifest *official_manifest, struct list *subs)
 		 * 	logging needed */
 		printf("zero pack downloads failed. \n");
 		printf("Failed - Server-side error, cannot download necessary files\n");
-		return ret;
+		return -ENOSWUPDSERVER;
 	}
 	iter = list_head(official_manifest->files);
 	while (iter) {

--- a/src/verify.c
+++ b/src/verify.c
@@ -681,6 +681,15 @@ int verify_main(int argc, char **argv)
 
 	official_manifest->files = consolidate_files(official_manifest->files);
 
+	/* when fixing or installing we need input files. */
+	if (cmdline_option_fix || cmdline_option_install) {
+		ret = get_required_files(official_manifest, subs);
+		if (ret != 0) {
+			ret = -ret;
+			goto clean_and_exit;
+		}
+	}
+
 	/* preparation work complete. */
 
 	/*
@@ -697,12 +706,6 @@ int verify_main(int argc, char **argv)
 	 */
 
 	if (cmdline_option_fix || cmdline_option_install) {
-		/* when fixing or installing we need input files. */
-		ret = get_required_files(official_manifest, subs);
-		if (ret != 0) {
-			goto brick_the_system_and_clean_curl;
-		}
-
 		/*
 		 * Next put the files in place that are missing completely.
 		 * This is to avoid updating a symlink to a library before the new full file


### PR DESCRIPTION
This series is a first pass at some error handling improvements, with the goal of using the same error codes for certain classes of errors, and to make sure the main program always exits with a positive value for errors.

I have not yet addressed the more complex error handling scenarios (e.g. in `src/staging.c`). That will come later.

One behavior change should be noted: for swupd operations that require zero packs, the operation will now fail if the packs fail to extract with `tar`. Previously, pack extraction issues were ignored.