### PR TITLE
Improved error reporting for adding bad bundle

### DIFF
--- a/test/functional/bundleadd/add-existing/lines-checked
+++ b/test/functional/bundleadd/add-existing/lines-checked
@@ -1,2 +1,2 @@
 Attempting to download version string to memory
-bundle(s) already installed, exiting now
+nothing to add, exiting now


### PR DESCRIPTION
Currently if you try and add a non existent bundle, e.g. "foo" you get
two lines of output

  foo bundle name is invalid, skipping it...
  bundle(s) already installed, exiting now

This is caused by the add_subscriptions function calling itself
recursivly but failing to pass up results in a meaningful way. This
change makes the return value of add_subscriptions be a bitmask so it
can signal errors and packages added distinctly.

I did think about changing this function to return a struct but
decided this was a step too far.

Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>