### PR TITLE
Add test to ensure man pages are up to date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ tap-driver.sh
 test-driver
 test-suite.log
 test/*.gcno
+test/documentation/manpages/test.log
 test/functional/Swupd_Root.pem
 test/functional/private.pem
 test/functional/*.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -107,6 +107,7 @@ BATS_LOG_DRIVER = $(tap_driver)
 TESTS = $(dist_check_SCRIPTS)
 
 BATS = \
+	test/documentation/manpages/test.bats \
 	test/functional/bundleadd/add-directory/test.bats \
 	test/functional/bundleadd/add-existing/test.bats \
 	test/functional/bundleadd/add-multiple/test.bats \
@@ -265,9 +266,6 @@ MANPAGES = \
 
 dist_man_MANS = \
 	$(MANPAGES)
-
-clean-local:
-	rm -f $(dist_man_MANS)
 
 man: $(dist_man_MANS)
 

--- a/test/documentation/manpages/test.bats
+++ b/test/documentation/manpages/test.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+setup() {
+  # Ensure that we have the conversion program
+  type -t rst2man.py > /dev/null
+  # Change to the toplevel git directory
+  type -t git >/dev/null || skip
+  cd "$(git rev-parse --show-toplevel)"
+}
+
+@test "Check manual pages are up to date" {
+  for rst in docs/*.[1-9].rst
+  do
+    [ -f "$rst" ] || continue	# Could use shopt -s nullglob
+    echo "$rst"
+    rst2man.py "$rst" | cmp  "${rst%.rst}" -
+  done
+}
+
+@test "Check manual pages are clean" {
+  for nroff in docs/*.[1-9]
+  do
+    [ -f "$nroff" ] || continue
+    echo "$nroff"
+    git diff-index --quiet HEAD "$nroff"
+  done
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
Current idea is to have the manual pages stored in the repo in nroff
format, as well as restructured test format. Users can just use the
nroff. Add test to ensure that the pages match.

Fixes #316
Fixes #425

Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>