### PR TITLE
Add verify --fix --picky functionality

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -168,7 +168,7 @@ extern void increment_retries(int *retries, int *timeout);
 extern int main_update(void);
 extern int add_included_manifests(struct manifest *mom, int current, struct list **subs);
 extern int main_verify(int current_version);
-extern int walk_tree(struct manifest *, const char *);
+extern int walk_tree(struct manifest *, const char *, bool);
 
 extern int get_latest_version(void);
 extern void read_versions(int *current_version, int *server_version, char *path_prefix);

--- a/src/verify.c
+++ b/src/verify.c
@@ -774,11 +774,21 @@ load_submanifests:
 		if ((file_not_fixed_count == 0) && (file_not_replaced_count == 0)) {
 			remove_orphaned_files(official_manifest);
 		}
+		if (cmdline_option_picky) {
+			char *start = mk_full_filename(path_prefix, "/usr");
+			fprintf(stderr, "--picky removing extra files under %s\n", start);
+			ret = walk_tree(official_manifest, start, true);
+			if (ret >= 0) {
+				file_checked_count = ret;
+				ret = 0;
+			}
+			free(start);
+		}
 		grabtime_stop(&times);
 	} else if (cmdline_option_picky) {
 		char *start = mk_full_filename(path_prefix, "/usr");
 		fprintf(stderr, "Generating list of extra files under %s\n", start);
-		ret = walk_tree(official_manifest, start);
+		ret = walk_tree(official_manifest, start, false);
 		if (ret >= 0) {
 			file_checked_count = ret;
 			ret = 0;


### PR DESCRIPTION
This is the basic implementation for a "factory reset" type of command.
It will take the functionality of verify --picky and act on the files found
as verify --fix does with files found mismatching in the manifest.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>