### PR TITLE
Add initial systemctl check for autoupdate

### DIFF
--- a/src/autoupdate.c
+++ b/src/autoupdate.c
@@ -112,7 +112,22 @@ int autoupdate_main(int argc, char **argv)
 		}
 		return (rc);
 	} else {
-		int rc = system("/usr/bin/systemctl is-enabled swupd-update.service > /dev/null");
+		/* In a container, "/usr/bin/systemctl" will return 1 with
+		 * "Failed to connect to bus: No such file or directory"
+		 * However /usr/bin/systemctl is-enabled ... will not fail, even when it
+		 * should. Check that systemctl is working before reporting the output
+		 * of is-enabled. */
+		int rc = system("/usr/bin/systemctl > /dev/null 2>&1");
+		if (rc != -1) {
+			rc = WEXITSTATUS(rc);
+		}
+
+		if (rc) {
+			fprintf(stderr, "Unable to determine autoupdate status\n");
+			return rc;
+		}
+
+		rc = system("/usr/bin/systemctl is-enabled swupd-update.service > /dev/null");
 		if (rc != -1) {
 			rc = WEXITSTATUS(rc);
 		}


### PR DESCRIPTION
In a container systemctl does not work, and /usr/bin/systemctl fails as
expected with "Failed to connect to bus: No such file or directory."
Because of this, swupd autoupdate will not work either. However,
"systemctl is-enabled ..." will not fail, even though it should.

Add an additional check to make sure /usr/bin/systemctl is working
before checking if swupd-update.service is-enabled. Report that swupd
was "Unable to determine autoupdate status" if this check fails.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

I tested this by applying the change in a docker container. It reported that it was unable to determine autoupdate status as expected. If anyone has better ideas for how to test this let me know.