### PR TITLE
clr-boot-manager fixes

### DIFF
--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -151,7 +151,6 @@ static bool parse_options(int argc, char **argv)
 		}
 	}
 
-
 	if (argc <= optind) {
 		printf("error: missing bundle(s) to be installed\n\n");
 		goto err;

--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -47,8 +47,8 @@ static void print_help(const char *name)
 }
 
 static const struct option prog_opts[] = {
-	{ "help", no_argument, 0, 'h'},
-	{ "all",  no_argument, 0, 'a' },
+	{ "help", no_argument, 0, 'h' },
+	{ "all", no_argument, 0, 'a' },
 	{ "url", required_argument, 0, 'u' },
 	{ "contenturl", required_argument, 0, 'c' },
 	{ "versionurl", required_argument, 0, 'v' },

--- a/src/scripts.c
+++ b/src/scripts.c
@@ -49,8 +49,10 @@ static void update_boot(void)
 
 static void update_triggers(void)
 {
-	system("/usr/bin/systemctl --no-block daemon-reload");
-	system("/usr/bin/systemctl --no-block restart update-triggers.target");
+	__attribute__((unused)) int ret = 0;
+
+	ret = system("/usr/bin/systemctl --no-block daemon-reload");
+	ret = system("/usr/bin/systemctl --no-block restart update-triggers.target");
 }
 
 void run_scripts(void)
@@ -80,6 +82,7 @@ void run_preupdate_scripts(struct manifest *manifest)
 	struct file *file;
 	struct stat sb;
 	char *script;
+	__attribute__((unused)) int ret = 0;
 
 	string_or_die(&script, "/usr/bin/clr_pre_update.sh");
 
@@ -98,7 +101,7 @@ void run_preupdate_scripts(struct manifest *manifest)
 
 		/* Check that system file matches file in manifest */
 		if (verify_file(file, script)) {
-			system(script);
+			ret = system(script);
 			break;
 		}
 	}

--- a/src/scripts.c
+++ b/src/scripts.c
@@ -32,41 +32,19 @@
 
 #include "swupd.h"
 
-static void update_kernel(void)
+static void update_boot(void)
 {
-	char *kernel_update_cmd = NULL;
+	char *boot_update_cmd = NULL;
+	__attribute__((unused)) int ret = 0;
 
 	if (strcmp("/", path_prefix) == 0) {
-		string_or_die(&kernel_update_cmd, "/usr/bin/kernel_updater.sh");
+		string_or_die(&boot_update_cmd, "/usr/bin/clr-boot-manager update");
 	} else {
-		string_or_die(&kernel_update_cmd, "%s/usr/bin/kernel_updater.sh --path %s", path_prefix, path_prefix);
+		string_or_die(&boot_update_cmd, "%s/usr/bin/clr-boot-manager update --path %s", path_prefix, path_prefix);
 	}
 
-	system(kernel_update_cmd);
-	free(kernel_update_cmd);
-}
-
-static void update_bootloader(void)
-{
-	char *bootloader_update_cmd = NULL;
-
-	if (strcmp("/", path_prefix) == 0) {
-		string_or_die(&bootloader_update_cmd, "/usr/bin/gummiboot_updaters.sh");
-	} else {
-		string_or_die(&bootloader_update_cmd, "%s/usr/bin/gummiboot_updaters.sh --path %s", path_prefix, path_prefix);
-	}
-
-	system(bootloader_update_cmd);
-	free(bootloader_update_cmd);
-
-	if (strcmp("/", path_prefix) == 0) {
-		string_or_die(&bootloader_update_cmd, "/usr/bin/systemdboot_updater.sh");
-	} else {
-		string_or_die(&bootloader_update_cmd, "%s/usr/bin/systemdboot_updater.sh --path %s", path_prefix, path_prefix);
-	}
-
-	system(bootloader_update_cmd);
-	free(bootloader_update_cmd);
+	ret = system(boot_update_cmd);
+	free(boot_update_cmd);
 }
 
 static void update_triggers(void)
@@ -80,12 +58,8 @@ void run_scripts(void)
 	printf("Calling post-update helper scripts.\n");
 
 	/* path_prefix aware helper */
-	if (need_update_boot) {
-		update_kernel();
-	}
-
-	if (need_update_bootloader) {
-		update_bootloader();
+	if (need_update_boot || need_update_bootloader) {
+		update_boot();
 	}
 
 	/* helpers which don't run when path_prefix is set */

--- a/src/verify.c
+++ b/src/verify.c
@@ -525,7 +525,7 @@ static void remove_orphaned_files(struct manifest *official_manifest)
 
 		/* Note: boot files marked as deleted should not be deleted by
 		 * verify/fix; this task is delegated to an external program
-		 * (currently /usr/bin/kernel_updater.sh).
+		 * (currently /usr/bin/clr-boot-manager).
 		 */
 		if (ignore(file)) {
 			continue;

--- a/test/functional/ignore-list
+++ b/test/functional/ignore-list
@@ -9,10 +9,6 @@
 ^No kernel update needed, skipping helper call out.$
 ^No bootloader update needed, skipping helper call out.$
 ^Update took .* seconds$
-^sh: .*/usr/bin/kernel_updater.sh: No such file or directory$
-^sh: .*/usr/bin/gummiboot_updaters.sh: No such file or directory$
-^sh: .*/usr/bin/systemdboot_updater.sh: No such file or directory$
-^sh: .*/usr/bin/kernel_updater.sh: not found$
-^sh: .*/usr/bin/gummiboot_updaters.sh: not found$
-^sh: .*/usr/bin/systemdboot_updater.sh: not found$
+^sh: .*/usr/bin/clr-boot-manager: No such file or directory$
+^sh: .*/usr/bin/clr-boot-manager: not found$
 ^Possible filedescriptor leak: .*$


### PR DESCRIPTION
This change adds a minor code-styling fix, but more importantly it moves `swupd-client` away from using the legacy compatibility scripts inside `clr-boot-manager`, enforcing direct usage of it.

Note that a potential issue with the previous behaviour is the compatibility scripts do not contain a bin prefix, i.e. `$root/usr/bin/*.sh` invoke `clr-boot-manager update $*`, meaning the host side tool is
employed rather than the rootfs one.