### PR TITLE
heuristics: do not ignore /usr/src/kernel

### DIFF
--- a/src/heuristics.c
+++ b/src/heuristics.c
@@ -63,6 +63,13 @@ static bool is_state(char *filename)
 		return false;
 	}
 
+	/* Compare the first part of the path, first all the entries inside
+	 * kernel directory, then only the kernel directoy */
+	if ((strncmp(filename, "/usr/src/kernel/", 16) == 0) ||
+	    ((strlen(filename) == 15) && (strncmp(filename, "/usr/src/kernel", 15) == 0))) {
+		return false;
+	}
+
 	if ((strncmp(filename, "/data", 5) == 0) ||
 	    (strncmp(filename, "/dev/", 5) == 0) ||
 	    (strncmp(filename, "/home/", 6) == 0) ||


### PR DESCRIPTION
Linux kernel sources are shipped in the /usr/src/kernel/<kernel_version>
directory. So, it need to be added as an exception in the is_state()
function.

Fixes #348

Debugged-by: Ornelas Aguayo, Jesus <jesus.ornelas.aguayo@intel.com>
Debugged-by: Mario Alfredo Carrillo Arevalo <mario.alfredo.c.arevalo@intel.com>
Signed-off-by: Miguel Bernal Marin <miguel.bernal.marin@linux.intel.com>