### PR TITLE
Wait for test server to become available before testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ test/functional/*/*/web-dir/*/staged/*.tar
 test/functional/*/*/web-dir/*/files/*.tar
 test/functional/*/*/web-dir/*/Manifest.MoM.sig
 test/functional/*/*/test.log
+test/functional/*/*/debug.log
 test/functional/*/*/state
 test/functional/*/*/lines-output
 verifytime

--- a/test/functional/checkupdate/slow-server/test.bats
+++ b/test/functional/checkupdate/slow-server/test.bats
@@ -6,6 +6,11 @@ server_pid=""
 port=""
 
 setup() {
+  # extra debug for touchy test
+  exec 21> $BATS_TEST_DIRNAME/debug.log
+  BASH_XTRACEFD=21
+  set -x
+
   for i in $(seq 8080 8180); do
     "$DIR/server.py" $i &
     sleep .5
@@ -23,6 +28,17 @@ teardown() {
 
 @test "check-update with a slow server" {
   slow_opts="-p $DIR/target-dir -F staging -u http://localhost:$port/"
+  # wait until server becomes available by expecting a successful curl
+  for i in $(seq 1 10); do
+    run curl http://localhost:$port/
+    if [ "$status" -ne 0 ]; then
+      sleep .5
+      continue
+    else
+      break
+    fi
+  done
+
   run sudo sh -c "$SWUPD check-update $slow_opts"
 
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Check that the simple test server in the checkupdate/slow-server/ test
is available before actually running the swupd command. This check is
done by testing the return status of a curl command on the server up to
ten times until successful.

Since this is an historically touchy test, output an additional
debug.log in the test directory with much more verbose logging (using
set -x).

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>