### PR TITLE
bundle.c: Fix bundle-add/remove

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -449,7 +449,7 @@ int remove_bundle(const char *bundle_name)
 		goto out_free_curl;
 	}
 
-	mix_exists = check_mix_exists();
+	mix_exists = (check_mix_exists() & system_on_mix());
 
 	swupd_curl_set_current_version(current_version);
 
@@ -848,7 +848,7 @@ int install_bundles_frontend(char **bundles)
 		goto clean_and_exit;
 	}
 
-	mix_exists = check_mix_exists();
+	mix_exists = (check_mix_exists() & system_on_mix());
 
 	swupd_curl_set_current_version(current_version);
 


### PR DESCRIPTION
Just because /usr/share/mix exists, don't assume that it has good
content. Check that there is content _and_ we successfully moved to a mix
before trying to use any content out of it.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>