### PR TITLE
Add 'swupd clean' command

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,6 +10,7 @@ bin_PROGRAMS = swupd
 swupd_SOURCES = \
 	src/autoupdate.c \
 	src/check_update.c \
+	src/clean.c \
 	src/clr_bundle_add.c \
 	src/clr_bundle_ls.c \
 	src/clr_bundle_rm.c \

--- a/include/swupd-internal.h
+++ b/include/swupd-internal.h
@@ -11,5 +11,6 @@ extern int verify_main(int argc, char **argv);
 extern int check_update_main(int argc, char **argv);
 extern int search_main(int argc, char **argv);
 extern int info_main(int argc, char **argv);
+extern int clean_main(int argc, char **argv);
 
 #endif

--- a/src/clean.c
+++ b/src/clean.c
@@ -1,0 +1,394 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2018 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define _GNU_SOURCE
+#include <ctype.h>
+#include <errno.h>
+#include <getopt.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "swupd.h"
+
+/* Default value if --all is not passed. */
+const int DAYS_TO_KEEP_FILES = 3;
+
+static void print_help()
+{
+	fprintf(stderr,
+		"Usage:\n"
+		"	swupd clean [options]\n"
+		"\n"
+		"Remove cached data used for old updates from state directory.\n"
+		"\n"
+		"Options:\n"
+		"   --all                   Remove all the cached content not only old\n"
+		"   --dry-run               Just print files that would be removed\n"
+		"   -S, --statedir DIR      Specify alternate swupd state directory\n"
+		"   -h, --help              Display this help message\n"
+		"\n");
+}
+
+static struct {
+	int all;
+	int dry_run;
+} options;
+
+static struct {
+	int files_removed;
+} stats;
+
+static struct timespec now;
+
+static const struct option prog_opts[] = {
+	{ "help", no_argument, 0, 'h' },
+	{ "all", no_argument, &options.all, 1 },
+	{ "statedir", required_argument, 0, 'S' },
+	{ "dry-run", no_argument, &options.dry_run, 1 },
+	{ 0, 0, 0, 0 }
+};
+
+static bool parse_options(int argc, char **argv)
+{
+	int opt;
+	while ((opt = getopt_long(argc, argv, "hS:", prog_opts, NULL)) != -1) {
+		switch (opt) {
+		case '?':
+			return false;
+		case 'h':
+			print_help();
+			exit(0);
+		case 'S':
+			if (!optarg || !set_state_dir(optarg)) {
+				fprintf(stderr, "Invalid --statedir argument\n\n");
+				return false;
+			}
+			break;
+		case 0:
+			/* Handle options that don't have shortcut. */
+			break;
+		default:
+			fprintf(stderr, "Error: unrecognized option: -%c,\n\n", opt);
+			return false;
+		}
+	}
+	return true;
+}
+
+typedef bool(remove_predicate_func)(const char *dir, const struct dirent *entry);
+
+/* Remove files from path for which pred returns true.
+ * Currently it doesn't recursively remove directories.
+ *
+ * Unless --all is set, the files are also filtered by their age.
+ */
+static int remove_if(const char *path, remove_predicate_func pred)
+{
+	int ret = 0;
+	DIR *dir;
+	const int seconds = DAYS_TO_KEEP_FILES * 60 * 60 * 24;
+
+	dir = opendir(path);
+	if (!dir) {
+		return errno;
+	}
+
+	char *file = NULL;
+
+	while (true) {
+		free_string(&file);
+		ret = 0;
+
+		/* Reset errno to distinguish between a previous
+		 * failure and the end of stream. */
+		errno = 0;
+		struct dirent *entry;
+		entry = readdir(dir);
+		if (!entry) {
+			if (errno) {
+				ret = errno;
+			}
+			break;
+		}
+
+		if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, "..")) {
+			continue;
+		}
+
+		string_or_die(&file, "%s/%s", path, entry->d_name);
+
+		struct stat stat;
+		ret = lstat(file, &stat);
+		if (ret != 0) {
+			fprintf(stderr, "couldn't access %s: %s\n", file, strerror(errno));
+			continue;
+		}
+
+		if (!options.all) {
+			if (now.tv_sec - stat.st_mtime <= seconds) {
+				continue;
+			}
+		}
+
+		if (!pred(path, entry)) {
+			continue;
+		}
+
+		if (options.dry_run) {
+			printf("%s\n", file);
+		} else {
+			if (S_ISDIR(stat.st_mode)) {
+				ret = rmdir(file);
+			} else {
+				ret = unlink(file);
+			}
+			if (ret != 0) {
+				fprintf(stderr, "couldn't remove file %s: %s\n", file, strerror(errno));
+			}
+		}
+		if (ret == 0) {
+			stats.files_removed++;
+		}
+	}
+
+	closedir(dir);
+	return ret;
+}
+
+static bool is_fullfile(const char UNUSED_PARAM *dir, const struct dirent *entry)
+{
+	return strlen(entry->d_name) == (SWUPD_HASH_LEN - 1);
+}
+
+static bool is_pack_indicator(const char UNUSED_PARAM *dir, const struct dirent *entry)
+{
+	static const char prefix[] = "pack-";
+	static const char suffix[] = ".tar";
+	static const size_t prefix_len = sizeof(prefix) - 1;
+	static const size_t suffix_len = sizeof(suffix) - 1;
+
+	const char *name = entry->d_name;
+	size_t len = strlen(name);
+	if (len < (prefix_len + suffix_len)) {
+		return false;
+	}
+	return !memcmp(name, prefix, prefix_len) && !memcmp(name + len - suffix_len, suffix, suffix_len);
+}
+
+static bool is_all_digits(const char *s)
+{
+	for (; *s; s++) {
+		if (!isdigit(*s)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool is_manifest(const char UNUSED_PARAM *dir, const struct dirent *entry)
+{
+	static const char prefix[] = "Manifest.";
+	static const size_t prefix_len = sizeof(prefix) - 1;
+	return !strncmp(entry->d_name, prefix, prefix_len);
+}
+
+static bool is_manifest_delta(const char UNUSED_PARAM *dir, const struct dirent *entry)
+{
+	static const char prefix[] = "Manifest-";
+	static const size_t prefix_len = sizeof(prefix) - 1;
+	return !strncmp(entry->d_name, prefix, prefix_len);
+}
+
+static char *read_mom_contents(int version)
+{
+	char *mom_path = NULL;
+	string_or_die(&mom_path, "%s/%d/Manifest.MoM", state_dir, version);
+	FILE *f = fopen(mom_path, "r");
+	free_string(&mom_path);
+	if (!f) {
+		/* This is a best effort. */
+		return NULL;
+	}
+
+	int fd = fileno(f);
+	if (fd == -1) {
+		goto end;
+	}
+
+	int ret;
+	struct stat stat;
+	ret = fstat(fd, &stat);
+	if (ret != 0) {
+		goto end;
+	}
+
+	char *contents = malloc(stat.st_size + 1);
+	if (!contents) {
+		goto end;
+	}
+
+	ret = fread(contents, stat.st_size, 1, f);
+	if (ret != 1) {
+		free(contents);
+		contents = NULL;
+	} else {
+		contents[stat.st_size] = 0;
+	}
+
+end:
+	fclose(f);
+	return contents;
+}
+
+static int clean_staged_manifests()
+{
+	DIR *dir;
+
+	dir = opendir(state_dir);
+	if (!dir) {
+		return errno;
+	}
+
+	/* NOTE: Currently Manifest files have their timestamp from generation
+	 * preserved. */
+
+	/* When --all is not used, keep the Manifests used by the current OS version. This
+	 * ensures that a regular 'clean' won't make 'search' redownload files. */
+	char *mom_contents = NULL;
+	if (!options.all) {
+		int current_version = get_current_version(path_prefix);
+		if (current_version < 0) {
+			fprintf(stderr, "Unable to determine current OS version\n");
+		} else {
+			mom_contents = read_mom_contents(current_version);
+		}
+	}
+
+	int ret = 0;
+	while (true) {
+		/* Reset errno to properly identify the end of stream. */
+		errno = 0;
+		struct dirent *entry;
+		entry = readdir(dir);
+		if (!entry) {
+			if (errno) {
+				ret = errno;
+			}
+			break;
+		}
+
+		const char *name = entry->d_name;
+		if (!strcmp(name, ".") || !strcmp(name, "..")) {
+			continue;
+		}
+		if (!is_all_digits(name)) {
+			continue;
+		}
+
+		/* This is not precise: it may keep Manifest files that we don't use, and
+		 * also will keep the previous version. If that extra precision is
+		 * required we should parse the manifest. */
+		if (mom_contents && strstr(mom_contents, name)) {
+			continue;
+		}
+
+		char *version_dir;
+		string_or_die(&version_dir, "%s/%s", state_dir, name);
+		ret = remove_if(version_dir, is_manifest);
+
+		/* Remove empty dirs if possible. */
+		(void)rmdir(version_dir);
+
+		free_string(&version_dir);
+		if (ret != 0) {
+			break;
+		}
+	}
+
+	free(mom_contents);
+	closedir(dir);
+	return ret;
+}
+
+int clean_main(int argc, char **argv)
+{
+	copyright_header("clean");
+
+	if (!parse_options(argc, argv)) {
+		return EXIT_FAILURE;
+	}
+
+	int ret = 0;
+	int lock_fd = 0;
+	ret = swupd_init(&lock_fd);
+	if (ret != 0) {
+		fprintf(stderr, "Failed swupd initialization, exiting now.\n");
+		return ret;
+	}
+
+	if (!options.all) {
+		ret = clock_gettime(CLOCK_REALTIME, &now);
+		if (ret != 0) {
+			perror("couldn't read current time to decide what files to clean");
+			goto end;
+		}
+	}
+
+	/* NOTE: Delete specific file patterns to avoid disasters in case some paths are
+	 * set incorrectly. */
+
+	/* Staged files. */
+	/* TODO: Consider parsing the current manifest (if available) and keeping all the
+	 * staged files of the current version. This helps recovering the current version. */
+	char *staged_dir = NULL;
+	string_or_die(&staged_dir, "%s/staged", state_dir);
+	ret = remove_if(staged_dir, is_fullfile);
+	free_string(&staged_dir);
+	if (ret != 0) {
+		goto end;
+	}
+
+	/* Pack presence indicator files. */
+	ret = remove_if(state_dir, is_pack_indicator);
+	if (ret != 0) {
+		goto end;
+	}
+
+	/* Manifest delta files. */
+	ret = remove_if(state_dir, is_manifest_delta);
+	if (ret != 0) {
+		goto end;
+	}
+
+	ret = clean_staged_manifests(state_dir);
+	if (ret != 0) {
+		goto end;
+	}
+
+	/* TODO: Also print the bytes removed, need to take into account the hardlinks. */
+	if (options.dry_run) {
+		printf("Would remove %d files.\n", stats.files_removed);
+	} else {
+		printf("%d files removed.\n", stats.files_removed);
+	}
+
+end:
+	swupd_deinit(lock_fd, NULL);
+	return ret;
+}

--- a/src/swupd.c
+++ b/src/swupd.c
@@ -44,6 +44,7 @@ static struct subcmd commands[] = {
 	{ "check-update", "Check if a new OS version is available", check_update_main },
 	{ "search", "Search Clear Linux for a binary or library", search_main },
 	{ "info", "Show the version and the update URLs", info_main },
+	{ "clean", "Clean cached files", clean_main },
 	{ 0 }
 };
 


### PR DESCRIPTION
This command removes old files from statedir. The interface is a bit
opaque so there will be room to modify the policy later.

By default it will delete staged files that are older than
DAYS_TO_KEEP_FILES. For manifests this heuristic is not good as older
manifests might still be used for the current OS version being run, so
also ensure that those do not get deleted. This prevents 'swupd
search' to redownload files.

The default behavior should be suitable to use in combination with
automatic updates, to control the size of state dir. There is also an
--all option to remove all the state files regardless of dates and
usage.

To avoid "disasters" in case some paths are set wrong, the command
explicitly delete patterns of files create by swupd.