### PR TITLE
Fix infinite signature failure loop

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -633,7 +633,6 @@ verify_mom:
 		printf("Failed to load %d MoM manifest\n", version);
 		goto out;
 	}
-	retried = false;
 
 	string_or_die(&filename, "%s/%i/Manifest.MoM", state_dir, version);
 	string_or_die(&url, "%s/%i/Manifest.MoM", content_url, version);


### PR DESCRIPTION
Unlike the regular manifest loading code, loading a MoM also requires signature
verification to succeed. We cannot reset the retries after a signature
failed because the manifest may load fine, but still fail verification,
resulting in endlessly loading and verifying the Manifest.MoM

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>