### PR TITLE
F/275

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -761,6 +761,7 @@ download_subscribed_packs:
 	while (iter) {
 		file = iter->data;
 		iter = iter->next;
+		complete++;
 
 		if (file->is_deleted || file->do_not_update || ignore(file)) {
 			continue;
@@ -780,13 +781,14 @@ download_subscribed_packs:
 
 		/* two loops are necessary, first to stage, then to rename. Total is
 		 * list_length * 2 */
-		print_progress(++complete, list_length * 2);
+		print_progress(complete, list_length * 2);
 	}
 
 	iter = list_head(to_install_files);
 	while (iter) {
 		file = iter->data;
 		iter = iter->next;
+		complete++;
 
 		if (file->is_deleted || file->do_not_update || ignore(file)) {
 			continue;
@@ -799,9 +801,9 @@ download_subscribed_packs:
 
 		rename_staged_file_to_final(file);
 		// This is the second half of this process
-		print_progress(++complete, list_length * 2);
+		print_progress(complete, list_length * 2);
 	}
-
+	print_progress(list_length * 2, list_length * 2); /* Force out 100% complete */
 	printf("\n");
 	sync();
 	grabtime_stop(&times);

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -40,8 +40,6 @@
 #include "signature.h"
 #include "swupd.h"
 
-static int last_percentage = -1;
-
 void check_root(void)
 {
 	if (getuid() != 0) {
@@ -955,6 +953,8 @@ bool string_in_list(char *string_to_check, struct list *list_to_check)
 
 void print_progress(unsigned int count, unsigned int max)
 {
+	static int last_percentage = -1;
+
 	if (isatty(fileno(stdout))) {
 		/* Only print when the percentage changes, so a maximum of 100 times per run */
 		int percentage = (int)(100 * ((float)count / (float)max));
@@ -967,6 +967,7 @@ void print_progress(unsigned int count, unsigned int max)
 		// Print the first one, then every 10 after that
 		if (count % 10 == 1) {
 			printf(".");
+			fflush(stdout);
 		}
 	}
 }

--- a/src/packs.c
+++ b/src/packs.c
@@ -109,15 +109,16 @@ int download_subscribed_packs(struct list *subs, bool required)
 	while (iter) {
 		sub = iter->data;
 		iter = iter->next;
+		complete++;
 
 		if (sub->oldversion == sub->version) { // pack didn't change in this release
 			continue;
 		}
 
 		err = download_pack(sub->oldversion, sub->version, sub->component);
-		print_progress(++complete, list_length);
+		print_progress(complete, list_length);
 		if (err < 0) {
-			if (required) {
+			if (required) { /* Probably need printf("\n") here */
 				return err;
 			} else {
 				continue;
@@ -125,6 +126,7 @@ int download_subscribed_packs(struct list *subs, bool required)
 		}
 	}
 
+	print_progress(list_length, list_length); /* Force out 100% */
 	printf("\n");
 	return 0;
 }

--- a/src/staging.c
+++ b/src/staging.c
@@ -311,6 +311,7 @@ int rename_all_files_to_final(struct list *updates)
 		struct file *file;
 		file = list->data;
 		list = list->next;
+		complete++;
 		if (file->do_not_update) {
 			skip += 1;
 			continue;
@@ -323,9 +324,10 @@ int rename_all_files_to_final(struct list *updates)
 			update_good += 1;
 		}
 
-		print_progress(++complete, list_length);
+		print_progress(complete, list_length);
 	}
 
+	print_progress(list_length, list_length); /* Force out 100% */
 	printf("\n");
 	return update_count - update_good - update_errs - (update_skip - skip);
 }

--- a/src/update.c
+++ b/src/update.c
@@ -74,14 +74,16 @@ static struct list *full_download_loop(struct list *updates, int isfailed)
 	while (iter) {
 		file = iter->data;
 		iter = iter->next;
+		complete++;
 
 		if (file->is_deleted) {
 			continue;
 		}
 
 		full_download(file);
-		print_progress(++complete, list_length);
+		print_progress(complete, list_length);
 	}
+	print_progress(list_length, list_length); /* Force out 100% */
 	printf("\n");
 
 	if (isfailed) {

--- a/src/verify.c
+++ b/src/verify.c
@@ -290,6 +290,7 @@ static struct list *download_loop(struct list *files, int isfailed)
 
 		file = iter->data;
 		iter = iter->next;
+		complete++;
 
 		if (file->is_deleted) {
 			continue;
@@ -321,9 +322,9 @@ static struct list *download_loop(struct list *files, int isfailed)
 			file->do_not_update = 1;
 		}
 		free(fullname);
-		print_progress(++complete, list_length);
+		print_progress(complete, list_length);
 	}
-
+	print_progress(list_length, list_length); /* Force out 100% */
 	printf("\n");
 	if (isfailed) {
 		list_free_list(files);
@@ -405,6 +406,7 @@ static void add_missing_files(struct manifest *official_manifest)
 
 		file = iter->data;
 		iter = iter->next;
+		complete++;
 
 		if ((file->is_deleted) ||
 		    (file->do_not_update)) {
@@ -461,9 +463,9 @@ static void add_missing_files(struct manifest *official_manifest)
 			}
 		}
 		free(fullname);
-		print_progress(++complete, list_length);
+		print_progress(complete, list_length);
 	}
-
+	print_progress(list_length, list_length);
 	printf("\n");
 }
 

--- a/test/functional/bundleadd/fix-missing-file/lines-checked
+++ b/test/functional/bundleadd/fix-missing-file/lines-checked
@@ -1,7 +1,12 @@
 Attempting to download version string to memory
+Downloading packs
 Retry #1 downloading subscribed packs
+Downloading packs
 Retry #2 downloading subscribed packs
+Downloading packs
 Retry #3 downloading subscribed packs
-Installing bundle(s) files...
+Downloading packs
+Installing bundle(s) files
 Path /foo is missing on the file system
-Bundle(s) installation done.
+Calling post-update helper scripts
+Bundle(s) installation done

--- a/test/functional/bundleadd/fix-missing-file/test.bats
+++ b/test/functional/bundleadd/fix-missing-file/test.bats
@@ -24,7 +24,7 @@ teardown() {
   run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
   [ "$status" -eq 0 ]
-  check_lines "$output"
+  check_lines "${output//./}"
   [ -f "$DIR/target-dir/foo" ]
 }
 


### PR DESCRIPTION
2 progress meter related changes, as 3 patches.

1) Fix the fix-missing-file so it doesn't get upset with extra dots coming out partway through other output. This will happen when we flush the progress meter.

2) Make the progress meter more accurate, and show 100% at the end of each step.  Issue #275 

3) Flush the non interactive progress meter, Issue #256 - adding this breaks the fix-missing-file.