### PR TITLE
Fix (doc) build failure for separate src and build dirs.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -287,7 +287,8 @@ clean-local:
 man: $(dist_man_MANS)
 
 .rst:
-	rst2man.py $< > $@
+	mkdir -p "$(dir $@)"
+	rst2man.py "$<" > "$@.tmp" && mv -f "$@.tmp" "$@"
 
 swupd.bash: $(top_srcdir)/scripts/swupd-completion.sh $(top_srcdir)/swupd
 	bash $<


### PR DESCRIPTION
Without this patch, if the docs are not up to date generating them fails if separate src and build dirs are used.
