### PR TITLE
PoC of swupd autoupdate command

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,7 @@ swupd_SOURCES = \
 	$(clr_bundle_add_SOURCES) \
 	$(clr_bundle_rm_SOURCES) \
 	$(clr_bundle_ls_SOURCES) \
+	$(swupd_autoupdate_SOURCES) \
 	$(swupd_search_SOURCES)
 
 check_PROGRAMS = \
@@ -63,6 +64,7 @@ swupd_update_SOURCES = src/main.c
 swupd_verify_SOURCES = src/verify.c src/extra_files.c
 swupd_check_update_SOURCES = src/check_update.c
 swupd_search_SOURCES = src/search.c
+swupd_autoupdate_SOURCES = src/autoupdate.c
 
 clr_bundle_add_SOURCES = src/clr_bundle_add.c
 clr_bundle_rm_SOURCES = src/clr_bundle_rm.c

--- a/docs/swupd.1
+++ b/docs/swupd.1
@@ -117,6 +117,15 @@ Specify an alternate swupd state directory. Normally \fBswupd\fP uses
 .UNINDENT
 .SH SUBCOMMANDS
 .sp
+\fBautoupdate [\-\-enable|\-\-disable]\fP
+.INDENT 0.0
+.INDENT 3.5
+Enables or disables automatic updates, or reports current
+status. Enabling updates does not cause an immediate update \-
+use \fIswupd update\fP to force one if desired.
+.UNINDENT
+.UNINDENT
+.sp
 \fBbundle\-add {bundles}\fP
 .INDENT 0.0
 .INDENT 3.5
@@ -330,6 +339,9 @@ On success, 0 is returned. A non\-zero return code signals a failure.
 If the subcommand \fBcheck\-update\fP was specified, the program returns
 \fB0\fP if an update is available, \fB1\fP if no update available, and a
 return value higher than \fB1\fP signals a failure.
+.sp
+If the subcommand was \fBautoupdate\fP without options, then the program
+returns \fB0\fP if automatic updating is enabled.
 .SS SEE ALSO
 .INDENT 0.0
 .IP \(bu 2

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -104,6 +104,12 @@ used to modify the core behavior and resources that swupd uses.
 SUBCOMMANDS
 ===========
 
+``autoupdate [--enable|--disable]``
+
+    Enables or disables automatic updates, or reports current
+    status. Enabling updates does not cause an immediate update -
+    use `swupd update` to force one if desired.
+
 ``bundle-add {bundles}``
 
     Installs new software bundles. Any bundle name listed after
@@ -248,6 +254,8 @@ If the subcommand ``check-update`` was specified, the program returns
 ``0`` if an update is available, ``1`` if no update available, and a
 return value higher than ``1`` signals a failure.
 
+If the subcommand was ``autoupdate`` without options, then the program
+returns ``0`` if automatic updating is enabled.
 
 SEE ALSO
 --------

--- a/include/swupd-internal.h
+++ b/include/swupd-internal.h
@@ -1,6 +1,7 @@
 #ifndef __INCLUDE_GUARD_SWUPD_INTERNAL_H
 #define __INCLUDE_GUARD_SWUPD_INTERNAL_H
 
+extern int autoupdate_main(int argc, char **argv);
 extern int bundle_add_main(int argc, char **argv);
 extern int bundle_remove_main(int argc, char **argv);
 extern int bundle_list_main(int argc, char **argv);

--- a/src/autoupdate.c
+++ b/src/autoupdate.c
@@ -1,0 +1,131 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright (c) 2012-2016 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Authors:
+ *         Icarus Sparry <icarus.w.sparry@intel.com>
+ */
+
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <getopt.h>
+#include <libgen.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "swupd.h"
+
+static void print_help(const char *name)
+{
+	fprintf(stderr, "Usage:\n");
+	fprintf(stderr, "   swupd %s [options]\n\n", basename((char *)name));
+	fprintf(stderr, "Help Options:\n");
+	fprintf(stderr, "   -h, --help              Show help options\n");
+	fprintf(stderr, "       --enable            enable autoupdates\n");
+	fprintf(stderr, "       --disable           disable autoupdates\n");
+	fprintf(stderr, "\n");
+}
+
+static int enable;
+static int disable;
+
+static const struct option prog_opts[] = {
+	{ "help", no_argument, 0, 'h' },
+	{ "enable", no_argument, &enable, 1 },
+	{ "disable", no_argument, &disable, 1 },
+	{ 0, 0, 0, 0 }
+};
+
+static bool parse_options(int argc, char **argv)
+{
+	int opt;
+
+	while ((opt = getopt_long(argc, argv, "h", prog_opts, NULL)) != -1) {
+		switch (opt) {
+		case '?':
+			print_help(argv[0]);
+			exit(EINVALID_OPTION);
+		case 'h':
+			print_help(argv[0]);
+			exit(EXIT_SUCCESS);
+		case 0: /* getopt_long has set the flag */
+			break;
+		default:
+			fprintf(stderr, "Error: unrecognized option\n\n");
+			goto err;
+		}
+	}
+
+	if (argc > optind) {
+		fprintf(stderr, "Error: unexpected arguements\n\n");
+		goto err;
+	}
+
+	return true;
+err:
+	print_help(argv[0]);
+	return false;
+}
+
+int autoupdate_main(int argc, char **argv)
+{
+	copyright_header("autoupdate settings");
+
+	if (!parse_options(argc, argv)) {
+		return EINVALID_OPTION;
+	}
+	if (enable && disable) {
+		fprintf(stderr, "Can not enable and disable at the same time\n");
+		exit(EXIT_FAILURE);
+	}
+	if (enable) {
+		int rc;
+		check_root();
+		fprintf(stderr, "Running systemctl to enable updates\n");
+		rc = system("/usr/bin/systemctl unmask --now swupd-update.service swupd-update.timer"
+			    " && /usr/bin/systemctl start swupd-update.timer > /dev/null");
+		if (rc != -1) {
+			rc = WEXITSTATUS(rc);
+		}
+		return (rc);
+	} else if (disable) {
+		int rc;
+		check_root();
+		fprintf(stderr, "Running systemctl to disable updates\n");
+		rc = system("/usr/bin/systemctl mask --now swupd-update.service swupd-update.timer > /dev/null");
+		if (rc != -1) {
+			rc = WEXITSTATUS(rc);
+		}
+		return (rc);
+	} else {
+		int rc = system("/usr/bin/systemctl is-enabled swupd-update.service > /dev/null");
+		if (rc != -1) {
+			rc = WEXITSTATUS(rc);
+		}
+		switch (rc) {
+		case 0:
+			printf("Enabled\n");
+			break;
+		case 1:
+			printf("Disabled\n");
+			break;
+		default:
+			fprintf(stderr, "Unable to determine autoupdate status\n");
+		}
+		return (rc);
+	}
+}

--- a/src/swupd.c
+++ b/src/swupd.c
@@ -34,6 +34,7 @@ struct subcmd {
 };
 
 static struct subcmd commands[] = {
+	{ "autoupdate", "Enable/disable automatic system updates", autoupdate_main },
 	{ "bundle-add", "Install a new bundle", bundle_add_main },
 	{ "bundle-remove", "Uninstall a bundle", bundle_remove_main },
 	{ "bundle-list", "List installed bundles", bundle_list_main },


### PR DESCRIPTION
"swupd autoupdate" returns 0 if autoupdates are enabled.
"sudo autoupdate --enable" will unmask swupd-update.service
"sudo autoupdate --disable" will mask swupd-update.service

Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>