### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/check_update.c
+++ b/src/check_update.c
@@ -139,7 +139,7 @@ static int check_update()
 	}
 	swupd_curl_init();
 
-	if (!check_network) {
+	if (!check_network()) {
 		fprintf(stderr, "Error: Network issue, unable to proceed with update\n");
 		return ENOSWUPDSERVER;
 	}

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -140,7 +140,7 @@ static int check_update()
 	swupd_curl_init();
 
 	if (!check_network()) {
-		fprintf(stderr, "Error: Network issue, unable to proceed with update\n");
+		fprintf(stderr, "Error: Network issue, unable to check for update\n");
 		return ENOSWUPDSERVER;
 	}
 

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -221,7 +221,7 @@ static void reload_parsed_opts(void)
 	sigcheck = curopts.sigcheck;
 }
 
-void static free_saved_opts(void)
+static void free_saved_opts(void)
 {
 	if (curopts.path_prefix != NULL) {
 		free(curopts.path_prefix);

--- a/test/functional/checkupdate/no-server-content/lines-checked
+++ b/test/functional/checkupdate/no-server-content/lines-checked
@@ -1,3 +1,2 @@
 Attempting to download version string to memory
-Current OS version: 10
-There are no updates available
+Error: Network issue, unable to check for update

--- a/test/functional/checkupdate/slow-server/lines-checked
+++ b/test/functional/checkupdate/slow-server/lines-checked
@@ -1,3 +1,4 @@
 Attempting to download version string to memory
+Range command not supported by server, download resume disabled.
 Current OS version: 10
 There is a new OS version available: 99990


### PR DESCRIPTION
Fixes compiler warnings in clr_bundle_rm.c and check_update.c.
Also fixes tests and improves error message for check_network()
failure in check_update.c.