### PR TITLE
Do not try to resume failed bundle-add pack downloads

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -278,7 +278,7 @@ static inline void account_delta_miss(void)
 
 extern void print_statistics(int version1, int version2);
 
-extern int download_subscribed_packs(struct list *subs, struct manifest *mom, bool required);
+extern int download_subscribed_packs(struct list *subs, struct manifest *mom, bool required, bool resume_ok);
 
 extern void try_delta(struct file *file);
 extern void full_download(struct file *file);
@@ -301,7 +301,7 @@ extern double swupd_query_url_content_size(char *url);
 extern CURLcode swupd_download_file_start(struct file *file);
 extern CURLcode swupd_download_file_complete(CURLcode curl_ret, struct file *file);
 extern int swupd_curl_get_file(const char *url, char *filename, struct file *file,
-			       struct version_container *tmp_version, bool pack);
+			       struct version_container *tmp_version, bool resume_ok);
 #define SWUPD_CURL_LOW_SPEED_LIMIT 1
 #define SWUPD_CURL_CONNECT_TIMEOUT 30
 #define SWUPD_CURL_RCV_TIMEOUT 120

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -695,7 +695,7 @@ static int install_bundles(struct list *bundles, struct list **subs, int current
 	(void)rm_staging_dir_contents("download");
 
 download_subscribed_packs:
-	if (download_subscribed_packs(*subs, mom, true)) {
+	if (download_subscribed_packs(*subs, mom, true, false)) {
 		if (retries < MAX_TRIES) {
 			increment_retries(&retries, &timeout);
 			printf("\nRetry #%d downloading subscribed packs\n", retries);

--- a/src/curl.c
+++ b/src/curl.c
@@ -309,14 +309,14 @@ CURLcode swupd_download_file_complete(CURLcode curl_ret, struct file *file)
 /* Download a single file SYNCHRONOUSLY
  * - If (in_memory_version_string != NULL) the file downloaded is expected
  *   to be a version file and it is downloaded to memory instead of disk.
- * - Packs are big.  If (pack == true) then the function allows resuming
+ * - Packs are big.  If (resume_ok == true) then the function allows resuming
  *   a previous/interrupted download.
  * - This function returns zero or a standard < 0 status code.
  * - If failure to download, partial download is not deleted.
  * - NOTE: See full_download() for multi/asynchronous downloading of fullfiles.
  */
 int swupd_curl_get_file(const char *url, char *filename, struct file *file,
-			struct version_container *in_memory_version_string, bool pack)
+			struct version_container *in_memory_version_string, bool resume_ok)
 {
 	CURLcode curl_ret;
 	long ret = 0;
@@ -346,7 +346,7 @@ int swupd_curl_get_file(const char *url, char *filename, struct file *file,
 		local->staging = filename;
 
 		if (lstat(filename, &stat) == 0) {
-			if (pack && resume_download_enabled) {
+			if (resume_ok && resume_download_enabled) {
 				curl_ret = curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE, (curl_off_t)stat.st_size);
 			} else {
 				unlink(filename);
@@ -470,7 +470,7 @@ exit:
 	}
 
 	if (err) {
-		if (!pack) {
+		if (!resume_ok) {
 			unlink(filename);
 		}
 	}

--- a/src/packs.c
+++ b/src/packs.c
@@ -35,7 +35,7 @@
 #include "swupd-build-variant.h"
 #include "swupd.h"
 
-static int download_pack(int oldversion, int newversion, char *module, int is_mix)
+static int download_pack(int oldversion, int newversion, char *module, int is_mix, bool resume_ok)
 {
 	FILE *tarfile = NULL;
 	char *url = NULL;
@@ -64,7 +64,7 @@ static int download_pack(int oldversion, int newversion, char *module, int is_mi
 	} else {
 		string_or_die(&url, "%s/%i/pack-%s-from-%i.tar", content_url, newversion, module, oldversion);
 
-		err = swupd_curl_get_file(url, filename, NULL, NULL, true);
+		err = swupd_curl_get_file(url, filename, NULL, NULL, resume_ok);
 		if (err) {
 			free(url);
 			if ((lstat(filename, &stat) == 0) && (stat.st_size == 0)) {
@@ -95,7 +95,7 @@ static int download_pack(int oldversion, int newversion, char *module, int is_mi
 }
 
 /* pull in packs for base and any subscription */
-int download_subscribed_packs(struct list *subs, struct manifest *mom, bool required)
+int download_subscribed_packs(struct list *subs, struct manifest *mom, bool required, bool resume_ok)
 {
 	struct list *iter;
 	struct sub *sub = NULL;
@@ -123,7 +123,7 @@ int download_subscribed_packs(struct list *subs, struct manifest *mom, bool requ
 		if (bundle) {
 			is_mix = bundle->is_mix;
 		}
-		err = download_pack(sub->oldversion, sub->version, sub->component, is_mix);
+		err = download_pack(sub->oldversion, sub->version, sub->component, is_mix, resume_ok);
 		print_progress(complete, list_length);
 		if (err < 0) {
 			if (required) { /* Probably need printf("\n") here */

--- a/src/update.c
+++ b/src/update.c
@@ -534,7 +534,7 @@ load_server_submanifests:
 
 download_packs:
 	/* Step 5: get the packs and untar */
-	ret = download_subscribed_packs(latest_subs, server_manifest, false);
+	ret = download_subscribed_packs(latest_subs, server_manifest, false, true);
 	if (ret) {
 		// packs don't always exist, tolerate that but not ENONET
 		if (retries < MAX_TRIES) {

--- a/src/verify.c
+++ b/src/verify.c
@@ -323,7 +323,7 @@ static int get_all_files(struct manifest *official_manifest, struct list *subs)
 	struct list *iter;
 
 	/* for install we need everything so synchronously download zero packs */
-	ret = download_subscribed_packs(subs, official_manifest, true);
+	ret = download_subscribed_packs(subs, official_manifest, true, false);
 	if (ret < 0) { // require zero pack
 		/* If we hit this point, we know we have a network connection, therefore
 		 * 	the error is server-side. This is also a critical error, so detailed


### PR DESCRIPTION
Fixes #352
This operation is fragile and can cause errors if a zero pack download
is interrupted resulting in an incomplete tar archive. A user reported
that having the incomplete pack around prevented the pack from being
re-downloaded and the content was incorrect so the bundle-add was not
completing. Instead of trying to resume a bundle-add pack download just
remove the old file and try again.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>