### PR TITLE
Fix swupd_lock file descriptor leaking

### DIFF
--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -176,6 +176,7 @@ int bundle_list_main(int argc, char **argv)
 	printf("Current OS version: %d\n", current_version);
 
 	list_free_list(list_bundles);
+	v_lockfile(lock_fd);
 
 	return ret;
 }


### PR DESCRIPTION
The swupd_lock is not properly closed
when the work is done with bundle-list
subcommand.