### PR TITLE
swupd-add-pkg: write valid-mix flag file

### DIFF
--- a/swupd-add-pkg
+++ b/swupd-add-pkg
@@ -177,3 +177,6 @@ cd -
 
 # Clean up files
 rm -rf Manifest.MoM Manifest.MoM.sig
+
+# write valid-mix flag file so swupd-client is aware of the mix
+touch "$MIX_DIR/.valid-mix"


### PR DESCRIPTION
swupd-client expects a .valid-mix file to exist in MIX_DIR when a valid
mix exists. Create this file after creating the mix.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>