### PR TITLE
Return meaningful errors for SSL Cert failures

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -52,9 +52,10 @@ int list_installable_bundles()
 	int current_version;
 	bool mix_exists;
 
-	if (swupd_curl_check_network()) {
+	int ret = swupd_curl_check_network();
+	if (ret) {
 		fprintf(stderr, "Error: Network issue, unable to download manifest\n");
-		return ENOSWUPDSERVER;
+		return ret;
 	}
 
 	current_version = get_current_version(path_prefix);

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -139,9 +139,10 @@ static int check_update()
 	}
 	swupd_curl_init();
 
-	if (swupd_curl_check_network()) {
+	int ret = swupd_curl_check_network();
+	if (ret) {
 		fprintf(stderr, "Error: Network issue, unable to check for update\n");
-		return ENOSWUPDSERVER;
+		return ret;
 	}
 
 	read_versions(&current_version, &server_version, path_prefix);

--- a/src/curl.c
+++ b/src/curl.c
@@ -172,6 +172,8 @@ int swupd_curl_check_network(void)
 			swupd_curl_test_resume();
 			goto cleanup;
 		case CURLE_SSL_CACERT:
+			fprintf(stderr, "Error: unable to verify server SSL certificate\n");
+			ret = EBADCERT;
 			break;
 		default:
 			swupd_curl_strerror(curl_ret);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -507,8 +507,9 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 	}
 	free_string(&filename);
 
-	if (swupd_curl_check_network()) {
-		ret = -ENOSWUPDSERVER;
+	ret = swupd_curl_check_network();
+	if (ret) {
+		ret = -ret;
 		goto out;
 	}
 

--- a/src/packs.c
+++ b/src/packs.c
@@ -104,8 +104,9 @@ int download_subscribed_packs(struct list *subs, struct manifest *mom, bool requ
 	unsigned int list_length = list_len(subs);
 	unsigned int complete = 0;
 
-	if (swupd_curl_check_network()) {
-		return -ENOSWUPDSERVER;
+	int ret = swupd_curl_check_network();
+	if (ret) {
+		return -ret;
 	}
 
 	fprintf(stderr, "Downloading packs...\n");

--- a/src/search.c
+++ b/src/search.c
@@ -865,9 +865,9 @@ int search_main(int argc, char **argv)
 		return ret;
 	}
 
-	if (swupd_curl_check_network()) {
+	ret = swupd_curl_check_network();
+	if (ret) {
 		fprintf(stderr, "Error: Network issue, unable to proceed with update\n");
-		ret = ENOSWUPDSERVER;
 		goto clean_exit;
 	}
 

--- a/src/swupd-error.h
+++ b/src/swupd-error.h
@@ -24,5 +24,6 @@
 #define ESIGNATURE 21		/* Cannot initialize signature verification */
 #define EBADTIME 22		/* System time is bad */
 #define EDOWNLOADPACKS 23       /* Pack download failed */
+#define EBADCERT 24		/* unable to verify server SSL certificate */
 
 #endif

--- a/src/update.c
+++ b/src/update.c
@@ -316,9 +316,9 @@ static int main_update()
 	clock_gettime(CLOCK_MONOTONIC_RAW, &ts_start);
 	grabtime_start(&times, "Main Update");
 
-	if (swupd_curl_check_network()) {
+	ret = swupd_curl_check_network();
+	if (ret) {
 		fprintf(stderr, "Error: Network issue, unable to proceed with update\n");
-		ret = ENOSWUPDSERVER;
 		goto clean_curl;
 	}
 

--- a/src/verify.c
+++ b/src/verify.c
@@ -778,9 +778,9 @@ int verify_main(int argc, char **argv)
 
 	fprintf(stderr, "Verifying version %i\n", version);
 
-	if (swupd_curl_check_network()) {
+	ret = swupd_curl_check_network();
+	if (ret) {
 		fprintf(stderr, "Error: Network issue, unable to download manifest\n");
-		ret = ENOSWUPDSERVER;
 		goto clean_and_exit;
 	}
 


### PR DESCRIPTION
Add a specific printf and separate failure code to indicate SSL cert
failures. This return code (24) will be returned to telemetry as well to
indicate this specific failure.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>