### PR TITLE
Fix findstatic warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,9 @@ install:
 # Ubuntu's default umask is 0002, but this break's swupd hash calculations.
 script:
         - sudo find test/functional -exec chmod g-w {} \;
-        - autoreconf --verbose --warnings=none --install --force && ./configure --enable-signature-verification && make -j48 && sudo sh -c 'umask 0022 && make -j48 check'
+        - autoreconf --verbose --warnings=none --install --force &&
+          ./configure --enable-signature-verification &&
+          make -j48 &&
+          sudo sh -c 'umask 0022 && make -j48 check' &&
+          sudo sh -c 'umask 0022 && make install'
 after_failure: cat test-suite.log

--- a/scripts/findstatic.pl
+++ b/scripts/findstatic.pl
@@ -14,6 +14,15 @@ $/ = $saved_delim;
 
 my(@lines) = split(/\n/s, $syms);
 
+# The design of this code expects there to be one definition
+# for each variable and multiple references. This just doesn't
+# work for "common" variables, which are declared multiple times
+# and lets the linker merge them.
+# In particular gcc creates a common variable __gnu_lto_v1 when invoked
+# with -flto for each file. So we pretend that we have a use for this variable.
+push(@lines, "MAGICRUNTIME: U __gnu_lto_v1");
+push(@lines, "MAGICRUNTIME: U __gnu_lto_slim");
+
 my(%def);
 my(%undef);
 my(%stype);

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -166,7 +166,7 @@ static int unload_tracked_bundle(const char *bundle_name, struct list **subs)
 }
 
 /* Return list of bundles that include bundle_name */
-void required_by(struct list **reqd_by, const char *bundle_name, struct manifest *mom, int recursion)
+static void required_by(struct list **reqd_by, const char *bundle_name, struct manifest *mom, int recursion)
 {
 	struct list *b, *i;
 	// track recursion level for indentation

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -879,6 +879,7 @@ bool version_files_consistent(void)
 	return (os_release_v >= state_v);
 }
 
+#if 0
 bool string_in_list(char *string_to_check, struct list *list_to_check)
 {
 	struct list *iter;
@@ -894,6 +895,7 @@ bool string_in_list(char *string_to_check, struct list *list_to_check)
 
 	return false;
 }
+#endif
 
 void print_progress(unsigned int count, unsigned int max)
 {

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -589,7 +589,7 @@ static void set_untracked_manifest_files(struct manifest *manifest)
 
 /* Removes the extracted Manifest.<bundle> and accompanying tar file, cache file, and
  * the signature file */
-void remove_manifest_files(char *filename, int version, char *hash)
+static void remove_manifest_files(char *filename, int version, char *hash)
 {
 	char *file;
 

--- a/src/search.c
+++ b/src/search.c
@@ -41,7 +41,7 @@ bool init = false;
 
 static char search_type = '0';
 static char scope = '0';
-int num_results = INT_MAX;
+static int num_results = INT_MAX;
 
 /* bundle_result contains the information to print along with
  * the internal relevancy score used to sort the output */
@@ -540,7 +540,7 @@ static bool file_search(char *filename, char *path, char *search_term)
 	return false;
 }
 
-double guess_score(char *bundle, char *file, char *search_term)
+static double guess_score(char *bundle, char *file, char *search_term)
 {
 	double multiplier = 1.0;
 	double score = 1.0;

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -222,7 +222,6 @@ extern struct list *create_update_list(struct manifest *server);
 extern void link_manifests(struct manifest *m1, struct manifest *m2);
 extern void link_submanifests(struct manifest *m1, struct manifest *m2, struct list *subs1, struct list *subs2, bool server);
 extern void free_manifest(struct manifest *manifest);
-extern void remove_manifest_files(char *filename, int version, char *hash);
 
 extern void grabtime_start(timelist *list, const char *name);
 extern void grabtime_stop(timelist *list);
@@ -383,7 +382,6 @@ extern bool is_tracked_bundle(const char *bundle_name);
 extern int remove_bundle(const char *bundle_name);
 extern int show_bundle_reqd_by(const char *bundle_name, bool server);
 extern int show_included_bundles(char *bundle_name);
-extern void required_by(struct list **list, const char *bundle_name, struct manifest *mom, int rl);
 extern int list_installable_bundles();
 extern int install_bundles_frontend(char **bundles);
 extern int add_subscriptions(struct list *bundles, struct list **subs, int current_version, struct manifest *mom, bool find_all, int recursion);

--- a/src/update.c
+++ b/src/update.c
@@ -97,9 +97,10 @@ static struct list *full_download_loop(struct list *updates, int isfailed)
 	return end_full_download();
 }
 
-/* This loads the upstream Clear Manifest.Full and local Manifest.full, and then checks
- * that there are no conflicts between the files they both include */
-int check_manifests_uniqueness(int clrver, int mixver)
+/* This loads the upstream Clear Manifest.Full and local
+ * Manifest.full, and then checks that there are no conflicts between
+ * the files they both include */
+static int check_manifests_uniqueness(int clrver, int mixver)
 {
 	struct manifest *clear = load_manifest_full(clrver, false);
 	struct manifest *mixer = load_manifest_full(mixver, true);

--- a/src/verifytime.c
+++ b/src/verifytime.c
@@ -28,7 +28,7 @@
 
 #define DAY_SECONDS 86400
 
-unsigned long int get_versionstamp(void)
+static unsigned long int get_versionstamp(void)
 {
 	struct stat statt;
 	FILE *fp = NULL;
@@ -62,7 +62,7 @@ unsigned long int get_versionstamp(void)
 	return strtoul(data, NULL, 10);
 }
 
-bool set_time(time_t mtime, char *time)
+static bool set_time(time_t mtime, char *time)
 {
 	if (stime(&mtime) != 0) {
 		fprintf(stderr, "Failed to set system time");


### PR DESCRIPTION
Fixes #448

Make a number of functions static, and bodge around the extra symbol
that gcc adds (__gnu_lto_v1) when compiling with -flto=4

Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>