### PR TITLE
Allow manpage generation to be optional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -270,7 +270,7 @@ release:
 	@git tag -a -m "$(PACKAGE_NAME) release $(PACKAGE_VERSION)" v$(PACKAGE_VERSION)
 	@printf "\nNew release $(PACKAGE_VERSION) tagged!\n\n"
 
-
+if ENABLE_MAN
 MANPAGES = \
 	docs/swupd.1 \
 	docs/check-update.service.4 \
@@ -290,6 +290,7 @@ man: $(dist_man_MANS)
 .rst:
 	mkdir -p "$$(dirname $@)"
 	rst2man.py "$<" > "$@.tmp" && mv -f "$@.tmp" "$@"
+endif
 
 swupd.bash: $(top_srcdir)/scripts/swupd-completion.sh $(top_srcdir)/swupd
 	bash $<

--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,22 @@ AS_IF(
   [XATTR=no]
 )
 
+AC_ARG_ENABLE(
+  [manpages],
+  [AS_HELP_STRING([--disable-manpages], [Do not enable manpage generation (disabled by default)])]
+)
+MANPAGES="yes"
+AS_IF(
+  [test -n "$enable_manpages" -a "$enable_manpages" = "yes"],
+  [MANPAGES="$enable_manpages"]
+)
+AS_IF(
+  [test "$enable_manpages" != "no"],
+  [MANPAGES="yes"],
+  [MANPAGES="no"]
+)
+AM_CONDITIONAL([ENABLE_MAN], [test "$enable_manpages" = "yes"])
+
 TARSELINUX="yes"
 AC_ARG_ENABLE(
   [tar-selinux],
@@ -298,13 +314,14 @@ swupd-client
 
 Configuration to build swupd-client:
 
-  Content URL:				${CONTENTURL}
-  Version URL:				${VERSIONURL}
-  Format Identifier:			${FORMATID}
-  Signature verification:		${SIGVERIFICATION}
-  Update certificate path:		${cert_path}
-  Use bzip compression:			${BZIP}
-  Run Tests:				${TESTS}
-  Use extended file attributes		${XATTR}
-  Use --selinux option for tar		${TARSELINUX}
+  Content URL:        ${CONTENTURL}
+  Version URL:        ${VERSIONURL}
+  Format Identifier:      ${FORMATID}
+  Signature verification:   ${SIGVERIFICATION}
+  Update certificate path:    ${cert_path}
+  Use bzip compression:     ${BZIP}
+  Run Tests:        ${TESTS}
+  Manpages:        ${MANPAGES}
+  Use extended file attributes    ${XATTR}
+  Use --selinux option for tar    ${TARSELINUX}
 ])


### PR DESCRIPTION
In a Yocto build environment we don't have rst2man.py and builds fail.
This allows a workaround and more flexibility in what is generated