### PR TITLE
Fix "Hardlink target error" when extracting

### DIFF
--- a/src/archives.c
+++ b/src/archives.c
@@ -143,6 +143,15 @@ int extract_to(const char *tarfile, const char *outputdir)
 		archive_entry_set_pathname(entry, fullpath);
 		free_string(&fullpath);
 
+		/* A hardlink must point to a real file, so set its output directory too. */
+		const char *original_hardlink = archive_entry_hardlink(entry);
+		if (original_hardlink) {
+			char *new_hardlink;
+			string_or_die(&new_hardlink, "%s/%s", outputdir, original_hardlink);
+			archive_entry_set_hardlink(entry, new_hardlink);
+			free_string(&new_hardlink);
+		}
+
 		/* write archive header, if successful continue to copy data */
 		r = archive_write_header(ext, entry);
 		if (_archive_check_err(ext, r)) {


### PR DESCRIPTION
In some cases packs may include files with entries of type "hard
link", that refer to previous files in the pack. Libarchive was
failing since it couldn't find the previous file in disk to archive,
because we change its output path.

Adjusting the hardlink target path (when it exists) fix the
issue. This is also what bsdtar does.

This patch was tested by simulating the update that goes from 19460 to
19580 with the desktop pack installed (that contains one hardlink in
the pack used by this update).

Fixes #351.