### PR TITLE
Fix tests that are lacking chown reverts

### DIFF
--- a/test/functional/update/rename-ghosted/test.bats
+++ b/test/functional/update/rename-ghosted/test.bats
@@ -19,7 +19,7 @@ setup() {
 }
 
 teardown() {
-  revert_chown_root -R "$DIR/web-dir"
+  revert_chown_root -R "$DIR/target-dir" "$DIR/web-dir"
 }
 
 @test "update rename ghosted file" {

--- a/test/functional/verify/ghosted/test.bats
+++ b/test/functional/verify/ghosted/test.bats
@@ -14,6 +14,7 @@ teardown() {
   clean_tars 10
   clean_tars 10 files
   sudo cp -r "$DIR/target-dir.bak/foo" "$DIR/target-dir"
+  revert_chown_root -R "$DIR/target-dir"
 }
 
 @test "verify ghosted file skipped" {

--- a/test/functional/verify/picky-ghosted-missing/test.bats
+++ b/test/functional/verify/picky-ghosted-missing/test.bats
@@ -13,6 +13,7 @@ setup() {
 teardown() {
   clean_tars 10
   sudo cp -r "$DIR/target-dir.bak/usr" "$DIR/target-dir/"
+  revert_chown_root -R "$DIR/target-dir"
 }
 
 @test "verify ghosted file not added during --picky" {


### PR DESCRIPTION
Most of the functional tests properly reverted the chown operations in teardown(), but three of them were missing the reverts.