### PR TITLE
Remove .signed files in functional tests

### DIFF
--- a/test/functional/bundleadd/add-directory/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/bundleadd/add-directory/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/add-directory/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/bundleadd/add-directory/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/add-directory/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/bundleadd/add-directory/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/add-existing/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/bundleadd/add-existing/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/add-existing/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/bundleadd/add-existing/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/add-existing/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/bundleadd/add-existing/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/add-multiple/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/bundleadd/add-multiple/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/add-multiple/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/bundleadd/add-multiple/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/add-multiple/web-dir/10/Manifest.test-bundle1.signed
+++ b/test/functional/bundleadd/add-multiple/web-dir/10/Manifest.test-bundle1.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/add-multiple/web-dir/10/Manifest.test-bundle2.signed
+++ b/test/functional/bundleadd/add-multiple/web-dir/10/Manifest.test-bundle2.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/boot-file/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/bundleadd/boot-file/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/boot-file/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/bundleadd/boot-file/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/boot-file/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/bundleadd/boot-file/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/fix-missing-file/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/bundleadd/fix-missing-file/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/fix-missing-file/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/bundleadd/fix-missing-file/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/fix-missing-file/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/bundleadd/fix-missing-file/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/include/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/bundleadd/include/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/include/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/bundleadd/include/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/include/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/bundleadd/include/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/list/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/bundleadd/list/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/list/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/bundleadd/list/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/verify-fix-path/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/bundleadd/verify-fix-path/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/verify-fix-path/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/bundleadd/verify-fix-path/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleadd/verify-fix-path/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/bundleadd/verify-fix-path/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleremove/boot-file/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/bundleremove/boot-file/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleremove/boot-file/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/bundleremove/boot-file/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleremove/boot-file/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/bundleremove/boot-file/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleremove/include/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/bundleremove/include/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleremove/include/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/bundleremove/include/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleremove/include/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/bundleremove/include/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleremove/include/web-dir/10/Manifest.test-bundle2.signed
+++ b/test/functional/bundleremove/include/web-dir/10/Manifest.test-bundle2.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleremove/remove-file/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/bundleremove/remove-file/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleremove/remove-file/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/bundleremove/remove-file/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/bundleremove/remove-file/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/bundleremove/remove-file/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-negfull-path/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/search/content-check-negfull-path/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-negfull-path/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/search/content-check-negfull-path/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-negfull-path/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/search/content-check-negfull-path/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-neglibtest/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/search/content-check-neglibtest/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-neglibtest/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/search/content-check-neglibtest/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-neglibtest/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/search/content-check-neglibtest/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-posbin/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/search/content-check-posbin/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-posbin/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/search/content-check-posbin/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-posbin/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/search/content-check-posbin/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-posebin/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/search/content-check-posebin/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-posebin/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/search/content-check-posebin/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-posebin/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/search/content-check-posebin/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-posfull-path/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/search/content-check-posfull-path/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-posfull-path/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/search/content-check-posfull-path/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-posfull-path/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/search/content-check-posfull-path/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-poslib32/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/search/content-check-poslib32/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-poslib32/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/search/content-check-poslib32/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-poslib32/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/search/content-check-poslib32/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-poslib64/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/search/content-check-poslib64/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-poslib64/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/search/content-check-poslib64/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/search/content-check-poslib64/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/search/content-check-poslib64/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/swupdlib.bash
+++ b/test/functional/swupdlib.bash
@@ -46,7 +46,7 @@ create_manifest_tar() {
   local ver=$1
   local name=$2
   chown_root "$DIR/web-dir/$ver/Manifest.$name"
-  sudo tar -C "$DIR/web-dir/$ver" -cf "$DIR/web-dir/$ver/Manifest.$name.tar" Manifest.$name Manifest.$name.signed
+  sudo tar -C "$DIR/web-dir/$ver" -cf "$DIR/web-dir/$ver/Manifest.$name.tar" Manifest.$name
 }
 
 create_fullfile_tar() {

--- a/test/functional/update/apply-full-file-delta/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/update/apply-full-file-delta/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/apply-full-file-delta/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/update/apply-full-file-delta/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/apply-full-file-delta/web-dir/100/Manifest.MoM.signed
+++ b/test/functional/update/apply-full-file-delta/web-dir/100/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/apply-full-file-delta/web-dir/100/Manifest.os-core.signed
+++ b/test/functional/update/apply-full-file-delta/web-dir/100/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/boot-file/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/update/boot-file/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/boot-file/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/update/boot-file/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/boot-file/web-dir/100/Manifest.MoM.signed
+++ b/test/functional/update/boot-file/web-dir/100/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/boot-file/web-dir/100/Manifest.os-core.signed
+++ b/test/functional/update/boot-file/web-dir/100/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/download/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/update/download/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/download/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/update/download/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/download/web-dir/100/Manifest.MoM.signed
+++ b/test/functional/update/download/web-dir/100/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/download/web-dir/100/Manifest.os-core.signed
+++ b/test/functional/update/download/web-dir/100/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle-with-tracked-file/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/update/include-old-bundle-with-tracked-file/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle-with-tracked-file/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/update/include-old-bundle-with-tracked-file/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle-with-tracked-file/web-dir/10/Manifest.test-bundle1.signed
+++ b/test/functional/update/include-old-bundle-with-tracked-file/web-dir/10/Manifest.test-bundle1.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle-with-tracked-file/web-dir/10/Manifest.test-bundle2.signed
+++ b/test/functional/update/include-old-bundle-with-tracked-file/web-dir/10/Manifest.test-bundle2.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle-with-tracked-file/web-dir/10/Manifest.test-bundle3.signed
+++ b/test/functional/update/include-old-bundle-with-tracked-file/web-dir/10/Manifest.test-bundle3.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle-with-tracked-file/web-dir/20/Manifest.MoM.signed
+++ b/test/functional/update/include-old-bundle-with-tracked-file/web-dir/20/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle-with-tracked-file/web-dir/20/Manifest.os-core.signed
+++ b/test/functional/update/include-old-bundle-with-tracked-file/web-dir/20/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle-with-tracked-file/web-dir/30/Manifest.MoM.signed
+++ b/test/functional/update/include-old-bundle-with-tracked-file/web-dir/30/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle-with-tracked-file/web-dir/30/Manifest.os-core.signed
+++ b/test/functional/update/include-old-bundle-with-tracked-file/web-dir/30/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle-with-tracked-file/web-dir/30/Manifest.test-bundle2.signed
+++ b/test/functional/update/include-old-bundle-with-tracked-file/web-dir/30/Manifest.test-bundle2.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle-with-tracked-file/web-dir/30/Manifest.test-bundle3.signed
+++ b/test/functional/update/include-old-bundle-with-tracked-file/web-dir/30/Manifest.test-bundle3.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/update/include-old-bundle/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/update/include-old-bundle/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle/web-dir/10/Manifest.test-bundle1.signed
+++ b/test/functional/update/include-old-bundle/web-dir/10/Manifest.test-bundle1.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle/web-dir/10/Manifest.test-bundle2.signed
+++ b/test/functional/update/include-old-bundle/web-dir/10/Manifest.test-bundle2.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle/web-dir/100/Manifest.MoM.signed
+++ b/test/functional/update/include-old-bundle/web-dir/100/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle/web-dir/100/Manifest.os-core.signed
+++ b/test/functional/update/include-old-bundle/web-dir/100/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include-old-bundle/web-dir/100/Manifest.test-bundle1.signed
+++ b/test/functional/update/include-old-bundle/web-dir/100/Manifest.test-bundle1.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/update/include/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/update/include/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include/web-dir/10/Manifest.test-bundle1.signed
+++ b/test/functional/update/include/web-dir/10/Manifest.test-bundle1.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include/web-dir/10/Manifest.test-bundle2.signed
+++ b/test/functional/update/include/web-dir/10/Manifest.test-bundle2.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include/web-dir/100/Manifest.MoM.signed
+++ b/test/functional/update/include/web-dir/100/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include/web-dir/100/Manifest.os-core.signed
+++ b/test/functional/update/include/web-dir/100/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include/web-dir/100/Manifest.test-bundle1.signed
+++ b/test/functional/update/include/web-dir/100/Manifest.test-bundle1.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include/web-dir/100/Manifest.test-bundle2.signed
+++ b/test/functional/update/include/web-dir/100/Manifest.test-bundle2.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include/web-dir/100/Manifest.test-bundle3.signed
+++ b/test/functional/update/include/web-dir/100/Manifest.test-bundle3.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include/web-dir/100/Manifest.test-bundle4.signed
+++ b/test/functional/update/include/web-dir/100/Manifest.test-bundle4.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include/web-dir/100/Manifest.test-bundle5.signed
+++ b/test/functional/update/include/web-dir/100/Manifest.test-bundle5.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include/web-dir/100/Manifest.test-bundle6.signed
+++ b/test/functional/update/include/web-dir/100/Manifest.test-bundle6.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/include/web-dir/100/Manifest.test-bundle7.signed
+++ b/test/functional/update/include/web-dir/100/Manifest.test-bundle7.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/missing-os-core/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/update/missing-os-core/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/missing-os-core/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/update/missing-os-core/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/missing-os-core/web-dir/10/Manifest.test-bundle1.signed
+++ b/test/functional/update/missing-os-core/web-dir/10/Manifest.test-bundle1.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/missing-os-core/web-dir/100/Manifest.MoM.signed
+++ b/test/functional/update/missing-os-core/web-dir/100/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/missing-os-core/web-dir/100/Manifest.os-core.signed
+++ b/test/functional/update/missing-os-core/web-dir/100/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/missing-os-core/web-dir/100/Manifest.test-bundle1.signed
+++ b/test/functional/update/missing-os-core/web-dir/100/Manifest.test-bundle1.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/newest-deleted/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/update/newest-deleted/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/newest-deleted/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/update/newest-deleted/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/newest-deleted/web-dir/10/Manifest.test-bundle1.signed
+++ b/test/functional/update/newest-deleted/web-dir/10/Manifest.test-bundle1.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/newest-deleted/web-dir/20/Manifest.MoM.signed
+++ b/test/functional/update/newest-deleted/web-dir/20/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/newest-deleted/web-dir/20/Manifest.os-core.signed
+++ b/test/functional/update/newest-deleted/web-dir/20/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/newest-deleted/web-dir/20/Manifest.test-bundle2.signed
+++ b/test/functional/update/newest-deleted/web-dir/20/Manifest.test-bundle2.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/newest-deleted/web-dir/30/Manifest.MoM.signed
+++ b/test/functional/update/newest-deleted/web-dir/30/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/newest-deleted/web-dir/30/Manifest.os-core.signed
+++ b/test/functional/update/newest-deleted/web-dir/30/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/newest-deleted/web-dir/30/Manifest.test-bundle2.signed
+++ b/test/functional/update/newest-deleted/web-dir/30/Manifest.test-bundle2.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/skip-verified-fullfiles/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/update/skip-verified-fullfiles/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/skip-verified-fullfiles/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/update/skip-verified-fullfiles/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/skip-verified-fullfiles/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/update/skip-verified-fullfiles/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/skip-verified-fullfiles/web-dir/100/Manifest.MoM.signed
+++ b/test/functional/update/skip-verified-fullfiles/web-dir/100/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/skip-verified-fullfiles/web-dir/100/Manifest.test-bundle.signed
+++ b/test/functional/update/skip-verified-fullfiles/web-dir/100/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/use-full-file/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/update/use-full-file/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/use-full-file/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/update/use-full-file/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/use-full-file/web-dir/100/Manifest.MoM.signed
+++ b/test/functional/update/use-full-file/web-dir/100/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/use-full-file/web-dir/100/Manifest.os-core.signed
+++ b/test/functional/update/use-full-file/web-dir/100/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/use-pack/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/update/use-pack/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/use-pack/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/update/use-pack/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/use-pack/web-dir/100/Manifest.MoM.signed
+++ b/test/functional/update/use-pack/web-dir/100/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/use-pack/web-dir/100/Manifest.os-core.signed
+++ b/test/functional/update/use-pack/web-dir/100/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/verify-fix-path-hash-mismatch/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/update/verify-fix-path-hash-mismatch/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/verify-fix-path-hash-mismatch/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/update/verify-fix-path-hash-mismatch/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/verify-fix-path-hash-mismatch/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/update/verify-fix-path-hash-mismatch/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/verify-fix-path-hash-mismatch/web-dir/100/Manifest.MoM.signed
+++ b/test/functional/update/verify-fix-path-hash-mismatch/web-dir/100/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/verify-fix-path-hash-mismatch/web-dir/100/Manifest.test-bundle.signed
+++ b/test/functional/update/verify-fix-path-hash-mismatch/web-dir/100/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/verify-fix-path-missing-dir/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/update/verify-fix-path-missing-dir/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/verify-fix-path-missing-dir/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/update/verify-fix-path-missing-dir/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/verify-fix-path-missing-dir/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/update/verify-fix-path-missing-dir/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/verify-fix-path-missing-dir/web-dir/100/Manifest.MoM.signed
+++ b/test/functional/update/verify-fix-path-missing-dir/web-dir/100/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/verify-fix-path-missing-dir/web-dir/100/Manifest.test-bundle.signed
+++ b/test/functional/update/verify-fix-path-missing-dir/web-dir/100/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/verify-fullfile-hash/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/update/verify-fullfile-hash/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/verify-fullfile-hash/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/update/verify-fullfile-hash/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/verify-fullfile-hash/web-dir/10/Manifest.test-bundle.signed
+++ b/test/functional/update/verify-fullfile-hash/web-dir/10/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/verify-fullfile-hash/web-dir/100/Manifest.MoM.signed
+++ b/test/functional/update/verify-fullfile-hash/web-dir/100/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/update/verify-fullfile-hash/web-dir/100/Manifest.test-bundle.signed
+++ b/test/functional/update/verify-fullfile-hash/web-dir/100/Manifest.test-bundle.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/add-missing-directory/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/verify/add-missing-directory/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/add-missing-directory/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/verify/add-missing-directory/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/add-missing-include-old/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/verify/add-missing-include-old/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/add-missing-include-old/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/verify/add-missing-include-old/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/add-missing-include-old/web-dir/10/Manifest.test-bundle1.signed
+++ b/test/functional/verify/add-missing-include-old/web-dir/10/Manifest.test-bundle1.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/add-missing-include-old/web-dir/10/Manifest.test-bundle2.signed
+++ b/test/functional/verify/add-missing-include-old/web-dir/10/Manifest.test-bundle2.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/add-missing-include-old/web-dir/100/Manifest.MoM.signed
+++ b/test/functional/verify/add-missing-include-old/web-dir/100/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/add-missing-include-old/web-dir/100/Manifest.os-core.signed
+++ b/test/functional/verify/add-missing-include-old/web-dir/100/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/add-missing-include-old/web-dir/100/Manifest.test-bundle1.signed
+++ b/test/functional/verify/add-missing-include-old/web-dir/100/Manifest.test-bundle1.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/add-missing-include/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/verify/add-missing-include/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/add-missing-include/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/verify/add-missing-include/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/add-missing-include/web-dir/10/Manifest.test-bundle1.signed
+++ b/test/functional/verify/add-missing-include/web-dir/10/Manifest.test-bundle1.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/add-missing-include/web-dir/10/Manifest.test-bundle2.signed
+++ b/test/functional/verify/add-missing-include/web-dir/10/Manifest.test-bundle2.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/boot-file-deleted/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/verify/boot-file-deleted/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/boot-file-deleted/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/verify/boot-file-deleted/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/boot-file-mismatch-fix/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/verify/boot-file-mismatch-fix/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/boot-file-mismatch-fix/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/verify/boot-file-mismatch-fix/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/boot-file-mismatch/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/verify/boot-file-mismatch/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/boot-file-mismatch/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/verify/boot-file-mismatch/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/check-missing-directory/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/verify/check-missing-directory/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/check-missing-directory/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/verify/check-missing-directory/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/directory-tree-deleted/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/verify/directory-tree-deleted/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/directory-tree-deleted/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/verify/directory-tree-deleted/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/empty-dir-deleted/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/verify/empty-dir-deleted/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/empty-dir-deleted/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/verify/empty-dir-deleted/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/install-directory/web-dir/10/Manifest.MoM.signed
+++ b/test/functional/verify/install-directory/web-dir/10/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/install-directory/web-dir/10/Manifest.os-core.signed
+++ b/test/functional/verify/install-directory/web-dir/10/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/install-latest-directory/web-dir/100/Manifest.MoM.signed
+++ b/test/functional/verify/install-latest-directory/web-dir/100/Manifest.MoM.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----

--- a/test/functional/verify/install-latest-directory/web-dir/100/Manifest.os-core.signed
+++ b/test/functional/verify/install-latest-directory/web-dir/100/Manifest.os-core.signed
@@ -1,3 +1,0 @@
------BEGIN PKCS7-----
-Empty
------END PKCS7-----


### PR DESCRIPTION
These files have never been used by the functional tests, so they can be safely removed from the tree.