### PR TITLE
fix for issue 261, compiler warning

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -662,7 +662,10 @@ verify_mom:
 					"  --nosigcheck, but system security may be compromised\n");
 			string_or_die(&log_cmd, "echo \"swupd security notice:"
 						" --nosigcheck used to bypass MoM signature verification failure\" | systemd-cat --priority=\"err\" --identifier=\"swupd\"");
-			(void)system(log_cmd);
+			if (system(log_cmd)) {
+				/* useless noise to suppress gcc & glibc conspiring
+				 * to make us check the result of system */
+			}
 			free(log_cmd);
 		}
 	}


### PR DESCRIPTION
glibc marks system() as a function whose return value should not be
ignored, which is generally reasonable. In this case we do want to
ignore the return value. Just casting to vooid is not enough to stop
the gcc warning. So instead we use the value in an if statement with
an empty body, which we trust the optimizer to remove so there is no
run time penalty.

The alternative solution would be to use
    #pragma GCC diagnostic push
    #pragma GCC diagnostic ignored "-Wwarn_unused_result"
    system(log_cmd);
    #pragma GCC diagnostic pop
but that is rather gcc specific.

Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>