### PR TITLE
Travis: Use github as upstream for check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ language: c
 # - libcurl 7.35.0 is too old. Installing a newer version.
 # - the Swupd_Root.pem cert must be installed out-of-tree to run the test suite with signature verification enabled
 install:
-        - wget http://downloads.sourceforge.net/project/check/check/0.10.0/check-0.10.0.tar.gz
-        - tar -xvf check-0.10.0.tar.gz
-        - pushd check-0.10.0 && ./configure --prefix=/usr && make -j48 && sudo make install && popd
+        - wget https://github.com/libcheck/check/releases/download/0.11.0/check-0.11.0.tar.gz
+        - tar -xvf check-0.11.0.tar.gz
+        - pushd check-0.11.0 && ./configure --prefix=/usr && make -j48 && sudo make install && popd
         - wget https://github.com/clearlinux/bsdiff/releases/download/v1.0.2/bsdiff-1.0.2.tar.xz
         - tar -xvf bsdiff-1.0.2.tar.xz
         - pushd bsdiff-1.0.2 && ./configure --prefix=/usr --disable-tests && make -j48 && sudo make install && popd


### PR DESCRIPTION
Recent outages to sourceforge break Travis CI runs. Use the github
release instead and update to the latest version of libcheck (0.11.0).

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>