### PR TITLE
Reduce the time between version checks.

### DIFF
--- a/data/swupd-update.timer
+++ b/data/swupd-update.timer
@@ -3,10 +3,10 @@ Description=Automatically Install Software Updates
 Documentation=man:swupd_update
 
 [Timer]
-OnBootSec=6h
-OnUnitActiveSec=6h
-AccuracySec=900
-RandomizedDelaySec=7200
+OnBootSec=45min
+OnUnitActiveSec=45min
+AccuracySec=300
+RandomizedDelaySec=2700
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We know these are cheap and our CDN takes care of the actual
bulk of the bandwith.

Spread the update checks between 45min0sec and 1hr33mins
effectively.