### PR TITLE
test: implement validation for lines-checked; improve check_lines() error reporting

### DIFF
--- a/test/functional/matcher.awk
+++ b/test/functional/matcher.awk
@@ -61,3 +61,6 @@ END {
     exit 1
   }
 }
+
+
+# vi: ft=awk sw=2 sts=2 et tw=80

--- a/test/functional/matcher.awk
+++ b/test/functional/matcher.awk
@@ -15,13 +15,22 @@ FILENAME ~ /ignore-list/ {
   toignore[$0]++
 }
 
+# Checks if LINE matches any pattern in the "toignore" array. Returns the first
+# matching pattern if true, 0 if false.
+function is_ignored(line) {
+  for (pattern in toignore) {
+    if (line ~ pattern) {
+      return pattern
+    }
+  }
+  return 0
+}
+
 FILENAME ~ /lines-output/ {
   # Skip to the next line if the current line matches any patterns from the
   # global ignore list.
-  for (pattern in toignore) {
-    if ($0 ~ pattern) {
-      next
-    }
+  if (is_ignored($0)) {
+    next
   }
 
   # An output line may match a regular expression from lines-checked, which

--- a/test/functional/swupdlib.bash
+++ b/test/functional/swupdlib.bash
@@ -106,6 +106,8 @@ check_lines() {
   if [ $ret -eq 1 ]; then
     echo -e "\nChecked lines versus actual output (note that actual output may contain ignored lines):\n"
     diff -u "$checked" "$outputfile"
+  elif [ $ret -eq 2 ]; then
+    echo -e "\n^ Error: lines-checked contains ignored lines\n"
   fi
 
   return $ret

--- a/test/functional/swupdlib.bash
+++ b/test/functional/swupdlib.bash
@@ -95,16 +95,20 @@ check_lines() {
   local checked="$DIR/lines-checked"
   local ignored="$DIR/../../ignore-list"
   local prog="$DIR/../../matcher.awk"
+  local ret
 
   echo "$outputstr" > "$outputfile"
 
   run awk -f "$prog" "$ignored" "$checked" "$outputfile"
+  ret=$status
+  echo "$output"
 
-  if [ $status -eq 1 ]; then
-    echo "$output"
+  if [ $ret -eq 1 ]; then
     echo -e "\nChecked lines versus actual output (note that actual output may contain ignored lines):\n"
     diff -u "$checked" "$outputfile"
   fi
+
+  return $ret
 }
 
 # This generates the private key and self signed certificate

--- a/test/functional/swupdlib.bash
+++ b/test/functional/swupdlib.bash
@@ -105,7 +105,9 @@ check_lines() {
 
   if [ $ret -eq 1 ]; then
     echo -e "\nChecked lines versus actual output (note that actual output may contain ignored lines):\n"
-    diff -u "$checked" "$outputfile"
+    # Omit ignored lines in the actual output to unobfuscate test error
+    # reporting.
+    diff -u "$checked" <(grep -Evf "$ignored" "$outputfile")
   elif [ $ret -eq 2 ]; then
     echo -e "\n^ Error: lines-checked contains ignored lines\n"
   fi

--- a/test/functional/swupdlib.bash
+++ b/test/functional/swupdlib.bash
@@ -98,7 +98,7 @@ check_lines() {
 
   echo "$outputstr" > "$outputfile"
 
-  run awk -f "$prog" "$checked" "$ignored" "$outputfile"
+  run awk -f "$prog" "$ignored" "$checked" "$outputfile"
 
   if [ $status -eq 1 ]; then
     echo "$output"

--- a/test/functional/swupdlib.bash
+++ b/test/functional/swupdlib.bash
@@ -104,7 +104,7 @@ check_lines() {
   echo "$output"
 
   if [ $ret -eq 1 ]; then
-    echo -e "\nChecked lines versus actual output (note that actual output may contain ignored lines):\n"
+    echo -e "\nChecked lines versus actual output:\n"
     # Omit ignored lines in the actual output to unobfuscate test error
     # reporting.
     diff -u "$checked" <(grep -Evf "$ignored" "$outputfile")

--- a/test/functional/update/rename/lines-checked
+++ b/test/functional/update/rename/lines-checked
@@ -1,0 +1,17 @@
+Update started.
+Attempting to download version string to memory
+Preparing to update from 10 to 20
+Extracting os-core pack for version 20
+Statistics for going from version 10 to version 20:
+    changed bundles   : 1
+    new bundles       : 0
+    deleted bundles   : 0
+    changed files     : 1
+    new files         : 2
+    deleted files     : 2
+Starting download of remaining update content. This may take a while...
+Finishing download of update content...
+Staging file content
+Applying update
+Update was applied.
+Update successful. System updated from version 10 to version 20

--- a/test/functional/update/rename/test.bats
+++ b/test/functional/update/rename/test.bats
@@ -26,7 +26,7 @@ teardown() {
 }
 
 @test "update simple rename" {
-  run sudo sh -xvc "$SWUPD update $SWUPD_OPTS"
+  run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
   check_lines "$output"
 


### PR DESCRIPTION
The output line checking for functional tests should ensure that lines from `lines-checked` do not match any patterns in `ignore-list`.

Also, fix an issue with the update/rename test and improve check_lines() error reporting to account for `ignore-list`.