### PR TITLE
Call clr-service-restart.

### DIFF
--- a/src/scripts.c
+++ b/src/scripts.c
@@ -81,6 +81,11 @@ static void update_triggers(bool block)
 			ret = system("/usr/bin/systemctl daemon-reload");
 		}
 
+		/* Check for daemons that need to be restarted */
+		if (access("/usr/bin/clr-service-restart", F_OK | X_OK) == 0) {
+			ret = system("/usr/bin/clr-service-restart");
+		}
+
 		string_or_die(&cmd, "/usr/bin/systemctl %s restart update-triggers.target", block_flag);
 	} else {
 		/* These must block so that new update triggers are executed after */


### PR DESCRIPTION
See: https://github.com/clearlinux/clr-service-restart

If present, clr-service-restart can be used to dynamically determine
whether running daemons need a restart based on whether they have
been updated, or whether they are holding references to library code
that has been replaced on disk.

This is synchronous - the units that do need restarted are restarted
and their startup status is verified afterwards. Each restart is
printed on the screen to display what is happening. If a failure
happens, and the unit is a unit provided by the OS vendor, a telemetry
record is created.

Right now only whitelisted units are restarted automatically, and
there are no whitelisted units at this time. These will be slowly
added over time as we understand and learn which units are considered
'safe' to restart, and which ones are not 'safe'.