### PR TITLE
Support IPv6 in download code

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -506,12 +506,6 @@ CURLcode swupd_curl_set_basic_options(CURL *curl, const char *url)
 		goto exit;
 	}
 
-#warning "setup a means to validate IPv6 works end to end"
-	curl_ret = curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
-	if (curl_ret != CURLE_OK) {
-		goto exit;
-	}
-
 	/* Avoid downloading HTML files for error responses if the HTTP code is >= 400 */
 	curl_ret = curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1);
 	if (curl_ret != CURLE_OK) {


### PR DESCRIPTION
Fixes #200

Because swupd-client uses libcurl, and my guess is that libcurl has
supported IPv6 for a long time, I don't see any reason to restrict
downloads to IPv4 only.