### PR TITLE
Fix compiler warnings in search.c

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -246,14 +246,18 @@ static bool file_search(char *filename, char *path, char *search_term)
 		return false;
 	}
 
-	pos = strstr(filename, path);
-	if (pos == NULL) {
-		return false;
+	if (path) {
+		pos = strstr(filename, path);
+		if (pos == NULL) {
+			return false;
+		}
 	}
 
-	/* match filename or substring of filename */
-	if (strcasestr(pos + strlen(path), search_term)) {
-		return true;
+	if (path && search_term) {
+		/* match filename or substring of filename */
+		if (strcasestr(pos + strlen(path), search_term)) {
+			return true;
+		}
 	}
 
 	return false;


### PR DESCRIPTION
Fixes #265 

The calls to strstr() and strcasestr() in file_search() from search.c
result in compiler warnings when -Wnonnull is specified, because GCC's
"nonnull" attribute applies to these functions.

The logic from the file_search() call sites prevent NULL pointers from
being passed to these functions, but to protect against future
refactoring introducing this bug, check that the appropriate pointers
are non-NULL before calling the string functions.