### PR TITLE
Add status checks for test swupd commands

### DIFF
--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -75,7 +75,10 @@ static bool parse_options(int argc, char **argv)
 			print_help(argv[0]);
 			exit(EXIT_SUCCESS);
 		case 'a':
-			return list_installable_bundles();
+			/* Exit early, we do not need to init swupd locally just to get a
+			 * list from the server
+			 * list_installable_bundles will supply the exit status */
+			exit(list_installable_bundles());
 			break;
 		case 'u':
 			if (!optarg) {

--- a/src/main.c
+++ b/src/main.c
@@ -196,7 +196,7 @@ static int print_versions()
 	}
 
 	if (server_version < 0) {
-		fprintf(stderr, "Cannot get latest the server version.Could not reach server\n");
+		fprintf(stderr, "Cannot get the latest server version. Could not reach server\n");
 		ret = 2;
 	} else {
 		fprintf(stderr, "Latest server version: %d\n", server_version);

--- a/src/update.c
+++ b/src/update.c
@@ -133,7 +133,7 @@ TRY_DOWNLOAD:
 	}
 
 	if (download_only) {
-		return -1;
+		return 0;
 	}
 
 	/*********** rootfs critical section starts ***************************
@@ -449,7 +449,7 @@ download_packs:
 	updates = list_sort(updates, file_sort_filename);
 
 	ret = update_loop(updates, server_manifest);
-	if (ret == 0) {
+	if (ret == 0 && !download_only) {
 		/* Failure to write the version file in the state directory
 		 * should not affect exit status. */
 		(void)update_device_latest_version(server_version);
@@ -503,11 +503,13 @@ clean_curl:
 	}
 	swupd_deinit(lock_fd, &latest_subs);
 
-	if ((current_version < server_version) && (ret == 0)) {
-		printf("Update successful. System updated from version %d to version %d\n",
-		       current_version, server_version);
-	} else if (ret == 0) {
-		printf("Update complete. System already up-to-date at version %d\n", current_version);
+	if (!download_only) {
+		if ((current_version < server_version) && (ret == 0)) {
+			printf("Update successful. System updated from version %d to version %d\n",
+			       current_version, server_version);
+		} else if (ret == 0) {
+			printf("Update complete. System already up-to-date at version %d\n", current_version);
+		}
 	}
 
 	if (nonpack > 0) {

--- a/src/update.c
+++ b/src/update.c
@@ -218,16 +218,20 @@ static int re_exec_update(bool versions_match)
 {
 	if (!versions_match) {
 		fprintf(stderr, "ERROR: Inconsistency between version files, exiting now.\n");
-		return -1;
+		return 1;
 	}
 
 	if (!swupd_cmd) {
 		fprintf(stderr, "ERROR: Unable to determine re-update command, exiting now.\n");
-		return -1;
+		return 1;
 	}
 
 	/* Run the swupd_cmd saved from main */
-	return system(swupd_cmd);
+	if (system(swupd_cmd) != 0) {
+		return 1;
+	}
+
+	return 0;
 }
 
 int main_update()

--- a/test/functional/bundleadd/add-directory/test.bats
+++ b/test/functional/bundleadd/add-directory/test.bats
@@ -22,6 +22,7 @@ teardown() {
 
 @test "bundle-add add bundle containing a directory" {
   run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
+  [ "$status" -eq 0 ]
   check_lines "$output"
   [ -d "$DIR/target-dir/usr/bin" ]
 }

--- a/test/functional/bundleadd/add-existing/test.bats
+++ b/test/functional/bundleadd/add-existing/test.bats
@@ -15,7 +15,7 @@ teardown() {
 
 @test "bundle-add an already existing bundle" {
   run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
-
+  [ "$status" -eq 0 ]
   check_lines "$output"
 }
 

--- a/test/functional/bundleadd/add-multiple/test.bats
+++ b/test/functional/bundleadd/add-multiple/test.bats
@@ -32,6 +32,7 @@ teardown() {
 @test "bundle-add add multiple bundles" {
   run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1 test-bundle2"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
   [ -d "$DIR/target-dir/usr/bin" ]
   [ -f "$DIR/target-dir/usr/foo" ]

--- a/test/functional/bundleadd/boot-file/test.bats
+++ b/test/functional/bundleadd/boot-file/test.bats
@@ -23,6 +23,7 @@ teardown() {
 @test "bundle-add add bundle containing boot file" {
   run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
   [ -f "$DIR/target-dir/usr/lib/kernel/testfile" ]
 }

--- a/test/functional/bundleadd/fix-missing-file/test.bats
+++ b/test/functional/bundleadd/fix-missing-file/test.bats
@@ -23,6 +23,7 @@ teardown() {
 @test "bundle-add verify_fix_path support" {
   run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
   [ -f "$DIR/target-dir/foo" ]
 }

--- a/test/functional/bundleadd/include/test.bats
+++ b/test/functional/bundleadd/include/test.bats
@@ -28,6 +28,7 @@ teardown() {
 @test "bundle-add verify include support" {
   run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
   ls "$DIR/target-dir/usr/bin"
   ls "$DIR/target-dir/usr/foo"

--- a/test/functional/bundleadd/verify-fix-path/test.bats
+++ b/test/functional/bundleadd/verify-fix-path/test.bats
@@ -31,6 +31,7 @@ teardown() {
 @test "bundle-add verify_fix_path support" {
   run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
   [ -d "$DIR/target-dir/usr/bin" ]
   [ -f "$DIR/target-dir/usr/bin/foo" ]

--- a/test/functional/bundlelist/all/test.bats
+++ b/test/functional/bundlelist/all/test.bats
@@ -15,6 +15,8 @@ teardown() {
 
 @test "bundle-list all bundles" {
   run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --all"
+
+  [ "$status" -eq 0 ]
   output=$(echo "$output" | sed -e 1,3d)
   check_lines "$output"
 }

--- a/test/functional/bundleremove/boot-file/test.bats
+++ b/test/functional/bundleremove/boot-file/test.bats
@@ -21,6 +21,7 @@ teardown() {
 @test "bundle-remove remove bundle containing a boot file" {
   run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
   [ ! -f "$DIR/target-dir/usr/lib/kernel/testfile" ]
 }

--- a/test/functional/bundleremove/include/test.bats
+++ b/test/functional/bundleremove/include/test.bats
@@ -18,6 +18,8 @@ teardown() {
 @test "bundle-remove remove bundle containing a file" {
   run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle"
 
+  # EBUNDLE_REMOVE == 3
+  [ "$status" -eq 3 ]
   check_lines "$output"
   [ -f "$DIR/target-dir/test-file" ]
   [ -f "$DIR/target-dir/test-file2" ]

--- a/test/functional/bundleremove/remove-file/test.bats
+++ b/test/functional/bundleremove/remove-file/test.bats
@@ -20,6 +20,7 @@ teardown() {
 @test "bundle-remove remove bundle containing a file" {
   run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
   [ ! -f "$DIR/target-dir/test-file" ]
 }

--- a/test/functional/bundleremove/remove-multiple/target-dir/.gitignore
+++ b/test/functional/bundleremove/remove-multiple/target-dir/.gitignore
@@ -1,0 +1,2 @@
+test-file*
+test-bundle*

--- a/test/functional/bundleremove/remove-multiple/test.bats
+++ b/test/functional/bundleremove/remove-multiple/test.bats
@@ -26,6 +26,7 @@ teardown() {
 @test "bundle-remove remove multiple bundles each containing a file" {
   run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle1 test-bundle2"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
   [ ! -f "$DIR/target-dir/test-file1" ] && [ ! -f "$DIR/target-dir/test-file2" ] && [ -f "$DIR/target-dir/test-file3" ]
 }

--- a/test/functional/checkupdate/no-server-content/test.bats
+++ b/test/functional/checkupdate/no-server-content/test.bats
@@ -5,7 +5,7 @@ load "../../swupdlib"
 @test "check-update with no server version file available" {
   run sudo sh -c "$SWUPD check-update $SWUPD_OPTS_NO_CERT"
 
-[ "$status" -ne 0 ]
+  [ "$status" -ne 0 ]
   check_lines "$output"
 }
 

--- a/test/functional/hashdump/file-hash-no-path-prefix/test.bats
+++ b/test/functional/hashdump/file-hash-no-path-prefix/test.bats
@@ -13,6 +13,7 @@ teardown() {
 @test "hashdump with prefix" {
   run sudo sh -c "$SWUPD hashdump $DIR/target-dir/test-hash"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
 }
 

--- a/test/functional/hashdump/file-hash/test.bats
+++ b/test/functional/hashdump/file-hash/test.bats
@@ -13,6 +13,7 @@ teardown() {
 @test "hashdump with prefix" {
   run sudo sh -c "$SWUPD hashdump --path=$DIR/target-dir /test-hash"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
 }
 

--- a/test/functional/search/content-check-negfull-path/test.bats
+++ b/test/functional/search/content-check-negfull-path/test.bats
@@ -17,6 +17,7 @@ teardown() {
 @test "search with non existant file, specifying full path" {
   run sudo sh -c "$SWUPD search $SWUPD_OPTS /usr/lib64/test-lib100"
 
+  [ "$status" -eq 0 ]
   echo "$output" | grep -q 'Search term not found.'
 }
 

--- a/test/functional/search/content-check-neglibtest/test.bats
+++ b/test/functional/search/content-check-neglibtest/test.bats
@@ -17,6 +17,7 @@ teardown() {
 @test "search with non existant library" {
   run sudo sh -c "$SWUPD search $SWUPD_OPTS -l libtest-nohit"
 
+  [ "$status" -eq 0 ]
   echo "$output" | grep -q 'Search term not found.'
 }
 

--- a/test/functional/search/content-check-posbin/test.bats
+++ b/test/functional/search/content-check-posbin/test.bats
@@ -17,6 +17,7 @@ teardown() {
 @test "search for a binary" {
   run sudo sh -c "$SWUPD search $SWUPD_OPTS -b test-bin"
 
+  [ "$status" -eq 0 ]
   echo "$output" | grep -q "'test-bundle'  :  '/usr/bin/test-bin'"
 }
 

--- a/test/functional/search/content-check-posebin/test.bats
+++ b/test/functional/search/content-check-posebin/test.bats
@@ -17,6 +17,7 @@ teardown() {
 @test "search for a file everywhere" {
   run sudo sh -c "$SWUPD search $SWUPD_OPTS test-bin"
 
+  [ "$status" -eq 0 ]
   echo "$output" | grep -q "'test-bundle'  :  '/usr/bin/test-bin'"
 }
 

--- a/test/functional/search/content-check-posfull-path/test.bats
+++ b/test/functional/search/content-check-posfull-path/test.bats
@@ -17,6 +17,7 @@ teardown() {
 @test "search for a file specifying the full path" {
   run sudo sh -c "$SWUPD search $SWUPD_OPTS /usr/lib64/test-lib64"
 
+  [ "$status" -eq 0 ]
   echo "$output" | grep -q "'test-bundle'  :  '/usr/lib64/test-lib64'"
 }
 

--- a/test/functional/search/content-check-poslib32/test.bats
+++ b/test/functional/search/content-check-poslib32/test.bats
@@ -17,6 +17,7 @@ teardown() {
 @test "search for a library in lib32" {
   run sudo sh -c "$SWUPD search $SWUPD_OPTS -l test-lib32"
 
+  [ "$status" -eq 0 ]
   echo "$output" | grep -q "'test-bundle'  :  '/usr/lib/test-lib32'"
 }
 

--- a/test/functional/search/content-check-poslib64/test.bats
+++ b/test/functional/search/content-check-poslib64/test.bats
@@ -17,6 +17,7 @@ teardown() {
 @test "search for a library in lib64" {
   run sudo sh -c "$SWUPD search $SWUPD_OPTS -l test-lib64"
 
+  [ "$status" -eq 0 ]
   echo "$output" | grep -q "'test-bundle'  :  '/usr/lib64/test-lib64'"
 }
 

--- a/test/functional/update/apply-full-file-delta/test.bats
+++ b/test/functional/update/apply-full-file-delta/test.bats
@@ -34,6 +34,7 @@ teardown() {
 
   run sudo sh -c "$SWUPD hashdump $DIR/target-dir/testfile"
 
+  [ "$status" -eq 0 ]
   echo "$output"
   [ "${lines[1]}" = "9f83d713da9df6cabd2abc9d9061f9b611a207e1e0dd22ed7a071ddb1cc1537a" ]
 }

--- a/test/functional/update/boot-file/test.bats
+++ b/test/functional/update/boot-file/test.bats
@@ -26,6 +26,7 @@ teardown() {
 @test "update add boot file" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
   [ -f "$DIR/target-dir/usr/lib/kernel/testfile" ]
 }

--- a/test/functional/update/download/test.bats
+++ b/test/functional/update/download/test.bats
@@ -26,6 +26,7 @@ teardown() {
 @test "update only download packs" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS --download"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
   [ ! -d "$DIR/target-dir/usr/bin" ]
 }

--- a/test/functional/update/include-old-bundle-with-tracked-file/test.bats
+++ b/test/functional/update/include-old-bundle-with-tracked-file/test.bats
@@ -47,6 +47,7 @@ teardown() {
 @test "update include a bundle from an older release" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
 
   # changed file

--- a/test/functional/update/include-old-bundle/test.bats
+++ b/test/functional/update/include-old-bundle/test.bats
@@ -42,6 +42,7 @@ teardown() {
 @test "update include a bundle from an older release" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
 
   # changed files

--- a/test/functional/update/include/test.bats
+++ b/test/functional/update/include/test.bats
@@ -63,6 +63,7 @@ teardown() {
 @test "update with includes" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
 
   # changed files

--- a/test/functional/update/missing-os-core/test.bats
+++ b/test/functional/update/missing-os-core/test.bats
@@ -31,6 +31,7 @@ teardown() {
 @test "update always add os-core to tracked bundles" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
 
   # changed files (hashes didn't change, only the versions)

--- a/test/functional/update/newest-deleted/test.bats
+++ b/test/functional/update/newest-deleted/test.bats
@@ -35,6 +35,7 @@ teardown() {
 @test "update where the newest version of a file was deleted" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
   [ ! -f "$DIR/target-dir/testfile" ]
 }

--- a/test/functional/update/re-update-bad-os-release/test.bats
+++ b/test/functional/update/re-update-bad-os-release/test.bats
@@ -53,12 +53,12 @@ teardown() {
   revert_chown_root "$DIR/web-dir/110/files/$targetfile"
   revert_chown_root "$DIR/web-dir/110/files/$targetfilefmt"
   sudo rm -rf "$DIR/target-dir/usr/bin/"
-  echo 'hi'
 }
 
 @test "update re-update bad os-release" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS_NO_FMT"
 
+  [ "$status" -eq 1 ]
   check_lines "$output"
   [ -d "$DIR/target-dir/usr/bin" ]
 }

--- a/test/functional/update/re-update-required/test.bats
+++ b/test/functional/update/re-update-required/test.bats
@@ -68,8 +68,8 @@ teardown() {
 
 @test "update re-update required" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS_NO_FMT"
-  #run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
   [ -d "$DIR/target-dir/usr/bin" ]
 }

--- a/test/functional/update/skip-verified-fullfiles/test.bats
+++ b/test/functional/update/skip-verified-fullfiles/test.bats
@@ -23,6 +23,7 @@ teardown() {
 @test "update fullfile download skipped when hash verifies correctly" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
 
   # changed file (hash is the same, but version changed)

--- a/test/functional/update/status-no-server-content/lines-checked
+++ b/test/functional/update/status-no-server-content/lines-checked
@@ -1,3 +1,3 @@
 Attempting to download version string to memory
 Current OS version: 10
-Cannot get latest the server version.Could not reach server
+Cannot get the latest server version. Could not reach server

--- a/test/functional/update/status-no-server-content/test.bats
+++ b/test/functional/update/status-no-server-content/test.bats
@@ -5,6 +5,7 @@ load "../../swupdlib"
 @test "update --status with no server content" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS --status"
 
+  [ "$status" -eq 2 ]
   check_lines "$output"
 }
 

--- a/test/functional/update/status-no-target-content/test.bats
+++ b/test/functional/update/status-no-target-content/test.bats
@@ -5,6 +5,7 @@ load "../../swupdlib"
 @test "update --status with no target content" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS --status"
 
+  [ "$status" -eq 2 ]
   check_lines "$output"
 }
 

--- a/test/functional/update/status-version-double-quote/test.bats
+++ b/test/functional/update/status-version-double-quote/test.bats
@@ -5,6 +5,7 @@ load "../../swupdlib"
 @test "update --status with double quote version" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS --status"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
 }
 

--- a/test/functional/update/status-version-single-quote/test.bats
+++ b/test/functional/update/status-version-single-quote/test.bats
@@ -5,6 +5,7 @@ load "../../swupdlib"
 @test "update --status with single quote version" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS --status"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
 }
 

--- a/test/functional/update/status/test.bats
+++ b/test/functional/update/status/test.bats
@@ -5,6 +5,7 @@ load "../../swupdlib"
 @test "update --status" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS --status"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
 }
 

--- a/test/functional/update/use-full-file/test.bats
+++ b/test/functional/update/use-full-file/test.bats
@@ -26,6 +26,7 @@ teardown() {
 @test "update use full file" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
   [ -d "$DIR/target-dir/usr/bin" ]
 }

--- a/test/functional/update/use-pack/test.bats
+++ b/test/functional/update/use-pack/test.bats
@@ -27,6 +27,7 @@ teardown() {
 @test "update using a pack" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
   [ -d "$DIR/target-dir/usr/bin" ]
 }

--- a/test/functional/update/verify-fix-path-hash-mismatch/test.bats
+++ b/test/functional/update/verify-fix-path-hash-mismatch/test.bats
@@ -33,6 +33,7 @@ teardown() {
 @test "update verify_fix_path corrects hash mismatch" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
   [ -d "$DIR/target-dir/usr/bin" ]
   [ -f "$DIR/target-dir/usr/bin/foo" ]

--- a/test/functional/update/verify-fix-path-missing-dir/test.bats
+++ b/test/functional/update/verify-fix-path-missing-dir/test.bats
@@ -38,6 +38,7 @@ teardown() {
 @test "update verify_fix_path corrects missing directory" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
+  [ "$status" -eq 0 ]
   check_lines "$output"
   [ -d "$DIR/target-dir/usr/bin" ]
   [ -f "$DIR/target-dir/usr/bin/foo" ]

--- a/test/functional/update/verify-fullfile-hash/test.bats
+++ b/test/functional/update/verify-fullfile-hash/test.bats
@@ -26,6 +26,7 @@ teardown() {
 @test "update fullfile hashes verified" {
   run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
+  [ "$status" -eq 1 ]
   check_lines "$output"
 
   [ ! -f "$DIR/target-dir/foo" ]


### PR DESCRIPTION
Adds status checks for each swupd command called in the functional
tests. At this point several of these tests fail due to some successful
commands returning error statuses.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

First commit should have test failures. I will push the fixes for those failures shortly.

Four following commits fix one previously-failing test each.