### PR TITLE
list: fix cloning lists of strings

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -301,15 +301,15 @@ struct list *list_clone(struct list *list)
 }
 
 /* deep clone a list of char * */
-struct list *list_deep_clone_strs(struct list *source)
+struct list *list_deep_clone_strs(struct list *list)
 {
-	struct list *clone = list_clone(source);
-	struct list *src_ptr = list_tail(source);
+	struct list *clone = NULL;
+	struct list *item;
 
-	while (src_ptr) {
-		char *cloned_item = strdup(src_ptr->data);
-		clone = list_prepend_data(clone, cloned_item);
-		src_ptr = src_ptr->prev;
+	item = list_tail(list);
+	while (item) {
+		clone = list_prepend_data(clone, strdup(item->data));
+		item = item->prev;
 	}
 
 	return clone;


### PR DESCRIPTION
The clone of strings lists was creating a copy of the items and adding
to the list, but still keeping the old ones around. Change the
function to just clone the items. This was causing invalid reads when
doing swupd search for a term that has matches, and causing crashes
for some users.

For the record, one of the valgrind reports:

  ==30978== Invalid read of size 1
  ==30978==    at 0x51FF680: __strcmp_ssse3 (in /usr/lib64/haswell/libc-2.27.so)
  ==30978==    by 0x407C1B: calculate_size (search.c:194)
  ==30978==    by 0x407C62: calculate_size (search.c:219)
  ==30978==    by 0x407C62: calculate_size (search.c:219)
  ==30978==    by 0x4075CD: apply_size_penalty (search.c:240)
  ==30978==    by 0x4075CD: do_search (search.c:715)
  ==30978==    by 0x4075CD: search_main (search.c:898)
  ==30978==    by 0x50B4B36: (below main) (libc-start.c:308)
  ==30978==  Address 0x65484b0 is 16 bytes before an unallocated block of size 0 in arena "client"