### PR TITLE
Fix re-exec capabilities over format bumps

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -158,6 +158,7 @@ extern char *version_url;
 extern char *content_url;
 extern char *cert_path;
 extern long update_server_port;
+extern char *default_format_path;
 extern bool set_path_prefix(char *path);
 extern int set_content_url(char *url);
 extern int set_version_url(char *url);
@@ -333,6 +334,7 @@ extern bool string_in_list(char *string_to_check, struct list *list_to_check);
 extern void print_progress(unsigned int count, unsigned int max);
 extern bool is_compatible_format(int format_num);
 extern bool is_current_version(int version);
+extern bool on_new_format(void);
 
 /* subscription.c */
 struct list *free_list_file(struct list *item);

--- a/src/globals.c
+++ b/src/globals.c
@@ -69,12 +69,12 @@ char *version_url = NULL;
 char *content_url = NULL;
 char *cert_path = NULL;
 long update_server_port = -1;
+char *default_format_path = "/usr/share/defaults/swupd/format";
 
 char *swupd_cmd = NULL;
 
 static const char *default_version_url_path = "/usr/share/defaults/swupd/versionurl";
 static const char *default_content_url_path = "/usr/share/defaults/swupd/contenturl";
-static const char *default_format_path = "/usr/share/defaults/swupd/format";
 
 timelist init_timelist(void)
 {

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -974,3 +974,25 @@ bool is_current_version(int version)
 
 	return (version == get_current_version(path_prefix));
 }
+
+/* Check if the format at default_format_path has changed from the beginning
+ * of the update */
+bool on_new_format(void)
+{
+	int res = -1;
+	char *ret_str;
+
+	res = get_value_from_path(&ret_str, default_format_path, false);
+	if (res != 0) {
+		// could not detect current format
+		return false;
+	}
+
+	res = strtoull(ret_str, NULL, 10);
+	free(ret_str);
+	/* is_compatible_format returns true if the argument matches the
+	 * format_string, which was read at the beginning of the update. Return the
+	 * opposite of is_compatible_format to indicate when the new format is
+	 * different from the one we started on. */
+	return !is_compatible_format(res);
+}

--- a/src/update.c
+++ b/src/update.c
@@ -476,7 +476,7 @@ download_packs:
 	grabtime_start(&times, "Run Scripts");
 
 	/* Determine if another update is needed so the scripts block */
-	if (string_in_list("update", post_update_actions) && (ret == 0)) {
+	if (on_new_format()) {
 		re_update = true;
 	}
 

--- a/test/functional/update/re-update-bad-os-release/web-dir/20/Manifest.MoM
+++ b/test/functional/update/re-update-bad-os-release/web-dir/20/Manifest.MoM
@@ -4,6 +4,5 @@ previous:	10
 filecount:	1
 timestamp:	1451940175
 contentsize:	13805671819
-actions:	update
 
 M...	daf943e78b505761e2f55cf0013aba577b78155918b1ea75161c9c8554827fac	20	os-core

--- a/test/functional/update/re-update-required/web-dir/20/Manifest.MoM
+++ b/test/functional/update/re-update-required/web-dir/20/Manifest.MoM
@@ -4,6 +4,5 @@ previous:	10
 filecount:	1
 timestamp:	1451940175
 contentsize:	13805671819
-actions:	update
 
 M...	95975ab39fe7f87207757b3bb0b1282a0f588f9838877824545545de44beaa71	20	os-core


### PR DESCRIPTION
Instead of relying on swupd-server to put the post-update action in the
correct manifest and in the correct format, do the format change
detection on the client.

Fixes #320 

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>