### PR TITLE
Remove copyright header messages

### DIFF
--- a/src/autoupdate.c
+++ b/src/autoupdate.c
@@ -83,8 +83,6 @@ err:
 
 int autoupdate_main(int argc, char **argv)
 {
-	copyright_header("autoupdate settings");
-
 	if (!parse_options(argc, argv)) {
 		return EINVALID_OPTION;
 	}

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -172,7 +172,6 @@ static int check_update()
 int check_update_main(int argc, char **argv)
 {
 	int ret;
-	copyright_header("software update checker");
 
 	if (!parse_options(argc, argv)) {
 		return EINVALID_OPTION;

--- a/src/clean.c
+++ b/src/clean.c
@@ -329,8 +329,6 @@ static int clean_staged_manifests(const char *path)
 
 int clean_main(int argc, char **argv)
 {
-	copyright_header("clean");
-
 	if (!parse_options(argc, argv)) {
 		return EXIT_FAILURE;
 	}

--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -186,8 +186,6 @@ err:
 
 int bundle_add_main(int argc, char **argv)
 {
-	copyright_header("bundle adder");
-
 	if (!parse_options(argc, argv)) {
 		return EINVALID_OPTION;
 	}

--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -181,8 +181,6 @@ int bundle_list_main(int argc, char **argv)
 	int lock_fd;
 	int ret;
 
-	copyright_header("bundle list");
-
 	if (!parse_options(argc, argv)) {
 		return EXIT_FAILURE;
 	}

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -237,8 +237,6 @@ int bundle_remove_main(int argc, char **argv)
 	int total = 0;
 	int bad = 0;
 
-	copyright_header("bundle remover");
-
 	if (!parse_options(argc, argv)) {
 		return EINVALID_OPTION;
 	}

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -636,9 +636,9 @@ out_fds:
 
 /* this function prints the initial message for all utils
 */
-void copyright_header(const char *name)
+void copyright_header(void)
 {
-	fprintf(stderr, PACKAGE " %s " VERSION "\n", name);
+	fprintf(stderr, PACKAGE " " VERSION "\n");
 	fprintf(stderr, "   Copyright (C) 2012-2018 Intel Corporation\n");
 	fprintf(stderr, "\n");
 }

--- a/src/info.c
+++ b/src/info.c
@@ -32,8 +32,6 @@ void print_update_conf_info()
 
 int info_main(int UNUSED_PARAM argc, char UNUSED_PARAM **argv)
 {
-	copyright_header("info");
-
 	if (!init_globals()) {
 		return EINIT_GLOBALS;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -106,7 +106,7 @@ static int parse_options(int argc, char **argv, int *index)
 			print_help(argv[0]);
 			exit(EXIT_SUCCESS);
 		case 'v':
-			copyright_header("swupd");
+			copyright_header();
 			fprintf(stderr, "Compile-time options: %s\n", BUILD_OPTS);
 			exit(EXIT_SUCCESS);
 		case '\01':

--- a/src/mirror.c
+++ b/src/mirror.c
@@ -249,7 +249,6 @@ out:
 int mirror_main(int argc, char **argv)
 {
 	int ret = 0;
-	copyright_header("mirror");
 	ret = parse_options(argc, argv);
 	if (ret != 0) {
 		return ret;

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -359,7 +359,7 @@ extern int rm_bundle_file(const char *bundle);
 extern void print_manifest_files(struct manifest *m);
 extern void swupd_deinit(int lock_fd, struct list **subs);
 extern int swupd_init(int *lock_fd);
-extern void copyright_header(const char *name);
+extern void copyright_header(void);
 extern void string_or_die(char **strp, const char *fmt, ...);
 extern void free_string(char **s);
 void update_motd(int new_release);

--- a/src/update.c
+++ b/src/update.c
@@ -866,7 +866,6 @@ static int print_versions()
 int update_main(int argc, char **argv)
 {
 	int ret = 0;
-	copyright_header("software update");
 
 	if (!parse_options(argc, argv)) {
 		return EINVALID_OPTION;

--- a/src/verify.c
+++ b/src/verify.c
@@ -740,8 +740,6 @@ int verify_main(int argc, char **argv)
 	struct list *subs = NULL;
 	timelist times;
 
-	copyright_header("software verify");
-
 	if (!parse_options(argc, argv)) {
 		ret = EINVALID_OPTION;
 		goto clean_args_and_exit;

--- a/test/functional/ignore-list
+++ b/test/functional/ignore-list
@@ -1,10 +1,3 @@
-^swupd-client bundle adder [0-9.]+$
-^swupd-client bundle remover [0-9.]+$
-^swupd-client bundle list [0-9.]+$
-^swupd-client software update [0-9.]+$
-^swupd-client software update checker [0-9.]+$
-^swupd-client software verify [0-9.]+$
-^.*Copyright \(C\) .*$
 ^$
 ^Downloading packs...
 ^Calling post-update helper scripts.$

--- a/test/functional/mirror/createdir-negative/lines-checked
+++ b/test/functional/mirror/createdir-negative/lines-checked
@@ -1,4 +1,3 @@
-REGEXP:^swupd-client mirror .*$
 REGEXP:^.*/etc/swupd: not a directory$
 Unable to set mirror url
 Default version URL not found. Use the -v option instead.

--- a/test/functional/mirror/createdir/lines-checked
+++ b/test/functional/mirror/createdir/lines-checked
@@ -1,4 +1,3 @@
-REGEXP:^swupd-client mirror .*$
 Set upstream mirror to http://example.com/swupd-file
 Installed version: -1
 Version URL:       http://example.com/swupd-file


### PR DESCRIPTION
swupd-client is properly open sourced and licensed. The copyright header
is unnecessary, confusing, and causes issues for scripts parsing output.