### PR TITLE
Fix warning message in archives

### DIFF
--- a/src/archives.c
+++ b/src/archives.c
@@ -133,7 +133,7 @@ int extract_to(const char *tarfile, const char *outputdir)
 			break;
 		}
 
-		if (_archive_check_err(ext, r)) {
+		if (_archive_check_err(a, r)) {
 			goto out;
 		}
 


### PR DESCRIPTION
Need to pass the same struct used in the operation to the
_archive_check_err helper.

This fixes issue of some Warnings appearing with "(null)" message,
since the writer did not had an error string associated.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>