### PR TITLE
Need to reexec systemd if it changed

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -75,6 +75,7 @@ extern int update_skip;
 extern bool update_complete;
 extern bool need_update_boot;
 extern bool need_update_bootloader;
+extern bool need_systemd_reexec;
 
 struct update_stat {
 	uint64_t st_mode;

--- a/src/globals.c
+++ b/src/globals.c
@@ -40,6 +40,7 @@ int update_count = 0;
 int update_skip = 0;
 bool need_update_boot = false;
 bool need_update_bootloader = false;
+bool need_systemd_reexec = false;
 bool update_complete = false;
 #if 0
 /* disabled unused global variables */

--- a/src/heuristics.c
+++ b/src/heuristics.c
@@ -98,6 +98,10 @@ static void boot_file_heuristics(struct file *file)
 		need_update_boot = true;
 	}
 
+	if (strcmp(file->filename, "/usr/lib/systemd/systemd") == 0) {
+		need_systemd_reexec = true;
+	}
+
 	if ((strncmp(file->filename, "/usr/lib/gummiboot", 18) == 0) ||
 	    (strncmp(file->filename, "/usr/bin/gummiboot", 18) == 0) ||
 	    (strncmp(file->filename, "/usr/bin/bootctl", 16) == 0) ||

--- a/src/scripts.c
+++ b/src/scripts.c
@@ -51,7 +51,13 @@ static void update_triggers(void)
 {
 	__attribute__((unused)) int ret = 0;
 
-	ret = system("/usr/bin/systemctl --no-block daemon-reload");
+	/* These must block so that new update triggers are executed after */
+	if (need_systemd_reexec) {
+		ret = system("/usr/bin/systemctl daemon-reexec");
+	} else {
+		ret = system("/usr/bin/systemctl daemon-reload");
+	}
+
 	ret = system("/usr/bin/systemctl --no-block restart update-triggers.target");
 }
 


### PR DESCRIPTION
We must not run these with --no-block because order must be preserved,
and critical components may need to be reexec'd, making this a core piece
of the swupd update process.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>