### PR TITLE
Delta manifests

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -164,7 +164,7 @@ extern void clean_curl_multi_queue(void);
 extern void increment_retries(int *retries, int *timeout);
 
 extern int main_update(void);
-extern int add_included_manifests(struct manifest *mom, struct list **subs);
+extern int add_included_manifests(struct manifest *mom, int current, struct list **subs);
 extern int main_verify(int current_version);
 
 extern int get_latest_version(void);

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -183,7 +183,7 @@ extern struct manifest *load_mom(int version);
 extern struct manifest *load_manifest(int current, int version, struct file *file, struct manifest *mom, bool header_only);
 extern struct list *create_update_list(struct manifest *current, struct manifest *server);
 extern void link_manifests(struct manifest *m1, struct manifest *m2);
-extern void link_submanifests(struct manifest *m1, struct manifest *m2, struct list *subs1, struct list *subs2);
+extern void link_submanifests(struct manifest *m1, struct manifest *m2, struct list *subs1, struct list *subs2, bool server);
 extern void free_manifest(struct manifest *manifest);
 extern void remove_manifest_files(char *filename, int version, char *hash);
 

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -850,7 +850,7 @@ void link_manifests(struct manifest *m1, struct manifest *m2)
 
 /* m1: old manifest
  * m2: new manifest */
-void link_submanifests(struct manifest *m1, struct manifest *m2, struct list *subs1, struct list *subs2)
+void link_submanifests(struct manifest *m1, struct manifest *m2, struct list *subs1, struct list *subs2, bool server)
 {
 	struct list *list1, *list2;
 	struct file *file1, *file2;
@@ -878,14 +878,15 @@ void link_submanifests(struct manifest *m1, struct manifest *m2, struct list *su
 			list1 = list1->next;
 			list2 = list2->next;
 
+			/* server (new) manifests will only bring in new bundles */
 			if (file2->last_change > m1->version && !file2->is_deleted) {
-				if (subbed1 && subbed2) {
+				if (!server && subbed1 && subbed2) {
 					account_changed_bundle();
 				} else if (!subbed1 && subbed2) {
 					account_new_bundle();
 				}
 			}
-			if (file2->last_change > m1->version && file2->is_deleted) {
+			if (!server && (file2->last_change > m1->version && file2->is_deleted)) {
 				if (subbed1) {
 					account_deleted_bundle();
 				}

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -503,11 +503,15 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 	char *tar;
 	struct stat sb;
 
-	string_or_die(&filename, "%s/%i/Manifest.%s.tar", state_dir, version, component);
+	/* Check for fullfile only, we will not be keeping the .tar around */
+	string_or_die(&filename, "%s/%i/Manifest.%s", state_dir, version, component);
 	if (stat(filename, &sb) == 0) {
+
 		ret = 0;
 		goto out;
 	}
+	free(filename);
+	string_or_die(&filename, "%s/%i/Manifest.%s.tar", state_dir, version, component);
 
 	if (!check_network()) {
 		ret = -ENOSWUPDSERVER;
@@ -547,6 +551,8 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 	free(tar);
 	if (ret != 0) {
 		goto out;
+	} else {
+		unlink(filename);
 	}
 
 out:

--- a/src/update.c
+++ b/src/update.c
@@ -190,7 +190,7 @@ TRY_DOWNLOAD:
 	return ret;
 }
 
-int add_included_manifests(struct manifest *mom, struct list **subs)
+int add_included_manifests(struct manifest *mom, int current, struct list **subs)
 {
 	struct list *subbed = NULL;
 	struct list *iter;
@@ -202,7 +202,9 @@ int add_included_manifests(struct manifest *mom, struct list **subs)
 		iter = iter->next;
 	}
 
-	if (add_subscriptions(subbed, subs, mom->version, mom, 0) >= 0) {
+	/* Pass the current version here, not the new, otherwise we will never
+	 * hit the Manifest delta path. */
+	if (add_subscriptions(subbed, subs, current, mom, 0) >= 0) {
 		ret = 0;
 	} else {
 		ret = -1;

--- a/src/verify.c
+++ b/src/verify.c
@@ -685,7 +685,7 @@ int verify_main(int argc, char **argv)
 		goto clean_and_exit;
 	}
 
-	ret = add_included_manifests(official_manifest, &subs);
+	ret = add_included_manifests(official_manifest, version, &subs);
 	if (ret) {
 		ret = EMANIFEST_LOAD;
 		goto clean_and_exit;


### PR DESCRIPTION
This patch-set enables delta file application for manifests, decreasing manifest download size by a factor of 150x or more in some cases.