### PR TITLE
Fix download/extract pack message

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -466,7 +466,6 @@ static int install_bundles(struct list *bundles, struct list **subs, int current
 	grabtime_start(&times, "Download packs");
 	(void)rm_staging_dir_contents("download");
 
-	printf("Downloading packs...\n");
 	(void)download_subscribed_packs(*subs, true);
 	grabtime_stop(&times);
 

--- a/src/packs.c
+++ b/src/packs.c
@@ -52,8 +52,6 @@ static int download_pack(int oldversion, int newversion, char *module)
 		return 0;
 	}
 
-	printf("Downloading %s pack for version %i\n", module, newversion);
-
 	string_or_die(&url, "%s/%i/pack-%s-from-%i.tar", content_url, newversion, module, oldversion);
 
 	err = swupd_curl_get_file(url, filename, NULL, NULL, true);
@@ -68,7 +66,7 @@ static int download_pack(int oldversion, int newversion, char *module)
 
 	free(url);
 
-	printf("Extracting pack.\n");
+	printf("Extracting %s pack for version %i\n", module, newversion);
 	string_or_die(&tar, TAR_COMMAND " -C %s " TAR_PERM_ATTR_ARGS " -xf %s/pack-%s-from-%i-to-%i.tar 2> /dev/null",
 		      state_dir, state_dir, module, oldversion, newversion);
 
@@ -104,6 +102,7 @@ int download_subscribed_packs(struct list *subs, bool required)
 		return -ENOSWUPDSERVER;
 	}
 
+	printf("Downloading packs...\n");
 	iter = list_head(subs);
 	while (iter) {
 		sub = iter->data;

--- a/test/functional/bundleadd/add-directory/lines-checked
+++ b/test/functional/bundleadd/add-directory/lines-checked
@@ -1,6 +1,4 @@
 Attempting to download version string to memory
-Downloading packs...
-Downloading test-bundle pack for version 10
-Extracting pack.
+Extracting test-bundle pack for version 10
 Installing bundle(s) files...
 Bundle(s) installation done.

--- a/test/functional/bundleadd/add-multiple/lines-checked
+++ b/test/functional/bundleadd/add-multiple/lines-checked
@@ -1,8 +1,5 @@
 Attempting to download version string to memory
-Downloading packs...
-Downloading test-bundle1 pack for version 10
-Extracting pack.
-Downloading test-bundle2 pack for version 10
-Extracting pack.
+Extracting test-bundle1 pack for version 10
+Extracting test-bundle2 pack for version 10
 Installing bundle(s) files...
 Bundle(s) installation done.

--- a/test/functional/bundleadd/boot-file/lines-checked
+++ b/test/functional/bundleadd/boot-file/lines-checked
@@ -1,6 +1,4 @@
 Attempting to download version string to memory
-Downloading packs...
-Downloading test-bundle pack for version 10
-Extracting pack.
+Extracting test-bundle pack for version 10
 Installing bundle(s) files...
 Bundle(s) installation done.

--- a/test/functional/bundleadd/fix-missing-file/lines-checked
+++ b/test/functional/bundleadd/fix-missing-file/lines-checked
@@ -1,6 +1,4 @@
 Attempting to download version string to memory
-Downloading packs...
-Downloading test-bundle pack for version 10
 Installing bundle(s) files...
 Path /foo is missing on the file system
 Bundle(s) installation done.

--- a/test/functional/bundleadd/include/lines-checked
+++ b/test/functional/bundleadd/include/lines-checked
@@ -1,8 +1,5 @@
 Attempting to download version string to memory
-Downloading packs...
-Downloading test-bundle pack for version 10
-Extracting pack.
-Downloading os-core pack for version 10
-Extracting pack.
+Extracting test-bundle pack for version 10
+Extracting os-core pack for version 10
 Installing bundle(s) files...
 Bundle(s) installation done.

--- a/test/functional/bundleadd/verify-fix-path/lines-checked
+++ b/test/functional/bundleadd/verify-fix-path/lines-checked
@@ -1,7 +1,5 @@
 Attempting to download version string to memory
-Downloading packs...
-Downloading test-bundle pack for version 10
-Extracting pack.
+Extracting test-bundle pack for version 10
 Installing bundle(s) files...
 REGEXP:Update target directory does not exist: .*/usr/bin. Trying to fix it
 Path /usr/bin is missing on the file system

--- a/test/functional/ignore-list
+++ b/test/functional/ignore-list
@@ -5,6 +5,7 @@
 ^swupd-client software verify [0-9.]+$
 ^.*Copyright \(C\) .*$
 ^$
+^Downloading packs...
 ^Calling post-update helper scripts.$
 ^No kernel update needed, skipping helper call out.$
 ^No bootloader update needed, skipping helper call out.$

--- a/test/functional/update/apply-full-file-delta/lines-checked
+++ b/test/functional/update/apply-full-file-delta/lines-checked
@@ -1,8 +1,7 @@
 Attempting to download version string to memory
 Update started.
 Preparing to update from 10 to 100
-Downloading os-core pack for version 100
-Extracting pack.
+Extracting os-core pack for version 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1
     new bundles       : 0

--- a/test/functional/update/boot-file/lines-checked
+++ b/test/functional/update/boot-file/lines-checked
@@ -1,7 +1,6 @@
 Attempting to download version string to memory
 Update started.
 Preparing to update from 10 to 100
-Downloading os-core pack for version 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1
     new bundles       : 0

--- a/test/functional/update/download/lines-checked
+++ b/test/functional/update/download/lines-checked
@@ -1,8 +1,7 @@
 Attempting to download version string to memory
 Update started.
 Preparing to update from 10 to 100
-Downloading os-core pack for version 100
-Extracting pack.
+Extracting os-core pack for version 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1
     new bundles       : 0

--- a/test/functional/update/include-old-bundle-with-tracked-file/lines-checked
+++ b/test/functional/update/include-old-bundle-with-tracked-file/lines-checked
@@ -1,9 +1,6 @@
 Attempting to download version string to memory
 Update started.
 Preparing to update from 20 to 30
-Downloading os-core pack for version 30
-Downloading test-bundle2 pack for version 30
-Downloading test-bundle3 pack for version 30
 Statistics for going from version 20 to version 30:
     changed bundles   : 3
     new bundles       : 0

--- a/test/functional/update/include-old-bundle/lines-checked
+++ b/test/functional/update/include-old-bundle/lines-checked
@@ -1,8 +1,6 @@
 Attempting to download version string to memory
 Update started.
 Preparing to update from 10 to 100
-Downloading os-core pack for version 100
-Downloading test-bundle1 pack for version 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 2
     new bundles       : 0

--- a/test/functional/update/include/lines-checked
+++ b/test/functional/update/include/lines-checked
@@ -1,14 +1,6 @@
 Attempting to download version string to memory
 Update started.
 Preparing to update from 10 to 100
-Downloading test-bundle3 pack for version 100
-Downloading test-bundle4 pack for version 100
-Downloading test-bundle5 pack for version 100
-Downloading test-bundle2 pack for version 100
-Downloading test-bundle7 pack for version 100
-Downloading test-bundle6 pack for version 100
-Downloading os-core pack for version 100
-Downloading test-bundle1 pack for version 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 2
     new bundles       : 6

--- a/test/functional/update/missing-os-core/lines-checked
+++ b/test/functional/update/missing-os-core/lines-checked
@@ -1,8 +1,6 @@
 Attempting to download version string to memory
 Update started.
 Preparing to update from 10 to 100
-Downloading os-core pack for version 100
-Downloading test-bundle1 pack for version 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 2
     new bundles       : 0

--- a/test/functional/update/newest-deleted/lines-checked
+++ b/test/functional/update/newest-deleted/lines-checked
@@ -1,9 +1,7 @@
 Attempting to download version string to memory
 Update started.
 Preparing to update from 20 to 30
-Downloading os-core pack for version 30
-Extracting pack.
-Downloading test-bundle2 pack for version 30
+Extracting os-core pack for version 30
 Statistics for going from version 20 to version 30:
     changed bundles   : 2
     new bundles       : 0

--- a/test/functional/update/skip-verified-fullfiles/lines-checked
+++ b/test/functional/update/skip-verified-fullfiles/lines-checked
@@ -1,7 +1,6 @@
 Attempting to download version string to memory
 Update started.
 Preparing to update from 10 to 100
-Downloading test-bundle pack for version 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1
     new bundles       : 0

--- a/test/functional/update/use-full-file/lines-checked
+++ b/test/functional/update/use-full-file/lines-checked
@@ -1,7 +1,6 @@
 Attempting to download version string to memory
 Update started.
 Preparing to update from 10 to 100
-Downloading os-core pack for version 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1
     new bundles       : 0

--- a/test/functional/update/use-pack/lines-checked
+++ b/test/functional/update/use-pack/lines-checked
@@ -1,8 +1,7 @@
 Attempting to download version string to memory
 Update started.
 Preparing to update from 10 to 100
-Downloading os-core pack for version 100
-Extracting pack.
+Extracting os-core pack for version 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1
     new bundles       : 0

--- a/test/functional/update/verify-fix-path-hash-mismatch/lines-checked
+++ b/test/functional/update/verify-fix-path-hash-mismatch/lines-checked
@@ -1,7 +1,6 @@
 Attempting to download version string to memory
 Update started.
 Preparing to update from 10 to 100
-Downloading test-bundle pack for version 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1
     new bundles       : 0

--- a/test/functional/update/verify-fix-path-missing-dir/lines-checked
+++ b/test/functional/update/verify-fix-path-missing-dir/lines-checked
@@ -1,7 +1,6 @@
 Attempting to download version string to memory
 Update started.
 Preparing to update from 10 to 100
-Downloading test-bundle pack for version 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1
     new bundles       : 0

--- a/test/functional/update/verify-fullfile-hash/lines-checked
+++ b/test/functional/update/verify-fullfile-hash/lines-checked
@@ -1,7 +1,6 @@
 Attempting to download version string to memory
 Update started.
 Preparing to update from 10 to 100
-Downloading test-bundle pack for version 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1
     new bundles       : 0

--- a/test/functional/verify/install-directory/lines-checked
+++ b/test/functional/verify/install-directory/lines-checked
@@ -1,7 +1,6 @@
 Verifying version 10
 Attempting to download version string to memory
-Downloading os-core pack for version 10
-Extracting pack.
+Extracting os-core pack for version 10
 Adding any missing files
 Inspected 1 files
   1 files were missing

--- a/test/functional/verify/install-latest-directory/lines-checked
+++ b/test/functional/verify/install-latest-directory/lines-checked
@@ -1,7 +1,6 @@
 Attempting to download version string to memory
 Verifying version 100
-Downloading os-core pack for version 100
-Extracting pack.
+Extracting os-core pack for version 100
 Adding any missing files
 Inspected 1 files
   1 files were missing


### PR DESCRIPTION
Swupd incorrectly says "Downloading pack <name>..." even if it does not
really download the pack. Fix this by saying downloading packs and only
printing if we downloaded a pack to extract.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>