### PR TITLE
Fix double free issue

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -544,6 +544,7 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 		goto out;
 	}
 	free(filename);
+	filename = NULL;
 
 	if (swupd_curl_check_network()) {
 		ret = -ENOSWUPDSERVER;
@@ -577,7 +578,9 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 			goto untar;
 		}
 		free(filename);
+		filename = NULL;
 		free(url);
+		url = NULL;
 	}
 
 	/* Either we're not on mix or it failed, try curl-ing the file if link didn't work */


### PR DESCRIPTION
In commit e18eb69, retrieve_manifests() was refactored to support the mixer integration feature, but it introduced a double free of the "filename" pointer when following certain code paths.

One code path to reproduce the issue is when a Manifest.MoM is not present in the state directory, and swupd_curl_check_network() fails.  A free(filename) was being called immediately before swupd_curl_check_network(), and then again after jumping to the "out" label for the error condition.

Resolve the issue by resetting the filename pointer to NULL after freeing the memory to prevent a later double free. I also reset the url pointer to NULL at the second call site for similar reasoning.
  