### PR TITLE
Do not delete /usr/lib/kernel

### DIFF
--- a/src/extra_files.c
+++ b/src/extra_files.c
@@ -57,6 +57,7 @@ static struct fileskip {
 	int len;
 } skip_dirs[] =
     { { shortname : "/lib/modules" },
+      { shortname : "/lib/kernel" },
       { shortname : "/local" } };
 static int path_prefix_len;
 


### PR DESCRIPTION
Add /lib/kernel as the files to skip in addition to /lib/modules as
these are managed by clear-boot-manager.

Fixes #313

Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>