### PR TITLE
Retry pack downloads on bundle-add

### DIFF
--- a/test/functional/bundleadd/fix-missing-file/lines-checked
+++ b/test/functional/bundleadd/fix-missing-file/lines-checked
@@ -1,4 +1,7 @@
 Attempting to download version string to memory
+Retry #1 downloading subscribed packs
+Retry #2 downloading subscribed packs
+Retry #3 downloading subscribed packs
 Installing bundle(s) files...
 Path /foo is missing on the file system
 Bundle(s) installation done.


### PR DESCRIPTION
The download_subscribed_packs() could fail for network issues or other related
problems, and because the only option for getting new packs is by downloading
zero packs or fullfiles, swupd should retry to get the packs before falling
into the verify_fix_path flow which signifies pack downloads errored out.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>