### PR TITLE
Fix generation of swupd.bash

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,11 +1,11 @@
 SUFFIXES= .rst
 
-EXTRA_DIST = COPYING scripts/findstatic.pl swupd.bash
+EXTRA_DIST = COPYING scripts/findstatic.pl
 
 AM_CFLAGS = -fPIC -Iinclude/ -O2 -g -Wall -W -Wformat-security -D_FORTIFY_SOURCE=2 -fno-common -std=gnu99
 ACLOCAL_AMFLAGS = -I m4
 
-bin_PROGRAMS = swupd
+bin_PROGRAMS = swupd swupd.bash
 
 swupd_SOURCES = \
 	src/swupd.c \
@@ -167,6 +167,7 @@ BATS = \
 	test/functional/checkupdate/no-target-content/test.bats \
 	test/functional/checkupdate/slow-server/test.bats \
 	test/functional/checkupdate/version-match/test.bats \
+	test/functional/completion/basic/test.bats \
 	test/functional/hashdump/file-hash/test.bats \
 	test/functional/hashdump/file-hash-no-path-prefix/test.bats \
 	test/functional/search/content-check-negfull-path/test.bats \

--- a/scripts/swupd-completion.sh
+++ b/scripts/swupd-completion.sh
@@ -63,7 +63,7 @@ do
 	#For the rest do nothing
 	("") : ;;
     esac
-done < <($SWUPDCOMMAND --help)
+done < <($SWUPDCOMMAND --help 2>&1)
 
 # Construct sed script
 #Convert all tabs to spaces
@@ -120,7 +120,7 @@ EOM
   printf '\t    break;;\n'
   for i in "${subcommandsfromhelp[@]}"; do
       printf '\t    ("%s")\n' "$i"
-      C="$($SWUPDCOMMAND $i --help | sed -e "$SEDSCRIPT" | tr '\n' ' ')"
+      C="$($SWUPDCOMMAND $i --help 2>&1 | sed -e "$SEDSCRIPT" | tr '\n' ' ')"
       printf '\t\topts="%s"\n' "$C"
       printf '\t\tbreak;;\n'
   done

--- a/test/functional/completion/basic/test.bats
+++ b/test/functional/completion/basic/test.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+load "../../swupdlib"
+
+@test "autocomplete exists" {
+  [ -e $SRCDIR/swupd.bash ]
+}
+
+@test "autocomplete syntax" {
+  bash $SRCDIR/swupd.bash
+}
+
+@test "autocomplete has autoupdate" {
+  grep -q  '("autoupdate")' $SRCDIR/swupd.bash
+}
+
+@test "autocomplete has expected hashdump opts" {
+  grep -q  'opts="-h --help -n --no-xattrs -p --path "' $SRCDIR/swupd.bash
+}
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
When output was changed to stderr for user output, this broke
automatic generation of the bash completion function.

Add suitable redirection to the generation script to capture stderr.

Add test to check the generated file looks reasonable.

Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>