### PR TITLE
DO NOT MERGE: Rough draft of fallback capath support.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -179,6 +179,12 @@ AS_IF(
 )
 
 AC_ARG_WITH(
+  [alt-ca-paths],
+  [AS_HELP_STRING([--with-alt-ca-paths=PATHS], [List of alternative CApaths to use for https connectivity])], 
+  [AC_DEFINE_UNQUOTED([ALT_CA_PATHS], ["$withval"], [List of alternative CApaths to use for https connectivity])]
+)
+
+AC_ARG_WITH(
   [contenturl],
   [AS_HELP_STRING([--with-contenturl=URL], [Default content url])],
   [AC_DEFINE_UNQUOTED([CONTENTURL], ["$withval"], [Default content url])]

--- a/src/update.c
+++ b/src/update.c
@@ -270,7 +270,7 @@ int main_update()
 	clock_gettime(CLOCK_MONOTONIC_RAW, &ts_start);
 	grabtime_start(&times, "Main Update");
 
-	if (!check_network()) {
+	if (swupd_curl_check_network()) {
 		fprintf(stderr, "Error: Network issue, unable to proceed with update\n");
 		ret = ENOSWUPDSERVER;
 		goto clean_curl;


### PR DESCRIPTION
@tmarcu, @phmccarty, @matthewrsj 

this is to support fallback trust sources for https connectivity in swupd, so that if the default trust store (configured in curl) does not work, it would try alternatives. this way, we protect the critical path for Clear Linux to be able to peform an update.

this PR is rather just an illustration to the two questions that i have:

1. i'd like to suggest an alternative way of checking connectivity. currently `check_network()` (from `src/version.c` is being used which internally fetches the version file, actually. instead, i propose that we have specialized `swupd_curl_check_network()` which, when called, also pick the appropriate trust store and if connection could not be established. additionally (this is not present yet in this PR), i think `swupd_curl_check_network()` could also be called immediately on `swupd_curl_init()`.

2. do you think we also need to make it a runtime command-line option? i noticed that most, if not all, build configuration options have their command-line analogs.