### PR TITLE
Handle stale mirrors

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -367,8 +367,6 @@ int swupd_curl_get_file(const char *url, char *filename, struct file *file,
 		}
 	} else {
 		// only download latest version number, storing in the provided pointer
-		fprintf(stderr, "Attempting to download version string to memory\n");
-
 		curl_ret = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, swupd_download_version_to_memory);
 		if (curl_ret != CURLE_OK) {
 			goto exit;

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -264,6 +264,10 @@ char *mk_full_filename(const char *prefix, const char *path)
 		abort();
 	}
 
+	if (prefix == NULL) {
+		return abspath;
+	}
+
 	// The prefix is a minimum of "/" or "".  If the prefix is only that,
 	// just use abspath.  If the prefix is longer than the minimal, insure
 	// it ends in not "/" and append abspath.

--- a/src/mirror.c
+++ b/src/mirror.c
@@ -53,11 +53,7 @@ static const struct option prog_opts[] = {
 static int unset_mirror_url()
 {
 	char *fullpath;
-	if (path_prefix != NULL) {
-		fullpath = mk_full_filename(path_prefix, "/etc/swupd");
-	} else {
-		string_or_die(&fullpath, "/etc/swupd");
-	}
+	fullpath = mk_full_filename(path_prefix, "/etc/swupd");
 
 	if (fullpath == NULL ||
 	    strcmp(fullpath, "/") == 0 ||
@@ -111,14 +107,10 @@ static int set_mirror_url(char *url)
 	char *version_path;
 	int ret = 0;
 	bool need_unset = false;
-	/* concatenate path_prefix and configuration paths if necessary */
-	if (path_prefix != NULL) {
-		content_path = mk_full_filename(path_prefix, MIRROR_CONTENT_URL_PATH);
-		version_path = mk_full_filename(path_prefix, MIRROR_VERSION_URL_PATH);
-	} else {
-		string_or_die(&content_path, "%s", MIRROR_CONTENT_URL_PATH);
-		string_or_die(&version_path, "%s", MIRROR_VERSION_URL_PATH);
-	}
+	/* concatenate path_prefix and configuration paths if necessary
+	 * if path_prefix is NULL the second argument will be returned */
+	content_path = mk_full_filename(path_prefix, MIRROR_CONTENT_URL_PATH);
+	version_path = mk_full_filename(path_prefix, MIRROR_VERSION_URL_PATH);
 
 	/* write url to path_prefix/MIRROR_CONTENT_URL_PATH */
 	ret = write_to_path(url, content_path);
@@ -148,11 +140,7 @@ void handle_mirror_if_stale(void)
 	char *ret_str = NULL;
 	char *fullpath = NULL;
 
-	if (path_prefix != NULL) {
-		fullpath = mk_full_filename(path_prefix, DEFAULT_VERSION_URL_PATH);
-	} else {
-		string_or_die(&fullpath, DEFAULT_VERSION_URL_PATH);
-	}
+	fullpath = mk_full_filename(path_prefix, DEFAULT_VERSION_URL_PATH);
 	int ret = get_value_from_path(&ret_str, fullpath, false);
 	if (ret != 0 || ret_str == NULL) {
 		/* no versionurl file here, might not exist under --path argument */

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -49,6 +49,9 @@ extern "C" {
 #define MIRROR_CONTENT_URL_PATH "/etc/swupd/mirror_contenturl"
 #define DEFAULT_FORMAT_PATH "/usr/share/defaults/swupd/format"
 
+#define MIRROR_STALE_WARN 20
+#define MIRROR_STALE_UNSET 500
+
 #define DEFAULT_CONTENTURL "https://cdn.download.clearlinux.org/update/"
 
 struct sub {
@@ -201,7 +204,7 @@ extern int add_included_manifests(struct manifest *mom, int current, struct list
 extern int main_verify(int current_version);
 extern int walk_tree(struct manifest *, const char *, bool, const regex_t *);
 
-extern int get_latest_version(void);
+extern int get_latest_version(char *v_url);
 extern void read_versions(int *current_version, int *server_version, char *path_prefix);
 extern int check_versions(int *current_version, int *server_version, int requested_version, char *path_prefix);
 extern int get_current_version(char *path_prefix);
@@ -406,6 +409,8 @@ extern void check_mix_versions(int *current_version, int *server_version, char *
 extern int read_mix_version_file(char *filename, char *path_prefix);
 
 extern void print_update_conf_info(void);
+
+extern void handle_mirror_if_stale(void);
 
 /* some disk sizes constants for the various features:
  *   ...consider adding build automation to catch at build time

--- a/src/update.c
+++ b/src/update.c
@@ -330,6 +330,8 @@ static int main_update()
 
 	read_subscriptions(&current_subs);
 
+	handle_mirror_if_stale();
+
 /* Step 1: get versions */
 version_check:
 	ret = check_versions(&current_version, &server_version, requested_version, path_prefix);

--- a/src/verify.c
+++ b/src/verify.c
@@ -768,7 +768,7 @@ int verify_main(int argc, char **argv)
 	}
 
 	if (version == -1) {
-		version = get_latest_version();
+		version = get_latest_version(NULL);
 		if (version < 0) {
 			fprintf(stderr, "Unable to get latest version for install\n");
 			ret = EXIT_FAILURE;
@@ -830,7 +830,7 @@ int verify_main(int argc, char **argv)
 			fprintf(stderr, "ERROR: Mismatching formats detected when verifying %d"
 					" (expected: %s; actual: %d)\n",
 				version, format_string, official_manifest->manifest_version);
-			int latest = get_latest_version();
+			int latest = get_latest_version(NULL);
 			if (latest > 0) {
 				fprintf(stderr, "Latest supported version to verify: %d\n", latest);
 			}

--- a/test/functional/bundleadd/statedir/lines-checked
+++ b/test/functional/bundleadd/statedir/lines-checked
@@ -1,2 +1,1 @@
-Attempting to download version string to memory
 nothing to add, exiting now

--- a/test/functional/bundlelist/all/list/lines-checked
+++ b/test/functional/bundlelist/all/list/lines-checked
@@ -1,2 +1,1 @@
-Attempting to download version string to memory
 os-core

--- a/test/functional/checkupdate/new-version/lines-checked
+++ b/test/functional/checkupdate/new-version/lines-checked
@@ -1,3 +1,2 @@
-Attempting to download version string to memory
 Current OS version: 10
 There is a new OS version available: 100

--- a/test/functional/checkupdate/no-server-content/lines-checked
+++ b/test/functional/checkupdate/no-server-content/lines-checked
@@ -1,2 +1,1 @@
-Attempting to download version string to memory
 Error: server does not report any version

--- a/test/functional/checkupdate/no-target-content/lines-checked
+++ b/test/functional/checkupdate/no-target-content/lines-checked
@@ -1,2 +1,1 @@
-Attempting to download version string to memory
 Unable to determine current OS version

--- a/test/functional/checkupdate/slow-server/lines-checked
+++ b/test/functional/checkupdate/slow-server/lines-checked
@@ -1,4 +1,3 @@
 Range command not supported by server, download resume disabled.
-Attempting to download version string to memory
 Current OS version: 10
 There is a new OS version available: 99990

--- a/test/functional/checkupdate/version-match/lines-checked
+++ b/test/functional/checkupdate/version-match/lines-checked
@@ -1,3 +1,2 @@
-Attempting to download version string to memory
 Current OS version: 10
 There are no updates available

--- a/test/functional/search/content-check-negfull-path/lines-checked
+++ b/test/functional/search/content-check-negfull-path/lines-checked
@@ -1,2 +1,1 @@
-Attempting to download version string to memory
 Searching for '/usr/lib64/test-lib100'

--- a/test/functional/search/content-check-neglibtest/lines-checked
+++ b/test/functional/search/content-check-neglibtest/lines-checked
@@ -1,2 +1,1 @@
-Attempting to download version string to memory
 Searching for 'libtest-nohit'

--- a/test/functional/search/content-check-posbin/lines-checked
+++ b/test/functional/search/content-check-posbin/lines-checked
@@ -1,2 +1,1 @@
-Attempting to download version string to memory
 Searching for 'test-bin'

--- a/test/functional/search/content-check-posebin/lines-checked
+++ b/test/functional/search/content-check-posebin/lines-checked
@@ -1,2 +1,1 @@
-Attempting to download version string to memory
 Searching for 'test-bin'

--- a/test/functional/search/content-check-posfull-path/lines-checked
+++ b/test/functional/search/content-check-posfull-path/lines-checked
@@ -1,2 +1,1 @@
-Attempting to download version string to memory
 Searching for '/usr/lib64/test-lib64'

--- a/test/functional/search/content-check-poslib32/lines-checked
+++ b/test/functional/search/content-check-poslib32/lines-checked
@@ -1,2 +1,1 @@
-Attempting to download version string to memory
 Searching for 'test-lib32'

--- a/test/functional/search/content-check-poslib64/lines-checked
+++ b/test/functional/search/content-check-poslib64/lines-checked
@@ -1,2 +1,1 @@
-Attempting to download version string to memory
 Searching for 'test-lib64'

--- a/test/functional/update/apply-full-file-delta/lines-checked
+++ b/test/functional/update/apply-full-file-delta/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 100
 Extracting os-core pack for version 100
 Statistics for going from version 10 to version 100:

--- a/test/functional/update/boot-file/lines-checked
+++ b/test/functional/update/boot-file/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1

--- a/test/functional/update/boot-skip/lines-checked
+++ b/test/functional/update/boot-skip/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1

--- a/test/functional/update/delta-without-rename-flag/lines-checked
+++ b/test/functional/update/delta-without-rename-flag/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 20
 Extracting os-core pack for version 20
 Statistics for going from version 10 to version 20:

--- a/test/functional/update/download/lines-checked
+++ b/test/functional/update/download/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 100
 Extracting os-core pack for version 100
 Statistics for going from version 10 to version 100:

--- a/test/functional/update/include-old-bundle-with-tracked-file/lines-checked
+++ b/test/functional/update/include-old-bundle-with-tracked-file/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 20 to 30
 Statistics for going from version 20 to version 30:
     changed bundles   : 3

--- a/test/functional/update/include-old-bundle/lines-checked
+++ b/test/functional/update/include-old-bundle/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 2

--- a/test/functional/update/include/lines-checked
+++ b/test/functional/update/include/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 2

--- a/test/functional/update/missing-os-core/lines-checked
+++ b/test/functional/update/missing-os-core/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 2

--- a/test/functional/update/newest-deleted/lines-checked
+++ b/test/functional/update/newest-deleted/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 20 to 30
 Extracting os-core pack for version 30
 Statistics for going from version 20 to version 30:

--- a/test/functional/update/newest-ghosted/lines-checked
+++ b/test/functional/update/newest-ghosted/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 20 to 30
 Extracting os-core pack for version 30
 Statistics for going from version 20 to version 30:

--- a/test/functional/update/re-update-bad-os-release/lines-checked
+++ b/test/functional/update/re-update-bad-os-release/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 20
 Statistics for going from version 10 to version 20:
     changed bundles   : 1

--- a/test/functional/update/re-update-required/lines-checked
+++ b/test/functional/update/re-update-required/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 20
 Statistics for going from version 10 to version 20:
     changed bundles   : 1
@@ -17,7 +16,6 @@ Update was applied.
 Update successful. System updated from version 10 to version 20
 3 files were not in a pack
 Update started.
-Attempting to download version string to memory
 Preparing to update from 100 to 110
 Statistics for going from version 100 to version 110:
     changed bundles   : 1

--- a/test/functional/update/rename-ghosted/lines-checked
+++ b/test/functional/update/rename-ghosted/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 20
 Extracting os-core pack for version 20
 Statistics for going from version 10 to version 20:

--- a/test/functional/update/rename/lines-checked
+++ b/test/functional/update/rename/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 20
 Extracting os-core pack for version 20
 Statistics for going from version 10 to version 20:

--- a/test/functional/update/skip-scripts/lines-checked
+++ b/test/functional/update/skip-scripts/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1

--- a/test/functional/update/skip-verified-fullfiles/lines-checked
+++ b/test/functional/update/skip-verified-fullfiles/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1

--- a/test/functional/update/statedir-bad-hash/lines-checked
+++ b/test/functional/update/statedir-bad-hash/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1

--- a/test/functional/update/status-no-server-content/lines-checked
+++ b/test/functional/update/status-no-server-content/lines-checked
@@ -1,3 +1,2 @@
-Attempting to download version string to memory
 Current OS version: 10
 Cannot get the latest server version. Could not reach server

--- a/test/functional/update/status-no-target-content/lines-checked
+++ b/test/functional/update/status-no-target-content/lines-checked
@@ -1,3 +1,2 @@
-Attempting to download version string to memory
 Cannot determine current OS version
 Latest server version: 100

--- a/test/functional/update/status-version-double-quote/lines-checked
+++ b/test/functional/update/status-version-double-quote/lines-checked
@@ -1,3 +1,2 @@
-Attempting to download version string to memory
 Current OS version: 10
 Latest server version: 100

--- a/test/functional/update/status-version-single-quote/lines-checked
+++ b/test/functional/update/status-version-single-quote/lines-checked
@@ -1,3 +1,2 @@
-Attempting to download version string to memory
 Current OS version: 10
 Latest server version: 100

--- a/test/functional/update/status/lines-checked
+++ b/test/functional/update/status/lines-checked
@@ -1,3 +1,2 @@
-Attempting to download version string to memory
 Current OS version: 10
 Latest server version: 100

--- a/test/functional/update/use-full-file/lines-checked
+++ b/test/functional/update/use-full-file/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1

--- a/test/functional/update/use-pack/lines-checked
+++ b/test/functional/update/use-pack/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 100
 Extracting os-core pack for version 100
 Statistics for going from version 10 to version 100:

--- a/test/functional/update/verify-fix-path-hash-mismatch/lines-checked
+++ b/test/functional/update/verify-fix-path-hash-mismatch/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1

--- a/test/functional/update/verify-fix-path-missing-dir/lines-checked
+++ b/test/functional/update/verify-fix-path-missing-dir/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1

--- a/test/functional/update/verify-fullfile-hash/lines-checked
+++ b/test/functional/update/verify-fullfile-hash/lines-checked
@@ -1,5 +1,4 @@
 Update started.
-Attempting to download version string to memory
 Preparing to update from 10 to 100
 Statistics for going from version 10 to version 100:
     changed bundles   : 1

--- a/test/functional/verify/format-mismatch/lines-checked
+++ b/test/functional/verify/format-mismatch/lines-checked
@@ -1,5 +1,4 @@
 Verifying version 20
 ERROR: Mismatching formats detected when verifying 20 (expected: 1; actual: 2)
-Attempting to download version string to memory
 Latest supported version to verify: 10
 Error: Fix did not fully succeed

--- a/test/functional/verify/install-latest-directory/lines-checked
+++ b/test/functional/verify/install-latest-directory/lines-checked
@@ -1,4 +1,3 @@
-Attempting to download version string to memory
 Verifying version 100
 Extracting os-core pack for version 100
 Adding any missing files

--- a/test/functional/verify/latest-missing/lines-checked
+++ b/test/functional/verify/latest-missing/lines-checked
@@ -1,3 +1,2 @@
-Attempting to download version string to memory
 Unable to get latest version for install
 Error: Fix did not fully succeed


### PR DESCRIPTION
Handle updates against configured mirrors by warning or unsetting
out-of-date mirrors. If a mirror is only slightly out of date warn the
user that the mirror is stale but continue normal operations. If a
mirror is out of date by a large range (arbitrary difference of 500, or
about a month and a half) simply unset the mirror and continue using the
upstream url.