### PR TITLE
Update "swupd verify" documentation to cover all options

### DIFF
--- a/docs/swupd.1
+++ b/docs/swupd.1
@@ -380,29 +380,19 @@ control of the software update program are verified according to the
 manifest data
 .INDENT 0.0
 .IP \(bu 2
+\fI\-m, \-\-manifest\fP
+.INDENT 2.0
+.INDENT 3.5
+Verify against manifest version M.
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
 \fI\-f, \-\-fix\fP
 .INDENT 2.0
 .INDENT 3.5
 Correct any issues found. This will overwrite incorrect file
 content, add missing files and do additional corrections, permissions
 etc.
-.UNINDENT
-.UNINDENT
-.IP \(bu 2
-\fI\-i, \-\-install\fP
-.INDENT 2.0
-.INDENT 3.5
-Install all files into {path} as specified by the \fI\-\-path={path}\fP
-option. Useful to generate a new system root, or verify side
-by side.
-.UNINDENT
-.UNINDENT
-.IP \(bu 2
-\fI\-q, \-\-quick\fP
-.INDENT 2.0
-.INDENT 3.5
-Omit checking hash values. Instead only corrects missing files
-and directories and/or symlinks.
 .UNINDENT
 .UNINDENT
 .IP \(bu 2
@@ -454,6 +444,30 @@ Matches nothing, because paths are never empty.
 .UNINDENT
 .UNINDENT
 .UNINDENT
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+\fI\-i, \-\-install\fP
+.INDENT 2.0
+.INDENT 3.5
+Install all files into {path} as specified by the \fI\-\-path={path}\fP
+option. Useful to generate a new system root, or verify side
+by side.
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+\fI\-q, \-\-quick\fP
+.INDENT 2.0
+.INDENT 3.5
+Omit checking hash values. Instead only corrects missing files
+and directories and/or symlinks.
+.UNINDENT
+.UNINDENT
+.IP \(bu 2
+\fI\-x, \-\-force\fP
+.INDENT 2.0
+.INDENT 3.5
+Attempt to proceed even if non\-critical errors found.
 .UNINDENT
 .UNINDENT
 .UNINDENT

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -272,22 +272,15 @@ SUBCOMMANDS
     control of the software update program are verified according to the
     manifest data
 
+    - `-m, --manifest`
+
+        Verify against manifest version M.
+
     - `-f, --fix`
 
         Correct any issues found. This will overwrite incorrect file
         content, add missing files and do additional corrections, permissions
         etc.
-
-    - `-i, --install`
-
-        Install all files into {path} as specified by the `--path={path}`
-        option. Useful to generate a new system root, or verify side
-        by side.
-
-    - `-q, --quick`
-
-        Omit checking hash values. Instead only corrects missing files
-        and directories and/or symlinks.
 
     - `-Y, --picky`
 
@@ -322,6 +315,22 @@ SUBCOMMANDS
         - empty string or ``^$``
 
             Matches nothing, because paths are never empty.
+
+    - `-i, --install`
+
+        Install all files into {path} as specified by the `--path={path}`
+        option. Useful to generate a new system root, or verify side
+        by side.
+
+    - `-q, --quick`
+
+        Omit checking hash values. Instead only corrects missing files
+        and directories and/or symlinks.
+
+    - `-x, --force`
+
+        Attempt to proceed even if non-critical errors found.
+
 
 ``info``
 


### PR DESCRIPTION
Add "swupd verify" options that were missing from the documentation
(swupd.1.rst) but listed by the tool when calling "swupd verify -h".
The order was also slightly changed to be identical to the order used
by "swupd verify -h".

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>