### PR TITLE
swupd-add-pkg: Fix upstream url not being filled in

### DIFF
--- a/swupd-add-pkg
+++ b/swupd-add-pkg
@@ -53,6 +53,8 @@ fi
 clearver=$(cat $MIX_DIR/.clearversion | tr -d ' ')
 echo -n "$clearver" | sudo tee "$MIX_DIR/version" > /dev/null
 
+sudo mixer init-mix -clearver $(cat "$MIX_DIR/.clearversion") -mixver $(cat "$MIX_DIR/.mixversion") -config "$BUILDCONF"
+
 if [[ -n "$pkg" && -n "$bundle" ]]; then
 	echo "Adding $pkg to $bundle..."
 


### PR DESCRIPTION
The script should be calling init-mix to fully and correctly setup the mix
directory. Without this, the upstream url was never being recorded, and the
yum-mix.conf did not get the URL substituted during chroots phase.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>