### PR TITLE
Fix automatic mix updates for mixer integration

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1434,7 +1434,12 @@ static int is_version_data(const char *filename)
 {
 	if (strcmp(filename, "/usr/lib/os-release") == 0 ||
 	    strcmp(filename, "/usr/share/clear/version") == 0 ||
-	    strcmp(filename, "/usr/share/clear/versionstamp") == 0) {
+	    strcmp(filename, "/usr/share/clear/versionstamp") == 0 ||
+	    strcmp(filename, "/usr/share/defaults/swupd/versionurl") == 0 ||
+	    strcmp(filename, "/usr/share/defaults/swupd/contenturl") == 0 ||
+	    strcmp(filename, "/usr/share/defaults/swupd/format") == 0 ||
+	    strcmp(filename, "/usr/share/clear/update-ca/Swupd_Root.pem") == 0 ||
+	    strcmp(filename, "/usr/share/clear/os-core-update-index") == 0) {
 		return 1;
 	}
 	return 0;

--- a/src/update.c
+++ b/src/update.c
@@ -351,15 +351,6 @@ version_check:
 		/* Check if a new upstream version is available so we can update to it still */
 		if (need_new_upstream(server_version)) {
 			printf("NEW CLEAR AVAILABLE %d\n", server_version);
-			ret = check_manifests_uniqueness(server_version, mix_server_version);
-			if (ret) {
-				printf("\n\t!! %i collisions were found between mix and upstream, please re-create mix !!\n", ret);
-				if (!allow_mix_collisions) {
-					ret = EXIT_FAILURE;
-					goto clean_curl;
-				}
-			}
-
 			/* Update the upstreamversion that will be used to generate the new mix content */
 			FILE *verfile = fopen(MIX_DIR "upstreamversion", "w+");
 			if (!verfile) {
@@ -374,6 +365,18 @@ version_check:
 				ret = EXIT_FAILURE;
 				goto clean_curl;
 			}
+
+			// new mix version
+			check_mix_versions(&mix_current_version, &mix_server_version, path_prefix);
+			ret = check_manifests_uniqueness(server_version, mix_server_version);
+			if (ret) {
+				printf("\n\t!! %i collisions were found between mix and upstream, please re-create mix !!\n", ret);
+				if (!allow_mix_collisions) {
+					ret = EXIT_FAILURE;
+					goto clean_curl;
+				}
+			}
+
 			goto version_check;
 		}
 		current_version = mix_current_version;


### PR DESCRIPTION
When a new upstream version is detected the new local mixer build must
be done before manifest uniqueness is checked. This is due to the fact
that os-core can change in the upstream version, so it has to be
re-built locally against the upstream content in order to avoid false
positives for file colisions.

Also add additional files are files that change on the system due to the
local mix. Add these to the ignore list for file colision checks.

Fixes #446 