### PR TITLE
Convert printf to fprintf(stderr, almost everywhere

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -51,19 +51,19 @@ int list_installable_bundles()
 
 	ret = swupd_init(&lock_fd);
 	if (ret != 0) {
-		printf("Error: Failed updater initialization. Exiting now\n");
+		fprintf(stderr, "Error: Failed updater initialization. Exiting now\n");
 		return ret;
 	}
 
 	if (!check_network()) {
-		printf("Error: Network issue, unable to download manifest\n");
+		fprintf(stderr, "Error: Network issue, unable to download manifest\n");
 		v_lockfile(lock_fd);
 		return ENOSWUPDSERVER;
 	}
 
 	current_version = get_current_version(path_prefix);
 	if (current_version < 0) {
-		printf("Error: Unable to determine current OS version\n");
+		fprintf(stderr, "Error: Unable to determine current OS version\n");
 		v_lockfile(lock_fd);
 		return ECURRENT_VERSION;
 	}
@@ -223,7 +223,7 @@ int remove_bundle(const char *bundle_name)
 
 	ret = swupd_init(&lock_fd);
 	if (ret != 0) {
-		printf("Failed updater initialization, exiting now.\n");
+		fprintf(stderr, "Failed updater initialization, exiting now.\n");
 		return ret;
 	}
 
@@ -239,13 +239,13 @@ int remove_bundle(const char *bundle_name)
 
 	if (!is_tracked_bundle(bundle_name)) {
 		ret = EBUNDLE_NOT_TRACKED;
-		printf("Warning: Bundle \"%s\" does not seem to be installed\n", bundle_name);
+		fprintf(stderr, "Warning: Bundle \"%s\" does not seem to be installed\n", bundle_name);
 		goto out_free_curl;
 	}
 
 	current_version = get_current_version(path_prefix);
 	if (current_version < 0) {
-		printf("Error: Unable to determine current OS version\n");
+		fprintf(stderr, "Error: Unable to determine current OS version\n");
 		ret = ECURRENT_VERSION;
 		goto out_free_curl;
 	}
@@ -254,13 +254,13 @@ int remove_bundle(const char *bundle_name)
 
 	current_mom = load_mom(current_version, false);
 	if (!current_mom) {
-		printf("Unable to download/verify %d Manifest.MoM\n", current_version);
+		fprintf(stderr, "Unable to download/verify %d Manifest.MoM\n", current_version);
 		ret = EMOM_NOTFOUND;
 		goto out_free_curl;
 	}
 
 	if (!search_bundle_in_manifest(current_mom, bundle_name)) {
-		printf("Bundle name is invalid, aborting removal\n");
+		fprintf(stderr, "Bundle name is invalid, aborting removal\n");
 		ret = EBUNDLE_REMOVE;
 		goto out_free_mom;
 	}
@@ -278,13 +278,13 @@ int remove_bundle(const char *bundle_name)
 	/* load all submanifest minus the one to be removed */
 	current_mom->submanifests = recurse_manifest(current_mom, subs, NULL);
 	if (!current_mom->submanifests) {
-		printf("Error: Cannot load MoM sub-manifests\n");
+		fprintf(stderr, "Error: Cannot load MoM sub-manifests\n");
 		ret = ERECURSE_MANIFEST;
 		goto out_free_mom;
 	}
 
 	if (is_included(bundle_name, current_mom)) {
-		printf("Error: bundle requested to be removed is required by other installed bundles\n");
+		fprintf(stderr, "Error: bundle requested to be removed is required by other installed bundles\n");
 		ret = EBUNDLE_REMOVE;
 		goto out_free_mom;
 	}
@@ -296,7 +296,7 @@ int remove_bundle(const char *bundle_name)
 	/* Now that we have the consolidated list of all files, load bundle to be removed submanifest*/
 	ret = load_bundle_manifest(bundle_name, subs, current_version, &bundle_manifest);
 	if (ret != 0 || !bundle_manifest) {
-		printf("Error: Cannot load %s sub-manifest (ret = %d)\n", bundle_name, ret);
+		fprintf(stderr, "Error: Cannot load %s sub-manifest (ret = %d)\n", bundle_name, ret);
 		goto out_free_mom;
 	}
 
@@ -304,13 +304,13 @@ int remove_bundle(const char *bundle_name)
 	bundle_manifest->files = list_sort(bundle_manifest->files, file_sort_filename);
 	deduplicate_files_from_manifest(&bundle_manifest, current_mom);
 
-	printf("Deleting bundle files...\n");
+	fprintf(stderr, "Deleting bundle files...\n");
 	remove_files_in_manifest_from_fs(bundle_manifest);
 
-	printf("Untracking bundle from system...\n");
+	fprintf(stderr, "Untracking bundle from system...\n");
 	rm_bundle_file(bundle_name);
 
-	printf("Success: Bundle removed\n");
+	fprintf(stderr, "Success: Bundle removed\n");
 
 	free_manifest(bundle_manifest);
 out_free_mom:
@@ -325,7 +325,7 @@ out_free_curl:
 		  current_version,
 		  ret);
 	if (ret) {
-		printf("Error: Bundle remove failed\n");
+		fprintf(stderr, "Error: Bundle remove failed\n");
 	}
 
 	swupd_deinit(lock_fd, &subs);
@@ -360,7 +360,7 @@ int add_subscriptions(struct list *bundles, struct list **subs, int current_vers
 
 		file = search_bundle_in_manifest(mom, bundle);
 		if (!file) {
-			printf("%s bundle name is invalid, skipping it...\n", bundle);
+			fprintf(stderr, "%s bundle name is invalid, skipping it...\n", bundle);
 			ret |= add_sub_BADNAME; /* Use this to get non-zero exit code */
 			continue;
 		}
@@ -384,7 +384,7 @@ int add_subscriptions(struct list *bundles, struct list **subs, int current_vers
 				increment_retries(&retries, &timeout);
 				goto retry_manifest_download;
 			}
-			printf("Unable to download manifest %s version %d, exiting now\n", bundle, file->last_change);
+			fprintf(stderr, "Unable to download manifest %s version %d, exiting now\n", bundle, file->last_change);
 			ret |= add_sub_ERR;
 			goto out;
 		}
@@ -434,7 +434,7 @@ static int install_bundles(struct list *bundles, struct list **subs, int current
 		/* something went wrong, print a message and exit */
 		const char *m;
 		if (ret == 0) { /* no bad names, no new packages */
-			printf("nothing to add, exiting now\n");
+			fprintf(stderr, "nothing to add, exiting now\n");
 			goto out;
 		}
 		if (ret & add_sub_ERR) {
@@ -445,7 +445,7 @@ static int install_bundles(struct list *bundles, struct list **subs, int current
 			m = "Unknown error";
 		}
 		ret = EBUNDLE_INSTALL;
-		printf("Error: %s - Aborting\n", m); /* Should be to stderr */
+		fprintf(stderr, "Error: %s - Aborting\n", m); /* Should be to stderr */
 		goto out;
 	}
 
@@ -453,7 +453,7 @@ static int install_bundles(struct list *bundles, struct list **subs, int current
 
 	to_install_bundles = recurse_manifest(mom, *subs, NULL);
 	if (!to_install_bundles) {
-		printf("Error: Cannot load to install bundles\n");
+		fprintf(stderr, "Error: Cannot load to install bundles\n");
 		ret = ERECURSE_MANIFEST;
 		goto out;
 	}
@@ -484,7 +484,7 @@ download_subscribed_packs:
 	set_subscription_versions(mom, NULL, subs);
 	mom->submanifests = recurse_manifest(mom, *subs, NULL);
 	if (!mom->submanifests) {
-		printf("Error: Cannot load installed bundles\n");
+		fprintf(stderr, "Error: Cannot load installed bundles\n");
 		ret = ERECURSE_MANIFEST;
 		goto out;
 	}
@@ -495,7 +495,7 @@ download_subscribed_packs:
 
 	/* step 4: Install all bundle(s) files into the fs */
 	grabtime_start(&times, "Installing bundle(s) files onto filesystem");
-	printf("Installing bundle(s) files...\n");
+	fprintf(stderr, "Installing bundle(s) files...\n");
 	iter = list_head(to_install_files);
 	while (iter) {
 		file = iter->data;
@@ -538,7 +538,7 @@ download_subscribed_packs:
 	run_scripts();
 
 	ret = 0;
-	printf("Bundle(s) installation done.\n");
+	fprintf(stderr, "Bundle(s) installation done.\n");
 	print_time_stats(&times);
 
 out:
@@ -568,13 +568,13 @@ int install_bundles_frontend(char **bundles)
 	/* initialize swupd and get current version from OS */
 	ret = swupd_init(&lock_fd);
 	if (ret != 0) {
-		printf("Failed updater initialization, exiting now.\n");
+		fprintf(stderr, "Failed updater initialization, exiting now.\n");
 		return ret;
 	}
 
 	current_version = get_current_version(path_prefix);
 	if (current_version < 0) {
-		printf("Error: Unable to determine current OS version\n");
+		fprintf(stderr, "Error: Unable to determine current OS version\n");
 		ret = ECURRENT_VERSION;
 		goto clean_and_exit;
 	}
@@ -583,7 +583,7 @@ int install_bundles_frontend(char **bundles)
 
 	mom = load_mom(current_version, false);
 	if (!mom) {
-		printf("Cannot load official manifest MoM for version %i\n", current_version);
+		fprintf(stderr, "Cannot load official manifest MoM for version %i\n", current_version);
 		ret = EMOM_NOTFOUND;
 		goto clean_and_exit;
 	}

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -32,19 +32,19 @@
 
 static void print_help(const char *name)
 {
-	printf("Usage:\n");
-	printf("   swupd %s [options] bundlename\n\n", basename((char *)name));
-	printf("Help Options:\n");
-	printf("   -h, --help              Show help options\n");
-	printf("   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
-	printf("   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
-	printf("   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
-	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
-	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
-	printf("   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
-	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
-	printf("   -S, --statedir          Specify alternate swupd state directory\n");
-	printf("\n");
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "   swupd %s [options] bundlename\n\n", basename((char *)name));
+	fprintf(stderr, "Help Options:\n");
+	fprintf(stderr, "   -h, --help              Show help options\n");
+	fprintf(stderr, "   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
+	fprintf(stderr, "   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
+	fprintf(stderr, "   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
+	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
+	fprintf(stderr, "   -x, --force             Attempt to proceed even if non-critical errors found\n");
+	fprintf(stderr, "   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
+	fprintf(stderr, "   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
+	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");
+	fprintf(stderr, "\n");
 }
 
 static const struct option prog_opts[] = {
@@ -72,7 +72,7 @@ static bool parse_options(int argc, char **argv)
 			exit(EXIT_SUCCESS);
 		case 'u':
 			if (!optarg) {
-				printf("error: invalid --url argument\n\n");
+				fprintf(stderr, "error: invalid --url argument\n\n");
 				goto err;
 			}
 			set_content_url(optarg);
@@ -80,7 +80,7 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'v':
 			if (!optarg) {
-				printf("Invalid --versionurl argument\n\n");
+				fprintf(stderr, "Invalid --versionurl argument\n\n");
 				goto err;
 			}
 			set_content_url(optarg);
@@ -88,25 +88,25 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'P':
 			if (sscanf(optarg, "%ld", &update_server_port) != 1) {
-				printf("Invalid --port argument\n\n");
+				fprintf(stderr, "Invalid --port argument\n\n");
 				goto err;
 			}
 			break;
 		case 'F':
 			if (!optarg || !set_format_string(optarg)) {
-				printf("Invalid --format argument\n\n");
+				fprintf(stderr, "Invalid --format argument\n\n");
 				goto err;
 			}
 			break;
 		case 'S':
 			if (!optarg || !set_state_dir(optarg)) {
-				printf("Invalid --statedir argument\n\n");
+				fprintf(stderr, "Invalid --statedir argument\n\n");
 				goto err;
 			}
 			break;
 		case 'p': /* default empty path_prefix checks the running OS */
 			if (!optarg || !set_path_prefix(optarg)) {
-				printf("Invalid --path argument\n\n");
+				fprintf(stderr, "Invalid --path argument\n\n");
 				goto err;
 			}
 			break;
@@ -117,7 +117,7 @@ static bool parse_options(int argc, char **argv)
 			sigcheck = false;
 			break;
 		default:
-			printf("error: unrecognized option\n\n");
+			fprintf(stderr, "error: unrecognized option\n\n");
 			goto err;
 		}
 	}
@@ -142,19 +142,19 @@ static int check_update()
 	read_versions(&current_version, &server_version, path_prefix);
 
 	if (server_version < 0) {
-		printf("Cannot reach update server\n");
+		fprintf(stderr, "Cannot reach update server\n");
 		return ENOSWUPDSERVER;
 	} else if (current_version < 0) {
-		printf("Unable to determine current OS version\n");
+		fprintf(stderr, "Unable to determine current OS version\n");
 		return ECURRENT_VERSION;
 	} else {
-		printf("Current OS version: %d\n", current_version);
+		fprintf(stderr, "Current OS version: %d\n", current_version);
 		if (current_version < server_version) {
-			printf("There is a new OS version available: %d\n", server_version);
+			fprintf(stderr, "There is a new OS version available: %d\n", server_version);
 			update_motd(server_version);
 			return 0; /* update available */
 		} else if (current_version >= server_version) {
-			printf("There are no updates available\n");
+			fprintf(stderr, "There are no updates available\n");
 		}
 		return 1; /* No update available */
 	}

--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -39,23 +39,23 @@ static char **bundles;
 
 static void print_help(const char *name)
 {
-	printf("Usage:\n");
-	printf("   swupd %s [options] [bundle1 bundle2 (...)]\n\n", basename((char *)name));
-	printf("Help Options:\n");
-	printf("   -h, --help              Show help options\n");
-	printf("   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
-	printf("   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
-	printf("   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
-	printf("   -P, --port=[port #]        Port number to connect to at the url for version string and content file downloads\n");
-	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
-	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
-	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
-	printf("   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
-	printf("   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
-	printf("   -S, --statedir          Specify alternate swupd state directory\n");
-	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
-	printf("   -t, --time         	   Show verbose time output for swupd operations\n");
-	printf("\n");
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "   swupd %s [options] [bundle1 bundle2 (...)]\n\n", basename((char *)name));
+	fprintf(stderr, "Help Options:\n");
+	fprintf(stderr, "   -h, --help              Show help options\n");
+	fprintf(stderr, "   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
+	fprintf(stderr, "   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
+	fprintf(stderr, "   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
+	fprintf(stderr, "   -P, --port=[port #]        Port number to connect to at the url for version string and content file downloads\n");
+	fprintf(stderr, "   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
+	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
+	fprintf(stderr, "   -x, --force             Attempt to proceed even if non-critical errors found\n");
+	fprintf(stderr, "   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
+	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
+	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");
+	fprintf(stderr, "   -C, --certpath          Specify alternate path to swupd certificates\n");
+	fprintf(stderr, "   -t, --time         	   Show verbose time output for swupd operations\n");
+	fprintf(stderr, "\n");
 }
 
 static const struct option prog_opts[] = {
@@ -88,7 +88,7 @@ static bool parse_options(int argc, char **argv)
 			exit(EXIT_SUCCESS);
 		case 'u':
 			if (!optarg) {
-				printf("error: invalid --url argument\n\n");
+				fprintf(stderr, "error: invalid --url argument\n\n");
 				goto err;
 			}
 			set_version_url(optarg);
@@ -96,45 +96,45 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'c':
 			if (!optarg) {
-				printf("Invalid --contenturl argument\n\n");
+				fprintf(stderr, "Invalid --contenturl argument\n\n");
 				goto err;
 			}
 			set_content_url(optarg);
 			break;
 		case 'v':
 			if (!optarg) {
-				printf("Invalid --versionurl argument\n\n");
+				fprintf(stderr, "Invalid --versionurl argument\n\n");
 				goto err;
 			}
 			set_version_url(optarg);
 			break;
 		case 'p': /* default empty path_prefix verifies the running OS */
 			if (!optarg || !set_path_prefix(optarg)) {
-				printf("Invalid --path argument\n\n");
+				fprintf(stderr, "Invalid --path argument\n\n");
 				goto err;
 			}
 			break;
 		case 'P':
 			if (sscanf(optarg, "%ld", &update_server_port) != 1) {
-				printf("Invalid --port argument\n\n");
+				fprintf(stderr, "Invalid --port argument\n\n");
 				goto err;
 			}
 			break;
 		case 'F':
 			if (!optarg || !set_format_string(optarg)) {
-				printf("Invalid --format argument\n\n");
+				fprintf(stderr, "Invalid --format argument\n\n");
 				goto err;
 			}
 			break;
 		case 'S':
 			if (!optarg || !set_state_dir(optarg)) {
-				printf("Invalid --statedir argument\n\n");
+				fprintf(stderr, "Invalid --statedir argument\n\n");
 				goto err;
 			}
 			break;
 		case 'l':
-			printf("error: [-l, --list] option is deprecated, use\n"
-			       "bundle-list [-a|--all] sub-command instead.\n\n");
+			fprintf(stderr, "error: [-l, --list] option is deprecated, use\n"
+					"bundle-list [-a|--all] sub-command instead.\n\n");
 			exit(EXIT_FAILURE);
 		case 'x':
 			force = true;
@@ -150,19 +150,19 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'C':
 			if (!optarg) {
-				printf("Invalid --certpath argument\n\n");
+				fprintf(stderr, "Invalid --certpath argument\n\n");
 				goto err;
 			}
 			set_cert_path(optarg);
 			break;
 		default:
-			printf("error: unrecognized option\n\n");
+			fprintf(stderr, "error: unrecognized option\n\n");
 			goto err;
 		}
 	}
 
 	if (argc <= optind) {
-		printf("error: missing bundle(s) to be installed\n\n");
+		fprintf(stderr, "error: missing bundle(s) to be installed\n\n");
 		goto err;
 	}
 

--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -29,22 +29,22 @@
 
 static void print_help(const char *name)
 {
-	printf("Usage:\n");
-	printf("   swupd %s [options]\n\n", basename((char *)name));
-	printf("Help Options:\n");
-	printf("   -h, --help              Show help options\n");
-	printf("   -a, --all               List all available bundles for the current version of Clear Linux\n");
-	printf("   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
-	printf("   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
-	printf("   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
-	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
-	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
-	printf("   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
-	printf("   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
-	printf("   -S, --statedir          Specify alternate swupd state directory\n");
-	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "   swupd %s [options]\n\n", basename((char *)name));
+	fprintf(stderr, "Help Options:\n");
+	fprintf(stderr, "   -h, --help              Show help options\n");
+	fprintf(stderr, "   -a, --all               List all available bundles for the current version of Clear Linux\n");
+	fprintf(stderr, "   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
+	fprintf(stderr, "   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
+	fprintf(stderr, "   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
+	fprintf(stderr, "   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
+	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
+	fprintf(stderr, "   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
+	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
+	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");
+	fprintf(stderr, "   -C, --certpath          Specify alternate path to swupd certificates\n");
 
-	printf("\n");
+	fprintf(stderr, "\n");
 }
 
 static const struct option prog_opts[] = {
@@ -78,7 +78,7 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'u':
 			if (!optarg) {
-				printf("error: invalid --url argument\n\n");
+				fprintf(stderr, "error: invalid --url argument\n\n");
 				goto err;
 			}
 			set_version_url(optarg);
@@ -86,27 +86,27 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'c':
 			if (!optarg) {
-				printf("Invalid --contenturl argument\n\n");
+				fprintf(stderr, "Invalid --contenturl argument\n\n");
 				goto err;
 			}
 			set_content_url(optarg);
 			break;
 		case 'v':
 			if (!optarg) {
-				printf("Invalid --versionurl argument\n\n");
+				fprintf(stderr, "Invalid --versionurl argument\n\n");
 				goto err;
 			}
 			set_version_url(optarg);
 			break;
 		case 'p': /* default empty path_prefix verifies the running OS */
 			if (!optarg || !set_path_prefix(optarg)) {
-				printf("Invalid --path argument\n\n");
+				fprintf(stderr, "Invalid --path argument\n\n");
 				goto err;
 			}
 			break;
 		case 'F':
 			if (!optarg || !set_format_string(optarg)) {
-				printf("Invalid --format argument\n\n");
+				fprintf(stderr, "Invalid --format argument\n\n");
 				goto err;
 			}
 			break;
@@ -118,20 +118,20 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'S':
 			if (!optarg || !set_state_dir(optarg)) {
-				printf("Invalid --statedir argument\n\n");
+				fprintf(stderr, "Invalid --statedir argument\n\n");
 				goto err;
 			}
 			break;
 		case 'C':
 			if (!optarg) {
-				printf("Invalid --certpath argument\n\n");
+				fprintf(stderr, "Invalid --certpath argument\n\n");
 				goto err;
 			}
 			set_cert_path(optarg);
 			break;
 
 		default:
-			printf("error: unrecognized option\n\n");
+			fprintf(stderr, "error: unrecognized option\n\n");
 			goto err;
 		}
 	}
@@ -158,13 +158,13 @@ int bundle_list_main(int argc, char **argv)
 
 	ret = swupd_init(&lock_fd);
 	if (ret != 0) {
-		printf("Error: Failed updater initialization. Exiting now\n");
+		fprintf(stderr, "Error: Failed updater initialization. Exiting now\n");
 		return ret;
 	}
 
 	current_version = get_current_version(path_prefix);
 	if (current_version < 0) {
-		printf("Error: Unable to determine current OS version\n");
+		fprintf(stderr, "Error: Unable to determine current OS version\n");
 		v_lockfile(lock_fd);
 		return ECURRENT_VERSION;
 	}
@@ -177,8 +177,8 @@ int bundle_list_main(int argc, char **argv)
 		printf("%s\n", (char *)item->data);
 		item = item->next;
 	}
-
-	printf("Current OS version: %d\n", current_version);
+	/* Should this be a different command */
+	fprintf(stderr, "Current OS version: %d\n", current_version);
 
 	list_free_list(list_bundles);
 	v_lockfile(lock_fd);

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -56,22 +56,22 @@ static char **bundles;
 
 static void print_help(const char *name)
 {
-	printf("Usage:\n");
-	printf("   swupd %s [options] [bundle1, bundle2, ...]\n\n", basename((char *)name));
-	printf("Help Options:\n");
-	printf("   -h, --help              Show help options\n");
-	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
-	printf("   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
-	printf("   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
-	printf("   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
-	printf("   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
-	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
-	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
-	printf("   -n, --nosigcheck       Do not attempt to enforce certificate or signature checks\n");
-	printf("   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
-	printf("   -S, --statedir          Specify alternate swupd state directory\n");
-	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
-	printf("\n");
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "   swupd %s [options] [bundle1, bundle2, ...]\n\n", basename((char *)name));
+	fprintf(stderr, "Help Options:\n");
+	fprintf(stderr, "   -h, --help              Show help options\n");
+	fprintf(stderr, "   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
+	fprintf(stderr, "   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
+	fprintf(stderr, "   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
+	fprintf(stderr, "   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
+	fprintf(stderr, "   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
+	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
+	fprintf(stderr, "   -x, --force             Attempt to proceed even if non-critical errors found\n");
+	fprintf(stderr, "   -n, --nosigcheck       Do not attempt to enforce certificate or signature checks\n");
+	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
+	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");
+	fprintf(stderr, "   -C, --certpath          Specify alternate path to swupd certificates\n");
+	fprintf(stderr, "\n");
 }
 
 static const struct option prog_opts[] = {
@@ -102,14 +102,14 @@ static bool parse_options(int argc, char **argv)
 			exit(EXIT_SUCCESS);
 		case 'p': /* default empty path_prefix removes on the running OS */
 			if (!optarg || !set_path_prefix(optarg)) {
-				printf("Invalid --path argument\n\n");
+				fprintf(stderr, "Invalid --path argument\n\n");
 				goto err;
 			}
 			string_or_die(&curopts.path_prefix, "%s", optarg);
 			break;
 		case 'u':
 			if (!optarg) {
-				printf("error: invalid --url argument\n\n");
+				fprintf(stderr, "error: invalid --url argument\n\n");
 				goto err;
 			}
 			set_version_url(optarg);
@@ -119,7 +119,7 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'c':
 			if (!optarg) {
-				printf("Invalid --contenturl argument\n\n");
+				fprintf(stderr, "Invalid --contenturl argument\n\n");
 				goto err;
 			}
 			set_content_url(optarg);
@@ -127,7 +127,7 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'v':
 			if (!optarg) {
-				printf("Invalid --versionurl argument\n\n");
+				fprintf(stderr, "Invalid --versionurl argument\n\n");
 				goto err;
 			}
 			set_version_url(optarg);
@@ -135,20 +135,20 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'P':
 			if (sscanf(optarg, "%ld", &update_server_port) != 1) {
-				printf("Invalid --port argument\n\n");
+				fprintf(stderr, "Invalid --port argument\n\n");
 				goto err;
 			}
 			break;
 		case 'F':
 			if (!optarg || !set_format_string(optarg)) {
-				printf("Invalid --format argument\n\n");
+				fprintf(stderr, "Invalid --format argument\n\n");
 				goto err;
 			}
 			string_or_die(&curopts.format_string, "%s", optarg);
 			break;
 		case 'S':
 			if (!optarg || !set_state_dir(optarg)) {
-				printf("Invalid --statedir argument\n\n");
+				fprintf(stderr, "Invalid --statedir argument\n\n");
 				goto err;
 			}
 			string_or_die(&curopts.state_dir, "%s", optarg);
@@ -166,20 +166,20 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'C':
 			if (!optarg) {
-				printf("Invalid --certpath argument\n\n");
+				fprintf(stderr, "Invalid --certpath argument\n\n");
 				goto err;
 			}
 			set_cert_path(optarg);
 			string_or_die(&curopts.cert_path, "%s", optarg);
 			break;
 		default:
-			printf("error: unrecognized option\n\n");
+			fprintf(stderr, "error: unrecognized option\n\n");
 			goto err;
 		}
 	}
 
 	if (argc <= optind) {
-		printf("error: missing bundle(s) to be removed\n\n");
+		fprintf(stderr, "error: missing bundle(s) to be removed\n\n");
 		goto err;
 	}
 
@@ -261,7 +261,7 @@ int bundle_remove_main(int argc, char **argv)
 	}
 
 	for (; *bundles; ++bundles, total++) {
-		printf("Removing bundle: %s\n", *bundles);
+		fprintf(stderr, "Removing bundle: %s\n", *bundles);
 
 		if (remove_bundle(*bundles) != 0) {
 			/* At least one bundle failed to be removed
@@ -281,9 +281,9 @@ int bundle_remove_main(int argc, char **argv)
 	}
 	/* print some statistics */
 	if (ret) {
-		printf("%i bundle(s) of %i failed to remove\n", bad, total);
+		fprintf(stderr, "%i bundle(s) of %i failed to remove\n", bad, total);
 	} else {
-		printf("%i bundle(s) were removed succesfully\n", total);
+		fprintf(stderr, "%i bundle(s) were removed succesfully\n", total);
 	}
 
 	/* free any parsed opt saved for reloading */

--- a/src/curl.c
+++ b/src/curl.c
@@ -58,13 +58,13 @@ int swupd_curl_init(void)
 
 	curl_ret = curl_global_init(CURL_GLOBAL_ALL);
 	if (curl_ret != CURLE_OK) {
-		printf("Error: failed to initialize CURL environment\n");
+		fprintf(stderr, "Error: failed to initialize CURL environment\n");
 		return -1;
 	}
 
 	curl = curl_easy_init();
 	if (curl == NULL) {
-		printf("Error: failed to initialize CURL session\n");
+		fprintf(stderr, "Error: failed to initialize CURL session\n");
 		curl_global_cleanup();
 		return -1;
 	}
@@ -243,7 +243,7 @@ int swupd_curl_get_file(const char *url, char *filename, struct file *file,
 		}
 	} else {
 		// only download latest version number, storing in the provided pointer
-		printf("Attempting to download version string to memory\n");
+		fprintf(stderr, "Attempting to download version string to memory\n");
 
 		curl_ret = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, swupd_download_version_to_memory);
 		if (curl_ret != CURLE_OK) {
@@ -303,43 +303,43 @@ exit:
 	} else { /* download failed but let our caller do it */
 		switch (curl_ret) {
 		case CURLE_COULDNT_RESOLVE_PROXY:
-			printf("Curl: Could not resolve proxy\n");
+			fprintf(stderr, "Curl: Could not resolve proxy\n");
 			err = -1;
 			break;
 		case CURLE_COULDNT_RESOLVE_HOST:
-			printf("Curl: Could not resolve host - '%s'\n", url);
+			fprintf(stderr, "Curl: Could not resolve host - '%s'\n", url);
 			err = -1;
 			break;
 		case CURLE_COULDNT_CONNECT:
-			printf("Curl: Could not connect to host or proxy\n");
+			fprintf(stderr, "Curl: Could not connect to host or proxy\n");
 			err = -ENONET;
 			break;
 		case CURLE_FILE_COULDNT_READ_FILE:
 			err = -1;
 			break;
 		case CURLE_PARTIAL_FILE:
-			printf("Curl: File incompletely downloaded from '%s' to '%s'\n",
-			       url, filename);
+			fprintf(stderr, "Curl: File incompletely downloaded from '%s' to '%s'\n",
+				url, filename);
 			err = -1;
 			break;
 		case CURLE_RECV_ERROR:
-			printf("Curl: Failure receiving data from server\n");
+			fprintf(stderr, "Curl: Failure receiving data from server\n");
 			err = -ENOLINK;
 			break;
 		case CURLE_WRITE_ERROR:
-			printf("Curl: Error downloading to local file - %s\n", filename);
+			fprintf(stderr, "Curl: Error downloading to local file - %s\n", filename);
 			err = -EIO;
 			break;
 		case CURLE_OPERATION_TIMEDOUT:
-			printf("Curl: Communicating with server timed out.\n");
+			fprintf(stderr, "Curl: Communicating with server timed out.\n");
 			err = -ETIMEDOUT;
 			break;
 		case CURLE_SSL_CACERT_BADFILE:
-			printf("Curl: Bad SSL Cert file, cannot ensure secure connection\n");
+			fprintf(stderr, "Curl: Bad SSL Cert file, cannot ensure secure connection\n");
 			err = -1;
 			break;
 		default:
-			printf("Curl error: %s\n", curl_easy_strerror(curl_ret));
+			fprintf(stderr, "Curl error: %s\n", curl_easy_strerror(curl_ret));
 			err = -1;
 			break;
 		}
@@ -405,7 +405,7 @@ void swupd_curl_test_resume(void)
 	curl_ret = curl_easy_perform(curl);
 
 	if (curl_ret == CURLE_RANGE_ERROR) {
-		printf("Range command not supported by server, download resume disabled.\n");
+		fprintf(stderr, "Range command not supported by server, download resume disabled.\n");
 		resume_download_enabled = false;
 	}
 exit:

--- a/src/download.c
+++ b/src/download.c
@@ -156,7 +156,7 @@ int start_full_download(bool pipelining)
 		MAX_XFER_BOTTOM = 1;
 	}
 
-	printf("Starting download of remaining update content. This may take a while...\n");
+	fprintf(stderr, "Starting download of remaining update content. This may take a while...\n");
 
 	return 0;
 }
@@ -302,8 +302,8 @@ int untar_full_download(void *data)
 	}
 	free(tarcommand);
 	if (err) {
-		printf("ignoring tar extract failure for fullfile %s.tar (ret %d)\n",
-		       file->hash, err);
+		fprintf(stderr, "ignoring tar extract failure for fullfile %s.tar (ret %d)\n",
+			file->hash, err);
 		goto exit;
 		/* FIXME: can we respond meaningfully to tar error codes?
 		 * symlink untars may have perm/xattr complaints and non-zero
@@ -322,7 +322,7 @@ int untar_full_download(void *data)
 	err = lstat(targetfile, &stat);
 	if (!err && !verify_file(file, targetfile)) {
 		/* Download was successful but the hash was bad. This is fatal*/
-		printf("Error: File content hash mismatch for %s (bad server data?)\n", targetfile);
+		fprintf(stderr, "Error: File content hash mismatch for %s (bad server data?)\n", targetfile);
 		exit(EXIT_FAILURE);
 	}
 
@@ -388,15 +388,15 @@ static int perform_curl_io_and_complete(int count, bool bounded)
 		/* The easy handle may have an error set, even if the server returns
 		 * HTTP 200, so retry the download for this case. */
 		if (ret == 200 && curl_ret != CURLE_OK) {
-			printf("Error for %s download: %s\n", file->hash,
-			       curl_easy_strerror(msg->data.result));
+			fprintf(stderr, "Error for %s download: %s\n", file->hash,
+				curl_easy_strerror(msg->data.result));
 			failed = list_prepend_data(failed, file);
 		} else if (ret == 200) {
 			/* When both web server and CURL report success, only then
 			 * proceed to uncompress. */
 			if (untar_full_download(file)) {
-				printf("Error for %s tarfile extraction, (check free space for %s?)\n",
-				       file->hash, state_dir);
+				fprintf(stderr, "Error for %s tarfile extraction, (check free space for %s?)\n",
+					file->hash, state_dir);
 				failed = list_prepend_data(failed, file);
 			}
 		} else if (ret == 0) {
@@ -405,17 +405,17 @@ static int perform_curl_io_and_complete(int count, bool bounded)
 			 */
 			if (local_download) {
 				if (untar_full_download(file)) {
-					printf("Error for %s tarfile extraction, (check free space for %s?)\n",
-					       file->hash, state_dir);
+					fprintf(stderr, "Error for %s tarfile extraction, (check free space for %s?)\n",
+						file->hash, state_dir);
 					failed = list_prepend_data(failed, file);
 				}
 			} else {
-				printf("Error for %s download: No response received\n",
-				       file->hash);
+				fprintf(stderr, "Error for %s download: No response received\n",
+					file->hash);
 				failed = list_prepend_data(failed, file);
 			}
 		} else {
-			printf("Error for %s download: Received %ld response\n", file->hash, ret);
+			fprintf(stderr, "Error for %s download: Received %ld response\n", file->hash, ret);
 			failed = list_prepend_data(failed, file);
 
 			unlink_all_staged_content(file);
@@ -565,7 +565,7 @@ void full_download(struct file *file)
 
 	/* Only print the first file so we don't spam on large misses */
 	if (nonpack == 0) {
-		printf("File %s was not in a pack\n", file->filename);
+		fprintf(stderr, "File %s was not in a pack\n", file->filename);
 	}
 	/* If we get here the pack is missing a file so we have to download it */
 	nonpack++;
@@ -638,7 +638,7 @@ struct list *end_full_download(void)
 {
 	int err;
 
-	printf("Finishing download of update content...\n");
+	fprintf(stderr, "Finishing download of update content...\n");
 
 	if (poll_fewer_than(0, 0) == 0) {
 		// The multi-stack is now emptied.

--- a/src/filedesc.c
+++ b/src/filedesc.c
@@ -75,7 +75,7 @@ void dump_file_descriptor_leaks(void)
 		memset(&buffer, 0, sizeof(buffer));
 		size = readlink(filename, buffer, PATH_MAXLEN);
 		if (size && !strstr(buffer, "socket")) {
-			printf("Possible filedescriptor leak: fd_number=\"%s\",fd_details=\"%s\"\n", entry->d_name, buffer);
+			fprintf(stderr, "Possible filedescriptor leak: fd_number=\"%s\",fd_details=\"%s\"\n", entry->d_name, buffer);
 		}
 		free(filename);
 	}

--- a/src/globals.c
+++ b/src/globals.c
@@ -86,7 +86,7 @@ static struct time *alloc_time(timelist *head)
 {
 	struct time *t = calloc(1, sizeof(struct time));
 	if (t == NULL) {
-		printf("ERROR: grab_time: Failed to to allocate memory...freeing and removing timing\n");
+		fprintf(stderr, "ERROR: grab_time: Failed to to allocate memory...freeing and removing timing\n");
 		while (!TAILQ_EMPTY(head)) {
 			struct time *iter = TAILQ_FIRST(head);
 			TAILQ_REMOVE(head, iter, times);
@@ -151,20 +151,20 @@ void print_time_stats(timelist *head)
 	double delta = 0;
 	struct time *t;
 
-	printf("\nRaw elapsed time stats:\n");
+	fprintf(stderr, "\nRaw elapsed time stats:\n");
 	TAILQ_FOREACH_REVERSE(t, head, timelist, times)
 	{
 		if (t->complete == true) {
 			delta = t->rawstop.tv_sec - t->rawstart.tv_sec + (t->rawstop.tv_nsec / 1000000.0) - (t->rawstart.tv_nsec / 1000000.0);
-			printf("%.4f\tms: %s\n", delta, t->name);
+			fprintf(stderr, "%.4f\tms: %s\n", delta, t->name);
 		}
 	}
-	printf("\nCPU process time stats:\n");
+	fprintf(stderr, "\nCPU process time stats:\n");
 	while (!TAILQ_EMPTY(head)) {
 		t = TAILQ_LAST(head, timelist);
 		if (t->complete == true) {
 			delta = t->procstop.tv_sec - t->procstart.tv_sec + (t->procstop.tv_nsec / 1000000.0) - (t->procstart.tv_nsec / 1000000.0);
-			printf("%.4f\tms: %s\n", delta, t->name);
+			fprintf(stderr, "%.4f\tms: %s\n", delta, t->name);
 		}
 		TAILQ_REMOVE(head, t, times);
 		free(t);
@@ -191,9 +191,9 @@ static int set_default_value_from_path(char **global, const char *path)
 	line[0] = 0;
 	if (fgets(line, LINE_MAX, file) == NULL) {
 		if (ferror(file)) {
-			printf("Error: Unable to read data from %s\n", rel_path);
+			fprintf(stderr, "Error: Unable to read data from %s\n", rel_path);
 		} else if (feof(file)) {
-			printf("Error: Contents of %s are empty\n", rel_path);
+			fprintf(stderr, "Error: Contents of %s are empty\n", rel_path);
 		}
 		goto fail;
 	}
@@ -284,7 +284,7 @@ bool set_state_dir(char *path)
 {
 	if (path) {
 		if (path[0] != '/') {
-			printf("statepath must be a full path starting with '/', not '%c'\n", path[0]);
+			fprintf(stderr, "statepath must be a full path starting with '/', not '%c'\n", path[0]);
 			return false;
 		}
 
@@ -349,8 +349,8 @@ bool set_format_string(char *userinput)
 }
 
 /* Initializes the path_prefix global variable. If the path parameter is not
- * NULL, path_prefix will be set to its value, but only if it is a positive
- * integer or the special value "staging". Otherwise, the default value of '/'
+ * NULL, path_prefix will be set to its value.
+ * Otherwise, the default value of '/'
  * is used. Note that the given path must exist.
  */
 bool set_path_prefix(char *path)
@@ -376,7 +376,7 @@ bool set_path_prefix(char *path)
 
 			cwd = get_current_dir_name();
 			if (cwd == NULL) {
-				printf("Unable to get current directory name (%s)\n", strerror(errno));
+				fprintf(stderr, "Unable to get current directory name (%s)\n", strerror(errno));
 				free(tmp);
 				return false;
 			}
@@ -406,8 +406,8 @@ bool set_path_prefix(char *path)
 	}
 	ret = stat(path_prefix, &statbuf);
 	if (ret != 0 || !S_ISDIR(statbuf.st_mode)) {
-		printf("Bad path_prefix %s (%s), cannot continue.\n",
-		       path_prefix, strerror(errno));
+		fprintf(stderr, "Bad path_prefix %s (%s), cannot continue.\n",
+			path_prefix, strerror(errno));
 		return false;
 	}
 
@@ -470,7 +470,7 @@ bool init_globals(void)
 		/* Fallback to configure time format_string if other sources fail */
 		set_format_string(FORMATID);
 #else
-		printf("Unable to determine format id. Use the -F option instead.\n");
+		fprintf(stderr, "Unable to determine format id. Use the -F option instead.\n");
 		exit(EXIT_FAILURE);
 #endif
 	}
@@ -485,7 +485,7 @@ bool init_globals(void)
 		ret = -1;
 #endif
 		if (ret) {
-			printf("\nDefault version URL not found. Use the -v option instead.\n");
+			fprintf(stderr, "\nDefault version URL not found. Use the -v option instead.\n");
 			exit(EXIT_FAILURE);
 		}
 	}
@@ -500,7 +500,7 @@ bool init_globals(void)
 		ret = -1;
 #endif
 		if (ret) {
-			printf("\nDefault content URL not found. Use the -c option instead.\n");
+			fprintf(stderr, "\nDefault content URL not found. Use the -c option instead.\n");
 			exit(EXIT_FAILURE);
 		}
 	}

--- a/src/hash.c
+++ b/src/hash.c
@@ -303,8 +303,8 @@ int verify_bundle_hash(struct manifest *manifest, struct file *bundle)
 			char *url;
 			char *tar;
 
-			printf("Warning: Downloading missing manifest for bundle %s version %d.\n",
-			       current->filename, current->last_change);
+			fprintf(stderr, "Warning: Downloading missing manifest for bundle %s version %d.\n",
+				current->filename, current->last_change);
 
 			string_or_die(&filename, "%s/%i/Manifest.%s", state_dir,
 				      current->last_change, current->filename);
@@ -314,7 +314,7 @@ int verify_bundle_hash(struct manifest *manifest, struct file *bundle)
 			free(url);
 
 			if (ret != 0) {
-				printf("Error: download of %s failed\n", filename);
+				fprintf(stderr, "Error: download of %s failed\n", filename);
 				unlink(filename);
 				free(filename);
 				break;
@@ -336,8 +336,8 @@ int verify_bundle_hash(struct manifest *manifest, struct file *bundle)
 		}
 
 		if (!verify_file(bundle, local)) {
-			printf("Warning: hash check failed for Manifest.%s for version %i. Deleting it.\n",
-			       current->filename, manifest->version);
+			fprintf(stderr, "Warning: hash check failed for Manifest.%s for version %i. Deleting it.\n",
+				current->filename, manifest->version);
 			unlink(local);
 			ret = 1;
 		}

--- a/src/hashdump.c
+++ b/src/hashdump.c
@@ -43,16 +43,16 @@ static struct option opts[] = {
 
 static void usage(const char *name)
 {
-	printf("Usage:\n");
-	printf("   swupd %s [OPTION...] filename\n\n", basename((char *)name));
-	printf("Help Options:\n");
-	printf("   -h, --help              Show help options\n\n");
-	printf("Application Options:\n");
-	printf("   -n, --no-xattrs         Ignore extended attributes\n");
-	printf("   -p, --path=[PATH...]    Use [PATH...] for leading path to filename\n");
-	printf("\n");
-	printf("The filename is the name of a file on the filesystem.\n");
-	printf("\n");
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "   swupd %s [OPTION...] filename\n\n", basename((char *)name));
+	fprintf(stderr, "Help Options:\n");
+	fprintf(stderr, "   -h, --help              Show help options\n\n");
+	fprintf(stderr, "Application Options:\n");
+	fprintf(stderr, "   -n, --no-xattrs         Ignore extended attributes\n");
+	fprintf(stderr, "   -p, --path=[PATH...]    Use [PATH...] for leading path to filename\n");
+	fprintf(stderr, "\n");
+	fprintf(stderr, "The filename is the name of a file on the filesystem.\n");
+	fprintf(stderr, "\n");
 }
 
 int hashdump_main(int argc, char **argv)
@@ -83,7 +83,7 @@ int hashdump_main(int argc, char **argv)
 			break;
 		case 'p':
 			if (!optarg || !set_path_prefix(optarg)) {
-				printf("Invalid --basepath argument\n\n");
+				fprintf(stderr, "Invalid --basepath argument\n\n");
 				free(file);
 				return EXIT_FAILURE;
 			}
@@ -127,18 +127,18 @@ int hashdump_main(int argc, char **argv)
 		}
 	}
 
-	printf("Calculating hash %s xattrs for: %s\n",
-	       (file->use_xattrs ? "with" : "without"), fullname);
+	fprintf(stderr, "Calculating hash %s xattrs for: %s\n",
+		(file->use_xattrs ? "with" : "without"), fullname);
 
 	populate_file_struct(file, fullname);
 	ret = compute_hash(file, fullname);
 	if (ret != 0) {
-		printf("compute_hash() failed\n");
+		fprintf(stderr, "compute_hash() failed\n");
 	} else {
 		printf("%s\n", file->hash);
 		if (file->is_dir) {
 			if (is_directory_mounted(fullname)) {
-				printf("!! dumped hash might not match a manifest hash because a mount is active\n");
+				fprintf(stderr, "!! dumped hash might not match a manifest hash because a mount is active\n");
 			}
 		}
 	}

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -43,7 +43,7 @@
 void check_root(void)
 {
 	if (getuid() != 0) {
-		printf("This program must be run as root..aborting.\n\n");
+		fprintf(stderr, "This program must be run as root..aborting.\n\n");
 		exit(EXIT_FAILURE);
 	}
 }
@@ -161,7 +161,7 @@ static int create_required_dirs(void)
 			string_or_die(&cmd, "mkdir -p %s/%s", state_dir, state_dirs[i]);
 			ret = system(cmd);
 			if (ret) {
-				printf("Error: failed to create %s/%s\n", state_dir, state_dirs[i]);
+				fprintf(stderr, "Error: failed to create %s/%s\n", state_dir, state_dirs[i]);
 				return -1;
 			}
 			free(cmd);
@@ -169,7 +169,7 @@ static int create_required_dirs(void)
 			string_or_die(&dir, "%s/%s", state_dir, state_dirs[i]);
 			ret = chmod(dir, S_IRWXU);
 			if (ret) {
-				printf("Error: failed to set mode for %s/%s\n", state_dir, state_dirs[i]);
+				fprintf(stderr, "Error: failed to set mode for %s/%s\n", state_dir, state_dirs[i]);
 				return -1;
 			}
 			free(dir);
@@ -178,7 +178,7 @@ static int create_required_dirs(void)
 		// chmod 700
 		ret = chmod(state_dir, S_IRWXU);
 		if (ret) {
-			printf("Error: failed to set mode for state dir (%s)\n", state_dir);
+			fprintf(stderr, "Error: failed to set mode for state dir (%s)\n", state_dir);
 			return -1;
 		}
 	}
@@ -644,9 +644,9 @@ out_fds:
 */
 void copyright_header(const char *name)
 {
-	printf(PACKAGE " %s " VERSION "\n", name);
-	printf("   Copyright (C) 2012-2016 Intel Corporation\n");
-	printf("\n");
+	fprintf(stderr, PACKAGE " %s " VERSION "\n", name);
+	fprintf(stderr, "   Copyright (C) 2012-2016 Intel Corporation\n");
+	fprintf(stderr, "\n");
 }
 
 void string_or_die(char **strp, const char *fmt, ...)
@@ -693,13 +693,13 @@ int get_dirfd_path(const char *fullname)
 
 	fd = open(dir, O_RDONLY);
 	if (fd < 0) {
-		printf("Failed to open dir %s (%s)\n", dir, strerror(errno));
+		fprintf(stderr, "Failed to open dir %s (%s)\n", dir, strerror(errno));
 		goto out;
 	}
 
 	real_path = realpath(dir, NULL);
 	if (!real_path) {
-		printf("Failed to get real path of %s (%s)\n", dir, strerror(errno));
+		fprintf(stderr, "Failed to get real path of %s (%s)\n", dir, strerror(errno));
 		close(fd);
 		goto out;
 	}
@@ -778,15 +778,15 @@ int verify_fix_path(char *targetpath, struct manifest *target_MoM)
 		/* Search for the file in the manifest, to get the hash for the file */
 		file = search_file_in_manifest(target_MoM, path);
 		if (file == NULL) {
-			printf("Error: Path %s not found in any of the subscribed manifests"
-			       "in verify_fix_path for path_prefix %s\n",
-			       path, path_prefix);
+			fprintf(stderr, "Error: Path %s not found in any of the subscribed manifests"
+					"in verify_fix_path for path_prefix %s\n",
+				path, path_prefix);
 			ret = -1;
 			goto end;
 		}
 
 		if (file->is_deleted) {
-			printf("Error: Path %s found deleted in verify_fix_path\n", path);
+			fprintf(stderr, "Error: Path %s found deleted in verify_fix_path\n", path);
 			ret = -1;
 			goto end;
 		}
@@ -796,9 +796,9 @@ int verify_fix_path(char *targetpath, struct manifest *target_MoM)
 			if (verify_file(file, target)) {
 				continue;
 			}
-			printf("Hash did not match for path : %s\n", path);
+			fprintf(stderr, "Hash did not match for path : %s\n", path);
 		} else if (ret == -1 && errno == ENOENT) {
-			printf("Path %s is missing on the file system\n", path);
+			fprintf(stderr, "Path %s is missing on the file system\n", path);
 		} else {
 			goto end;
 		}
@@ -816,19 +816,19 @@ int verify_fix_path(char *targetpath, struct manifest *target_MoM)
 		ret = swupd_curl_get_file(url, tar_dotfile, NULL, NULL, false);
 
 		if (ret != 0) {
-			printf("Error: Failed to download file %s in verify_fix_path\n", file->filename);
+			fprintf(stderr, "Error: Failed to download file %s in verify_fix_path\n", file->filename);
 			unlink(tar_dotfile);
 			goto end;
 		}
 		if (untar_full_download(file) != 0) {
-			printf("Error: Failed to untar file %s\n", file->filename);
+			fprintf(stderr, "Error: Failed to untar file %s\n", file->filename);
 			ret = -1;
 			goto end;
 		}
 
 		ret = do_staging(file, target_MoM);
 		if (ret != 0) {
-			printf("Error: Path %s failed to stage in verify_fix_path\n", path);
+			fprintf(stderr, "Error: Path %s failed to stage in verify_fix_path\n", path);
 			goto end;
 		}
 	}
@@ -866,8 +866,8 @@ void set_local_download(void)
 
 	/* protocols must match for download logic */
 	if (version_local != content_local) {
-		printf("\nVersion and content URLs must both use the HTTP/HTTPS protocols"
-		       " or the libcurl FILE protocol.\n");
+		fprintf(stderr, "\nVersion and content URLs must both use the HTTP/HTTPS protocols"
+				" or the libcurl FILE protocol.\n");
 		exit(EXIT_FAILURE);
 	}
 

--- a/src/lock.c
+++ b/src/lock.c
@@ -61,7 +61,7 @@ int p_lockfile(void)
 	lock_fd = open(lockfile, O_RDWR | O_CREAT | O_CLOEXEC, 0600);
 
 	if (lock_fd < 0) {
-		printf("Error: failed to open %s: %s\n", lockfile, strerror(errno));
+		fprintf(stderr, "Error: failed to open %s: %s\n", lockfile, strerror(errno));
 		free(lockfile);
 		return -1;
 	}
@@ -74,7 +74,7 @@ int p_lockfile(void)
 		if ((errno == EAGAIN) || (errno == EACCES)) {
 			ret = -EAGAIN;
 		}
-		printf("Error: cannot acquire lock file. Another swupd process is already running.\n");
+		fprintf(stderr, "Error: cannot acquire lock file. Another swupd process is already running.\n");
 		close(lock_fd);
 		return ret;
 	} else {

--- a/src/main.c
+++ b/src/main.c
@@ -56,29 +56,29 @@ static const struct option prog_opts[] = {
 
 static void print_help(const char *name)
 {
-	printf("Usage:\n");
-	printf("   swupd %s [OPTION...]\n\n", basename((char *)name));
-	printf("Help Options:\n");
-	printf("   -h, --help              Show help options\n\n");
-	printf("Application Options:\n");
-	printf("   -d, --download          Download all content, but do not actually install the update\n");
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "   swupd %s [OPTION...]\n\n", basename((char *)name));
+	fprintf(stderr, "Help Options:\n");
+	fprintf(stderr, "   -h, --help              Show help options\n\n");
+	fprintf(stderr, "Application Options:\n");
+	fprintf(stderr, "   -d, --download          Download all content, but do not actually install the update\n");
 #warning "remove user configurable url when alternative exists"
-	printf("   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
-	printf("   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
+	fprintf(stderr, "   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
+	fprintf(stderr, "   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
 #warning "remove user configurable content url when alternative exists"
-	printf("   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
+	fprintf(stderr, "   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
 #warning "remove user configurable version url when alternative exists"
-	printf("   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
-	printf("   -s, --status            Show current OS version and latest version available on server\n");
-	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
-	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
-	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
-	printf("   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
-	printf("   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
-	printf("   -S, --statedir          Specify alternate swupd state directory\n");
-	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
-	printf("   -t, --time         	   Show verbose time output for swupd operations\n");
-	printf("\n");
+	fprintf(stderr, "   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
+	fprintf(stderr, "   -s, --status            Show current OS version and latest version available on server\n");
+	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
+	fprintf(stderr, "   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
+	fprintf(stderr, "   -x, --force             Attempt to proceed even if non-critical errors found\n");
+	fprintf(stderr, "   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
+	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
+	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");
+	fprintf(stderr, "   -C, --certpath          Specify alternate path to swupd certificates\n");
+	fprintf(stderr, "   -t, --time         	   Show verbose time output for swupd operations\n");
+	fprintf(stderr, "\n");
 }
 
 static bool parse_options(int argc, char **argv)
@@ -96,7 +96,7 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'u':
 			if (!optarg) {
-				printf("Invalid --url argument\n\n");
+				fprintf(stderr, "Invalid --url argument\n\n");
 				goto err;
 			}
 			set_version_url(optarg);
@@ -107,20 +107,20 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'P':
 			if (sscanf(optarg, "%ld", &update_server_port) != 1) {
-				printf("Invalid --port argument\n\n");
+				fprintf(stderr, "Invalid --port argument\n\n");
 				goto err;
 			}
 			break;
 		case 'c':
 			if (!optarg) {
-				printf("Invalid --contenturl argument\n\n");
+				fprintf(stderr, "Invalid --contenturl argument\n\n");
 				goto err;
 			}
 			set_content_url(optarg);
 			break;
 		case 'v':
 			if (!optarg) {
-				printf("Invalid --versionurl argument\n\n");
+				fprintf(stderr, "Invalid --versionurl argument\n\n");
 				goto err;
 			}
 			set_version_url(optarg);
@@ -130,19 +130,19 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'F':
 			if (!optarg || !set_format_string(optarg)) {
-				printf("Invalid --format argument\n\n");
+				fprintf(stderr, "Invalid --format argument\n\n");
 				goto err;
 			}
 			break;
 		case 'S':
 			if (!optarg || !set_state_dir(optarg)) {
-				printf("Invalid --statedir argument\n\n");
+				fprintf(stderr, "Invalid --statedir argument\n\n");
 				goto err;
 			}
 			break;
 		case 'p': /* default empty path_prefix updates the running OS */
 			if (!optarg || !set_path_prefix(optarg)) {
-				printf("Invalid --path argument\n\n");
+				fprintf(stderr, "Invalid --path argument\n\n");
 				goto err;
 			}
 			break;
@@ -157,13 +157,13 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'C':
 			if (!optarg) {
-				printf("Invalid --certpath argument\n\n");
+				fprintf(stderr, "Invalid --certpath argument\n\n");
 				goto err;
 			}
 			set_cert_path(optarg);
 			break;
 		default:
-			printf("Unrecognized option\n\n");
+			fprintf(stderr, "Unrecognized option\n\n");
 			goto err;
 		}
 	}
@@ -189,17 +189,17 @@ static int print_versions()
 	read_versions(&current_version, &server_version, path_prefix);
 
 	if (current_version < 0) {
-		printf("Cannot determine current OS version\n");
+		fprintf(stderr, "Cannot determine current OS version\n");
 		ret = 2;
 	} else {
-		printf("Current OS version: %d\n", current_version);
+		fprintf(stderr, "Current OS version: %d\n", current_version);
 	}
 
 	if (server_version < 0) {
-		printf("Cannot get latest the server version.Could not reach server\n");
+		fprintf(stderr, "Cannot get latest the server version.Could not reach server\n");
 		ret = 2;
 	} else {
-		printf("Latest server version: %d\n", server_version);
+		fprintf(stderr, "Latest server version: %d\n", server_version);
 	}
 	if ((ret == 0) && (server_version <= current_version)) {
 		ret = 1;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -583,7 +583,7 @@ void remove_manifest_files(char *filename, int version, char *hash)
 {
 	char *file;
 
-	printf("Warning: Removing corrupt Manifest.%s artifacts and re-downloading...\n", filename);
+	fprintf(stderr, "Warning: Removing corrupt Manifest.%s artifacts and re-downloading...\n", filename);
 	string_or_die(&file, "%s/%i/Manifest.%s", state_dir, version, filename);
 	unlink(file);
 	free(file);
@@ -623,7 +623,7 @@ struct manifest *load_mom(int version, bool latest)
 verify_mom:
 	ret = retrieve_manifests(version, version, "MoM", NULL);
 	if (ret != 0) {
-		printf("Failed to retrieve %d MoM manifest\n", version);
+		fprintf(stderr, "Failed to retrieve %d MoM manifest\n", version);
 		return NULL;
 	}
 
@@ -635,7 +635,7 @@ verify_mom:
 			retried = true;
 			goto verify_mom;
 		}
-		printf("Failed to load %d MoM manifest\n", version);
+		fprintf(stderr, "Failed to load %d MoM manifest\n", version);
 		goto out;
 	}
 
@@ -649,13 +649,13 @@ verify_mom:
 				retried = true;
 				goto verify_mom;
 			}
-			printf("WARNING!!! FAILED TO VERIFY SIGNATURE OF Manifest.MoM\n");
+			fprintf(stderr, "WARNING!!! FAILED TO VERIFY SIGNATURE OF Manifest.MoM\n");
 			free(filename);
 			free(url);
 			return NULL;
 		} else {
-			printf("FAILED TO VERIFY SIGNATURE OF Manifest.MoM. Operation proceeding due to\n"
-			       "  --nosigcheck, but system security may be compromised\n");
+			fprintf(stderr, "FAILED TO VERIFY SIGNATURE OF Manifest.MoM. Operation proceeding due to\n"
+					"  --nosigcheck, but system security may be compromised\n");
 			string_or_die(&log_cmd, "echo \"swupd security notice:"
 						" --nosigcheck used to bypass MoM signature verification failure\" | systemd-cat --priority=\"err\" --identifier=\"swupd\"");
 			(void)system(log_cmd);
@@ -693,7 +693,7 @@ struct manifest *load_manifest(int current, int version, struct file *file, stru
 retry_load:
 	ret = retrieve_manifests(current, version, file->filename, file);
 	if (ret != 0) {
-		printf("Failed to retrieve %d %s manifest\n", version, file->filename);
+		fprintf(stderr, "Failed to retrieve %d %s manifest\n", version, file->filename);
 		return NULL;
 	}
 
@@ -719,7 +719,7 @@ retry_load:
 			retried = true;
 			goto retry_load;
 		}
-		printf("Failed to load %d %s manifest\n", version, file->filename);
+		fprintf(stderr, "Failed to load %d %s manifest\n", version, file->filename);
 		return NULL;
 	}
 
@@ -1150,7 +1150,7 @@ void debug_write_manifest(struct manifest *manifest, char *filename)
 
 	out = fopen(fullfile, "w");
 	if (out == NULL) {
-		printf("Failed to open %s for write\n", fullfile);
+		fprintf(stderr, "Failed to open %s for write\n", fullfile);
 	}
 	if (out == NULL) {
 		abort();
@@ -1294,7 +1294,7 @@ void remove_files_in_manifest_from_fs(struct manifest *m)
 		free(fullfile);
 		count++;
 	}
-	printf("Total deleted files: %i\n", count);
+	fprintf(stderr, "Total deleted files: %i\n", count);
 }
 
 /* free all files found in m1 that happens to be

--- a/src/packs.c
+++ b/src/packs.c
@@ -66,7 +66,7 @@ static int download_pack(int oldversion, int newversion, char *module)
 
 	free(url);
 
-	printf("Extracting %s pack for version %i\n", module, newversion);
+	fprintf(stderr, "Extracting %s pack for version %i\n", module, newversion);
 	string_or_die(&tar, TAR_COMMAND " -C %s " TAR_PERM_ATTR_ARGS " -xf %s/pack-%s-from-%i-to-%i.tar 2> /dev/null",
 		      state_dir, state_dir, module, oldversion, newversion);
 
@@ -102,7 +102,7 @@ int download_subscribed_packs(struct list *subs, bool required)
 		return -ENOSWUPDSERVER;
 	}
 
-	printf("Downloading packs...\n");
+	fprintf(stderr, "Downloading packs...\n");
 	iter = list_head(subs);
 	while (iter) {
 		sub = iter->data;

--- a/src/scripts.c
+++ b/src/scripts.c
@@ -63,7 +63,7 @@ static void update_triggers(void)
 
 void run_scripts(void)
 {
-	printf("Calling post-update helper scripts.\n");
+	fprintf(stderr, "Calling post-update helper scripts.\n");
 
 	/* path_prefix aware helper */
 	if (need_update_boot || need_update_bootloader) {

--- a/src/search.c
+++ b/src/search.c
@@ -53,31 +53,31 @@ static char *bin_paths[] = {
 
 static void print_help(const char *name)
 {
-	printf("Usage:\n");
-	printf("	swupd %s [Options] 'search_term'\n", basename((char *)name));
-	printf("		'search_term': A substring of a binary, library or filename (default)\n");
-	printf("		Return: Bundle name : filename matching search term\n\n");
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "	swupd %s [Options] 'search_term'\n", basename((char *)name));
+	fprintf(stderr, "		'search_term': A substring of a binary, library or filename (default)\n");
+	fprintf(stderr, "		Return: Bundle name : filename matching search term\n\n");
 
-	printf("Help Options:\n");
-	printf("   -h, --help              Display this help\n");
-	printf("   -l, --library           Search paths where libraries are located for a match\n");
-	printf("   -b, --binary            Search paths where binaries are located for a match\n");
-	printf("   -s, --scope=[query type] 'b' or 'o' for first hit per (b)undle, or one hit total across the (o)s\n");
-	printf("   -d, --display-files	   Output full file list, no search done\n");
-	printf("   -i, --init              Download all manifests then return, no search done\n");
-	printf("   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
-	printf("   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
-	printf("   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
-	printf("   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
-	printf("   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
-	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
-	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
-	printf("   -S, --statedir          Specify alternate swupd state directory\n");
-	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
+	fprintf(stderr, "Help Options:\n");
+	fprintf(stderr, "   -h, --help              Display this help\n");
+	fprintf(stderr, "   -l, --library           Search paths where libraries are located for a match\n");
+	fprintf(stderr, "   -b, --binary            Search paths where binaries are located for a match\n");
+	fprintf(stderr, "   -s, --scope=[query type] 'b' or 'o' for first hit per (b)undle, or one hit total across the (o)s\n");
+	fprintf(stderr, "   -d, --display-files	   Output full file list, no search done\n");
+	fprintf(stderr, "   -i, --init              Download all manifests then return, no search done\n");
+	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
+	fprintf(stderr, "   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
+	fprintf(stderr, "   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
+	fprintf(stderr, "   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
+	fprintf(stderr, "   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
+	fprintf(stderr, "   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
+	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
+	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");
+	fprintf(stderr, "   -C, --certpath          Specify alternate path to swupd certificates\n");
 
-	printf("\nResults format:\n");
-	printf(" 'Bundle Name'  :  'File matching search term'\n\n");
-	printf("\n");
+	fprintf(stderr, "\nResults format:\n");
+	fprintf(stderr, " 'Bundle Name'  :  'File matching search term'\n\n");
+	fprintf(stderr, "\n");
 }
 
 static const struct option prog_opts[] = {
@@ -111,7 +111,7 @@ static bool parse_options(int argc, char **argv)
 			exit(0);
 		case 'u':
 			if (!optarg) {
-				printf("error: invalid --url argument\n\n");
+				fprintf(stderr, "error: invalid --url argument\n\n");
 				goto err;
 			}
 			set_version_url(optarg);
@@ -119,33 +119,33 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'c':
 			if (!optarg) {
-				printf("Invalid --contenturl argument\n\n");
+				fprintf(stderr, "Invalid --contenturl argument\n\n");
 				goto err;
 			}
 			set_content_url(optarg);
 			break;
 		case 'v':
 			if (!optarg) {
-				printf("Invalid --versionurl argument\n\n");
+				fprintf(stderr, "Invalid --versionurl argument\n\n");
 				goto err;
 			}
 			set_version_url(optarg);
 			break;
 		case 'P':
 			if (sscanf(optarg, "%ld", &update_server_port) != 1) {
-				printf("Invalid --port argument\n\n");
+				fprintf(stderr, "Invalid --port argument\n\n");
 				goto err;
 			}
 			break;
 		case 'p': /* default empty path_prefix verifies the running OS */
 			if (!optarg || !set_path_prefix(optarg)) {
-				printf("Invalid --path argument\n\n");
+				fprintf(stderr, "Invalid --path argument\n\n");
 				goto err;
 			}
 			break;
 		case 's':
 			if (!optarg || (strcmp(optarg, "b") && (strcmp(optarg, "o")))) {
-				printf("Invalid --scope argument. Must be 'b' or 'o'\n\n");
+				fprintf(stderr, "Invalid --scope argument. Must be 'b' or 'o'\n\n");
 				goto err;
 			}
 
@@ -158,20 +158,20 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'F':
 			if (!optarg || !set_format_string(optarg)) {
-				printf("Invalid --format argument\n\n");
+				fprintf(stderr, "Invalid --format argument\n\n");
 				goto err;
 			}
 			break;
 		case 'S':
 			if (!optarg || !set_state_dir(optarg)) {
-				printf("Invalid --statedir argument\n\n");
+				fprintf(stderr, "Invalid --statedir argument\n\n");
 				goto err;
 			}
 			break;
 		case 'l':
 			if (search_type != '0') {
-				printf("Error, cannot specify multiple search types "
-				       "(-l and -b are mutually exclusive)\n");
+				fprintf(stderr, "Error, cannot specify multiple search types "
+						"(-l and -b are mutually exclusive)\n");
 				goto err;
 			}
 
@@ -185,8 +185,8 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'b':
 			if (search_type != '0') {
-				printf("Error, cannot specify multiple search types "
-				       "(-l and -b are mutually exclusive)\n");
+				fprintf(stderr, "Error, cannot specify multiple search types "
+						"(-l and -b are mutually exclusive)\n");
 				goto err;
 			}
 
@@ -197,32 +197,32 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'C':
 			if (!optarg) {
-				printf("Invalid --certpath argument\n\n");
+				fprintf(stderr, "Invalid --certpath argument\n\n");
 				goto err;
 			}
 			set_cert_path(optarg);
 			break;
 		default:
-			printf("Error: unrecognized option: -'%c',\n\n", opt);
+			fprintf(stderr, "Error: unrecognized option: -'%c',\n\n", opt);
 			goto err;
 		}
 	}
 
 	if ((optind == argc) && (!init) && (!display_files)) {
-		printf("Error: Search term missing\n\n");
+		fprintf(stderr, "Error: Search term missing\n\n");
 		print_help(argv[0]);
 		return false;
 	}
 
 	if ((optind == argc - 1) && (display_files)) {
-		printf("Error: Cannot supply a search term and -d, --display-files together\n");
+		fprintf(stderr, "Error: Cannot supply a search term and -d, --display-files together\n");
 		return false;
 	}
 
 	search_string = argv[optind];
 
 	if (optind + 1 < argc) {
-		printf("Error, only 1 search term supported at a time\n");
+		fprintf(stderr, "Error, only 1 search term supported at a time\n");
 		return false;
 	}
 
@@ -292,13 +292,13 @@ static void do_search(struct manifest *MoM, char search_type, char *search_term)
 		/* Load sub-manifest */
 		subman = load_manifest(file->last_change, file->last_change, file, MoM, false);
 		if (!subman) {
-			printf("Failed to load manifest %s\n", file->filename);
+			fprintf(stderr, "Failed to load manifest %s\n", file->filename);
 			continue;
 		}
 
 		if (display_files) {
 			/* Display bundle name. Marked up for pattern matchability */
-			printf("--Bundle: %s--\n", file->filename);
+			fprintf(stderr, "--Bundle: %s--\n", file->filename);
 		}
 
 		/* Loop through sub-manifest, searching for files matching the desired pattern */
@@ -337,7 +337,7 @@ static void do_search(struct manifest *MoM, char search_type, char *search_term)
 					}
 				}
 			} else {
-				printf("Unrecognized search type. -b or -l supported\n");
+				fprintf(stderr, "Unrecognized search type. -b or -l supported\n");
 				done_with_search = true;
 				break;
 			}
@@ -360,7 +360,7 @@ static void do_search(struct manifest *MoM, char search_type, char *search_term)
 	}
 
 	if (!hit_count) {
-		printf("Search term not found.\n");
+		fprintf(stderr, "Search term not found.\n");
 	}
 }
 
@@ -418,7 +418,7 @@ static int download_manifests(struct manifest **MoM, struct list **subs)
 
 	current_version = get_current_version(path_prefix);
 	if (current_version < 0) {
-		printf("Error: Unable to determine current OS version\n");
+		fprintf(stderr, "Error: Unable to determine current OS version\n");
 		return ECURRENT_VERSION;
 	}
 
@@ -426,17 +426,17 @@ static int download_manifests(struct manifest **MoM, struct list **subs)
 
 	*MoM = load_mom(current_version, false);
 	if (!(*MoM)) {
-		printf("Cannot load official manifest MoM for version %i\n", current_version);
+		fprintf(stderr, "Cannot load official manifest MoM for version %i\n", current_version);
 		return EMOM_NOTFOUND;
 	}
 
 	list = (*MoM)->manifests;
 	size = query_total_download_size(list);
 	if (size == -1) {
-		printf("Downloading manifests. Expect a delay, up to 100MB may be downloaded\n");
+		fprintf(stderr, "Downloading manifests. Expect a delay, up to 100MB may be downloaded\n");
 	} else if (size > 0) {
-		printf("Downloading Clear Linux manifests\n");
-		printf("   %.2f MB total...\n\n", size);
+		fprintf(stderr, "Downloading Clear Linux manifests\n");
+		fprintf(stderr, "   %.2f MB total...\n\n", size);
 	}
 
 	while (list) {
@@ -455,7 +455,7 @@ static int download_manifests(struct manifest **MoM, struct list **subs)
 			/* Do download */
 			subMan = load_manifest(current_version, file->last_change, file, *MoM, false);
 			if (!subMan) {
-				printf("Cannot load official manifest MoM for version %i\n", current_version);
+				fprintf(stderr, "Cannot load official manifest MoM for version %i\n", current_version);
 			} else {
 				did_download = true;
 			}
@@ -467,7 +467,7 @@ static int download_manifests(struct manifest **MoM, struct list **subs)
 			string_or_die(&url, "%s/%i/Manifest.%s.tar", content_url, current_version,
 				      file->filename);
 
-			printf("Error: Failure reading from %s\n", url);
+			fprintf(stderr, "Error: Failure reading from %s\n", url);
 			free(url);
 		}
 
@@ -477,7 +477,7 @@ static int download_manifests(struct manifest **MoM, struct list **subs)
 	}
 
 	if (did_download) {
-		printf("Completed manifests download.\n\n");
+		fprintf(stderr, "Completed manifests download.\n\n");
 	}
 
 	return ret;
@@ -496,28 +496,28 @@ int search_main(int argc, char **argv)
 
 	ret = swupd_init(&lock_fd);
 	if (ret != 0) {
-		printf("Failed swupd initialization, exiting now.\n");
+		fprintf(stderr, "Failed swupd initialization, exiting now.\n");
 		return ret;
 	}
 
 	if (!check_network()) {
-		printf("Error: Network issue, unable to proceed with update\n");
+		fprintf(stderr, "Error: Network issue, unable to proceed with update\n");
 		ret = ENOSWUPDSERVER;
 		goto clean_exit;
 	}
 
 	if (!init) {
-		printf("Searching for '%s'\n\n", search_string);
+		fprintf(stderr, "Searching for '%s'\n\n", search_string);
 	}
 
 	ret = download_manifests(&MoM, &subs);
 	if (ret != 0) {
-		printf("Error: Failed to download manifests\n");
+		fprintf(stderr, "Error: Failed to download manifests\n");
 		goto clean_exit;
 	}
 
 	if (init) {
-		printf("Successfully retreived manifests. Exiting\n");
+		fprintf(stderr, "Successfully retreived manifests. Exiting\n");
 		ret = 0;
 		goto clean_exit;
 	}
@@ -525,7 +525,7 @@ int search_main(int argc, char **argv)
 	/* Arbitrary upper limit to ensure we aren't getting handed garbage */
 	if (!display_files &&
 	    ((strlen(search_string) <= 0) || (strlen(search_string) > NAME_MAX))) {
-		printf("Error - search string invalid\n");
+		fprintf(stderr, "Error - search string invalid\n");
 		ret = EXIT_FAILURE;
 		goto clean_exit;
 	}

--- a/src/signature.c
+++ b/src/signature.c
@@ -87,24 +87,24 @@ bool initialize_signature(void)
 			/* The system time wasn't sane, print out what it is and the cert validity range */
 			time(&currtime);
 			timeinfo = localtime(&currtime);
-			printf("Warning: Current time is %s\n", asctime(timeinfo));
-			printf("Certificate validity is:\n");
+			fprintf(stderr, "Warning: Current time is %s\n", asctime(timeinfo));
+			fprintf(stderr, "Certificate validity is:\n");
 			b = BIO_new_fp(stdout, BIO_NOCLOSE);
 			if (b == NULL) {
-				printf("Failed to create BIO wrapping stream\n");
+				fprintf(stderr, "Failed to create BIO wrapping stream\n");
 				goto fail;
 			}
 			/* The ASN1_TIME_print function does not include a newline... */
 			if (!ASN1_TIME_print(b, X509_get_notBefore(cert))) {
-				printf("\nFailed to get certificate begin date\n");
+				fprintf(stderr, "\nFailed to get certificate begin date\n");
 				goto fail;
 			}
-			printf("\n");
+			fprintf(stderr, "\n");
 			if (!ASN1_TIME_print(b, X509_get_notAfter(cert))) {
-				printf("\nFailed to get certificate expiration date\n");
+				fprintf(stderr, "\nFailed to get certificate expiration date\n");
 				goto fail;
 			}
-			printf("\n");
+			fprintf(stderr, "\n");
 			BIO_free(b);
 		}
 		goto fail;
@@ -120,7 +120,7 @@ bool initialize_signature(void)
 
 	return true;
 fail:
-	printf("Failed to verify certificate: %s\n", X509_verify_cert_error_string(ret));
+	fprintf(stderr, "Failed to verify certificate: %s\n", X509_verify_cert_error_string(ret));
 	return false;
 }
 
@@ -325,10 +325,10 @@ static int validate_certificate(void)
 	/* TODO: CRL and Chains are not required for the current setup, but we may
 	 * implement them in the future 
 	if (!crl) {
-		printf("No certificate revocation list provided\n");
+		fprintf(stderr, "No certificate revocation list provided\n");
 	}
 	if (!chain) {
-		printf("No certificate chain provided\n");
+		fprintf(stderr, "No certificate chain provided\n");
 	}
 	*/
 
@@ -402,8 +402,8 @@ error:
 int verify_callback(int ok, X509_STORE_CTX *stor)
 {
 	if (!ok) {
-		printf("Certificate verification error: %s\n",
-		       X509_verify_cert_error_string(stor->error));
+		fprintf(stderr, "Certificate verification error: %s\n",
+			X509_verify_cert_error_string(stor->error));
 	}
 	return ok;
 }

--- a/src/staging.c
+++ b/src/staging.c
@@ -95,17 +95,17 @@ int do_staging(struct file *file, struct manifest *MoM)
 	ret = stat(targetpath, &s);
 
 	if ((ret == -1) && (errno == ENOENT)) {
-		printf("Update target directory does not exist: %s. Trying to fix it\n", targetpath);
+		fprintf(stderr, "Update target directory does not exist: %s. Trying to fix it\n", targetpath);
 		verify_fix_path(dir, MoM);
 	} else if (!S_ISDIR(s.st_mode)) {
-		printf("Error: Update target exists but is NOT a directory: %s\n", targetpath);
+		fprintf(stderr, "Error: Update target exists but is NOT a directory: %s\n", targetpath);
 	}
 
 	free(targetpath);
 	string_or_die(&target, "%s%s/.update.%s", path_prefix, rel_dir, base);
 	ret = swupd_rm(target);
 	if (ret < 0 && ret != -ENOENT) {
-		printf("Error: Failed to remove %s\n", target);
+		fprintf(stderr, "Error: Failed to remove %s\n", target);
 	}
 
 	string_or_die(&statfile, "%s%s", path_prefix, file->filename);
@@ -281,15 +281,15 @@ int rename_staged_file_to_final(struct file *file)
 			/* this will fail if the directory was not already emptied */
 			ret = rename(target, lostnfound);
 			if (ret < 0 && errno != ENOTEMPTY && errno != EEXIST) {
-				printf("Error: failed to move %s to lost+found: %s\n",
-				       base, strerror(errno));
+				fprintf(stderr, "Error: failed to move %s to lost+found: %s\n",
+					base, strerror(errno));
 			}
 			free(lostnfound);
 		} else {
 			ret = rename(file->staging, target);
 			if (ret < 0) {
-				printf("Error: failed to rename staged %s to final: %s\n",
-				       file->hash, strerror(errno));
+				fprintf(stderr, "Error: failed to rename staged %s to final: %s\n",
+					file->hash, strerror(errno));
 			}
 			unlink(file->staging);
 		}

--- a/src/swupd.c
+++ b/src/swupd.c
@@ -53,22 +53,22 @@ static const struct option prog_opts[] = {
 
 static void print_help(const char *name)
 {
-	printf("Usage:\n");
-	printf("    %s [OPTION...]\n", basename((char *)name));
-	printf(" or %s [OPTION...] SUBCOMMAND [OPTION...]\n\n", basename((char *)name));
-	printf("Help Options:\n");
-	printf("   -h, --help              Show help options\n");
-	printf("   -v, --version           Output version information and exit\n\n");
-	printf("Subcommands:\n");
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "    %s [OPTION...]\n", basename((char *)name));
+	fprintf(stderr, " or %s [OPTION...] SUBCOMMAND [OPTION...]\n\n", basename((char *)name));
+	fprintf(stderr, "Help Options:\n");
+	fprintf(stderr, "   -h, --help              Show help options\n");
+	fprintf(stderr, "   -v, --version           Output version information and exit\n\n");
+	fprintf(stderr, "Subcommands:\n");
 
 	struct subcmd *entry = commands;
 
 	while (entry->name != NULL) {
-		printf("   %-20s    %-30s\n", entry->name, entry->doc);
+		fprintf(stderr, "   %-20s    %-30s\n", entry->name, entry->doc);
 		entry++;
 	}
-	printf("\n");
-	printf("To view subcommand options, run `%s SUBCOMMAND --help'\n", basename((char *)name));
+	fprintf(stderr, "\n");
+	fprintf(stderr, "To view subcommand options, run `%s SUBCOMMAND --help'\n", basename((char *)name));
 }
 
 static int subcmd_index(char *arg)
@@ -103,7 +103,7 @@ static int parse_options(int argc, char **argv, int *index)
 			exit(EXIT_SUCCESS);
 		case 'v':
 			copyright_header("swupd");
-			printf("Compile-time options: %s\n", BUILD_OPTS);
+			fprintf(stderr, "Compile-time options: %s\n", BUILD_OPTS);
 			exit(EXIT_SUCCESS);
 		case '\01':
 			/* found a subcommand, or a random non-option argument */
@@ -118,7 +118,7 @@ static int parse_options(int argc, char **argv, int *index)
 			}
 		case '?':
 			/* for unknown options, an error message is printed automatically */
-			printf("\n");
+			fprintf(stderr, "\n");
 			goto error;
 		default:
 			/* should be unreachable */
@@ -142,7 +142,7 @@ int main(int argc, char **argv)
 	if (parse_options(argc, argv, &index) < 0) {
 		return EINVALID_OPTION;
 	}
-
+	setvbuf(stdout, NULL, _IOLBF, BUFSIZ);
 	/* Reset optind to 0 (instead of the default value, 1) at this point,
 	 * because option parsing is restarted for the given subcommand, and
 	 * subcommand optstrings are not prefixed with "-", which is a GNU

--- a/src/update.c
+++ b/src/update.c
@@ -121,13 +121,13 @@ TRY_DOWNLOAD:
 	   amount of &times */
 	if (list_head(failed) != NULL && retries < MAX_TRIES) {
 		increment_retries(&retries, &timeout);
-		printf("Starting download retry #%d\n", retries);
+		fprintf(stderr, "Starting download retry #%d\n", retries);
 		clean_curl_multi_queue();
 		goto TRY_DOWNLOAD;
 	}
 
 	if (retries >= MAX_TRIES) {
-		printf("ERROR: Could not download all files, aborting update\n");
+		fprintf(stderr, "ERROR: Could not download all files, aborting update\n");
 		list_free_list(failed);
 		return -1;
 	}
@@ -145,7 +145,7 @@ TRY_DOWNLOAD:
 
 	/* starting at list_head in the filename alpha-sorted updates list
 	 * means node directories are added before leaf files */
-	printf("Staging file content\n");
+	fprintf(stderr, "Staging file content\n");
 	iter = list_head(updates);
 	while (iter) {
 		file = iter->data;
@@ -161,7 +161,7 @@ TRY_DOWNLOAD:
 
 		ret = do_staging(file, server_manifest);
 		if (ret < 0) {
-			printf("File staging failed: %s\n", file->filename);
+			fprintf(stderr, "File staging failed: %s\n", file->filename);
 			return ret;
 		}
 	}
@@ -243,7 +243,7 @@ int main_update()
 	ret = swupd_init(&lock_fd);
 	if (ret != 0) {
 		/* being here means we already close log by a previously caught error */
-		printf("Updater failed to initialize, exiting now.\n");
+		fprintf(stderr, "Updater failed to initialize, exiting now.\n");
 		return ret;
 	}
 
@@ -253,12 +253,12 @@ int main_update()
 	grabtime_start(&times, "Main Update");
 
 	if (!check_network()) {
-		printf("Error: Network issue, unable to proceed with update\n");
+		fprintf(stderr, "Error: Network issue, unable to proceed with update\n");
 		ret = ENOSWUPDSERVER;
 		goto clean_curl;
 	}
 
-	printf("Update started.\n");
+	fprintf(stderr, "Update started.\n");
 
 	grabtime_start(&times, "Update Step 1: get versions");
 
@@ -273,17 +273,17 @@ int main_update()
 		goto clean_curl;
 	}
 	if (server_version <= current_version) {
-		printf("Version on server (%i) is not newer than system version (%i)\n", server_version, current_version);
+		fprintf(stderr, "Version on server (%i) is not newer than system version (%i)\n", server_version, current_version);
 		ret = EXIT_SUCCESS;
 		goto clean_curl;
 	}
 
-	printf("Preparing to update from %i to %i\n", current_version, server_version);
+	fprintf(stderr, "Preparing to update from %i to %i\n", current_version, server_version);
 
 	/* Step 2: housekeeping */
 
 	if (rm_staging_dir_contents("download")) {
-		printf("Error cleaning download directory\n");
+		fprintf(stderr, "Error cleaning download directory\n");
 		ret = EXIT_FAILURE;
 		goto clean_curl;
 	}
@@ -300,10 +300,10 @@ load_current_mom:
 		 * - we just don't apply deltas */
 		if (retries < MAX_TRIES) {
 			increment_retries(&retries, &timeout);
-			printf("Retry #%d downloading from/to MoM Manifests\n", retries);
+			fprintf(stderr, "Retry #%d downloading from/to MoM Manifests\n", retries);
 			goto load_current_mom;
 		}
-		printf("Failure retrieving manifest from server\n");
+		fprintf(stderr, "Failure retrieving manifest from server\n");
 		ret = EMOM_NOTFOUND;
 		goto clean_exit;
 	}
@@ -319,11 +319,11 @@ load_server_mom:
 	if (!server_manifest) {
 		if (retries < MAX_TRIES) {
 			increment_retries(&retries, &timeout);
-			printf("Retry #%d downloading server Manifests\n", retries);
+			fprintf(stderr, "Retry #%d downloading server Manifests\n", retries);
 			goto load_server_mom;
 		}
-		printf("Failure retrieving manifest from server\n");
-		printf("Unable to load manifest after retrying (config or network problem?)\n");
+		fprintf(stderr, "Failure retrieving manifest from server\n");
+		fprintf(stderr, "Unable to load manifest after retrying (config or network problem?)\n");
 		ret = EMOM_NOTFOUND;
 		goto clean_exit;
 	}
@@ -340,7 +340,7 @@ load_current_submanifests:
 	if (!current_manifest->submanifests) {
 		if (retries < MAX_TRIES) {
 			increment_retries(&retries, &timeout);
-			printf("Retry #%d downloading current sub-manifests\n", retries);
+			fprintf(stderr, "Retry #%d downloading current sub-manifests\n", retries);
 			goto load_current_submanifests;
 		}
 		ret = ERECURSE_MANIFEST;

--- a/src/verify.c
+++ b/src/verify.c
@@ -77,28 +77,28 @@ static const struct option prog_opts[] = {
 
 static void print_help(const char *name)
 {
-	printf("Usage:\n");
-	printf("   swupd %s [OPTION...]\n\n", basename((char *)name));
-	printf("Help Options:\n");
-	printf("   -h, --help              Show help options\n\n");
-	printf("Application Options:\n");
-	printf("   -m, --manifest=M        Verify against manifest version M\n");
-	printf("   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
-	printf("   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
-	printf("   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
-	printf("   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
-	printf("   -v, --versionurl=[URL]  RFC-3986 encoded url for version file downloads\n");
-	printf("   -f, --fix               Fix local issues relative to server manifest (will not modify ignored files)\n");
-	printf("   -i, --install           Similar to \"--fix\" but optimized for install all files to empty directory\n");
-	printf("   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
-	printf("   -q, --quick             Don't compare hashes, only fix missing files\n");
-	printf("   -x, --force             Attempt to proceed even if non-critical errors found\n");
-	printf("   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
-	printf("   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
-	printf("   -S, --statedir          Specify alternate swupd state directory\n");
-	printf("   -C, --certpath          Specify alternate path to swupd certificates\n");
-	printf("   -t, --time         	   Show verbose time output for swupd operations\n");
-	printf("\n");
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "   swupd %s [OPTION...]\n\n", basename((char *)name));
+	fprintf(stderr, "Help Options:\n");
+	fprintf(stderr, "   -h, --help              Show help options\n\n");
+	fprintf(stderr, "Application Options:\n");
+	fprintf(stderr, "   -m, --manifest=M        Verify against manifest version M\n");
+	fprintf(stderr, "   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
+	fprintf(stderr, "   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
+	fprintf(stderr, "   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
+	fprintf(stderr, "   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
+	fprintf(stderr, "   -v, --versionurl=[URL]  RFC-3986 encoded url for version file downloads\n");
+	fprintf(stderr, "   -f, --fix               Fix local issues relative to server manifest (will not modify ignored files)\n");
+	fprintf(stderr, "   -i, --install           Similar to \"--fix\" but optimized for install all files to empty directory\n");
+	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
+	fprintf(stderr, "   -q, --quick             Don't compare hashes, only fix missing files\n");
+	fprintf(stderr, "   -x, --force             Attempt to proceed even if non-critical errors found\n");
+	fprintf(stderr, "   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
+	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
+	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");
+	fprintf(stderr, "   -C, --certpath          Specify alternate path to swupd certificates\n");
+	fprintf(stderr, "   -t, --time         	   Show verbose time output for swupd operations\n");
+	fprintf(stderr, "\n");
 }
 
 static bool parse_options(int argc, char **argv)
@@ -115,19 +115,19 @@ static bool parse_options(int argc, char **argv)
 			if (strcmp("latest", optarg) == 0) {
 				version = -1;
 			} else if (sscanf(optarg, "%i", &version) != 1) {
-				printf("Invalid --manifest argument\n\n");
+				fprintf(stderr, "Invalid --manifest argument\n\n");
 				goto err;
 			}
 			break;
 		case 'p': /* default empty path_prefix verifies the running OS */
 			if (!optarg || !set_path_prefix(optarg)) {
-				printf("Invalid --path argument\n\n");
+				fprintf(stderr, "Invalid --path argument\n\n");
 				goto err;
 			}
 			break;
 		case 'u':
 			if (!optarg) {
-				printf("Invalid --url argument\n\n");
+				fprintf(stderr, "Invalid --url argument\n\n");
 				goto err;
 			}
 			set_version_url(optarg);
@@ -135,20 +135,20 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'P':
 			if (sscanf(optarg, "%ld", &update_server_port) != 1) {
-				printf("Invalid --port argument\n\n");
+				fprintf(stderr, "Invalid --port argument\n\n");
 				goto err;
 			}
 			break;
 		case 'c':
 			if (!optarg) {
-				printf("Invalid --contenturl argument\n\n");
+				fprintf(stderr, "Invalid --contenturl argument\n\n");
 				goto err;
 			}
 			set_content_url(optarg);
 			break;
 		case 'v':
 			if (!optarg) {
-				printf("Invalid --versionurl argument\n\n");
+				fprintf(stderr, "Invalid --versionurl argument\n\n");
 				goto err;
 			}
 			set_version_url(optarg);
@@ -162,13 +162,13 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'F':
 			if (!optarg || !set_format_string(optarg)) {
-				printf("Invalid --format argument\n\n");
+				fprintf(stderr, "Invalid --format argument\n\n");
 				goto err;
 			}
 			break;
 		case 'S':
 			if (!optarg || !set_state_dir(optarg)) {
-				printf("Invalid --statedir argument\n\n");
+				fprintf(stderr, "Invalid --statedir argument\n\n");
 				goto err;
 			}
 			break;
@@ -189,32 +189,32 @@ static bool parse_options(int argc, char **argv)
 			break;
 		case 'C':
 			if (!optarg) {
-				printf("Invalid --certpath argument\n\n");
+				fprintf(stderr, "Invalid --certpath argument\n\n");
 				goto err;
 			}
 			set_cert_path(optarg);
 			break;
 		default:
-			printf("Unrecognized option\n\n");
+			fprintf(stderr, "Unrecognized option\n\n");
 			goto err;
 		}
 	}
 
 	if (cmdline_option_install) {
 		if (version == 0) {
-			printf("--install option requires -m version option\n");
+			fprintf(stderr, "--install option requires -m version option\n");
 			return false;
 		}
 		if (path_prefix == NULL) {
-			printf("--install option requires --path option\n");
+			fprintf(stderr, "--install option requires --path option\n");
 			return false;
 		}
 		if (cmdline_option_fix) {
-			printf("--install and --fix options are mutually exclusive\n");
+			fprintf(stderr, "--install and --fix options are mutually exclusive\n");
 			return false;
 		}
 	} else if (version == -1) {
-		printf("-m latest only supported with --install\n");
+		fprintf(stderr, "-m latest only supported with --install\n");
 		return false;
 	}
 
@@ -244,8 +244,8 @@ static int get_all_files(struct manifest *official_manifest, struct list *subs)
 		/* If we hit this point, we know we have a network connection, therefore
 		 * 	the error is server-side. This is also a critical error, so detailed
 		 * 	logging needed */
-		printf("zero pack downloads failed. \n");
-		printf("Failed - Server-side error, cannot download necessary files\n");
+		fprintf(stderr, "zero pack downloads failed. \n");
+		fprintf(stderr, "Failed - Server-side error, cannot download necessary files\n");
 		return -ENOSWUPDSERVER;
 	}
 	iter = list_head(official_manifest->files);
@@ -332,7 +332,7 @@ RETRY_DOWNLOADS:
 		/* If we hit this point, the network is accessible but we were
 		 * 	unable to download the needed files. This is a terminal error
 		 * 	and we need good logging */
-		printf("Error: Unable to download neccessary files for this OS release\n");
+		fprintf(stderr, "Error: Unable to download neccessary files for this OS release\n");
 		return -EFULLDOWNLOAD;
 	}
 
@@ -346,13 +346,13 @@ RETRY_DOWNLOADS:
 	   amount of &times */
 	if (list_head(failed) != NULL && retries < MAX_TRIES) {
 		increment_retries(&retries, &timeout);
-		printf("Starting download retry #%d\n", retries);
+		fprintf(stderr, "Starting download retry #%d\n", retries);
 		clean_curl_multi_queue();
 		goto RETRY_DOWNLOADS;
 	}
 
 	if (retries >= MAX_TRIES) {
-		printf("ERROR: Could not download all files, aborting update\n");
+		fprintf(stderr, "ERROR: Could not download all files, aborting update\n");
 		list_free_list(failed);
 		return -EFULLDOWNLOAD;
 	}
@@ -412,6 +412,7 @@ static void add_missing_files(struct manifest *official_manifest)
 		if (hash_is_zeros(local.hash)) {
 			file_missing_count++;
 			if (cmdline_option_install == false) {
+				/* Log to stdout, so we can post-process */
 				printf("Missing file: %s\n", fullname);
 			}
 		} else {
@@ -483,6 +484,7 @@ static void deal_with_hash_mismatches(struct manifest *official_manifest, bool r
 			continue;
 		} else {
 			file_mismatch_count++;
+			/* Log to stdout, so we can post-process it */
 			printf("Hash mismatch for file: %s\n", fullname);
 		}
 
@@ -556,7 +558,7 @@ static void remove_orphaned_files(struct manifest *official_manifest)
 
 		fd = get_dirfd_path(fullname);
 		if (fd < 0) {
-			printf("Not safe to delete: %s\n", fullname);
+			fprintf(stderr, "Not safe to delete: %s\n", fullname);
 			free(fullname);
 			file_not_deleted_count++;
 			continue;
@@ -567,10 +569,10 @@ static void remove_orphaned_files(struct manifest *official_manifest)
 		if (!S_ISDIR(sb.st_mode)) {
 			ret = unlinkat(fd, base, 0);
 			if (ret && errno != ENOENT) {
-				printf("Failed to remove %s (%i: %s)\n", fullname, errno, strerror(errno));
+				fprintf(stderr, "Failed to remove %s (%i: %s)\n", fullname, errno, strerror(errno));
 				file_not_deleted_count++;
 			} else {
-				printf("Deleted %s\n", fullname);
+				fprintf(stderr, "Deleted %s\n", fullname);
 				file_deleted_count++;
 			}
 		} else {
@@ -578,14 +580,14 @@ static void remove_orphaned_files(struct manifest *official_manifest)
 			if (ret) {
 				file_not_deleted_count++;
 				if (errno != ENOTEMPTY) {
-					printf("Failed to remove empty folder %s (%i: %s)\n",
-					       fullname, errno, strerror(errno));
+					fprintf(stderr, "Failed to remove empty folder %s (%i: %s)\n",
+						fullname, errno, strerror(errno));
 				} else {
 					//FIXME: Add force removal option?
-					printf("Couldn't remove directory containing untracked files: %s\n", fullname);
+					fprintf(stderr, "Couldn't remove directory containing untracked files: %s\n", fullname);
 				}
 			} else {
-				printf("Deleted %s\n", fullname);
+				fprintf(stderr, "Deleted %s\n", fullname);
 				file_deleted_count++;
 			}
 		}
@@ -623,7 +625,7 @@ int verify_main(int argc, char **argv)
 
 	ret = swupd_init(&lock_fd);
 	if (ret != 0) {
-		printf("Failed verify initialization, exiting now.\n");
+		fprintf(stderr, "Failed verify initialization, exiting now.\n");
 		return ret;
 	}
 
@@ -631,7 +633,7 @@ int verify_main(int argc, char **argv)
 	if (!version) {
 		version = get_current_version(path_prefix);
 		if (version < 0) {
-			printf("Error: Unable to determine current OS version\n");
+			fprintf(stderr, "Error: Unable to determine current OS version\n");
 			ret = ECURRENT_VERSION;
 			goto clean_and_exit;
 		}
@@ -640,16 +642,16 @@ int verify_main(int argc, char **argv)
 	if (version == -1) {
 		version = get_latest_version();
 		if (version < 0) {
-			printf("Unable to get latest version for install\n");
+			fprintf(stderr, "Unable to get latest version for install\n");
 			ret = EXIT_FAILURE;
 			goto clean_and_exit;
 		}
 	}
 
-	printf("Verifying version %i\n", version);
+	fprintf(stderr, "Verifying version %i\n", version);
 
 	if (!check_network()) {
-		printf("Error: Network issue, unable to download manifest\n");
+		fprintf(stderr, "Error: Network issue, unable to download manifest\n");
 		ret = ENOSWUPDSERVER;
 		goto clean_and_exit;
 	}
@@ -663,7 +665,7 @@ int verify_main(int argc, char **argv)
 
 	ret = rm_staging_dir_contents("download");
 	if (ret != 0) {
-		printf("Failed to remove prior downloads, carrying on anyway\n");
+		fprintf(stderr, "Failed to remove prior downloads, carrying on anyway\n");
 	}
 
 	times = init_timelist();
@@ -676,7 +678,7 @@ int verify_main(int argc, char **argv)
 		 * is not available, or if there is a server error and a manifest is
 		 * not provided.
 		 */
-		printf("Unable to download/verify %d Manifest.MoM\n", version);
+		fprintf(stderr, "Unable to download/verify %d Manifest.MoM\n", version);
 		ret = EMOM_NOTFOUND;
 
 		/* No repair is possible without a manifest, nor is accurate reporting
@@ -697,10 +699,10 @@ load_submanifests:
 	if (!official_manifest->submanifests) {
 		if (retries < MAX_TRIES) {
 			increment_retries(&retries, &timeout);
-			printf("Retry #%d downloading MoM sub-manifests\n", retries);
+			fprintf(stderr, "Retry #%d downloading MoM sub-manifests\n", retries);
 			goto load_submanifests;
 		}
-		printf("Error: Cannot load MoM sub-manifests\n");
+		fprintf(stderr, "Error: Cannot load MoM sub-manifests\n");
 		ret = ERECURSE_MANIFEST;
 		goto clean_and_exit;
 	}
@@ -744,7 +746,7 @@ load_submanifests:
 		 * has unintended side effect. So lets do the safest thing first.
 		 */
 		grabtime_start(&times, "Add missing files");
-		printf("Adding any missing files\n");
+		fprintf(stderr, "Adding any missing files\n");
 		add_missing_files(official_manifest);
 		grabtime_stop(&times);
 	}
@@ -758,7 +760,7 @@ load_submanifests:
 		bool repair = true;
 
 		grabtime_start(&times, "Fixing modified files");
-		printf("Fixing modified files\n");
+		fprintf(stderr, "Fixing modified files\n");
 		deal_with_hash_mismatches(official_manifest, repair);
 
 		/* removing files could be risky, so only do it if the
@@ -770,7 +772,7 @@ load_submanifests:
 	} else {
 		bool repair = false;
 
-		printf("Verifying files\n");
+		fprintf(stderr, "Verifying files\n");
 		deal_with_hash_mismatches(official_manifest, repair);
 	}
 	free_manifest(official_manifest);
@@ -783,30 +785,30 @@ brick_the_system_and_clean_curl:
 	 */
 
 	/* report a summary of what we managed to do and not do */
-	printf("Inspected %i files\n", file_checked_count);
+	fprintf(stderr, "Inspected %i files\n", file_checked_count);
 
 	if (cmdline_option_fix || cmdline_option_install) {
-		printf("  %i files were missing\n", file_missing_count);
+		fprintf(stderr, "  %i files were missing\n", file_missing_count);
 		if (file_missing_count) {
-			printf("    %i of %i missing files were replaced\n", file_replaced_count, file_missing_count);
-			printf("    %i of %i missing files were not replaced\n", file_not_replaced_count, file_missing_count);
+			fprintf(stderr, "    %i of %i missing files were replaced\n", file_replaced_count, file_missing_count);
+			fprintf(stderr, "    %i of %i missing files were not replaced\n", file_not_replaced_count, file_missing_count);
 		}
 	}
 
 	if (!cmdline_option_quick && file_mismatch_count > 0) {
-		printf("  %i files did not match\n", file_mismatch_count);
+		fprintf(stderr, "  %i files did not match\n", file_mismatch_count);
 		if (cmdline_option_fix) {
-			printf("    %i of %i files were fixed\n", file_fixed_count, file_mismatch_count);
-			printf("    %i of %i files were not fixed\n", file_not_fixed_count, file_mismatch_count);
+			fprintf(stderr, "    %i of %i files were fixed\n", file_fixed_count, file_mismatch_count);
+			fprintf(stderr, "    %i of %i files were not fixed\n", file_not_fixed_count, file_mismatch_count);
 		}
 	}
 
 	if ((file_not_fixed_count == 0) && (file_not_replaced_count == 0) &&
 	    cmdline_option_fix && !cmdline_option_quick) {
-		printf("  %i files found which should be deleted\n", file_extraneous_count);
+		fprintf(stderr, "  %i files found which should be deleted\n", file_extraneous_count);
 		if (file_extraneous_count) {
-			printf("    %i of %i files were deleted\n", file_deleted_count, file_extraneous_count);
-			printf("    %i of %i files were not deleted\n", file_not_deleted_count, file_extraneous_count);
+			fprintf(stderr, "    %i of %i files were deleted\n", file_deleted_count, file_extraneous_count);
+			fprintf(stderr, "    %i of %i files were not deleted\n", file_not_deleted_count, file_extraneous_count);
 		}
 	}
 
@@ -857,17 +859,17 @@ clean_and_exit:
 		  file_extraneous_count);
 	if (ret == EXIT_SUCCESS) {
 		if (cmdline_option_fix || cmdline_option_install) {
-			printf("Fix successful\n");
+			fprintf(stderr, "Fix successful\n");
 		} else {
 			/* This is just a verification */
-			printf("Verify successful\n");
+			fprintf(stderr, "Verify successful\n");
 		}
 	} else {
 		if (cmdline_option_fix || cmdline_option_install) {
-			printf("Error: Fix did not fully succeed\n");
+			fprintf(stderr, "Error: Fix did not fully succeed\n");
 		} else {
 			/* This is just a verification */
-			printf("Error: Verify did not fully succeed\n");
+			fprintf(stderr, "Error: Verify did not fully succeed\n");
 		}
 	}
 

--- a/src/verifytime.c
+++ b/src/verifytime.c
@@ -36,18 +36,18 @@ unsigned long int get_versionstamp(void)
 	const char *filename = "/usr/share/clear/versionstamp";
 
 	if (stat(filename, &statt) == -1) {
-		printf("%s does not exist!\n", filename);
+		fprintf(stderr, "%s does not exist!\n", filename);
 		return 0;
 	}
 
 	fp = fopen(filename, "r");
 	if (fp == NULL) {
-		printf("Failed to open %s\n", filename);
+		fprintf(stderr, "Failed to open %s\n", filename);
 		return 0;
 	}
 
 	if (fgets(data, 11, fp) == NULL) {
-		printf("Failed to read %s\n", filename);
+		fprintf(stderr, "Failed to read %s\n", filename);
 		fclose(fp);
 		return 0;
 	}
@@ -65,10 +65,10 @@ unsigned long int get_versionstamp(void)
 bool set_time(time_t mtime, char *time)
 {
 	if (stime(&mtime) != 0) {
-		printf("Failed to set system time");
+		fprintf(stderr, "Failed to set system time");
 		return false;
 	}
-	printf("Set system time to %s\n", time);
+	fprintf(stderr, "Set system time to %s\n", time);
 	return true;
 }
 
@@ -92,7 +92,7 @@ int main()
 		/* TODO: Get even better time than the versionstamp using a collection of servers,
 		 * and fallback to using versionstamp time if it does not work or seem reasonable.
 		 * The system time wasn't sane, so set it here and try again */
-		printf("Warning: Current time is %s\nAttempting to fix...", asctime(timeinfo));
+		fprintf(stderr, "Warning: Current time is %s\nAttempting to fix...", asctime(timeinfo));
 		if (set_time(versiontime, asctime(timeinfo)) == false) {
 			return 1;
 		}

--- a/src/version.c
+++ b/src/version.c
@@ -159,15 +159,15 @@ int check_versions(int *current_version,
 	read_versions(current_version, server_version, path_prefix);
 
 	if (*current_version < 0) {
-		printf("Error: Unable to determine current OS version\n");
+		fprintf(stderr, "Error: Unable to determine current OS version\n");
 		return -1;
 	}
 	if (*current_version == 0) {
-		printf("Update from version 0 not supported yet.\n");
+		fprintf(stderr, "Update from version 0 not supported yet.\n");
 		return -1;
 	}
 	if (SWUPD_VERSION_IS_DEVEL(*current_version) || SWUPD_VERSION_IS_RESVD(*current_version)) {
-		printf("Update of dev build not supported %d\n", *current_version);
+		fprintf(stderr, "Update of dev build not supported %d\n", *current_version);
 		return -1;
 	}
 	swupd_curl_set_current_version(*current_version);


### PR DESCRIPTION
Write error and informative messages to stderr, only
write data to stdout so it can be piped to other programs.

Make stdout line buffered, rather than introduce race conditions into tests

Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>