### PR TITLE
Do not fail on verifytime failure

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -602,12 +602,11 @@ int swupd_init(int *lock_fd)
 
 	check_root();
 
-	/* Check that our system time is reasonably valid before continuing,
-	 * or the certificate verification will fail with invalid time */
+	/* Check that our system time is reasonably valid, print a warning if not.
+	 * Certificate verification can fail with invalid time. */
 	if (timecheck) {
 		if (system("verifytime") != 0) {
-			ret = EBADTIME;
-			goto out_fds;
+			fprintf(stderr, "Warning: failed to verify system time\n");
 		}
 	}
 


### PR DESCRIPTION
Fixes #234
Fixes #289

The verifytime program is a helper program used by swupd to correct
certain time skews. If verifytime fails, however, this should not be a
failure for swupd. Swupd should continue to try and verify the signature
if possible. Instead of failing print out a warning to give the user a
hint to why their signature verification may fail.

The use case this solves is when the /usr/share/clear/versionstamp file
does not exist, verifytime will fail even if the system time is in an OK
state.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>