### PR TITLE
Update mixer integration to use latest features

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -170,35 +170,16 @@ void print_time_stats(timelist *head)
 	}
 }
 
-/* If the MIX_BUNDLES_DIR has any content then we can run through
+/* If the MIX_BUNDLES_DIR has the valid-mix flag file we can run through
  * adding the mix data to the OS */
 bool check_mix_exists(void)
 {
-	DIR *dir;
-	struct dirent *entry;
 	char *fullpath;
-
-	string_or_die(&fullpath, "%s%s", path_prefix, MIX_DIR);
-
-	dir = opendir(fullpath);
+	bool ret;
+	string_or_die(&fullpath, "%s%s/.valid-mix", path_prefix, MIX_DIR);
+	ret = access(fullpath, F_OK) == 0;
 	free_string(&fullpath);
-
-	if (dir == NULL) {
-		return false;
-	}
-	for (; (entry = readdir(dir));) {
-		if (!entry) {
-			break;
-		}
-		if (!strcmp(entry->d_name, ".") ||
-		    !strcmp(entry->d_name, "..")) {
-			continue;
-		}
-		break;
-	}
-	closedir(dir);
-	/* If more than /. & /.. exists, then at least one bundle exists */
-	return entry != NULL;
+	return ret;
 }
 
 /* Once system is on mix this file should exist */

--- a/src/update.c
+++ b/src/update.c
@@ -274,8 +274,8 @@ static int re_exec_update(bool versions_match)
 
 static bool need_new_upstream(int server)
 {
-	if (!access(MIX_DIR ".clearversion", R_OK)) {
-		int version = read_mix_version_file(MIX_DIR ".clearversion", path_prefix);
+	if (!access(MIX_DIR "upstreamversion", R_OK)) {
+		int version = read_mix_version_file(MIX_DIR "upstreamversion", path_prefix);
 		if (version < server) {
 			return true;
 		}
@@ -359,17 +359,17 @@ version_check:
 				}
 			}
 
-			/* Update the clearversion that will be used to generate the new mix content */
-			FILE *verfile = fopen(MIX_DIR ".clearversion", "w+");
+			/* Update the upstreamversion that will be used to generate the new mix content */
+			FILE *verfile = fopen(MIX_DIR "upstreamversion", "w+");
 			if (!verfile) {
-				fprintf(stderr, "ERROR: fopen() %s/.clearversion returned %s\n", MIX_DIR, strerror(errno));
+				fprintf(stderr, "ERROR: fopen() %s/upstreamversion returned %s\n", MIX_DIR, strerror(errno));
 			} else {
 				fprintf(verfile, "%d", server_version);
 				fclose(verfile);
 			}
 
-			if (system("/usr/bin/swupd-add-pkg regenerate") != 0) {
-				fprintf(stderr, "ERROR: Could not execute swupd-add-pkg\n");
+			if (system("/usr/bin/mixin build") != 0) {
+				fprintf(stderr, "ERROR: Could not execute mixin\n");
 				ret = EXIT_FAILURE;
 				goto clean_curl;
 			}


### PR DESCRIPTION
Update mixer integration to key off the .valid-mix flag file to check if
a mix exists. Also update the .clearversion filename to upstreamurl (it
has changed in upstream).

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>