### PR TITLE
support mixing http and file URLs

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -134,7 +134,6 @@ struct time {
 typedef TAILQ_HEAD(timelist, time) timelist;
 
 extern bool download_only;
-extern bool local_download;
 extern bool verify_esp_only;
 extern bool have_manifest_diskspace;
 extern bool have_network;
@@ -327,7 +326,6 @@ void update_motd(int new_release);
 void delete_motd(void);
 extern int get_dirfd_path(const char *fullname);
 extern int verify_fix_path(char *targetpath, struct manifest *manifest);
-extern void set_local_download(void);
 extern struct list *files_from_bundles(struct list *bundles);
 extern bool version_files_consistent(void);
 extern bool string_in_list(char *string_to_check, struct list *list_to_check);

--- a/src/curl.c
+++ b/src/curl.c
@@ -200,6 +200,7 @@ int swupd_curl_get_file(const char *url, char *filename, struct file *file,
 	long ret = 0;
 	int err = -1;
 	struct file *local = NULL;
+	bool local_download = strncmp(url, "file://", 7) == 0;
 
 	if (!curl) {
 		abort();

--- a/src/download.c
+++ b/src/download.c
@@ -348,6 +348,8 @@ static int perform_curl_io_and_complete(int count, bool bounded)
 	while (count > 0) {
 		CURL *handle;
 		struct file *file;
+		char *url = NULL;
+		bool local_download;
 
 		/* This function may return NULL before processing the
 		 * requested number of messages (stored in variable "count").
@@ -379,6 +381,13 @@ static int perform_curl_io_and_complete(int count, bool bounded)
 			curl_easy_cleanup(handle);
 			continue;
 		}
+
+		curl_ret = curl_easy_getinfo(handle, CURLINFO_EFFECTIVE_URL, &url);
+		if (curl_ret != CURLE_OK) {
+			curl_easy_cleanup(handle);
+			continue;
+		}
+		local_download = strncmp(url, "file://", 7) == 0;
 
 		/* Get error code from easy handle and augment it if
 		 * completing the download encounters further problems. */

--- a/src/globals.c
+++ b/src/globals.c
@@ -64,7 +64,6 @@ char *state_dir = NULL;
  */
 bool download_only;
 bool verbose_time = false;
-bool local_download = false;
 bool have_manifest_diskspace = false; /* assume no until checked */
 bool have_network = false;	    /* assume no access until proved */
 char *version_url = NULL;
@@ -541,9 +540,6 @@ bool init_globals(void)
 			exit(EXIT_FAILURE);
 		}
 	}
-
-	/* must set this global after version_url and content_url */
-	set_local_download();
 
 #ifdef SIGNATURES
 	set_cert_path(NULL);

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -859,38 +859,6 @@ end:
 	return ret;
 }
 
-/* In case both version_url and content_url have the file:// prefix, use
- * libcurl's file protocol to copy files from the local filesystem instead of
- * downloading from a web server.  The local_download global variable defaults
- * to false and is used to determine how to handle libcurl results after a
- * curl_*_perform.
- */
-void set_local_download(void)
-{
-	bool version_local = false;
-	bool content_local = false;
-
-	if (strncmp(version_url, "file://", 7) == 0) {
-		version_local = true;
-	}
-	if (strncmp(content_url, "file://", 7) == 0) {
-		content_local = true;
-	}
-
-	/* protocols must match for download logic */
-	if (version_local != content_local) {
-		fprintf(stderr, "\nVersion and content URLs must both use the HTTP/HTTPS protocols"
-				" or the libcurl FILE protocol.\n");
-		exit(EXIT_FAILURE);
-	}
-
-	if (version_local && content_local) {
-		local_download = true;
-	}
-
-	return;
-}
-
 struct list *files_from_bundles(struct list *bundles)
 {
 	struct list *files = NULL;


### PR DESCRIPTION
I need this in the context of the script that implements
https://github.com/clearlinux/swupd-client/issues/249: it works around
the lack of the "-m" parameter for "swupd
update" (https://github.com/clearlinux/swupd-client/issues/257) by
creationg a local directory with "version/format<xxx>/latest" and
using that via file://, while the actual content comes via http://.