### PR TITLE
Let umask sort out mirror conf dir perms

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -145,6 +145,8 @@ BATS = \
 	test/functional/completion/basic/test.bats \
 	test/functional/hashdump/file-hash/test.bats \
 	test/functional/hashdump/file-hash-no-path-prefix/test.bats \
+	test/functional/mirror/createdir/test.bats \
+	test/functional/mirror/createdir-negative/test.bats \
 	test/functional/search/content-check-negfull-path/test.bats \
 	test/functional/search/content-check-neglibtest/test.bats \
 	test/functional/search/content-check-posbin/test.bats \

--- a/test/functional/mirror/createdir-negative/lines-checked
+++ b/test/functional/mirror/createdir-negative/lines-checked
@@ -1,0 +1,4 @@
+REGEXP:^swupd-client mirror .*$
+REGEXP:^.*/etc/swupd: not a directory$
+Unable to set mirror url
+Default version URL not found. Use the -v option instead.

--- a/test/functional/mirror/createdir-negative/test.bats
+++ b/test/functional/mirror/createdir-negative/test.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+load "../../swupdlib"
+
+setup() {
+  clean_test_dir
+  sudo mkdir -p "$DIR/target-dir/usr/share/defaults/swupd/"
+  echo 4 | sudo tee "$DIR/target-dir/usr/share/defaults/swupd/format"
+  sudo mkdir -p "$DIR/target-dir/etc"
+}
+
+teardown() {
+  sudo rm -rf "$DIR/target-dir/etc/swupd"
+  sudo rm -rf "$DIR/target-dir/foo"
+}
+
+@test "mirror /etc/swupd is a file" {
+  sudo rm -rf "$DIR/target-dir/etc/swupd"
+  sudo touch "$DIR/target-dir/etc/swupd"
+  [[ -f "$DIR/target-dir/etc/swupd" ]] && ! [[ -L "$DIR/target-dir/etc/swupd" ]]
+  run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+  check_lines "$output"
+}
+
+@test "mirror /etc/swupd is a symlink to a file" {
+  sudo rm -rf "$DIR/target-dir/etc/swupd"
+  sudo rm -rf "$DIR/target-dir/foo"
+  sudo touch "$DIR/target-dir/foo"
+  sudo ln -s "$DIR/target-dir/foo" "$DIR/target-dir/etc/swupd"
+  run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+  check_lines "$output"
+  sudo rm "$DIR/target-dir/foo"
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/test/functional/mirror/createdir-negative/test.bats
+++ b/test/functional/mirror/createdir-negative/test.bats
@@ -5,7 +5,7 @@ load "../../swupdlib"
 setup() {
   clean_test_dir
   sudo mkdir -p "$DIR/target-dir/usr/share/defaults/swupd/"
-  echo 4 | sudo tee "$DIR/target-dir/usr/share/defaults/swupd/format"
+  echo 1 | sudo tee "$DIR/target-dir/usr/share/defaults/swupd/format"
   sudo mkdir -p "$DIR/target-dir/etc"
 }
 
@@ -19,6 +19,7 @@ teardown() {
   sudo touch "$DIR/target-dir/etc/swupd"
   [[ -f "$DIR/target-dir/etc/swupd" ]] && ! [[ -L "$DIR/target-dir/etc/swupd" ]]
   run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+  [[ $status != 0 ]]
   check_lines "$output"
 }
 
@@ -28,6 +29,7 @@ teardown() {
   sudo touch "$DIR/target-dir/foo"
   sudo ln -s "$DIR/target-dir/foo" "$DIR/target-dir/etc/swupd"
   run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+  [[ $status != 0 ]]
   check_lines "$output"
   sudo rm "$DIR/target-dir/foo"
 }

--- a/test/functional/mirror/createdir/lines-checked
+++ b/test/functional/mirror/createdir/lines-checked
@@ -1,0 +1,5 @@
+REGEXP:^swupd-client mirror .*$
+Set upstream mirror to http://example.com/swupd-file
+Installed version: -1
+Version URL:       http://example.com/swupd-file
+Content URL:       http://example.com/swupd-file

--- a/test/functional/mirror/createdir/test.bats
+++ b/test/functional/mirror/createdir/test.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+load "../../swupdlib"
+
+setup() {
+  clean_test_dir
+  sudo mkdir -p "$DIR/target-dir/usr/share/defaults/swupd/"
+  echo 4 | sudo tee "$DIR/target-dir/usr/share/defaults/swupd/format"
+  sudo mkdir -p "$DIR/target-dir/etc"
+}
+
+teardown() {
+  sudo rm -rf "$DIR/target-dir/etc/swupd"
+  sudo rm -rf "$DIR/target-dir/foo"
+}
+
+@test "mirror /etc/swupd does not exist" {
+  sudo rm -rf "$DIR/target-dir/etc/swupd"
+  run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+  check_lines "$output"
+  [[ "http://example.com/swupd-file" == $(<$DIR/target-dir/etc/swupd/mirror_contenturl) ]]
+  [[ "http://example.com/swupd-file" == $(<$DIR/target-dir/etc/swupd/mirror_versionurl) ]]
+}
+
+@test "mirror /etc/swupd already exists" {
+  sudo mkdir "$DIR/target-dir/etc/swupd"
+  run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+  check_lines "$output"
+  [[ "http://example.com/swupd-file" == $(<$DIR/target-dir/etc/swupd/mirror_contenturl) ]]
+  [[ "http://example.com/swupd-file" == $(<$DIR/target-dir/etc/swupd/mirror_versionurl) ]]
+}
+
+@test "mirror /etc/swupd is a symlink to a directory" {
+  sudo rm -rf "$DIR/target-dir/etc/swupd"
+  sudo rm -rf "$DIR/target-dir/foo"
+  sudo mkdir "$DIR/target-dir/foo"
+  sudo ln -s "$DIR/target-dir/foo" "$DIR/target-dir/etc/swupd"
+  run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+  check_lines "$output"
+  ! [[ -L "$DIR/target-dir/etc/swupd" ]]
+  [[ "http://example.com/swupd-file" == $(<$DIR/target-dir/etc/swupd/mirror_contenturl) ]]
+  [[ "http://example.com/swupd-file" == $(<$DIR/target-dir/etc/swupd/mirror_versionurl) ]]
+  sudo rm -rf "$DIR/target-dir/foo"
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/test/functional/mirror/createdir/test.bats
+++ b/test/functional/mirror/createdir/test.bats
@@ -5,7 +5,7 @@ load "../../swupdlib"
 setup() {
   clean_test_dir
   sudo mkdir -p "$DIR/target-dir/usr/share/defaults/swupd/"
-  echo 4 | sudo tee "$DIR/target-dir/usr/share/defaults/swupd/format"
+  echo 1 | sudo tee "$DIR/target-dir/usr/share/defaults/swupd/format"
   sudo mkdir -p "$DIR/target-dir/etc"
 }
 
@@ -17,6 +17,7 @@ teardown() {
 @test "mirror /etc/swupd does not exist" {
   sudo rm -rf "$DIR/target-dir/etc/swupd"
   run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+  [[ $status -eq 0 ]]
   check_lines "$output"
   [[ "http://example.com/swupd-file" == $(<$DIR/target-dir/etc/swupd/mirror_contenturl) ]]
   [[ "http://example.com/swupd-file" == $(<$DIR/target-dir/etc/swupd/mirror_versionurl) ]]
@@ -25,6 +26,7 @@ teardown() {
 @test "mirror /etc/swupd already exists" {
   sudo mkdir "$DIR/target-dir/etc/swupd"
   run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+  [[ $status -eq 0 ]]
   check_lines "$output"
   [[ "http://example.com/swupd-file" == $(<$DIR/target-dir/etc/swupd/mirror_contenturl) ]]
   [[ "http://example.com/swupd-file" == $(<$DIR/target-dir/etc/swupd/mirror_versionurl) ]]
@@ -36,6 +38,7 @@ teardown() {
   sudo mkdir "$DIR/target-dir/foo"
   sudo ln -s "$DIR/target-dir/foo" "$DIR/target-dir/etc/swupd"
   run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+  [[ $status -eq 0 ]]
   check_lines "$output"
   ! [[ -L "$DIR/target-dir/etc/swupd" ]]
   [[ "http://example.com/swupd-file" == $(<$DIR/target-dir/etc/swupd/mirror_contenturl) ]]

--- a/test/functional/swupdlib.bash
+++ b/test/functional/swupdlib.bash
@@ -15,6 +15,8 @@ export SWUPD_OPTS_NO_FMT="-S $STATE_DIR -p $DIR/target-dir -u file://$DIR/web-di
 
 export SWUPD_OPTS_NO_CERT="-S $STATE_DIR -p $DIR/target-dir -F staging -u file://$DIR/web-dir"
 
+export SWUPD_OPTS_MIRROR="-p $DIR/target-dir"
+
 export CERT="$BATS_TEST_DIRNAME/Swupd_Root.pem"
 
 export CERTCONF="$BATS_TEST_DIRNAME/certattributes.cnf"


### PR DESCRIPTION
Set /etc/swupd permissions to 0777 to let the default umask policy
handle stripping bits appropriately.