### PR TITLE
Error handling fixes for fullfile downloads

### DIFF
--- a/src/download.c
+++ b/src/download.c
@@ -500,6 +500,12 @@ static int poll_fewer_than(size_t xfer_queue_high, size_t xfer_queue_low)
 			}
 		}
 
+		// Do more work before processing the queue
+		curlm_ret = curl_multi_perform(mcurl, &running);
+		if (curlm_ret != CURLM_OK) {
+			return -1;
+		}
+
 		// Instead of using "numfds" as a hint for how many transfers
 		// to process, try to drain the queue to the lower bound.
 		int remaining = mcurl_size - xfer_queue_low;

--- a/src/download.c
+++ b/src/download.c
@@ -552,7 +552,6 @@ void full_download(struct file *file)
 
 	ret = poll_fewer_than(MAX_XFER, MAX_XFER_BOTTOM);
 	if (ret != 0) {
-		clean_curl_multi_queue();
 		goto out_bad;
 	}
 
@@ -595,7 +594,6 @@ void full_download(struct file *file)
 
 	ret = poll_fewer_than(MAX_XFER + 10, MAX_XFER);
 	if (ret != 0) {
-		clean_curl_multi_queue();
 		goto out_bad;
 	}
 

--- a/src/download.c
+++ b/src/download.c
@@ -167,6 +167,7 @@ static void free_curl_list_data(void *data)
 	CURL *curl = file->curl;
 	(void)swupd_download_file_complete(CURLE_OK, file);
 	if (curl != NULL) {
+		/* Must remove handle out of multi queue first!*/
 		curl_multi_remove_handle(mcurl, curl);
 		curl_easy_cleanup(curl);
 		file->curl = NULL;
@@ -599,14 +600,8 @@ void full_download(struct file *file)
 	goto out_good;
 
 out_bad:
-	(void)swupd_download_file_complete(CURLE_OK, file);
 	failed = list_prepend_data(failed, file);
-	if (curl != NULL) {
-		/* Must remove handle out of multi queue first!*/
-		curl_multi_remove_handle(mcurl, curl);
-		curl_easy_cleanup(curl);
-		file->curl = NULL;
-	}
+	free_curl_list_data(file);
 	free(filename);
 out_good:
 	free(url);

--- a/src/download.c
+++ b/src/download.c
@@ -169,6 +169,7 @@ static void free_curl_list_data(void *data)
 	if (curl != NULL) {
 		curl_multi_remove_handle(mcurl, curl);
 		curl_easy_cleanup(curl);
+		file->curl = NULL;
 	}
 }
 
@@ -604,6 +605,7 @@ out_bad:
 		/* Must remove handle out of multi queue first!*/
 		curl_multi_remove_handle(mcurl, curl);
 		curl_easy_cleanup(curl);
+		file->curl = NULL;
 	}
 	free(filename);
 out_good:

--- a/src/download.c
+++ b/src/download.c
@@ -551,7 +551,7 @@ void full_download(struct file *file)
 	file->curl = curl;
 
 	ret = poll_fewer_than(MAX_XFER, MAX_XFER_BOTTOM);
-	if (ret) {
+	if (ret != 0) {
 		clean_curl_multi_queue();
 		goto out_bad;
 	}
@@ -593,9 +593,12 @@ void full_download(struct file *file)
 	 * it with a counter variable. */
 	mcurl_size++;
 
-	if (poll_fewer_than(MAX_XFER + 10, MAX_XFER) != 0) {
+	ret = poll_fewer_than(MAX_XFER + 10, MAX_XFER);
+	if (ret != 0) {
 		clean_curl_multi_queue();
+		goto out_bad;
 	}
+
 	ret = 0;
 	goto out_good;
 

--- a/src/download.c
+++ b/src/download.c
@@ -498,12 +498,13 @@ static int poll_fewer_than(size_t xfer_queue_high, size_t xfer_queue_low)
 			if (running == 0) {
 				break;
 			}
-
-			continue;
 		}
 
-		// At this point, there are some potential events to process
-		if (perform_curl_io_and_complete(numfds, true) != 0) {
+		// Instead of using "numfds" as a hint for how many transfers
+		// to process, try to drain the queue to the lower bound.
+		int remaining = mcurl_size - xfer_queue_low;
+
+		if (perform_curl_io_and_complete(remaining, true) != 0) {
 			return -1;
 		}
 


### PR DESCRIPTION
This series addresses a couple of double frees encountered in error paths and also a "hysteresis escape" that was hitting these error paths.