### PR TITLE
Remove unused variable

### DIFF
--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -178,7 +178,6 @@ err:
 
 int bundle_list_main(int argc, char **argv)
 {
-	int current_version;
 	int lock_fd;
 	int ret;
 


### PR DESCRIPTION
Should have been removed in
2111507a57c4b7ea660ba65e0436f51038c8fbb2 ("Don't show OS version after
the bundles"), but escaped.