### PR TITLE
Use libarchive instead of calling out to tar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ install:
         - pushd curl-7.51.0 && ./configure --prefix=/usr && make -j48 && sudo make install && popd
         - wget https://download.clearlinux.org/releases/13010/clear/Swupd_Root.pem
         - sudo install -D -m0644 Swupd_Root.pem /usr/share/clear/update-ca/Swupd_Root.pem
+        - wget https://github.com/libarchive/libarchive/archive/v3.3.1.tar.gz
+        - tar -xvf v3.3.1.tar.gz
+        - pushd libarchive-3.3.1 && autoreconf -fi && ./configure --prefix=/usr && make && sudo make install && popd
         - sudo apt-get install python3-docutils
         - sudo ln -s /usr/share/docutils/scripts/python3/rst2man /usr/bin/rst2man.py
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -28,6 +28,7 @@ check_PROGRAMS = \
 	swupd_sig_verifytest
 
 SWUPD_COMMON_SOURCES = \
+	src/archives.c \
 	src/curl.c \
 	src/delta.c \
 	src/download.c \
@@ -82,9 +83,9 @@ swupd_locktest_SOURCES = test/locktest.c
 swupd_sig_verifytest_SOURCES = test/signature_verify_test.c
 
 
-AM_CPPFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/include
+AM_CPPFLAGS = $(AM_CFLAGS) $(libarchive_CFLAGS) -I$(top_srcdir)/include
 SWUPD_COMPRESSION_LIBS = $(lzma_LIBS) $(zlib_LIBS) $(bzip2_LIBS)
-SWUPD_CORE_LIBS = libswupd.la ${curl_LIBS} $(openssl_LIBS) $(SWUPD_COMPRESSION_LIBS) $(bsdiff_LIBS)
+SWUPD_CORE_LIBS = libswupd.la ${curl_LIBS} $(openssl_LIBS) $(libarchive_LIBS) $(SWUPD_COMPRESSION_LIBS) $(bsdiff_LIBS)
 
 swupd_LDADD = $(SWUPD_CORE_LIBS) $(pthread_LIBS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,7 @@ PKG_CHECK_MODULES([lzma], [liblzma])
 PKG_CHECK_MODULES([zlib], [zlib])
 PKG_CHECK_MODULES([curl], [libcurl])
 PKG_CHECK_MODULES([openssl], [libcrypto >= 1.0.1])
+PKG_CHECK_MODULES([libarchive], [libarchive])
 AC_CHECK_LIB([pthread], [pthread_create])
 
 

--- a/include/swupd.h
+++ b/include/swupd.h
@@ -225,6 +225,8 @@ extern int get_value_from_path(char **contents, const char *path, bool is_abs_pa
 extern int get_version_from_path(const char *abs_path);
 extern timelist init_timelist(void);
 
+extern int extract_to(const char *tarfile, const char *outputdir);
+
 static inline int bsearch_file_helper(const void *A, const void *B)
 {
 	struct file *key = (struct file *)A;

--- a/src/archives.c
+++ b/src/archives.c
@@ -1,0 +1,180 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2017 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Authors:
+ *         Matthew Johnson <mathew.johnson@intel.com>
+ *
+ */
+
+#include <archive.h>
+#include <archive_entry.h>
+#include <stdlib.h>
+
+#include "swupd.h"
+
+/* _archive_check_err(ar, ret)
+ *
+ * Check and print archive errors */
+static int _archive_check_err(struct archive *ar, int ret)
+{
+	int is_fatal = 0;
+
+	if (ret < ARCHIVE_WARN || ret == ARCHIVE_RETRY) {
+		/* error was worse than a warning or error was ARCHIVE_RETRY (greater
+		 * than ARCHIVE_WARN), which indicates failure with retry possible.
+		 * Regardless, indicate that the operation did not succeed.  */
+		fprintf(stderr, "Error: %s\n", archive_error_string(ar));
+		is_fatal = 1;
+	} else if (ret < ARCHIVE_OK) {
+		/* operation succeeded, warning encountered */
+		fprintf(stderr, "Warning: %s\n", archive_error_string(ar));
+		is_fatal = 0;
+	}
+
+	return is_fatal;
+}
+
+/* copy_data(ar, aw)
+ *
+ * Copy archive data from ar to aw */
+static int copy_data(struct archive *ar, struct archive *aw)
+{
+	int r;
+	const void *buffer;
+	size_t size;
+	off_t offset;
+
+	for (;;) {
+		r = archive_read_data_block(ar, &buffer, &size, &offset);
+		if (r == ARCHIVE_EOF) {
+			return ARCHIVE_OK;
+		} else if (r < ARCHIVE_OK) {
+			return r;
+		}
+
+		r = archive_write_data_block(aw, buffer, size, offset);
+		if (r < ARCHIVE_OK) {
+			return r;
+		}
+	}
+}
+
+/* extract_to(tarfile, outputdir)
+ *
+ * Extracts tar archive tarfile to outputdir. Refuses to extract any object
+ * whose final location would be altered by a symlink on disk. */
+int extract_to(const char *tarfile, const char *outputdir)
+{
+	struct archive *a, *ext;
+	struct archive_entry *entry;
+	int flags;
+	int r = 0;
+
+	/* set which attributes we want to restore */
+	flags = ARCHIVE_EXTRACT_TIME;
+	flags |= ARCHIVE_EXTRACT_PERM;
+	flags |= ARCHIVE_EXTRACT_OWNER;
+	flags |= ARCHIVE_EXTRACT_XATTR;
+
+	/* set security flags */
+	flags |= ARCHIVE_EXTRACT_SECURE_SYMLINKS;
+	flags |= ARCHIVE_EXTRACT_SECURE_NODOTDOT;
+
+	/* set up read */
+	a = archive_read_new();
+	r = archive_read_support_format_tar(a);
+	if (_archive_check_err(a, r)) {
+		goto out_read;
+	}
+
+	r = archive_read_support_filter_all(a);
+	if (_archive_check_err(a, r)) {
+		goto out_read;
+	}
+
+	/* set up write */
+	ext = archive_write_disk_new();
+	r = archive_write_disk_set_options(ext, flags);
+	if (_archive_check_err(ext, r)) {
+		goto out;
+	}
+
+	r = archive_write_disk_set_standard_lookup(ext);
+	if (_archive_check_err(ext, r)) {
+		goto out;
+	}
+
+	r = archive_read_open_filename(a, tarfile, 10240);
+	if (_archive_check_err(a, r)) {
+		/* could not open archive for read */
+		goto out;
+	}
+
+	/* read and write loop */
+	for (;;) {
+		r = archive_read_next_header(a, &entry);
+		if (r == ARCHIVE_EOF) {
+			/* reached end of file */
+			r = 0;
+			break;
+		}
+
+		if (_archive_check_err(ext, r)) {
+			goto out;
+		}
+
+		/* set output directory */
+		char *fullpath;
+		string_or_die(&fullpath, "%s/%s", outputdir, archive_entry_pathname(entry));
+		archive_entry_set_pathname(entry, fullpath);
+		free(fullpath);
+
+		/* write archive header, if successful continue to copy data */
+		r = archive_write_header(ext, entry);
+		if (_archive_check_err(ext, r)) {
+			goto out;
+		}
+
+		if (archive_entry_size(entry) > 0) {
+			r = copy_data(a, ext);
+			if (_archive_check_err(ext, r)) {
+				goto out;
+			}
+		}
+
+		/* flush pending file attribute changes */
+		r = archive_write_finish_entry(ext);
+		if (_archive_check_err(ext, r)) {
+			goto out;
+		}
+	}
+
+	/* at this point everything else was successful, we need to set the
+	 * returncode to the result of archive_write_close in case it fails */
+	r = archive_write_close(ext);
+	/* call _archive_check_err() for correct error message */
+	_archive_check_err(ext, r);
+out:
+	/* archive_write_free calls archive_write_close but does not report the
+	 * error. If 'goto out' is called, we already have an error we are handling
+	 * so don't overwrite that returncode. */
+	archive_write_free(ext);
+out_read:
+	archive_read_close(a);
+	archive_read_free(a);
+	return r;
+}

--- a/src/hash.c
+++ b/src/hash.c
@@ -301,7 +301,6 @@ int verify_bundle_hash(struct manifest *manifest, struct file *bundle)
 			/* missing bundle manifest - attempt to download it */
 			char *filename;
 			char *url;
-			char *tar;
 
 			fprintf(stderr, "Warning: Downloading missing manifest for bundle %s version %d.\n",
 				current->filename, current->last_change);
@@ -319,17 +318,13 @@ int verify_bundle_hash(struct manifest *manifest, struct file *bundle)
 				free(filename);
 				break;
 			}
+
+			char *outputdir;
+			string_or_die(&outputdir, "%s/%i", state_dir, current->last_change);
+			ret = extract_to(filename, outputdir);
+			free(outputdir);
 			free(filename);
 
-			string_or_die(&tar, TAR_COMMAND " -C %s/%i -xf %s/%i/Manifest.%s.tar 2> /dev/null",
-				      state_dir, current->last_change, state_dir,
-				      current->last_change, current->filename);
-
-			ret = system(tar);
-			free(tar);
-			if (WIFEXITED(ret)) {
-				ret = WEXITSTATUS(ret);
-			}
 			if (ret != 0) {
 				break;
 			}

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -529,7 +529,6 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 	char *dir;
 	char *basedir;
 	int ret = 0;
-	char *tar;
 	struct stat sb;
 
 	if (!is_mix) {
@@ -556,7 +555,6 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 	if ((ret != 0) && (errno != EEXIST)) {
 		goto out;
 	}
-	free(dir);
 
 	/* FILE is not set for a MoM, only for bundle manifests */
 	if (file && current < version && strcmp(component, "full") != 0) {
@@ -593,15 +591,8 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 	}
 
 untar:
-	string_or_die(&tar, TAR_COMMAND " -C %s/%i -xf %s/%i/Manifest.%s.tar 2> /dev/null",
-		      state_dir, version, state_dir, version, component);
-
-	/* this is is historically a point of odd errors */
-	ret = system(tar);
-	if (WIFEXITED(ret)) {
-		ret = WEXITSTATUS(ret);
-	}
-	free(tar);
+	ret = extract_to(filename, dir);
+	free(dir);
 	if (ret != 0) {
 		goto out;
 	} else {

--- a/src/packs.c
+++ b/src/packs.c
@@ -38,7 +38,6 @@
 static int download_pack(int oldversion, int newversion, char *module, int is_mix)
 {
 	FILE *tarfile = NULL;
-	char *tar = NULL;
 	char *url = NULL;
 	int err = -1;
 	char *filename;
@@ -77,14 +76,8 @@ static int download_pack(int oldversion, int newversion, char *module, int is_mi
 	}
 
 	fprintf(stderr, "\nExtracting %s pack for version %i\n", module, newversion);
-	string_or_die(&tar, TAR_COMMAND " -C %s " TAR_PERM_ATTR_ARGS " -xf %s/pack-%s-from-%i-to-%i.tar 2> /dev/null",
-		      state_dir, state_dir, module, oldversion, newversion);
+	err = extract_to(filename, state_dir);
 
-	err = system(tar);
-	if (WIFEXITED(err)) {
-		err = WEXITSTATUS(err);
-	}
-	free(tar);
 	unlink(filename);
 	/* make a zero sized file to prevent redownload */
 	tarfile = fopen(filename, "w");


### PR DESCRIPTION
Use libarchive in order to make use of its security features and avoid
calling out to tar via a shell. The TAR_COMMAND is still used in
staging.c to complete the copy when a hardlink fails.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>