### PR TITLE
travis: install rst2man dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ language: c
 # - bsdiff 1.* is the Clear Linux OS fork
 # - libcurl 7.35.0 is too old. Installing a newer version.
 # - the Swupd_Root.pem cert must be installed out-of-tree to run the test suite with signature verification enabled
+# - python3-docutils for the rst2man script
 install:
         - wget https://github.com/libcheck/check/releases/download/0.11.0/check-0.11.0.tar.gz
         - tar -xvf check-0.11.0.tar.gz
@@ -19,6 +20,8 @@ install:
         - pushd curl-7.51.0 && ./configure --prefix=/usr && make -j48 && sudo make install && popd
         - wget https://download.clearlinux.org/releases/13010/clear/Swupd_Root.pem
         - sudo install -D -m0644 Swupd_Root.pem /usr/share/clear/update-ca/Swupd_Root.pem
+        - sudo apt-get install python3-docutils
+        - sudo ln -s /usr/share/docutils/scripts/python3/rst2man /usr/bin/rst2man.py
 
 # Ubuntu's default umask is 0002, but this break's swupd hash calculations.
 script:


### PR DESCRIPTION
Because rst2man.py is called when the timestamps on *.rst are newer than
their associated man pages, we need to have rst2man.py just in case we
hit this condition for the build.