### PR TITLE
Change certpath to be full path of certificate

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -161,7 +161,7 @@ AC_ARG_WITH(
   [certpath],
   [AS_HELP_STRING([--with-certpath=PATH], [Location of CA certificates])]
 )
-default_cert_path="/usr/share/clear/update-ca"
+default_cert_path="/usr/share/clear/update-ca/Swupd_Root.pem"
 cert_path=
 # Makes sure --with-certpath receives an argument that is not "yes" or "no",
 # and uses the default path if only --enable-signature-verification is passed.
@@ -176,18 +176,6 @@ AS_IF(
   [cert_path="$with_certpath"],
   [test "$enable_signature_verification" = "yes"],
   [cert_path="$default_cert_path"]
-)
-
-AC_ARG_WITH(
-  [swupdcert],
-  [AS_HELP_STRING([--with-swupdcert=FILE], [swupd verification cert])],
-  [AC_DEFINE_UNQUOTED([SWUPDCERT], ["$withval"], [swupd verification cert])],
-  [AC_DEFINE([SWUPDCERT], ["Swupd_Root.pem"], [swupd verification cert])]
-)
-AS_IF(
-  [test -n "$with_swupdcert" -a "$with_swupdcert" != "no" -a "$with_swupdcert" != "yes"],
-  [SWUPDCERT="$with_swupdcert"],
-  [SWUPDCERT="Swupd_Root.pem"]
 )
 
 AC_ARG_WITH(
@@ -298,7 +286,6 @@ Configuration to build swupd-client:
   Format Identifier:			${FORMATID}
   Signature verification:		${SIGVERIFICATION}
   CA certificate path:			${cert_path}
-  SSL Certificate file:			${SWUPDCERT}
   Use bzip compression:			${BZIP}
   Run Tests:				${TESTS}
   Use extended file attributes		${XATTR}

--- a/src/signature.c
+++ b/src/signature.c
@@ -70,7 +70,7 @@ bool initialize_signature(void)
 	struct tm *alttime;
 	struct stat statt;
 
-	string_or_die(&CERTNAME, "%s/%s", cert_path, SWUPDCERT);
+	string_or_die(&CERTNAME, "%s", cert_path);
 
 	ERR_load_crypto_strings();
 	ERR_load_PKCS7_strings();

--- a/test/functional/swupdlib.bash
+++ b/test/functional/swupdlib.bash
@@ -9,7 +9,7 @@ export DIR="$BATS_TEST_DIRNAME"
 
 export STATE_DIR="$BATS_TEST_DIRNAME/state"
 
-export SWUPD_OPTS="-S $STATE_DIR -p $DIR/target-dir -F staging -u file://$DIR/web-dir -C $BATS_TEST_DIRNAME/../../"
+export SWUPD_OPTS="-S $STATE_DIR -p $DIR/target-dir -F staging -u file://$DIR/web-dir -C $BATS_TEST_DIRNAME/../../Swupd_Root.pem"
 
 export SWUPD_OPTS_NO_CERT="-S $STATE_DIR -p $DIR/target-dir -F staging -u file://$DIR/web-dir"
 


### PR DESCRIPTION
The mixer and image creator treat the certpath as the full path of the
certificate filename, and swupd should too. If someone is overriding the
certificate with the cert path option, use the supplied string and don't
append a pre-defined name to it.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>