### PR TITLE
Remove bad or unusable Manifest content and retry

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -185,6 +185,7 @@ extern struct list *create_update_list(struct manifest *current, struct manifest
 extern void link_manifests(struct manifest *m1, struct manifest *m2);
 extern void link_submanifests(struct manifest *m1, struct manifest *m2, struct list *subs1, struct list *subs2);
 extern void free_manifest(struct manifest *manifest);
+extern void remove_manifest_files(char *filename, int version, char *hash);
 
 extern void grabtime_start(timelist *list, const char *name);
 extern void grabtime_stop(timelist *list);

--- a/src/hash.c
+++ b/src/hash.c
@@ -288,6 +288,8 @@ int verify_bundle_hash(struct manifest *manifest, struct file *bundle)
 		string_or_die(&local, "%s/%i/Manifest.%s", state_dir,
 			      current->last_change, current->filename);
 
+		/* *NOTE* If the file is changed after being hardlinked, the hash will be different,
+		 * but the inode will not change making swupd skip hash check thinking they still match */
 		if (stat(local, &sb) == 0 && stat(cached, &sb2) == 0 && sb.st_ino == sb2.st_ino) {
 			free(cached);
 			break;


### PR DESCRIPTION
For various reasons - partial downloads, power failure, user exiting -
the /var/lib/swupd state directory may become corrupt. When this happens,
manifests can be rendered unusable, causing various errors in swupd such as
signature failures, or errors reading the manifest. This patch attempts to
avoid such things causing updates or verifies to fail by cleaning up the
Manifests artifacts of what it could not use, and re-downloading them to
try again.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>