### PR TITLE
RFC: Print warning when systemd not operable

### DIFF
--- a/src/scripts.c
+++ b/src/scripts.c
@@ -53,6 +53,15 @@ static void update_triggers(bool block)
 	char *block_flag = NULL;
 	__attribute__((unused)) int ret = 0;
 
+	/* Check that systemd is working (container case)
+	 * and return if it is not after printing an error */
+	ret = system("/usr/bin/systemctl > /dev/null 2>&1");
+	if (ret != 0) {
+		fprintf(stderr, "WARNING: systemctl not operable, "
+		                "unable to run systemd update triggers\n");
+		return;
+	}
+
 	/* These must block so that new update triggers are executed after */
 	if (need_systemd_reexec) {
 		ret = system("/usr/bin/systemctl daemon-reexec");


### PR DESCRIPTION
When running swupd in a container systemd is not operable and fails with
a "Failed to connect to bus" error. Instead of printing these errors
directly check if systemd is operable at all and print a warning if not,
then return early from the update_triggers.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

## RFC
swupd is never able to run in a container due to systemd not being present. Is this the right approach, warning and exit? I don't think it is reasonable to say updates failed every time in the container when it is just the post-update scripts that are being run.

However, with those post-update commands never being run in a container can we call the update complete?