### PR TITLE
Add basic progress status for long-running tasks

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -330,6 +330,7 @@ extern void set_local_download(void);
 extern struct list *files_from_bundles(struct list *bundles);
 extern bool version_files_consistent(void);
 extern bool string_in_list(char *string_to_check, struct list *list_to_check);
+extern void print_progress(unsigned int count, unsigned int max);
 
 /* subscription.c */
 struct list *free_list_file(struct list *item);

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -40,6 +40,8 @@
 #include "signature.h"
 #include "swupd.h"
 
+static int last_percentage = -1;
+
 void check_root(void)
 {
 	if (getuid() != 0) {
@@ -943,8 +945,13 @@ bool string_in_list(char *string_to_check, struct list *list_to_check)
 void print_progress(unsigned int count, unsigned int max)
 {
 	if (isatty(fileno(stdout))) {
-		printf("\r\t...%d%%", (int)(100 * ((float)count / (float)max)));
-		fflush(stdout);
+		/* Only print when the percentage changes, so a maximum of 100 times per run */
+		int percentage = (int)(100 * ((float)count / (float)max));
+		if (percentage != last_percentage) {
+			printf("\r\t...%d%%", percentage);
+			fflush(stdout);
+			last_percentage = percentage;
+		}
 	} else {
 		// Print the first one, then every 10 after that
 		if (count % 10 == 1) {

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -945,5 +945,10 @@ void print_progress(unsigned int count, unsigned int max)
 	if (isatty(fileno(stdout))) {
 		printf("\r\t...%d%%", (int)(100 * ((float)count / (float)max)));
 		fflush(stdout);
+	} else {
+		// Print the first one, then every 10 after that
+		if (count % 10 == 1) {
+			printf(".");
+		}
 	}
 }

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -939,3 +939,11 @@ bool string_in_list(char *string_to_check, struct list *list_to_check)
 
 	return false;
 }
+
+void print_progress(unsigned int count, unsigned int max)
+{
+	if (isatty(fileno(stdout))) {
+		printf("\r\t...%d%%", (int)(100 * ((float)count / (float)max)));
+		fflush(stdout);
+	}
+}

--- a/src/packs.c
+++ b/src/packs.c
@@ -66,7 +66,7 @@ static int download_pack(int oldversion, int newversion, char *module)
 
 	free(url);
 
-	fprintf(stderr, "Extracting %s pack for version %i\n", module, newversion);
+	fprintf(stderr, "\nExtracting %s pack for version %i\n", module, newversion);
 	string_or_die(&tar, TAR_COMMAND " -C %s " TAR_PERM_ATTR_ARGS " -xf %s/pack-%s-from-%i-to-%i.tar 2> /dev/null",
 		      state_dir, state_dir, module, oldversion, newversion);
 

--- a/src/packs.c
+++ b/src/packs.c
@@ -97,6 +97,8 @@ int download_subscribed_packs(struct list *subs, bool required)
 	struct list *iter;
 	struct sub *sub = NULL;
 	int err;
+	unsigned int list_length = list_len(subs);
+	unsigned int complete = 0;
 
 	if (!check_network()) {
 		return -ENOSWUPDSERVER;
@@ -113,6 +115,7 @@ int download_subscribed_packs(struct list *subs, bool required)
 		}
 
 		err = download_pack(sub->oldversion, sub->version, sub->component);
+		print_progress(++complete, list_length);
 		if (err < 0) {
 			if (required) {
 				return err;
@@ -122,5 +125,6 @@ int download_subscribed_packs(struct list *subs, bool required)
 		}
 	}
 
+	printf("\n");
 	return 0;
 }

--- a/src/staging.c
+++ b/src/staging.c
@@ -303,6 +303,8 @@ int rename_all_files_to_final(struct list *updates)
 {
 	int ret, update_errs = 0, update_good = 0, skip = 0;
 	struct list *list;
+	unsigned int complete = 0;
+	unsigned int list_length = list_len(updates);
 
 	list = list_head(updates);
 	while (list) {
@@ -320,7 +322,10 @@ int rename_all_files_to_final(struct list *updates)
 		} else {
 			update_good += 1;
 		}
+
+		print_progress(++complete, list_length);
 	}
 
+	printf("\n");
 	return update_count - update_good - update_errs - (update_skip - skip);
 }

--- a/src/update.c
+++ b/src/update.c
@@ -177,6 +177,7 @@ TRY_DOWNLOAD:
 	sync();
 
 	/* rename to apply update */
+	printf("Applying update\n");
 	ret = rename_all_files_to_final(updates);
 	if (ret != 0) {
 		return ret;

--- a/src/update.c
+++ b/src/update.c
@@ -67,6 +67,8 @@ static struct list *full_download_loop(struct list *updates, int isfailed)
 {
 	struct list *iter;
 	struct file *file;
+	unsigned int list_length = list_len(updates);
+	unsigned int complete = 0;
 
 	iter = list_head(updates);
 	while (iter) {
@@ -78,7 +80,9 @@ static struct list *full_download_loop(struct list *updates, int isfailed)
 		}
 
 		full_download(file);
+		print_progress(++complete, list_length);
 	}
+	printf("\n");
 
 	if (isfailed) {
 		list_free_list(updates);

--- a/src/verify.c
+++ b/src/verify.c
@@ -275,6 +275,8 @@ static struct list *download_loop(struct list *files, int isfailed)
 	int ret;
 	struct file local;
 	struct list *iter;
+	unsigned int complete = 0;
+	unsigned int list_length = list_len(files);
 
 	iter = list_head(files);
 	while (iter) {
@@ -314,8 +316,10 @@ static struct list *download_loop(struct list *files, int isfailed)
 			file->do_not_update = 1;
 		}
 		free(fullname);
+		print_progress(++complete, list_length);
 	}
 
+	printf("\n");
 	if (isfailed) {
 		list_free_list(files);
 	}
@@ -421,7 +425,7 @@ static void add_missing_files(struct manifest *official_manifest)
 			file_missing_count++;
 			if (cmdline_option_install == false) {
 				/* Log to stdout, so we can post-process */
-				printf("Missing file: %s\n", fullname);
+				printf("\nMissing file: %s\n", fullname);
 			}
 		} else {
 			free(fullname);
@@ -443,17 +447,18 @@ static void add_missing_files(struct manifest *official_manifest)
 		}
 		if ((ret != 0) || hash_needs_work(file, local.hash)) {
 			file_not_replaced_count++;
-			printf("\tnot fixed\n");
+			printf("\n\tnot fixed\n");
 		} else {
 			file_replaced_count++;
 			file->do_not_update = 1;
 			if (cmdline_option_install == false) {
-				printf("\tfixed\n");
+				printf("\n\tfixed\n");
 			}
 		}
 		free(fullname);
 		print_progress(++complete, list_length);
 	}
+
 	printf("\n");
 }
 

--- a/src/verify.c
+++ b/src/verify.c
@@ -386,6 +386,8 @@ static void add_missing_files(struct manifest *official_manifest)
 	int ret;
 	struct file local;
 	struct list *iter;
+	unsigned int list_length = list_len(official_manifest->files);
+	unsigned int complete = 0;
 
 	iter = list_head(official_manifest->files);
 	while (iter) {
@@ -450,7 +452,9 @@ static void add_missing_files(struct manifest *official_manifest)
 			}
 		}
 		free(fullname);
+		print_progress(++complete, list_length);
 	}
+	printf("\n");
 }
 
 static void deal_with_hash_mismatches(struct manifest *official_manifest, bool repair)

--- a/test/functional/ignore-list
+++ b/test/functional/ignore-list
@@ -13,3 +13,4 @@
 ^sh: .*/usr/bin/clr-boot-manager: No such file or directory$
 ^sh: .*/usr/bin/clr-boot-manager: not found$
 ^Possible filedescriptor leak: .*$
+^\.+$

--- a/test/functional/update/apply-full-file-delta/lines-checked
+++ b/test/functional/update/apply-full-file-delta/lines-checked
@@ -12,5 +12,6 @@ Statistics for going from version 10 to version 100:
 Starting download of remaining update content. This may take a while...
 Finishing download of update content...
 Staging file content
+Applying update
 Update was applied.
 Update successful. System updated from version 10 to version 100

--- a/test/functional/update/boot-file/lines-checked
+++ b/test/functional/update/boot-file/lines-checked
@@ -12,6 +12,7 @@ Starting download of remaining update content. This may take a while...
 File /usr/lib/kernel/testfile was not in a pack
 Finishing download of update content...
 Staging file content
+Applying update
 Update was applied.
 Update successful. System updated from version 10 to version 100
 1 files were not in a pack

--- a/test/functional/update/include-old-bundle-with-tracked-file/lines-checked
+++ b/test/functional/update/include-old-bundle-with-tracked-file/lines-checked
@@ -12,6 +12,7 @@ Starting download of remaining update content. This may take a while...
 File /os-core was not in a pack
 Finishing download of update content...
 Staging file content
+Applying update
 Update was applied.
 Update successful. System updated from version 20 to version 30
 2 files were not in a pack

--- a/test/functional/update/include-old-bundle/lines-checked
+++ b/test/functional/update/include-old-bundle/lines-checked
@@ -12,6 +12,7 @@ Starting download of remaining update content. This may take a while...
 File /os-core was not in a pack
 Finishing download of update content...
 Staging file content
+Applying update
 Update was applied.
 Update successful. System updated from version 10 to version 100
 3 files were not in a pack

--- a/test/functional/update/include/lines-checked
+++ b/test/functional/update/include/lines-checked
@@ -12,6 +12,7 @@ Starting download of remaining update content. This may take a while...
 File /usr/bin was not in a pack
 Finishing download of update content...
 Staging file content
+Applying update
 Update was applied.
 Update successful. System updated from version 10 to version 100
 8 files were not in a pack

--- a/test/functional/update/missing-os-core/lines-checked
+++ b/test/functional/update/missing-os-core/lines-checked
@@ -12,6 +12,7 @@ Starting download of remaining update content. This may take a while...
 File /os-core was not in a pack
 Finishing download of update content...
 Staging file content
+Applying update
 Update was applied.
 Update successful. System updated from version 10 to version 100
 1 files were not in a pack

--- a/test/functional/update/newest-deleted/lines-checked
+++ b/test/functional/update/newest-deleted/lines-checked
@@ -12,5 +12,6 @@ Statistics for going from version 20 to version 30:
 Starting download of remaining update content. This may take a while...
 Finishing download of update content...
 Staging file content
+Applying update
 Update was applied.
 Update successful. System updated from version 20 to version 30

--- a/test/functional/update/re-update-bad-os-release/lines-checked
+++ b/test/functional/update/re-update-bad-os-release/lines-checked
@@ -12,6 +12,7 @@ Starting download of remaining update content. This may take a while...
 File /usr/bin was not in a pack
 Finishing download of update content...
 Staging file content
+Applying update
 Update was applied.
 Update successful. System updated from version 10 to version 20
 2 files were not in a pack

--- a/test/functional/update/re-update-required/lines-checked
+++ b/test/functional/update/re-update-required/lines-checked
@@ -12,6 +12,7 @@ Starting download of remaining update content. This may take a while...
 File /usr/bin was not in a pack
 Finishing download of update content...
 Staging file content
+Applying update
 Update was applied.
 Update successful. System updated from version 10 to version 20
 3 files were not in a pack
@@ -29,6 +30,7 @@ Starting download of remaining update content. This may take a while...
 File /usr/lib/os-release was not in a pack
 Finishing download of update content...
 Staging file content
+Applying update
 Update was applied.
 Update successful. System updated from version 100 to version 110
 1 files were not in a pack

--- a/test/functional/update/skip-verified-fullfiles/lines-checked
+++ b/test/functional/update/skip-verified-fullfiles/lines-checked
@@ -11,5 +11,6 @@ Statistics for going from version 10 to version 100:
 Starting download of remaining update content. This may take a while...
 Finishing download of update content...
 Staging file content
+Applying update
 Update was applied.
 Update successful. System updated from version 10 to version 100

--- a/test/functional/update/use-full-file/lines-checked
+++ b/test/functional/update/use-full-file/lines-checked
@@ -12,6 +12,7 @@ Starting download of remaining update content. This may take a while...
 File /usr/bin was not in a pack
 Finishing download of update content...
 Staging file content
+Applying update
 Update was applied.
 Update successful. System updated from version 10 to version 100
 1 files were not in a pack

--- a/test/functional/update/use-pack/lines-checked
+++ b/test/functional/update/use-pack/lines-checked
@@ -12,5 +12,6 @@ Statistics for going from version 10 to version 100:
 Starting download of remaining update content. This may take a while...
 Finishing download of update content...
 Staging file content
+Applying update
 Update was applied.
 Update successful. System updated from version 10 to version 100

--- a/test/functional/update/verify-fix-path-hash-mismatch/lines-checked
+++ b/test/functional/update/verify-fix-path-hash-mismatch/lines-checked
@@ -15,6 +15,7 @@ Staging file content
 REGEXP:^Update target directory does not exist: .*/target-dir/usr/bin. Trying to fix it$
 Hash did not match for path : /usr
 Path /usr/bin is missing on the file system
+Applying update
 Update was applied.
 Update successful. System updated from version 10 to version 100
 1 files were not in a pack

--- a/test/functional/update/verify-fix-path-missing-dir/lines-checked
+++ b/test/functional/update/verify-fix-path-missing-dir/lines-checked
@@ -14,6 +14,7 @@ Finishing download of update content...
 Staging file content
 REGEXP:^Update target directory does not exist: .*/target-dir/usr/bin. Trying to fix it$
 Path /usr/bin is missing on the file system
+Applying update
 Update was applied.
 Update successful. System updated from version 10 to version 100
 1 files were not in a pack


### PR DESCRIPTION
Add a basic progress indication for a couple potentially long-running
swupd tasks (download_pack and add_missing_files). The progress
indication is displayed as a percentage:
```
...85%
```
It overwrites its own line so the progress will update in place. It may
be interrupted by other swupd output:
```
...45%
Extracting os-core pack for version 10000
...50%
Extracting os-core-update pack for version 9000
...55%
```
The progress indication will then resume updating in place, on the same
line.

This progress is only displayed when outputting to a TTY, and will not
output anything when the output is being redirected. This is nice for
testing and logging, but means that these progress updates will not be
caught by processes that capture swupd output, such as ister.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

## RFC
I'd like to hear thoughts on this approach. A possible work-around for hiding the progress updates from calling processes is to log the progress to a file when not in a tty.