### PR TITLE
Fix swupd options for bundle-list --all unit test

### DIFF
--- a/test/functional/bundlelist/all/list/test.bats
+++ b/test/functional/bundlelist/all/list/test.bats
@@ -14,7 +14,7 @@ teardown() {
 }
 
 @test "bundle-list all bundles" {
-  run sudo sh -c "$SWUPD bundle-list --all"
+  run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --all"
 
   check_lines "$output"
 }

--- a/test/functional/bundlelist/all/test.bats
+++ b/test/functional/bundlelist/all/test.bats
@@ -14,8 +14,8 @@ teardown() {
 }
 
 @test "bundle-list all bundles" {
-  run sudo sh -c "$SWUPD bundle-list --all"
-
+  run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --all"
+  output=$(echo "$output" | sed -e 1,3d)
   check_lines "$output"
 }
 


### PR DESCRIPTION
The swupd unit tests need a group of
options for execution environment, this
var was missed.

Signed-off-by: Mario Alfredo Carrillo Arevalo <mario.alfredo.c.arevalo@intel.com>