### PR TITLE
Add support for automated building within docker environment.

### DIFF
--- a/continous.sh
+++ b/continous.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# This file is part of swupd-client.
+#
+# Copyright © 2017 Intel Corporation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 2 or later of the License.
+#
+
+DIRN="$(basename $(pwd))"
+PROJ_NAME="swupd-client"
+PROJ_CI_NAME="docker-ci-${PROJ_NAME}"
+
+# Check docker is available
+if ! type docker &>/dev/null; then
+    echo "Please ensure docker is installed first"
+    exit 1
+fi
+
+# Check docker is running
+if ! docker version &>/dev/null; then
+    echo "Docker is not running"
+    exit 1
+fi
+
+# Check we're in the right directory
+if [[ "${DIRN}" != "${PROJ_NAME}" ]]; then
+    echo "Please run from the root ${PROJ_NAME} directory"
+    exit 1
+fi
+
+# Check that docker-ci image is installed
+if ! docker inspect "${PROJ_CI_NAME}" &>/dev/null; then
+    echo "${PROJ_CI_NAME} not installed, building docker image.."
+    echo "....Please wait, this may take some time."
+    docker build -t "${PROJ_CI_NAME}" docker/ || exit 1
+fi
+
+# Build the current tree through bind mount within the docker image
+echo "Beginning build of ${PROJ_NAME}..."
+exec docker run -ti -v $(pwd):/source:ro --rm "${PROJ_CI_NAME}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+#
+# This file is part of swupd-client.
+#
+# Copyright © 2017 Intel Corporation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 2 or later of the License.
+#
+#
+
+FROM clearlinux:latest
+ADD dockerrun.sh /dockerrun.sh
+ADD https://download.clearlinux.org/releases/13010/clear/Swupd_Root.pem /usr/share/clear/update-ca/Swupd_Root.pem
+RUN swupd update && swupd bundle-add os-core-update-dev sysadmin-basic os-testsuite c-basic
+
+CMD ["/dockerrun.sh"]

--- a/docker/dockerrun.sh
+++ b/docker/dockerrun.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# This file is part of swupd-client.
+#
+# Copyright © 2017 Intel Corporation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 2 or later of the License.
+#
+
+# Enforce correct umask
+umask 0022
+
+mkdir -p /build
+cd /build
+
+if [[ ! -d /source ]]; then
+    echo "Missing source tree!" >&2
+    exit 1
+fi
+
+# Copy all the files across to prevent contaminating the bind mount
+cp -Ra /source/. /build
+
+die_fatal()
+{
+    echo "$*"
+    exit 1
+}
+
+die_log_fatal()
+{
+    if [[ -e test-suite.log ]]; then
+        cat test-suite.log
+    else
+        echo "test-suite.log is missing." >&2
+    fi
+    exit 1
+}
+
+jobCount="-j$(($(getconf _NPROCESSORS_ONLN)+1))"
+
+# Fix file permissions in the event of dodgy umask
+find test/functional -exec chmod g-w {} \;
+
+# Configure the build
+autoreconf --verbose --warnings=none --install --force || die_fatal "Configure failure"
+./configure --enable-signature-verification  || die_fatal "Configure failure"
+
+# Build error
+make $jobCount || die_fatal "Build failure"
+
+# Test suite failure, print the log
+make $jobCount check || die_log_fatal


### PR DESCRIPTION
This change adds a simple "./continous.sh" script which will allow
developers to test their changes against "clearlinux:latest" within a
clean Docker container.

If the container does not already exist, it will be created on demand.
Future builds will be done near instantly within the container.

Signed-off-by: Ikey Doherty <michael.i.doherty@intel.com>