### PR TITLE
Add new bundle-list sub-command

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,7 @@ swupd_SOURCES = \
 	$(swupd_verify_SOURCES) \
 	$(clr_bundle_add_SOURCES) \
 	$(clr_bundle_rm_SOURCES) \
+	$(clr_bundle_ls_SOURCES) \
 	$(swupd_search_SOURCES)
 
 check_PROGRAMS = \
@@ -65,6 +66,7 @@ swupd_search_SOURCES = src/search.c
 
 clr_bundle_add_SOURCES = src/clr_bundle_add.c
 clr_bundle_rm_SOURCES = src/clr_bundle_rm.c
+clr_bundle_ls_SOURCES = src/clr_bundle_ls.c
 
 swupd_hashdump_SOURCES = src/hashdump.c
 

--- a/docs/swupd.1
+++ b/docs/swupd.1
@@ -125,6 +125,19 @@ the listed bundles, either directly or indirectly\.
 .IP "" 0
 .
 .P
+\fBbundle\-list\fR
+.
+.IP "" 4
+.
+.nf
+
+List all installed sofware bundles in the local system\.
+.
+.fi
+.
+.IP "" 0
+.
+.P
 \fBcheck\-update\fR
 .
 .IP "" 4

--- a/docs/swupd.1.md
+++ b/docs/swupd.1.md
@@ -110,6 +110,10 @@ to modify the core behavior and resources that swupd uses.
     will be removed from the system, as well as all bundles that required
     the listed bundles, either directly or indirectly.
 
+`bundle-list`
+
+    List all installed sofware bundles in the local system.
+
 `check-update`
 
     Checks whether an update is available and prints out the information

--- a/include/swupd-internal.h
+++ b/include/swupd-internal.h
@@ -3,6 +3,7 @@
 
 extern int bundle_add_main(int argc, char **argv);
 extern int bundle_remove_main(int argc, char **argv);
+extern int bundle_list_main(int argc, char **argv);
 extern int hashdump_main(int argc, char **argv);
 extern int update_main(int argc, char **argv);
 extern int verify_main(int argc, char **argv);

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -310,6 +310,7 @@ extern int remove_bundle(const char *bundle_name);
 extern int list_installable_bundles();
 extern int install_bundles_frontend(char **bundles);
 extern int add_subscriptions(struct list *bundles, struct list **subs, int current_version, struct manifest *mom, int recursion);
+void read_local_bundles(struct list **list_bundles);
 
 /* telemetry.c */
 typedef enum telem_prio_t {

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -589,3 +589,33 @@ clean_and_exit:
 
 	return ret;
 }
+
+/*
+ * This function will read /usr/share/clear/bundles/
+ * in order to get the bundle names, these will be
+ * saved in a list.
+ */
+void read_local_bundles(struct list **list_bundles)
+{
+	char *path = NULL;
+	DIR *dir;
+	struct dirent *ent;
+
+	string_or_die(&path, "%s/%s", path_prefix, BUNDLES_DIR);
+
+	dir = opendir(path);
+	if (dir) {
+		while ((ent = readdir(dir))) {
+			if ((strcmp(ent->d_name, ".") == 0) ||
+			(strcmp(ent->d_name, "..") == 0)) {
+				continue;
+			}
+
+			*list_bundles = list_append_data(*list_bundles, ent->d_name);
+		}
+
+		closedir(dir);
+	}
+
+	free(path);
+}

--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -1,0 +1,64 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2012-2016 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Authors:
+ *         Mario Alfredo Carrillo Arevalo <mario.alfredo.c.arevalo@intel.com>
+ *         Jaime A. Garcia <jaime.garcia.naranjo@linux.intel.com>
+ */
+
+#define _GNU_SOURCE
+#include "swupd.h"
+#include "config.h"
+
+int bundle_list_main(int argc, char **argv)
+{
+	int current_version;
+	int lock_fd;
+	int ret;
+	struct list *list_bundles = NULL;
+	struct list *item = NULL;
+
+	copyright_header("bundle list");
+
+	ret = swupd_init(&lock_fd);
+	if (ret != 0) {
+		printf("Error: Failed updater initialization. Exiting now\n");
+		return ret;
+	}
+
+	current_version = get_current_version(path_prefix);
+	if (current_version < 0) {
+		printf("Error: Unable to determine current OS version\n");
+		v_lockfile(lock_fd);
+		return ECURRENT_VERSION;
+	}
+
+	read_local_bundles(&list_bundles);
+
+	item = list_head(list_bundles);
+
+	while (item) {
+		printf("%s\n", (char *)item->data);
+		item = item->next;
+	}
+
+	printf("Current OS version: %d\n", current_version);
+
+	list_free_list(list_bundles);
+
+	return ret;
+}

--- a/src/swupd.c
+++ b/src/swupd.c
@@ -36,6 +36,7 @@ struct subcmd {
 static struct subcmd commands[] = {
 	{ "bundle-add", "Install a new bundle", bundle_add_main },
 	{ "bundle-remove", "Uninstall a bundle", bundle_remove_main },
+	{ "bundle-list", "List installed bundles", bundle_list_main },
 	{ "hashdump", "Dumps the HMAC hash of a file", hashdump_main },
 	{ "update", "Update to latest OS version", update_main },
 	{ "verify", "Verify content for OS version", verify_main },


### PR DESCRIPTION
This group of patches add a new sub-command to swupd "bundle-list", this sub-command allows to show which bundles are installed in the local system.