### PR TITLE
Add support for new manifest header line

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -76,6 +76,7 @@ extern bool update_complete;
 extern bool need_update_boot;
 extern bool need_update_bootloader;
 extern bool need_systemd_reexec;
+extern char *post_update_action;
 
 struct update_stat {
 	uint64_t st_mode;

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -181,7 +181,7 @@ extern void apply_heuristics(struct file *file);
 
 extern int file_sort_filename(const void *a, const void *b);
 extern int file_sort_filename_reverse(const void *a, const void *b);
-extern struct manifest *load_mom(int version);
+extern struct manifest *load_mom(int version, bool latest);
 extern struct manifest *load_manifest(int current, int version, struct file *file, struct manifest *mom, bool header_only);
 extern struct list *create_update_list(struct manifest *current, struct manifest *server);
 extern void link_manifests(struct manifest *m1, struct manifest *m2);

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -70,7 +70,7 @@ int list_installable_bundles()
 
 	swupd_curl_set_current_version(current_version);
 
-	MoM = load_mom(current_version);
+	MoM = load_mom(current_version, false);
 	if (!MoM) {
 		v_lockfile(lock_fd);
 		return EMOM_NOTFOUND;
@@ -104,7 +104,7 @@ static int load_bundle_manifest(const char *bundle_name, struct list *subs, int 
 	*submanifest = NULL;
 
 	swupd_curl_set_current_version(version);
-	mom = load_mom(version);
+	mom = load_mom(version, false);
 	if (!mom) {
 		return EMOM_NOTFOUND;
 	}
@@ -252,7 +252,7 @@ int remove_bundle(const char *bundle_name)
 
 	swupd_curl_set_current_version(current_version);
 
-	current_mom = load_mom(current_version);
+	current_mom = load_mom(current_version, false);
 	if (!current_mom) {
 		printf("Unable to download/verify %d Manifest.MoM\n", current_version);
 		ret = EMOM_NOTFOUND;
@@ -581,7 +581,7 @@ int install_bundles_frontend(char **bundles)
 
 	swupd_curl_set_current_version(current_version);
 
-	mom = load_mom(current_version);
+	mom = load_mom(current_version, false);
 	if (!mom) {
 		printf("Cannot load official manifest MoM for version %i\n", current_version);
 		ret = EMOM_NOTFOUND;

--- a/src/globals.c
+++ b/src/globals.c
@@ -42,6 +42,7 @@ bool need_update_boot = false;
 bool need_update_bootloader = false;
 bool need_systemd_reexec = false;
 bool update_complete = false;
+char *post_update_action = NULL;
 #if 0
 /* disabled unused global variables */
 bool ignore_config = true;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -233,6 +233,9 @@ static struct manifest *manifest_from_file(int version, char *component, bool he
 		if (strncmp(line, "contentsize:", 12) == 0) {
 			contentsize = strtoull(c, NULL, 10);
 		}
+		if (strncmp(line, "actions:", 8) == 0) {
+			post_update_action = strdup(c);
+		}
 		if (strncmp(line, "includes:", 9) == 0) {
 			includes = list_prepend_data(includes, strdup(c));
 			if (!includes->data) {

--- a/src/search.c
+++ b/src/search.c
@@ -424,7 +424,7 @@ static int download_manifests(struct manifest **MoM, struct list **subs)
 
 	swupd_curl_set_current_version(current_version);
 
-	*MoM = load_mom(current_version);
+	*MoM = load_mom(current_version, false);
 	if (!(*MoM)) {
 		printf("Cannot load official manifest MoM for version %i\n", current_version);
 		return EMOM_NOTFOUND;

--- a/src/update.c
+++ b/src/update.c
@@ -294,7 +294,7 @@ load_current_mom:
 	/* Step 3: setup manifests */
 
 	/* get the from/to MoM manifests */
-	current_manifest = load_mom(current_version);
+	current_manifest = load_mom(current_version, false);
 	if (!current_manifest) {
 		/* TODO: possibly remove this as not getting a "from" manifest is not fatal
 		 * - we just don't apply deltas */
@@ -315,7 +315,7 @@ load_current_mom:
 load_server_mom:
 	grabtime_stop(&times); // Close step 2
 	grabtime_start(&times, "Recurse and Consolidate Manifests");
-	server_manifest = load_mom(server_version);
+	server_manifest = load_mom(server_version, true);
 	if (!server_manifest) {
 		if (retries < MAX_TRIES) {
 			increment_retries(&retries, &timeout);

--- a/src/update.c
+++ b/src/update.c
@@ -214,6 +214,15 @@ int add_included_manifests(struct manifest *mom, int current, struct list **subs
 	return ret;
 }
 
+static void run_postupdate_action(void)
+{
+	if (post_update_action == NULL) {
+		return;
+	}
+	fprintf(stderr, "**** [Warning] Post update action was detected in this update, please run: ****\n\t$ %s\n", post_update_action);
+	free(post_update_action);
+}
+
 int main_update()
 {
 	int current_version = -1, server_version = -1;
@@ -485,6 +494,7 @@ clean_curl:
 	if (nonpack > 0) {
 		printf("%i files were not in a pack\n", nonpack);
 	}
+	run_postupdate_action();
 
 	return ret;
 }

--- a/src/verify.c
+++ b/src/verify.c
@@ -669,7 +669,7 @@ int verify_main(int argc, char **argv)
 	times = init_timelist();
 
 	grabtime_start(&times, "Load and recurse Manifests");
-	official_manifest = load_mom(version);
+	official_manifest = load_mom(version, false);
 
 	if (!official_manifest) {
 		/* This is hit when or if an OS version is specified for --fix which


### PR DESCRIPTION
The swupd client should support parsing extra data in the case that a format
bump occurred, or other possibly breaking change, so that it can at least
notify the user of more action needing to be taken post update.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>