### PR TITLE
Rerun swupd until there are no new version available

### DIFF
--- a/src/update.c
+++ b/src/update.c
@@ -237,6 +237,7 @@ int main_update()
 	struct timespec ts_start, ts_stop; // For main swupd update time
 	timelist times;
 	double delta;
+	bool updated = false;
 
 	srand(time(NULL));
 
@@ -485,6 +486,7 @@ clean_curl:
 	swupd_deinit(lock_fd, &latest_subs);
 
 	if ((current_version < server_version) && (ret == 0)) {
+		updated = true;
 		printf("Update successful. System updated from version %d to version %d\n",
 		       current_version, server_version);
 	} else if (ret == 0) {
@@ -495,6 +497,10 @@ clean_curl:
 		printf("%i files were not in a pack\n", nonpack);
 	}
 	run_postupdate_action();
+
+	if (updated) {
+		ret = main_update();
+	}
 
 	return ret;
 }


### PR DESCRIPTION
swupd needs to be run multiple times when there are format bumps.

This PR reruns swupd after a successful update until there are no
new updates available on the server.

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>