### PR TITLE
show tar errors

### DIFF
--- a/src/download.c
+++ b/src/download.c
@@ -198,7 +198,7 @@ static int check_tarfile_content(struct file *file, const char *tarfilename)
 	FILE *tar;
 	int count = 0;
 
-	string_or_die(&tarcommand, TAR_COMMAND " -tf %s/download/%s.tar 2> /dev/null", state_dir, file->hash);
+	string_or_die(&tarcommand, TAR_COMMAND " -tf %s/download/%s.tar", state_dir, file->hash);
 
 	err = access(tarfilename, R_OK);
 	if (err) {
@@ -293,7 +293,7 @@ int untar_full_download(void *data)
 	}
 
 	/* modern tar will automatically determine the compression type used */
-	string_or_die(&tarcommand, TAR_COMMAND " -C %s/staged/ " TAR_PERM_ATTR_ARGS " -xf %s 2> /dev/null",
+	string_or_die(&tarcommand, TAR_COMMAND " -C %s/staged/ " TAR_PERM_ATTR_ARGS " -xf %s",
 		      state_dir, tarfile);
 
 	err = system(tarcommand);

--- a/src/hash.c
+++ b/src/hash.c
@@ -321,7 +321,7 @@ int verify_bundle_hash(struct manifest *manifest, struct file *bundle)
 			}
 			free(filename);
 
-			string_or_die(&tar, TAR_COMMAND " -C %s/%i -xf %s/%i/Manifest.%s.tar 2> /dev/null",
+			string_or_die(&tar, TAR_COMMAND " -C %s/%i -xf %s/%i/Manifest.%s.tar",
 				      state_dir, current->last_change, state_dir,
 				      current->last_change, current->filename);
 

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -543,7 +543,7 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 		goto out;
 	}
 
-	string_or_die(&tar, TAR_COMMAND " -C %s/%i -xf %s/%i/Manifest.%s.tar 2> /dev/null",
+	string_or_die(&tar, TAR_COMMAND " -C %s/%i -xf %s/%i/Manifest.%s.tar",
 		      state_dir, version, state_dir, version, component);
 
 	/* this is is historically a point of odd errors */

--- a/src/packs.c
+++ b/src/packs.c
@@ -67,7 +67,7 @@ static int download_pack(int oldversion, int newversion, char *module)
 	free(url);
 
 	fprintf(stderr, "\nExtracting %s pack for version %i\n", module, newversion);
-	string_or_die(&tar, TAR_COMMAND " -C %s " TAR_PERM_ATTR_ARGS " -xf %s/pack-%s-from-%i-to-%i.tar 2> /dev/null",
+	string_or_die(&tar, TAR_COMMAND " -C %s " TAR_PERM_ATTR_ARGS " -xf %s/pack-%s-from-%i-to-%i.tar",
 		      state_dir, state_dir, module, oldversion, newversion);
 
 	err = system(tar);

--- a/src/staging.c
+++ b/src/staging.c
@@ -148,7 +148,7 @@ int do_staging(struct file *file, struct manifest *MoM)
 			ret = -errno;
 			goto out;
 		}
-		string_or_die(&tarcommand, TAR_COMMAND " -C '%s' " TAR_PERM_ATTR_ARGS " -cf - './%s' 2> /dev/null | " TAR_COMMAND " -C '%s%s' " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
+		string_or_die(&tarcommand, TAR_COMMAND " -C '%s' " TAR_PERM_ATTR_ARGS " -cf - './%s' | " TAR_COMMAND " -C '%s%s' " TAR_PERM_ATTR_ARGS " -xf -",
 			      rename_tmpdir, base, path_prefix, rel_dir);
 		ret = system(tarcommand);
 		if (WIFEXITED(ret)) {
@@ -185,7 +185,7 @@ int do_staging(struct file *file, struct manifest *MoM)
 				ret = -errno;
 				goto out;
 			}
-			string_or_die(&tarcommand, TAR_COMMAND " -C '%s/staged' " TAR_PERM_ATTR_ARGS " -cf - '.update.%s' 2> /dev/null | " TAR_COMMAND " -C '%s%s' " TAR_PERM_ATTR_ARGS " -xf - 2> /dev/null",
+			string_or_die(&tarcommand, TAR_COMMAND " -C '%s/staged' " TAR_PERM_ATTR_ARGS " -cf - '.update.%s' | " TAR_COMMAND " -C '%s%s' " TAR_PERM_ATTR_ARGS " -xf -",
 				      state_dir, base, path_prefix, rel_dir);
 			ret = system(tarcommand);
 			if (WIFEXITED(ret)) {


### PR DESCRIPTION
Sending all tar stderr to /dev/null makes it hard to determine why
something failed.

This is particularly relevant for the issues we still do not fully
understand in https://github.com/clearlinux/swupd-server/pull/48.
I also needed this to see that I was simply running out of disk space
during a test.