### PR TITLE
Add -Y option to parseargs argument

### DIFF
--- a/src/verify.c
+++ b/src/verify.c
@@ -108,7 +108,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxnItm:p:u:P:c:v:fiF:qS:C:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hxnItm:p:u:P:c:v:fYiF:qS:C:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':


### PR DESCRIPTION
--picky option was being recognized by swupd verify but not
its equivalent -Y

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>