### PR TITLE
Avoid retries in local downloads for manifests and packs

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -595,7 +595,7 @@ int add_subscriptions(struct list *bundles, struct list **subs, int current_vers
 	retry_manifest_download:
 		manifest = load_manifest(current_version, file->last_change, file, mom, true);
 		if (!manifest) {
-			if (retries < MAX_TRIES) {
+			if (retries < MAX_TRIES && !content_url_is_local) {
 				increment_retries(&retries, &timeout);
 				goto retry_manifest_download;
 			}
@@ -685,7 +685,7 @@ static int install_bundles(struct list *bundles, struct list **subs, int current
 
 download_subscribed_packs:
 	if (download_subscribed_packs(*subs, mom, true, false)) {
-		if (retries < MAX_TRIES) {
+		if (retries < MAX_TRIES && !content_url_is_local) {
 			increment_retries(&retries, &timeout);
 			printf("\nRetry #%d downloading subscribed packs\n", retries);
 			goto download_subscribed_packs;

--- a/src/globals.c
+++ b/src/globals.c
@@ -69,6 +69,7 @@ bool verbose_time = false;
 bool have_manifest_diskspace = false; /* assume no until checked */
 char *version_url = NULL;
 char *content_url = NULL;
+bool content_url_is_local = false;
 char *cert_path = NULL;
 long update_server_port = -1;
 char *swupd_cmd = NULL;
@@ -314,7 +315,12 @@ int set_content_url(char *url)
 		return 0;
 	}
 
-	return set_url(&content_url, url, DEFAULT_CONTENT_URL_PATH);
+	int ret = set_url(&content_url, url, DEFAULT_CONTENT_URL_PATH);
+	if (ret == 0) {
+		content_url_is_local = strncmp(content_url, "file://", 7) == 0;
+	}
+
+	return ret;
 }
 
 /* Initializes the version_url global variable. If the url parameter is not

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -181,6 +181,7 @@ extern char *state_dir;
 
 extern char *version_url;
 extern char *content_url;
+extern bool content_url_is_local;
 extern char *cert_path;
 extern long update_server_port;
 extern char *default_format_path;

--- a/test/functional/bundleadd/bad-manifest/lines-checked
+++ b/test/functional/bundleadd/bad-manifest/lines-checked
@@ -2,17 +2,5 @@ Error: preposterous (9000000) number of files in test-bundle Manifest, more than
 Warning: Removing corrupt Manifest.test-bundle artifacts and re-downloading...
 Error: preposterous (9000000) number of files in test-bundle Manifest, more than 4 million skipping
 Failed to load 10 test-bundle manifest
-Error: preposterous (9000000) number of files in test-bundle Manifest, more than 4 million skipping
-Warning: Removing corrupt Manifest.test-bundle artifacts and re-downloading...
-Error: preposterous (9000000) number of files in test-bundle Manifest, more than 4 million skipping
-Failed to load 10 test-bundle manifest
-Error: preposterous (9000000) number of files in test-bundle Manifest, more than 4 million skipping
-Warning: Removing corrupt Manifest.test-bundle artifacts and re-downloading...
-Error: preposterous (9000000) number of files in test-bundle Manifest, more than 4 million skipping
-Failed to load 10 test-bundle manifest
-Error: preposterous (9000000) number of files in test-bundle Manifest, more than 4 million skipping
-Warning: Removing corrupt Manifest.test-bundle artifacts and re-downloading...
-Error: preposterous (9000000) number of files in test-bundle Manifest, more than 4 million skipping
-Failed to load 10 test-bundle manifest
 Unable to download manifest test-bundle version 10, exiting now
 Error: Processing error - Aborting

--- a/test/functional/bundleadd/fix-missing-file/lines-checked
+++ b/test/functional/bundleadd/fix-missing-file/lines-checked
@@ -1,10 +1,4 @@
 Downloading packs
-Retry #1 downloading subscribed packs
-Downloading packs
-Retry #2 downloading subscribed packs
-Downloading packs
-Retry #3 downloading subscribed packs
-Downloading packs
 Installing bundle(s) files
 Path /foo is missing on the file system  fixing
 Calling post-update helper scripts


### PR DESCRIPTION
If content_url is local, do not attempt certain certain download
retries. I've focused on changing only the spots that caused 'make
check' to sleep as a first step. But I agree the retry logic needs
some extra care as posted in #221.

This patch reduces the time of running 'make check' in my system from
2m44s to 24s.