### PR TITLE
Add newline to informational print

### DIFF
--- a/src/download.c
+++ b/src/download.c
@@ -565,7 +565,7 @@ void full_download(struct file *file)
 
 	/* Only print the first file so we don't spam on large misses */
 	if (nonpack == 0) {
-		fprintf(stderr, "File %s was not in a pack\n", file->filename);
+		fprintf(stderr, "\nFile %s was not in a pack\n", file->filename);
 	}
 	/* If we get here the pack is missing a file so we have to download it */
 	nonpack++;


### PR DESCRIPTION
Add newline so progress updates are printed correctly. Instead of this:
```
...10%File /file was not in a pack
...11%
```
Print a newline before the message:
```
...10%
File /file was not in a pack
...11%
```
Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>