### PR TITLE
Add verbose timing to swupd operation

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <sys/queue.h>
 
 #include "list.h"
 #include "swupd-error.h"
@@ -64,6 +65,7 @@ struct version_container {
 
 struct header;
 
+extern bool verbose_time;
 extern bool force;
 extern bool sigcheck;
 extern bool timecheck;
@@ -115,6 +117,19 @@ struct file {
 	CURL *curl;    /* curl handle if downloading */
 	FILE *fh;      /* file written into during downloading */
 };
+
+struct time {
+	struct timespec procstart;
+	struct timespec procstop;
+	struct timespec rawstart;
+	struct timespec rawstop;
+	const char *name;
+	bool complete;
+	TAILQ_ENTRY(time) times;
+};
+
+typedef TAILQ_HEAD(timelist, time) timelist;
+
 
 extern bool download_only;
 extern bool local_download;
@@ -170,6 +185,12 @@ extern struct list *create_update_list(struct manifest *current, struct manifest
 extern void link_manifests(struct manifest *m1, struct manifest *m2);
 extern void link_submanifests(struct manifest *m1, struct manifest *m2, struct list *subs1, struct list *subs2);
 extern void free_manifest(struct manifest *manifest);
+
+extern void grabtime_start(timelist *list, const char *name);
+extern void grabtime_stop(timelist *list);
+extern void print_time_stats(timelist *list);
+extern timelist init_timelist(void);
+
 
 extern int swupd_stats[];
 static inline void account_new_file(void)

--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -54,6 +54,7 @@ static void print_help(const char *name)
 	printf("   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
+	printf("   -t, --time         	   Show verbose time output for swupd operations\n");
 	printf("\n");
 }
 
@@ -71,6 +72,7 @@ static const struct option prog_opts[] = {
 	{ "ignore-time", no_argument, 0, 'I' },
 	{ "statedir", required_argument, 0, 'S' },
 	{ "certpath", required_argument, 0, 'C' },
+	{ "time", no_argument, 0, 't'},
 	{ 0, 0, 0, 0 }
 };
 
@@ -78,7 +80,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxnIu:c:v:P:p:F:lS:C:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxnIu:c:v:P:p:F:lS:tC:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -142,6 +144,9 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'I':
 			timecheck = false;
+			break;
+		case 't':
+			verbose_time = true;
 			break;
 		case 'C':
 			if (!optarg) {

--- a/src/main.c
+++ b/src/main.c
@@ -50,6 +50,7 @@ static const struct option prog_opts[] = {
 	{ "ignore-time", no_argument, 0, 'I' },
 	{ "statedir", required_argument, 0, 'S' },
 	{ "certpath", required_argument, 0, 'C' },
+	{ "time", no_argument, 0, 't'},
 	{ 0, 0, 0, 0 }
 };
 
@@ -76,6 +77,7 @@ static void print_help(const char *name)
 	printf("   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
+	printf("   -t, --time         	   Show verbose time output for swupd operations\n");
 	printf("\n");
 }
 
@@ -83,7 +85,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxnIdu:P:c:v:sF:p:S:C:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxnIdtu:P:c:v:sF:p:S:C:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -99,6 +101,9 @@ static bool parse_options(int argc, char **argv)
 			}
 			set_version_url(optarg);
 			set_content_url(optarg);
+			break;
+		case 't':
+			verbose_time = true;
 			break;
 		case 'P':
 			if (sscanf(optarg, "%ld", &update_server_port) != 1) {


### PR DESCRIPTION
This introduces a -t/--time option to update, verify, and bundle-add commands, displaying raw elapsed time and CPU process time for integral swupd operations within the given code paths.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>