### PR TITLE
clean: fix returning garbage in failure cases

### DIFF
--- a/src/clean.c
+++ b/src/clean.c
@@ -226,6 +226,7 @@ static char *read_mom_contents(int version)
 		return NULL;
 	}
 
+	char *contents = NULL;
 	int fd = fileno(f);
 	if (fd == -1) {
 		goto end;
@@ -238,7 +239,7 @@ static char *read_mom_contents(int version)
 		goto end;
 	}
 
-	char *contents = malloc(stat.st_size + 1);
+	contents = malloc(stat.st_size + 1);
 	if (!contents) {
 		goto end;
 	}


### PR DESCRIPTION
The variable contents was not being properly set when early failures
happen in read_mom_contents.

Found with clang static analyzer.