### PR TITLE
clean: fix missing argument in function

### DIFF
--- a/src/clean.c
+++ b/src/clean.c
@@ -257,11 +257,11 @@ end:
 	return contents;
 }
 
-static int clean_staged_manifests()
+static int clean_staged_manifests(const char *path)
 {
 	DIR *dir;
 
-	dir = opendir(state_dir);
+	dir = opendir(path);
 	if (!dir) {
 		return errno;
 	}


### PR DESCRIPTION
It worked because state_dir is a global, but let's follow the same
approach as other functions and take the state directory as an
argument.