### PR TITLE
Fix invalid call to stat when FALLBACK_CAPATHS is empty

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -94,8 +94,7 @@ int swupd_curl_init(void)
 		fallback_capaths[0] = NULL;
 		i = 1;
 
-		tok = strtok_r(str, ":", &ctx);
-		do {
+		for (tok = strtok_r(str, ":", &ctx); tok; tok = strtok_r(NULL, ":", &ctx)) {
 			if (stat(tok, &st)) {
 				continue;
 			}
@@ -108,8 +107,7 @@ int swupd_curl_init(void)
 			}
 			fallback_capaths[i] = strdup(tok);
 			i++;
-
-		} while ((tok = strtok_r(NULL, ":", &ctx)));
+		}
 		fallback_capaths_no = i;
 		free_string(&str);
 	}


### PR DESCRIPTION
Loop wasn't taking into account the constant being set but empty. In
that case tok was set to NULL and stat was called with it. Replace
'do-while' with a 'while' to also perform the check the first time.