### PR TITLE
Update: Fix memory leak on subscription list

### DIFF
--- a/src/update.c
+++ b/src/update.c
@@ -627,6 +627,11 @@ clean_curl:
 	if (re_update) {
 		versions_match = version_files_consistent();
 	}
+	if (latest_subs) {
+		list_free_list(current_subs);
+	} else {
+		free_subscriptions(&current_subs);
+	}
 	swupd_deinit(lock_fd, &latest_subs);
 
 	if (!download_only) {


### PR DESCRIPTION
If current_subs was cloned free the list structure. Free the list
and subscription data otherwise.

Fixes issue #363