### PR TITLE
Report real contentsize for swupd search bundles

### DIFF
--- a/include/list.h
+++ b/include/list.h
@@ -54,4 +54,6 @@ void list_free_list(struct list *list);
 /* shallow copy of the the list */
 struct list *list_clone(struct list *list);
 
+/* deep copy of a string list */
+struct list *list_deep_clone_strs(struct list *source);
 #endif

--- a/src/list.c
+++ b/src/list.c
@@ -299,3 +299,18 @@ struct list *list_clone(struct list *list)
 
 	return clone;
 }
+
+/* deep clone a list of char * */
+struct list *list_deep_clone_strs(struct list *source)
+{
+	struct list *clone = list_clone(source);
+	struct list *src_ptr = list_tail(source);
+
+	while (src_ptr) {
+		char *cloned_item = strdup(src_ptr->data);
+		clone = list_prepend_data(clone, cloned_item);
+		src_ptr = src_ptr->prev;
+	}
+
+	return clone;
+}


### PR DESCRIPTION
When reporting bundles for swupd search include their included bundles'
contentsizes as well for more accurate size reporting. For bundles that
are not installed on the client system, this skips any installed
includes and only reports contentsize for uninstalled includes. For
bundles that are installed on the system calculate the entire
contentsize for all includes and report this as the "installed size" of
the bundle.

When the scope is 'o' (one hit only) do not print size information.
Since only the first hit was taken it is unlikely that contentsize was
calculated for all that bundle's includes.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

I performed a quick analysis on performance of tracking the included contentsizes to see if there was much of a slowdown with this patch applied. For each search term I ran the search five times both before and after applying the patch. The results show there is no significant performance difference.

search term | with patch | without patch
--- | --- | ---
curl | 0.73s | 0.71s
/usr/bin/curl | 0.84s | 0.81s
/usr/share/clear/bundles/os-clr-on-clr | 0.90s | 0.91s

Fixes #389 