### PR TITLE
Set mirror override path perm to 0755

### DIFF
--- a/src/mirror.c
+++ b/src/mirror.c
@@ -74,7 +74,7 @@ static int write_to_path(char *content, char *path)
 	dir = dirname(tmp);
 	/* attempt to  make the directory
 	 * ignore EEXIST errors */
-	int ret = mkdir(dir, S_IRWXU);
+	int ret = mkdir(dir, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
 	char *cmd;
 	string_or_die(&cmd, "mkdir -p %s", dir);
 	ret = system(cmd);


### PR DESCRIPTION
When /etc/swupd is created to hold mirror URL override files, set the
permissions to 0755.

Fixes #437