### PR TITLE
Differentiate between various early network failures.

### DIFF
--- a/include/swupd-error.h
+++ b/include/swupd-error.h
@@ -23,5 +23,6 @@
 #define ECURRENT_VERSION 20     /* Cannot determine current OS version */
 #define ESIGNATURE 21		/* Cannot initialize signature verification */
 #define EBADTIME 22		/* System time is bad */
+#define EDOWNLOADPACKS 23       /* Pack download failed */
 
 #endif

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -139,12 +139,14 @@ static int check_update()
 	}
 	swupd_curl_init();
 
+	if (!check_network) {
+		fprintf(stderr, "Error: Network issue, unable to proceed with update\n");
+		return ENOSWUPDSERVER;
+	}
+
 	read_versions(&current_version, &server_version, path_prefix);
 
-	if (server_version < 0) {
-		fprintf(stderr, "Cannot reach update server\n");
-		return ENOSWUPDSERVER;
-	} else if (current_version < 0) {
+	if (current_version < 0) {
 		fprintf(stderr, "Unable to determine current OS version\n");
 		return ECURRENT_VERSION;
 	} else {

--- a/src/update.c
+++ b/src/update.c
@@ -415,8 +415,8 @@ download_packs:
 			printf("Retry #%d downloading packs\n", retries);
 			goto download_packs;
 		}
-		printf("No network, or server unavailable for pack downloads\n");
-		ret = ENOSWUPDSERVER;
+		printf("Pack download failed\n");
+		ret = EDOWNLOADPACKS;
 		goto clean_exit;
 	}
 	grabtime_stop(&times);

--- a/src/verify.c
+++ b/src/verify.c
@@ -252,7 +252,7 @@ static int get_all_files(struct manifest *official_manifest, struct list *subs)
 		 * 	logging needed */
 		fprintf(stderr, "zero pack downloads failed. \n");
 		fprintf(stderr, "Failed - Server-side error, cannot download necessary files\n");
-		return -ENOSWUPDSERVER;
+		return -EDOWNLOADPACKS;
 	}
 	iter = list_head(official_manifest->files);
 	while (iter) {

--- a/test/functional/checkupdate/no-server-content/lines-checked
+++ b/test/functional/checkupdate/no-server-content/lines-checked
@@ -1,2 +1,3 @@
 Attempting to download version string to memory
-Cannot reach update server
+Current OS version: 10
+There are no updates available


### PR DESCRIPTION
We draw a hard line with error codes, such that:

Error code 16 is reserved for failures resulting from the basic
network check. Any call to check_network() that fails will
return this error code. No other error path returns this
error code.

Additionally, check_network() is called in every normal code path.

All other, possibly network related issues, return a different
error code. If the basic network check succeeds, but e.g. pack
downloads fail, we return a new (23) error code so that we
can better establish the conditions through telemetry and
determine whether the error is on the client or the server,
which is highly likely with this new error code 23.

Subsequently, for automated updates, we can choose to ignore
update failures if the automated periodical updates fail
due to no network being available. Calling the program
from a shell will still produce an error code, as normal.