### PR TITLE
Forbid certain state_dir values to prevent disasters

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -353,7 +353,15 @@ bool set_state_dir(char *path)
 {
 	if (path) {
 		if (path[0] != '/') {
-			fprintf(stderr, "statepath must be a full path starting with '/', not '%c'\n", path[0]);
+			fprintf(stderr, "state dir must be a full path starting with '/', not '%c'\n", path[0]);
+			return false;
+		}
+
+		/* Prevent some disasters: since the state dir can be destroyed and
+		 * reconstructed, make sure we never set those by accident and nuke the
+		 * system. */
+		if (!strcmp(path, "/") || !strcmp(path, "/var") || !strcmp(path, "/usr")) {
+			fprintf(stderr, "Refusing to use '%s' as a state dir because it might be erased first.\n", path);
 			return false;
 		}
 


### PR DESCRIPTION
During initialization swupd may delete the state_dir to ensure it is
in the right shape. That means that by accident, passing "-S /" to any
command is dangerous.

Since neither /, /usr or /var are really useful as state dirs, let's
prevent some damage by not allowing them.