### PR TITLE
Remove root requirement for check-update

### DIFF
--- a/src/check_update.c
+++ b/src/check_update.c
@@ -133,7 +133,6 @@ static int check_update()
 {
 	int current_version, server_version;
 
-	check_root();
 	if (!init_globals()) {
 		return EINIT_GLOBALS;
 	}
@@ -158,7 +157,6 @@ static int check_update()
 		fprintf(stderr, "Current OS version: %d\n", current_version);
 		if (current_version < server_version) {
 			fprintf(stderr, "There is a new OS version available: %d\n", server_version);
-			update_motd(server_version);
 			return 0; /* update available */
 		} else if (current_version >= server_version) {
 			fprintf(stderr, "There are no updates available\n");

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -672,19 +672,6 @@ void free_string(char **s)
 	}
 }
 
-void update_motd(int new_release)
-{
-	FILE *motd_fp = NULL;
-
-	motd_fp = fopen(MOTD_FILE, "w");
-
-	if (motd_fp != NULL) {
-		fprintf(motd_fp, "There is a new OS version available: %d\n", new_release);
-		fprintf(motd_fp, "Upgrade to the latest version using 'swupd update'\n");
-		fclose(motd_fp);
-	}
-}
-
 void delete_motd(void)
 {
 	if (unlink(MOTD_FILE) == ENOMEM) {


### PR DESCRIPTION
Also removes a call to update an unused motd file. The motd is now
managed differently in Clear Linux and the MOTD_FILE does not even exist
where it expects it to. Since this was the only reason root was required
just remove the functionality entirely.

Fixes #398 (the best we can do for now)

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>