### PR TITLE
build: validate --with-formatid input

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -222,6 +222,11 @@ AS_IF(
   [FORMATID='!! Warning !! --with-formatid not specified!'],
   [FORMATID='!! Warning !! --with-formatid not specified!']
 )
+AS_IF(
+  [test -n "$with_formatid"],
+  [echo "$with_formatid" | grep -q -E '^([[1-9]][[0-9]]*|staging)$' || \
+    AC_MSG_ERROR(['--with-formatid' has an invalid value ($with_formatid). Supported values are positive integers or "staging".])]
+)
 
 AC_ARG_WITH(
   [systemdsystemunitdir],


### PR DESCRIPTION
To ensure validity of the format number hardcoded in the binary, check
the supplied input against a regular expression using grep.

Note that the double square brackets are needed for the regex character
classes because square brackets are used for M4 quotation in Autoconf;
an extra pair of square brackets is needed to prevent them from being
stripped in the configure script.