### PR TITLE
Add free_string function and use everywhere

### DIFF
--- a/include/swupd.h
+++ b/include/swupd.h
@@ -357,6 +357,7 @@ extern void swupd_deinit(int lock_fd, struct list **subs);
 extern int swupd_init(int *lock_fd);
 extern void copyright_header(const char *name);
 extern void string_or_die(char **strp, const char *fmt, ...);
+extern void free_string(char **s);
 void update_motd(int new_release);
 void delete_motd(void);
 extern int get_dirfd_path(const char *fullname);

--- a/src/archives.c
+++ b/src/archives.c
@@ -141,7 +141,7 @@ int extract_to(const char *tarfile, const char *outputdir)
 		char *fullpath;
 		string_or_die(&fullpath, "%s/%s", outputdir, archive_entry_pathname(entry));
 		archive_entry_set_pathname(entry, fullpath);
-		free(fullpath);
+		free_string(&fullpath);
 
 		/* write archive header, if successful continue to copy data */
 		r = archive_write_header(ext, entry);

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -144,7 +144,7 @@ bool is_tracked_bundle(const char *bundle_name)
 		ret = false;
 	}
 
-	free(filename);
+	free_string(&filename);
 	return ret;
 }
 
@@ -248,7 +248,7 @@ int show_included_bundles(char *bundle_name)
 		}
 
 		fprintf(stderr, "Error: %s - Aborting\n", m);
-		free(m);
+		free_string(&m);
 		ret = 1;
 		goto out;
 	}
@@ -383,7 +383,7 @@ int show_bundle_reqd_by(const char *bundle_name, bool server)
 		bundle = iter->data;
 		iter = iter->next;
 		printf("%s", bundle);
-		free(bundle);
+		free_string(&bundle);
 	}
 
 	ret = 0;
@@ -742,20 +742,20 @@ download_subscribed_packs:
 		if (access(hashpath, F_OK) < 0) {
 			/* fallback to verify_fix_path below, which will check the hash
 			 * itself */
-			free(hashpath);
-			free(fullpath);
+			free_string(&hashpath);
+			free_string(&fullpath);
 			continue;
 		}
 
 		ret = verify_file(file, hashpath);
 		if (!ret) {
 			fprintf(stderr, "Error: hash check failed for %s\n", fullpath);
-			free(hashpath);
-			free(fullpath);
+			free_string(&hashpath);
+			free_string(&fullpath);
 			goto out;
 		}
-		free(hashpath);
-		free(fullpath);
+		free_string(&hashpath);
+		free_string(&fullpath);
 	}
 
 	iter = list_head(to_install_files);
@@ -879,7 +879,7 @@ int install_bundles_frontend(char **bundles)
 			} else {
 				string_or_die(&bundles_list_str, "%s", *bundles);
 			}
-			free(tmp);
+			free_string(&tmp);
 		}
 	}
 	grabtime_stop(&times);
@@ -933,5 +933,5 @@ void read_local_bundles(struct list **list_bundles)
 		closedir(dir);
 	}
 
-	free(path);
+	free_string(&path);
 }

--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -34,12 +34,12 @@ static char *cmdline_option_deps = NULL;
 
 static void free_has_dep(void)
 {
-	free(cmdline_option_has_dep);
+	free_string(&cmdline_option_has_dep);
 }
 
 static void free_deps(void)
 {
-	free(cmdline_option_deps);
+	free_string(&cmdline_option_deps);
 }
 
 static void print_help(const char *name)

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -223,29 +223,12 @@ static void reload_parsed_opts(void)
 
 static void free_saved_opts(void)
 {
-	if (curopts.path_prefix != NULL) {
-		free(curopts.path_prefix);
-	}
-
-	if (curopts.version_url != NULL) {
-		free(curopts.version_url);
-	}
-
-	if (curopts.content_url != NULL) {
-		free(curopts.content_url);
-	}
-
-	if (curopts.format_string != NULL) {
-		free(curopts.format_string);
-	}
-
-	if (curopts.state_dir != NULL) {
-		free(curopts.state_dir);
-	}
-
-	if (curopts.cert_path != NULL) {
-		free(curopts.cert_path);
-	}
+	free_string(&curopts.path_prefix);
+	free_string(&curopts.version_url);
+	free_string(&curopts.content_url);
+	free_string(&curopts.format_string);
+	free_string(&curopts.state_dir);
+	free_string(&curopts.cert_path);
 }
 
 int bundle_remove_main(int argc, char **argv)

--- a/src/curl.c
+++ b/src/curl.c
@@ -111,7 +111,7 @@ int swupd_curl_init(void)
 
 		} while ((tok = strtok_r(NULL, ":", &ctx)));
 		fallback_capaths_no = i;
-		free(str);
+		free_string(&str);
 	}
 #else
 	fallback_capaths = (char **)malloc(sizeof(char *));
@@ -533,8 +533,8 @@ static void swupd_curl_test_resume(void)
 		resume_download_enabled = false;
 	}
 exit:
-	free(tmp_version.version);
-	free(url);
+	free_string(&tmp_version.version);
+	free_string(&url);
 
 	return;
 }

--- a/src/delta.c
+++ b/src/delta.c
@@ -64,10 +64,10 @@ void try_delta(struct file *file)
 	/* check if the full file is there already, because if it is, don't do the delta */
 	string_or_die(&filename, "%s/staged/%s", state_dir, file->hash);
 	if (lstat(filename, &stat) == 0) {
-		free(filename);
+		free_string(&filename);
 		return;
 	}
-	free(filename);
+	free_string(&filename);
 
 	do_delta(file);
 }
@@ -85,7 +85,7 @@ static void do_delta(struct file *file)
 	string_or_die(&filename, "%s/staged/%s", state_dir, file->hash);
 	ret = lstat(filename, &sb);
 	if (ret == 0) {
-		free(filename);
+		free_string(&filename);
 		return;
 	}
 
@@ -94,8 +94,8 @@ static void do_delta(struct file *file)
 
 	ret = stat(deltafile, &sb);
 	if (ret != 0) {
-		free(deltafile);
-		free(filename);
+		free_string(&deltafile);
+		free_string(&filename);
 		return;
 	}
 
@@ -127,9 +127,9 @@ static void do_delta(struct file *file)
 	unlink(deltafile);
 
 out:
-	free(origin);
-	free(deltafile);
-	free(filename);
-	free(tmp);
-	free(tmp2);
+	free_string(&origin);
+	free_string(&deltafile);
+	free_string(&filename);
+	free_string(&tmp);
+	free_string(&tmp2);
 }

--- a/src/extra_files.c
+++ b/src/extra_files.c
@@ -104,7 +104,7 @@ static void handle(const char *filename, bool is_dir, bool fix)
 		if (remove(temp)) {
 			fprintf(stderr, "Removing %s failed: %s", temp, strerror(errno));
 		}
-		free(temp);
+		free_string(&temp);
 	} else {
 		printf("%s%s\n", filename, is_dir ? "/" : "");
 	}
@@ -172,7 +172,7 @@ int walk_tree(struct manifest *manifest, const char *start, bool fix, const rege
 	rc = nF;
 tidy:
 	for (int i = 0; i < nF; i++) {
-		free(F[i].filename);
+		free_string(&F[i].filename);
 	}
 	free(F);
 

--- a/src/filedesc.c
+++ b/src/filedesc.c
@@ -77,7 +77,7 @@ void dump_file_descriptor_leaks(void)
 		if (size && !strstr(buffer, "socket")) {
 			fprintf(stderr, "Possible filedescriptor leak: fd_number=\"%s\",fd_details=\"%s\"\n", entry->d_name, buffer);
 		}
-		free(filename);
+		free_string(&filename);
 	}
 
 	closedir(dir);

--- a/src/globals.c
+++ b/src/globals.c
@@ -180,7 +180,7 @@ bool check_mix_exists(void)
 	string_or_die(&fullpath, "%s%s", path_prefix, MIX_DIR);
 
 	dir = opendir(fullpath);
-	free(fullpath);
+	free_string(&fullpath);
 
 	if (dir == NULL) {
 		return false;
@@ -226,7 +226,7 @@ int get_value_from_path(char **contents, const char *path, bool is_abs_path)
 
 	file = fopen(rel_path, "r");
 	if (!file) {
-		free(rel_path);
+		free_string(&rel_path);
 		return ret;
 	}
 
@@ -251,7 +251,7 @@ int get_value_from_path(char **contents, const char *path, bool is_abs_path)
 	ret = 0;
 fail:
 	fclose(file);
-	free(rel_path);
+	free_string(&rel_path);
 	return ret;
 }
 
@@ -276,7 +276,7 @@ static int set_default_value_from_path(char **global, const char *path)
 	ret = get_value_from_path(&ret_str, path, false);
 	if (ret == 0 && ret_str) {
 		string_or_die(global, "%s", ret_str);
-		free(ret_str);
+		free_string(&ret_str);
 	}
 
 	return ret;
@@ -287,9 +287,7 @@ static int set_url(char **global, char *url, const char *path)
 	int ret = 0;
 
 	if (url) {
-		if (*global) {
-			free(*global);
-		}
+		free_string(global);
 		string_or_die(global, "%s", url);
 	} else {
 		if (*global) {
@@ -359,10 +357,7 @@ bool set_state_dir(char *path)
 			return false;
 		}
 
-		if (state_dir) {
-			free(state_dir);
-		}
-
+		free_string(&state_dir);
 		string_or_die(&state_dir, "%s", path);
 	} else {
 		if (state_dir) {
@@ -390,9 +385,7 @@ bool set_format_string(char *userinput)
 	if (userinput) {
 		// allow "staging" as a format string
 		if ((strcmp(userinput, "staging") == 0)) {
-			if (format_string) {
-				free(format_string);
-			}
+			free_string(&format_string);
 			string_or_die(&format_string, "%s", userinput);
 			return true;
 		}
@@ -401,9 +394,7 @@ bool set_format_string(char *userinput)
 		if (!is_valid_integer_format(userinput)) {
 			return false;
 		}
-		if (format_string) {
-			free(format_string);
-		}
+		free_string(&format_string);
 		string_or_die(&format_string, "%s", userinput);
 	} else {
 		/* no option passed; use the default value */
@@ -434,10 +425,7 @@ bool set_path_prefix(char *path)
 		char *tmp;
 
 		/* in case multiple -p options are passed */
-		if (path_prefix) {
-			free(path_prefix);
-		}
-
+		free_string(&path_prefix);
 		string_or_die(&tmp, "%s", path);
 
 		/* ensure path_prefix is absolute, at least '/', ends in '/',
@@ -448,21 +436,20 @@ bool set_path_prefix(char *path)
 			cwd = get_current_dir_name();
 			if (cwd == NULL) {
 				fprintf(stderr, "Unable to get current directory name (%s)\n", strerror(errno));
-				free(tmp);
+				free_string(&tmp);
 				return false;
 			}
 
-			free(tmp);
+			free_string(&tmp);
 			string_or_die(&tmp, "%s/%s", cwd, path);
-
-			free(cwd);
+			free_string(&cwd);
 		}
 
 		len = strlen(tmp);
 		if (!len || (tmp[len - 1] != '/')) {
 			char *tmp_old = tmp;
 			string_or_die(&tmp, "%s/", tmp_old);
-			free(tmp_old);
+			free_string(&tmp_old);
 		}
 
 		path_prefix = tmp;
@@ -591,33 +578,17 @@ bool init_globals(void)
 
 void free_globals(void)
 {
-	/* freeing all globals and set ALL them to NULL
+	/* freeing all globals and set ALL them to NULL (via free_string)
 	 * to avoid memory corruption on multiple calls
 	 * to swupd_init() */
-	free(content_url);
-	content_url = NULL;
-
-	free(version_url);
-	version_url = NULL;
-
-	free(path_prefix);
-	path_prefix = NULL;
-
-	free(format_string);
-	format_string = NULL;
-
-	free(mounted_dirs);
-	mounted_dirs = NULL;
-
-	free(state_dir);
-	state_dir = NULL;
-
+	free_string(&content_url);
+	free_string(&version_url);
+	free_string(&path_prefix);
+	free_string(&format_string);
+	free_string(&mounted_dirs);
+	free_string(&state_dir);
 	list_free_list(post_update_actions);
-
-	if (bundle_to_add != NULL) {
-		free(bundle_to_add);
-		bundle_to_add = NULL;
-	}
+	free_string(&bundle_to_add);
 }
 
 void save_cmd(char **argv)

--- a/src/hash.c
+++ b/src/hash.c
@@ -102,7 +102,7 @@ static void hmac_sha256_for_data(char *hash,
 	}
 
 	hash_assign(digest_str, hash);
-	free(digest_str);
+	free_string(&digest_str);
 }
 
 static void hmac_sha256_for_string(char *hash,
@@ -140,7 +140,7 @@ static void hmac_compute_key(const char *filename,
 	}
 
 	if (xattrs_blob_len != 0) {
-		free(xattrs_blob);
+		free_string(&xattrs_blob);
 	}
 }
 
@@ -291,7 +291,7 @@ int verify_bundle_hash(struct manifest *manifest, struct file *bundle)
 		/* *NOTE* If the file is changed after being hardlinked, the hash will be different,
 		 * but the inode will not change making swupd skip hash check thinking they still match */
 		if (stat(local, &sb) == 0 && stat(cached, &sb2) == 0 && sb.st_ino == sb2.st_ino) {
-			free(cached);
+			free_string(&cached);
 			break;
 		} else {
 			unlink(cached);
@@ -310,20 +310,20 @@ int verify_bundle_hash(struct manifest *manifest, struct file *bundle)
 			string_or_die(&url, "%s/%i/Manifest.%s.tar", content_url,
 				      current->last_change, current->filename);
 			ret = swupd_curl_get_file(url, filename, NULL, NULL, false);
-			free(url);
+			free_string(&url);
 
 			if (ret != 0) {
 				fprintf(stderr, "Error: download of %s failed\n", filename);
 				unlink(filename);
-				free(filename);
+				free_string(&filename);
 				break;
 			}
 
 			char *outputdir;
 			string_or_die(&outputdir, "%s/%i", state_dir, current->last_change);
 			ret = extract_to(filename, outputdir);
-			free(outputdir);
-			free(filename);
+			free_string(&outputdir);
+			free_string(&filename);
 
 			if (ret != 0) {
 				break;
@@ -339,10 +339,10 @@ int verify_bundle_hash(struct manifest *manifest, struct file *bundle)
 		if (link(local, cached) != 0) {
 			unlink(cached);
 		}
-		free(cached);
+		free_string(&cached);
 		break;
 	}
 
-	free(local);
+	free_string(&local);
 	return ret;
 }

--- a/src/hashdump.c
+++ b/src/hashdump.c
@@ -112,7 +112,7 @@ int hashdump_main(int argc, char **argv)
 
 	ret = set_path_prefix(NULL);
 	if (!ret) {
-		free(file->filename);
+		free_string(&file->filename);
 		free(file);
 		return EXIT_FAILURE;
 	}
@@ -143,8 +143,8 @@ int hashdump_main(int argc, char **argv)
 		}
 	}
 
-	free(fullname);
-	free(file->filename);
+	free_string(&fullname);
+	free_string(&file->filename);
 	free(file);
 	return 0;
 }

--- a/src/lock.c
+++ b/src/lock.c
@@ -62,11 +62,11 @@ int p_lockfile(void)
 
 	if (lock_fd < 0) {
 		fprintf(stderr, "Error: failed to open %s: %s\n", lockfile, strerror(errno));
-		free(lockfile);
+		free_string(&lockfile);
 		return -1;
 	}
 
-	free(lockfile);
+	free_string(&lockfile);
 
 	/* try to get an advisory region lock for the file */
 	ret = fcntl(lock_fd, F_SETLK, &fl);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -186,10 +186,10 @@ static struct manifest *manifest_from_file(int version, char *component, bool he
 
 	infile = fopen(filename, "rbm");
 	if (infile == NULL) {
-		free(filename);
+		free_string(&filename);
 		return NULL;
 	}
-	free(filename);
+	free_string(&filename);
 
 	/* line 1: MANIFEST\t<version> */
 	line[0] = 0;
@@ -452,7 +452,7 @@ void free_manifest(struct manifest *manifest)
 	if (manifest->includes) {
 		list_free_list_and_data(manifest->includes, free);
 	}
-	free(manifest->component);
+	free_string(&manifest->component);
 	free(manifest);
 }
 
@@ -514,10 +514,10 @@ static int try_delta_manifest_download(int current, int new, char *component, st
 	}
 out:
 	unlink(deltafile);
-	free(original);
-	free(url);
-	free(newfile);
-	free(deltafile);
+	free_string(&original);
+	free_string(&url);
+	free_string(&newfile);
+	free_string(&deltafile);
 	return ret;
 }
 
@@ -543,8 +543,7 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 		ret = 0;
 		goto out;
 	}
-	free(filename);
-	filename = NULL;
+	free_string(&filename);
 
 	if (swupd_curl_check_network()) {
 		ret = -ENOSWUPDSERVER;
@@ -577,10 +576,8 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 		if (ret == 0) {
 			goto untar;
 		}
-		free(filename);
-		filename = NULL;
-		free(url);
-		url = NULL;
+		free_string(&filename);
+		free_string(&url);
 	}
 
 	/* Either we're not on mix or it failed, try curl-ing the file if link didn't work */
@@ -595,7 +592,7 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 
 untar:
 	ret = extract_to(filename, dir);
-	free(dir);
+	free_string(&dir);
 	if (ret != 0) {
 		goto out;
 	} else {
@@ -605,8 +602,8 @@ untar:
 	}
 
 out:
-	free(filename);
-	free(url);
+	free_string(&filename);
+	free_string(&url);
 	return ret;
 }
 
@@ -636,17 +633,17 @@ void remove_manifest_files(char *filename, int version, char *hash)
 	fprintf(stderr, "Warning: Removing corrupt Manifest.%s artifacts and re-downloading...\n", filename);
 	string_or_die(&file, "%s/%i/Manifest.%s", state_dir, version, filename);
 	unlink(file);
-	free(file);
+	free_string(&file);
 	string_or_die(&file, "%s/%i/Manifest.%s.tar", state_dir, version, filename);
 	unlink(file);
-	free(file);
+	free_string(&file);
 	string_or_die(&file, "%s/%i/Manifest.%s.sig", state_dir, version, filename);
 	unlink(file);
-	free(file);
+	free_string(&file);
 	if (hash != NULL) {
 		string_or_die(&file, "%s/%i/Manifest.%s.%s", state_dir, version, filename, hash);
 		unlink(file);
-		free(file);
+		free_string(&file);
 	}
 }
 
@@ -709,8 +706,8 @@ verify_mom:
 				goto verify_mom;
 			}
 			fprintf(stderr, "WARNING!!! FAILED TO VERIFY SIGNATURE OF Manifest.MoM version %d\n", version);
-			free(filename);
-			free(url);
+			free_string(&filename);
+			free_string(&url);
 			free_manifest(manifest);
 			return NULL;
 		}
@@ -722,10 +719,10 @@ verify_mom:
 			/* useless noise to suppress gcc & glibc conspiring
 			 * to make us check the result of system */
 		}
-		free(log_cmd);
+		free_string(&log_cmd);
 	}
-	free(filename);
-	free(url);
+	free_string(&filename);
+	free_string(&url);
 	return manifest;
 
 out:
@@ -823,10 +820,10 @@ static bool is_installed_and_verified(struct file *file)
 	char *fullname = mk_full_filename(path_prefix, file->filename);
 
 	if (verify_file(file, fullname)) {
-		free(fullname);
+		free_string(&fullname);
 		return true;
 	}
-	free(fullname);
+	free_string(&fullname);
 	return false;
 }
 
@@ -1377,10 +1374,10 @@ void remove_files_in_manifest_from_fs(struct manifest *m)
 		iter = iter->next;
 		string_or_die(&fullfile, "%s/%s", path_prefix, file->filename);
 		if (swupd_rm(fullfile) != 0) {
-			free(fullfile);
+			free_string(&fullfile);
 			continue;
 		}
-		free(fullfile);
+		free_string(&fullfile);
 		count++;
 	}
 	fprintf(stderr, "Total deleted files: %i\n", count);

--- a/src/packs.c
+++ b/src/packs.c
@@ -47,7 +47,7 @@ static int download_pack(int oldversion, int newversion, char *module, int is_mi
 
 	err = lstat(filename, &stat);
 	if (err == 0 && stat.st_size == 0) {
-		free(filename);
+		free_string(&filename);
 		return 0;
 	}
 
@@ -55,22 +55,22 @@ static int download_pack(int oldversion, int newversion, char *module, int is_mi
 		string_or_die(&url, "%s/%i/pack-%s-from-%i.tar", MIX_STATE_DIR, newversion, module, oldversion);
 		err = link(url, filename);
 		if (err) {
-			free(filename);
-			free(url);
+			free_string(&filename);
+			free_string(&url);
 			return err;
 		}
 		printf("Linked %s to %s\n", url, filename);
-		free(url);
+		free_string(&url);
 	} else {
 		string_or_die(&url, "%s/%i/pack-%s-from-%i.tar", content_url, newversion, module, oldversion);
 
 		err = swupd_curl_get_file(url, filename, NULL, NULL, resume_ok);
 		if (err) {
-			free(url);
+			free_string(&url);
 			if ((lstat(filename, &stat) == 0) && (stat.st_size == 0)) {
 				unlink(filename);
 			}
-			free(filename);
+			free_string(&filename);
 			return err;
 		}
 	}
@@ -81,7 +81,7 @@ static int download_pack(int oldversion, int newversion, char *module, int is_mi
 	unlink(filename);
 	/* make a zero sized file to prevent redownload */
 	tarfile = fopen(filename, "w");
-	free(filename);
+	free_string(&filename);
 	if (tarfile) {
 		fclose(tarfile);
 	}

--- a/src/scripts.c
+++ b/src/scripts.c
@@ -45,7 +45,7 @@ static void update_boot(void)
 	}
 
 	ret = system(boot_update_cmd);
-	free(boot_update_cmd);
+	free_string(&boot_update_cmd);
 }
 
 static void update_triggers(bool block)
@@ -103,7 +103,7 @@ static void update_triggers(bool block)
 	}
 	ret = system(cmd);
 
-	free(cmd);
+	free_string(&cmd);
 }
 
 void run_scripts(bool block)
@@ -150,7 +150,7 @@ void run_preupdate_scripts(struct manifest *manifest)
 	}
 
 	if (stat(script, &sb) == -1) {
-		free(script);
+		free_string(&script);
 		return;
 	}
 
@@ -169,5 +169,5 @@ void run_preupdate_scripts(struct manifest *manifest)
 		}
 	}
 
-	free(script);
+	free_string(&script);
 }

--- a/src/search.c
+++ b/src/search.c
@@ -389,17 +389,17 @@ static double query_total_download_size(struct list *list)
 				      file->last_change, file->filename);
 
 			ret = swupd_query_url_content_size(url);
-			free(url);
+			free_string(&url);
 			if (ret != -1) {
 				/* Convert file size from bytes to MB */
 				ret = ret / 1000000;
 				size_sum += ret;
 			} else {
-				free(untard_file);
+				free_string(&untard_file);
 				return ret;
 			}
 		}
-		free(untard_file);
+		free_string(&untard_file);
 	}
 
 	return size_sum;
@@ -472,12 +472,12 @@ static int download_manifests(struct manifest **MoM, struct list **subs)
 				      file->filename);
 
 			fprintf(stderr, "Error: Failure reading from %s\n", url);
-			free(url);
+			free_string(&url);
 		}
 
 		unlink(tarfile);
-		free(untard_file);
-		free(tarfile);
+		free_string(&untard_file);
+		free_string(&tarfile);
 	}
 
 	if (did_download) {

--- a/src/signature.c
+++ b/src/signature.c
@@ -251,7 +251,7 @@ error:
 		ERR_print_errors_fp(stderr);
 	}
 
-	free(errorstr);
+	free_string(&errorstr);
 
 	if (sig) {
 		munmap(sig, sig_len);
@@ -452,9 +452,9 @@ bool download_and_verify_signature(const char *data_url, const char *data_filena
 		result = false;
 	}
 out:
-	free(local);
-	free(sig_filename);
-	free(sig_url);
+	free_string(&local);
+	free_string(&sig_filename);
+	free_string(&sig_url);
 	return result;
 }
 

--- a/src/staging.c
+++ b/src/staging.c
@@ -49,7 +49,7 @@ static int create_staging_renamedir(char *rename_tmpdir)
 		 * confusion */
 		;
 	}
-	free(rmcommand);
+	free_string(&rmcommand);
 
 	ret = mkdir(rename_tmpdir, S_IRWXU);
 	if (ret == -1 && errno != EEXIST) {
@@ -101,7 +101,7 @@ int do_staging(struct file *file, struct manifest *MoM)
 		fprintf(stderr, "Error: Update target exists but is NOT a directory: %s\n", targetpath);
 	}
 
-	free(targetpath);
+	free_string(&targetpath);
 	string_or_die(&target, "%s%s/.update.%s", path_prefix, rel_dir, base);
 	ret = swupd_rm(target);
 	if (ret < 0 && ret != -ENOENT) {
@@ -124,7 +124,7 @@ int do_staging(struct file *file, struct manifest *MoM)
 			}
 		}
 	}
-	free(statfile);
+	free_string(&statfile);
 
 	if (file->is_dir || S_ISDIR(s.st_mode)) {
 		/* In the btrfs only scenario there was an implicit
@@ -154,7 +154,7 @@ int do_staging(struct file *file, struct manifest *MoM)
 		if (WIFEXITED(ret)) {
 			ret = WEXITSTATUS(ret);
 		}
-		free(tarcommand);
+		free_string(&tarcommand);
 		if (rename(rename_target, original)) {
 			ret = -errno;
 			goto out;
@@ -191,7 +191,7 @@ int do_staging(struct file *file, struct manifest *MoM)
 			if (WIFEXITED(ret)) {
 				ret = WEXITSTATUS(ret);
 			}
-			free(tarcommand);
+			free_string(&tarcommand);
 			ret = rename(rename_target, original);
 			if (ret) {
 				ret = -errno;
@@ -202,30 +202,24 @@ int do_staging(struct file *file, struct manifest *MoM)
 		struct stat buf;
 		int err;
 
-		if (file->staging) {
-			/* this must never happen...full file never finished download */
-			free(file->staging);
-			file->staging = NULL;
-		}
-
+		free_string(&file->staging);
 		string_or_die(&file->staging, "%s%s/.update.%s", path_prefix, rel_dir, base);
 
 		err = lstat(file->staging, &buf);
 		if (err != 0) {
-			free(file->staging);
-			file->staging = NULL;
+			free_string(&file->staging);
 			ret = -EDOTFILE_WRITE;
 			goto out;
 		}
 	}
 
 out:
-	free(target);
-	free(original);
-	free(rename_target);
-	free(rename_tmpdir);
-	free(tmp);
-	free(tmp2);
+	free_string(&target);
+	free_string(&original);
+	free_string(&rename_target);
+	free_string(&rename_tmpdir);
+	free_string(&tmp);
+	free_string(&tmp2);
 
 	return ret;
 }
@@ -239,7 +233,7 @@ int rename_staged_file_to_final(struct file *file)
 	string_or_die(&target, "%s%s", path_prefix, file->filename);
 
 	if (!file->staging && !file->is_deleted && !file->is_dir) {
-		free(target);
+		free_string(&target);
 		return -1;
 	}
 
@@ -272,11 +266,11 @@ int rename_staged_file_to_final(struct file *file)
 			string_or_die(&lostnfound, "%slost+found", path_prefix);
 			ret = mkdir(lostnfound, S_IRWXU);
 			if ((ret != 0) && (errno != EEXIST)) {
-				free(lostnfound);
-				free(target);
+				free_string(&lostnfound);
+				free_string(&target);
 				return ret;
 			}
-			free(lostnfound);
+			free_string(&lostnfound);
 
 			base = basename(file->filename);
 			string_or_die(&lostnfound, "%slost+found/%s", path_prefix, base);
@@ -286,7 +280,7 @@ int rename_staged_file_to_final(struct file *file)
 				fprintf(stderr, "Error: failed to move %s to lost+found: %s\n",
 					base, strerror(errno));
 			}
-			free(lostnfound);
+			free_string(&lostnfound);
 		} else {
 			ret = rename(file->staging, target);
 			if (ret < 0) {
@@ -297,7 +291,7 @@ int rename_staged_file_to_final(struct file *file)
 		}
 	}
 
-	free(target);
+	free_string(&target);
 	return ret;
 }
 

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -38,7 +38,7 @@ static void free_subscription_data(void *data)
 {
 	struct sub *sub = (struct sub *)data;
 
-	free(sub->component);
+	free_string(&sub->component);
 	free(sub);
 }
 
@@ -104,7 +104,7 @@ void read_subscriptions(struct list **subs)
 		closedir(dir);
 	}
 
-	free(path);
+	free_string(&path);
 
 	/* Always add os-core */
 	if (!have_os_core) {

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -45,7 +45,7 @@ void telemetry(telem_prio_t level, const char *class, const char *fmt, ...)
 
 	fd = mkstemp(filename);
 	if (fd < 0) {
-		free(filename);
+		free_string(&filename);
 		return;
 	}
 
@@ -60,13 +60,13 @@ void telemetry(telem_prio_t level, const char *class, const char *fmt, ...)
 
 	filename_n = basename(filename);
 	if (!filename_n) {
-		free(filename);
+		free_string(&filename);
 		return;
 	}
 
 	string_or_die(&newname, "%s/telemetry/%s", state_dir, filename_n);
 
 	rename(filename, newname);
-	free(filename);
-	free(newname);
+	free_string(&filename);
+	free_string(&newname);
 }

--- a/src/update.c
+++ b/src/update.c
@@ -649,8 +649,7 @@ clean_curl:
 	}
 
 	/* free swupd_cmd now that is no longer needed */
-	free(swupd_cmd);
-	swupd_cmd = NULL;
+	free_string(&swupd_cmd);
 
 	return ret;
 }

--- a/src/verify.c
+++ b/src/verify.c
@@ -149,9 +149,9 @@ static bool compile_whitelist()
 	success = true;
 
 done:
-	free(full_regex);
+	free_string(&full_regex);
 	if (error_buffer) {
-		free(error_buffer);
+		free_string(&error_buffer);
 	}
 	return success;
 }
@@ -384,7 +384,7 @@ static struct list *download_loop(struct list *files, int isfailed)
 			ret = compute_hash(&local, fullname);
 		}
 		if (ret != 0) {
-			free(fullname);
+			free_string(&fullname);
 			continue;
 		}
 
@@ -405,8 +405,8 @@ static struct list *download_loop(struct list *files, int isfailed)
 					}
 				}
 				untar_full_download(file);
-				free(filename);
-				free(url);
+				free_string(&filename);
+				free_string(&url);
 				continue;
 			}
 			full_download(file);
@@ -414,7 +414,7 @@ static struct list *download_loop(struct list *files, int isfailed)
 			/* mark the file as good to save time later */
 			file->do_not_update = 1;
 		}
-		free(fullname);
+		free_string(&fullname);
 		print_progress(complete, list_length);
 	}
 	print_progress(list_length, list_length); /* Force out 100% */
@@ -516,7 +516,7 @@ static void add_missing_files(struct manifest *official_manifest)
 		ret = compute_hash_lazy(&local, fullname);
 		if (ret != 0) {
 			file_not_replaced_count++;
-			free(fullname);
+			free_string(&fullname);
 			continue;
 		}
 
@@ -528,7 +528,7 @@ static void add_missing_files(struct manifest *official_manifest)
 				printf("\nMissing file: %s\n", fullname);
 			}
 		} else {
-			free(fullname);
+			free_string(&fullname);
 			continue;
 		}
 
@@ -555,7 +555,7 @@ static void add_missing_files(struct manifest *official_manifest)
 				printf("\n\tfixed\n");
 			}
 		}
-		free(fullname);
+		free_string(&fullname);
 		print_progress(complete, list_length);
 	}
 	print_progress(list_length, list_length);
@@ -612,7 +612,7 @@ static void check_and_fix_one(struct file *file, struct manifest *official_manif
 		printf("\tnot fixed\n");
 	}
 end:
-	free(fullname);
+	free_string(&fullname);
 }
 
 static void deal_with_hash_mismatches(struct manifest *official_manifest, bool repair)
@@ -677,7 +677,7 @@ static void remove_orphaned_files(struct manifest *official_manifest)
 
 		if (lstat(fullname, &sb) != 0) {
 			/* correctly, the file is not present */
-			free(fullname);
+			free_string(&fullname);
 			continue;
 		}
 
@@ -686,7 +686,7 @@ static void remove_orphaned_files(struct manifest *official_manifest)
 		fd = get_dirfd_path(fullname);
 		if (fd < 0) {
 			fprintf(stderr, "Not safe to delete: %s\n", fullname);
-			free(fullname);
+			free_string(&fullname);
 			file_not_deleted_count++;
 			continue;
 		}
@@ -718,7 +718,7 @@ static void remove_orphaned_files(struct manifest *official_manifest)
 				file_deleted_count++;
 			}
 		}
-		free(fullname);
+		free_string(&fullname);
 		close(fd);
 	}
 }
@@ -944,7 +944,7 @@ load_submanifests:
 				file_checked_count = ret;
 				ret = 0;
 			}
-			free(start);
+			free_string(&start);
 		}
 		grabtime_stop(&times);
 	} else if (cmdline_option_picky) {
@@ -955,7 +955,7 @@ load_submanifests:
 			file_checked_count = ret;
 			ret = 0;
 		}
-		free(start);
+		free_string(&start);
 	} else {
 		bool repair = false;
 

--- a/src/version.c
+++ b/src/version.c
@@ -65,9 +65,9 @@ int get_latest_version(void)
 	}
 
 out:
-	free(path);
-	free(url);
-	free(tmp_version.version);
+	free_string(&path);
+	free_string(&url);
+	free_string(&tmp_version.version);
 	cached_version = ret;
 	return ret;
 }
@@ -83,11 +83,11 @@ int get_current_version(char *path_prefix)
 	string_or_die(&buildstamp, "%s/usr/lib/os-release", path_prefix);
 	file = fopen(buildstamp, "rm");
 	if (!file) {
-		free(buildstamp);
+		free_string(&buildstamp);
 		string_or_die(&buildstamp, "%s/etc/os-release", path_prefix);
 		file = fopen(buildstamp, "rm");
 		if (!file) {
-			free(buildstamp);
+			free_string(&buildstamp);
 			return v;
 		}
 	}
@@ -117,7 +117,7 @@ int get_current_version(char *path_prefix)
 		}
 	}
 
-	free(buildstamp);
+	free_string(&buildstamp);
 	fclose(file);
 	return v;
 }
@@ -178,7 +178,7 @@ int read_mix_version_file(char *filename, char *path_prefix)
 	string_or_die(&buildstamp, "%s%s", path_prefix, filename);
 	file = fopen(buildstamp, "rm");
 	if (!file) {
-		free(buildstamp);
+		free_string(&buildstamp);
 		return v;
 	}
 
@@ -196,7 +196,7 @@ int read_mix_version_file(char *filename, char *path_prefix)
 
 		v = strtoull(line, NULL, 10);
 	}
-	free(buildstamp);
+	free_string(&buildstamp);
 	fclose(file);
 	return v;
 }
@@ -214,7 +214,7 @@ int update_device_latest_version(int version)
 	string_or_die(&path, "%s/version", state_dir);
 	file = fopen(path, "w");
 	if (!file) {
-		free(path);
+		free_string(&path);
 		return -1;
 	}
 
@@ -222,6 +222,6 @@ int update_device_latest_version(int version)
 	fflush(file);
 	fdatasync(fileno(file));
 	fclose(file);
-	free(path);
+	free_string(&path);
 	return 0;
 }

--- a/src/xattrs.c
+++ b/src/xattrs.c
@@ -220,9 +220,8 @@ static void xattrs_do_action(xattrs_action_type_t action,
 		ret = xattr_get_value(src_filename, sorted_list[i], &value, &value_len,
 				      action);
 		if (ret < 0) {
-			free(value);
+			free_string(&value);
 			value_len = 0;
-			value = NULL;
 			break;
 		}
 
@@ -231,7 +230,7 @@ static void xattrs_do_action(xattrs_action_type_t action,
 			 * case. */
 			ret = lsetxattr(dst_filename, sorted_list[i],
 					value, value_len, 0);
-			free(value);
+			free_string(&value);
 			if (ret < 0) {
 				break;
 			}
@@ -293,11 +292,11 @@ int xattrs_compare(const char *filename1, const char *filename2)
 	}
 out:
 	if (old_xattrs_len != 0) {
-		free(old_xattrs);
+		free_string(&old_xattrs);
 	}
 
 	if (new_xattrs_len != 0) {
-		free(new_xattrs);
+		free_string(&new_xattrs);
 	}
 
 	return ret;


### PR DESCRIPTION
Fixes #357
Add free_string() function to insure code is consistently resetting
pointers to NULL after resetting dynamic memory. Use this helper
everywhere strings are being freed.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>