### PR TITLE
Try to recover from invalid certificate date

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -91,6 +91,9 @@ swupd_fuzz_LDADD = $(SWUPD_CORE_LIBS) $(pthread_LIBS)
 swupd_locktest_LDADD = $(SWUPD_CORE_LIBS) $(pthread_LIBS)
 swupd_sig_verifytest_LDADD = $(SWUPD_CORE_LIBS)
 
+verifytime_SOURCES = src/verifytime.c
+bin_PROGRAMS += verifytime
+
 noinst_HEADERS = $(top_srcdir)/include/*
 
 EXTRA_DIST += \

--- a/include/swupd-error.h
+++ b/include/swupd-error.h
@@ -22,5 +22,6 @@
 #define EREQUIRED_DIRS 19       /* Cannot create required dirs */
 #define ECURRENT_VERSION 20     /* Cannot determine current OS version */
 #define ESIGNATURE 21		/* Cannot initialize signature verification */
+#define EBADTIME 22				/* System time is bad */
 
 #endif

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -66,6 +66,7 @@ struct header;
 
 extern bool force;
 extern bool sigcheck;
+extern bool timecheck;
 extern int verbose;
 extern int update_count;
 extern int update_skip;

--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -51,6 +51,7 @@ static void print_help(const char *name)
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	printf("   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
+	printf("   -I, --ignore-certtime   Ignore system/certificate time when validating signature\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
 	printf("\n");
@@ -67,6 +68,7 @@ static const struct option prog_opts[] = {
 	{ "format", required_argument, 0, 'F' },
 	{ "force", no_argument, 0, 'x' },
 	{ "nosigcheck", no_argument, 0, 'n' },
+	{ "ignore", no_argument, 0, 'I'},
 	{ "statedir", required_argument, 0, 'S' },
 	{ "certpath", required_argument, 0, 'C' },
 	{ 0, 0, 0, 0 }
@@ -76,7 +78,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxnu:c:v:P:p:F:lS:C:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxnIu:c:v:P:p:F:lS:C:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -137,6 +139,9 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'n':
 			sigcheck = false;
+			break;
+		case 'I':
+			timecheck = false;
 			break;
 		case 'C':
 			if (!optarg) {

--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -40,6 +40,7 @@ static void print_help(const char *name)
 	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	printf("   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
+	printf("   -I, --ignore-certtime   Ignore system/certificate time when validating signature\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
 
@@ -56,6 +57,7 @@ static const struct option prog_opts[] = {
 	{ "format", required_argument, 0, 'F' },
 	{ "nosigcheck", no_argument, 0, 'n' },
 	{ "statedir", required_argument, 0, 'S' },
+	{ "ignore", no_argument, 0, 'I'},
 	{ "certpath", required_argument, 0, 'C' },
 
 	{ 0, 0, 0, 0 }
@@ -65,7 +67,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hanu:c:v:p:F:S:C:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hanIu:c:v:p:F:S:C:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -110,6 +112,9 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'n':
 			sigcheck = false;
+			break;
+		case 'I':
+			timecheck = false;
 			break;
 		case 'S':
 			if (!optarg || !set_state_dir(optarg)) {

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -52,6 +52,7 @@ static void print_help(const char *name)
 	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	printf("   -n, --nosigcheck       Do not attempt to enforce certificate or signature checks\n");
+	printf("   -I, --ignore-certtime   Ignore system/certificate time when validating signature\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
 	printf("\n");
@@ -67,6 +68,7 @@ static const struct option prog_opts[] = {
 	{ "format", required_argument, 0, 'F' },
 	{ "force", no_argument, 0, 'x' },
 	{ "nosigcheck", no_argument, 0, 'n' },
+	{ "ignore", no_argument, 0, 'I'},
 	{ "statedir", required_argument, 0, 'S' },
 	{ "certpath", required_argument, 0, 'C' },
 	{ 0, 0, 0, 0 }
@@ -76,7 +78,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxnp:u:c:v:P:F:S:C:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxnIp:u:c:v:P:F:S:C:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -133,6 +135,9 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'n':
 			sigcheck = false;
+			break;
+		case 'I':
+			timecheck = false;
 			break;
 		case 'C':
 			if (!optarg) {

--- a/src/globals.c
+++ b/src/globals.c
@@ -33,6 +33,7 @@
 
 bool force = false;
 bool sigcheck = true;
+bool timecheck = true;
 bool verify_esp_only;
 bool verify_bundles_only = false;
 int update_count = 0;

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -591,6 +591,15 @@ int swupd_init(int *lock_fd)
 
 	check_root();
 
+	/* Check that our system time is reasonably valid before continuing,
+	 * or the certificate verification will fail with invalid time */
+	if (timecheck) {
+		if (system("verifytime") != 0) {
+			ret = EBADTIME;
+			goto out_fds;
+		}
+	}
+
 	if (!init_globals()) {
 		ret = EINIT_GLOBALS;
 		goto out_fds;

--- a/src/main.c
+++ b/src/main.c
@@ -47,6 +47,7 @@ static const struct option prog_opts[] = {
 	{ "path", required_argument, 0, 'p' },
 	{ "force", no_argument, 0, 'x' },
 	{ "nosigcheck", no_argument, 0, 'n' },
+	{ "ignore", no_argument, 0, 'I'},
 	{ "statedir", required_argument, 0, 'S' },
 	{ "certpath", required_argument, 0, 'C' },
 	{ 0, 0, 0, 0 }
@@ -72,6 +73,7 @@ static void print_help(const char *name)
 	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	printf("   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
+	printf("   -I, --ignore-certtime   Ignore system/certificate time when validating signature\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
 	printf("\n");
@@ -81,7 +83,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxndu:P:c:v:sF:p:S:C:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxnIdu:P:c:v:sF:p:S:C:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -144,6 +146,9 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'n':
 			sigcheck = false;
+			break;
+		case 'I':
+			timecheck = false;
 			break;
 		case 'C':
 			if (!optarg) {

--- a/src/search.c
+++ b/src/search.c
@@ -65,6 +65,7 @@ static void print_help(const char *name)
 	printf("   -s, --scope=[query type] 'b' or 'o' for first hit per (b)undle, or one hit total across the (o)s\n");
 	printf("   -d, --display-files	   Output full file list, no search done\n");
 	printf("   -i, --init              Download all manifests then return, no search done\n");
+	printf("   -I, --ignore-certtime   Ignore system/certificate time when validating signature\n");
 	printf("   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
 	printf("   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
 	printf("   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
@@ -91,6 +92,7 @@ static const struct option prog_opts[] = {
 	{ "path", required_argument, 0, 'p' },
 	{ "format", required_argument, 0, 'F' },
 	{ "init", no_argument, 0, 'i' },
+	{ "ignore", no_argument, 0, 'I'},
 	{ "display-files", no_argument, 0, 'd' },
 	{ "statedir", required_argument, 0, 'S' },
 	{ "certpath", required_argument, 0, 'C' },
@@ -101,7 +103,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hu:c:v:P:p:F:s:lbidS:C:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hu:c:v:P:p:F:s:lbiIdS:C:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -177,6 +179,9 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'i':
 			init = true;
+			break;
+		case 'I':
+			timecheck = false;
 			break;
 		case 'b':
 			if (search_type != '0') {

--- a/src/verify.c
+++ b/src/verify.c
@@ -64,6 +64,7 @@ static const struct option prog_opts[] = {
 	{ "versionurl", required_argument, 0, 'v' },
 	{ "fix", no_argument, 0, 'f' },
 	{ "install", no_argument, 0, 'i' },
+	{ "ignore", no_argument, 0, 'I'},
 	{ "format", required_argument, 0, 'F' },
 	{ "quick", no_argument, 0, 'q' },
 	{ "force", no_argument, 0, 'x' },
@@ -92,6 +93,7 @@ static void print_help(const char *name)
 	printf("   -q, --quick             Don't compare hashes, only fix missing files\n");
 	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	printf("   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
+	printf("   -I, --ignore-certtime   Ignore system/certificate time when validating signature\n");
 	printf("   -S, --statedir          Specify alternate swupd state directory\n");
 	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
 	printf("\n");
@@ -101,7 +103,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxnm:p:u:P:c:v:fiF:qS:C:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxnIm:p:u:P:c:v:fiF:qS:C:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -176,6 +178,9 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'n':
 			sigcheck = false;
+			break;
+		case 'I':
+			timecheck = false;
 			break;
 		case 'C':
 			if (!optarg) {

--- a/src/verifytime.c
+++ b/src/verifytime.c
@@ -1,0 +1,102 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2017 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Authors:
+ *         Tudor Marcu <tudor.marcu@intel.com>
+ *
+ */
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#define DAY_SECONDS 86400
+
+unsigned long int get_versionstamp(void)
+{
+	struct stat statt;
+	FILE *fp = NULL;
+	char data[11];
+	const char *filename = "/usr/share/clear/versionstamp";
+
+	if (stat(filename, &statt) == -1) {
+		printf("%s does not exist!\n", filename);
+		return 0;
+	}
+
+	fp = fopen(filename, "r");
+	if (fp == NULL) {
+		printf("Failed to open %s\n", filename);
+		return 0;
+	}
+
+	if (fgets(data, 11, fp) == NULL) {
+		printf("Failed to read %s\n", filename);
+		fclose(fp);
+		return 0;
+	}
+
+	/* If we read a 0 the versionstamp is wrong/corrupt */
+	if (strtoul(data, NULL, 10) == 0) {
+		fclose (fp);
+		return 0;
+	}
+
+	fclose(fp);
+	return strtoul(data, NULL, 10);
+}
+
+bool set_time(time_t mtime, char *time)
+{
+	if (stime(&mtime) != 0) {
+		printf("Failed to set system time");
+		return false;
+	}
+	printf("Set system time to %s\n", time);
+	return true;
+}
+
+int main()
+{
+	time_t currtime;
+	struct tm *timeinfo;
+	unsigned long int versionstamp;
+
+	time(&currtime);
+	timeinfo = localtime(&currtime);
+
+	versionstamp = get_versionstamp();
+	if (versionstamp == 0) {
+		return 1;
+	}
+	time_t versiontime = (time_t)versionstamp;
+
+	/* Give it a day's worth of tolerance */
+	if ((unsigned long int)currtime < (versionstamp - DAY_SECONDS)) {
+		/* TODO: Get even better time than the versionstamp using a collection of servers,
+		 * and fallback to using versionstamp time if it does not work or seem reasonable.
+		 * The system time wasn't sane, so set it here and try again */
+		printf("Warning: Current time is %s\nAttempting to fix...", asctime(timeinfo));
+		if (set_time(versiontime, asctime(timeinfo)) == false) {
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/test/functional/swupdlib.bash
+++ b/test/functional/swupdlib.bash
@@ -9,7 +9,7 @@ export DIR="$BATS_TEST_DIRNAME"
 
 export STATE_DIR="$BATS_TEST_DIRNAME/state"
 
-export SWUPD_OPTS="-S $STATE_DIR -p $DIR/target-dir -F staging -u file://$DIR/web-dir -C $BATS_TEST_DIRNAME/../../Swupd_Root.pem"
+export SWUPD_OPTS="-S $STATE_DIR -p $DIR/target-dir -F staging -u file://$DIR/web-dir -C $BATS_TEST_DIRNAME/../../Swupd_Root.pem -I"
 
 export SWUPD_OPTS_NO_CERT="-S $STATE_DIR -p $DIR/target-dir -F staging -u file://$DIR/web-dir"
 


### PR DESCRIPTION
The system clock may be terribly off, especially on new hardware that has not
yet been calibrated. Updates rely on the certificate and system time being
sane to verify validity, so if a mismatch is found the certificate will
be deemed invalid and the update stopped. This patch attempts to fix the
system time to something sane using the time from the versionstamp,
which should not have been touched by any user except root. If the time is
normal and verification fails, the cert cannot be trusted.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>