### PR TITLE
Fix a "preposterous check

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -258,7 +258,7 @@ static struct manifest *manifest_from_file(int version, char *component, bool he
 		}
 		if (strncmp(line, "contentsize:", 12) == 0) {
 			contentsize = strtoull(c, NULL, 10);
-			if (contentsize > 2000000000) {
+			if (contentsize > 2000000000000UL) {
 				fprintf(stderr, "Error: preposterous (%" PRIu64 ") size of files in %s Manifest, more than 2TB skipping\n",
 					contentsize, component);
 				goto err_close;


### PR DESCRIPTION
2`*`10^12 rather than 2`*`10^9

Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>