### PR TITLE
Portability for Makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -287,7 +287,7 @@ clean-local:
 man: $(dist_man_MANS)
 
 .rst:
-	mkdir -p "$(dir $@)"
+	mkdir -p "$$(dirname $@)"
 	rst2man.py "$<" > "$@.tmp" && mv -f "$@.tmp" "$@"
 
 swupd.bash: $(top_srcdir)/scripts/swupd-completion.sh $(top_srcdir)/swupd


### PR DESCRIPTION
Fixes #300

Do not use GNU Make 'dir' function, instead use shell dirname command.
Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>