### PR TITLE
Update: Change log order to have a clearer output

### DIFF
--- a/src/update.c
+++ b/src/update.c
@@ -624,6 +624,10 @@ clean_curl:
 	}
 	swupd_deinit(lock_fd, &latest_subs);
 
+	if (nonpack > 0) {
+		printf("%i files were not in a pack\n", nonpack);
+	}
+
 	if (!download_only) {
 		if ((current_version < server_version) && (ret == 0)) {
 			printf("Update successful. System updated from version %d to version %d\n",
@@ -631,10 +635,6 @@ clean_curl:
 		} else if (ret == 0) {
 			printf("Update complete. System already up-to-date at version %d\n", current_version);
 		}
-	}
-
-	if (nonpack > 0) {
-		printf("%i files were not in a pack\n", nonpack);
 	}
 
 	if (re_update && ret == 0) {

--- a/test/functional/update/boot-file/lines-checked
+++ b/test/functional/update/boot-file/lines-checked
@@ -13,5 +13,5 @@ Finishing download of update content...
 Staging file content
 Applying update
 Update was applied.
-Update successful. System updated from version 10 to version 100
 1 files were not in a pack
+Update successful. System updated from version 10 to version 100

--- a/test/functional/update/boot-skip/lines-checked
+++ b/test/functional/update/boot-skip/lines-checked
@@ -14,5 +14,5 @@ Staging file content
 Applying update
 Update was applied.
 WARNING: boot files update skipped due to --no-boot-update argument
-Update successful. System updated from version 10 to version 100
 1 files were not in a pack
+Update successful. System updated from version 10 to version 100

--- a/test/functional/update/include-old-bundle-with-tracked-file/lines-checked
+++ b/test/functional/update/include-old-bundle-with-tracked-file/lines-checked
@@ -13,5 +13,5 @@ Finishing download of update content...
 Staging file content
 Applying update
 Update was applied.
-Update successful. System updated from version 20 to version 30
 2 files were not in a pack
+Update successful. System updated from version 20 to version 30

--- a/test/functional/update/include-old-bundle/lines-checked
+++ b/test/functional/update/include-old-bundle/lines-checked
@@ -13,5 +13,5 @@ Finishing download of update content...
 Staging file content
 Applying update
 Update was applied.
-Update successful. System updated from version 10 to version 100
 3 files were not in a pack
+Update successful. System updated from version 10 to version 100

--- a/test/functional/update/include/lines-checked
+++ b/test/functional/update/include/lines-checked
@@ -13,5 +13,5 @@ Finishing download of update content...
 Staging file content
 Applying update
 Update was applied.
-Update successful. System updated from version 10 to version 100
 8 files were not in a pack
+Update successful. System updated from version 10 to version 100

--- a/test/functional/update/missing-os-core/lines-checked
+++ b/test/functional/update/missing-os-core/lines-checked
@@ -13,5 +13,5 @@ Finishing download of update content...
 Staging file content
 Applying update
 Update was applied.
-Update successful. System updated from version 10 to version 100
 1 files were not in a pack
+Update successful. System updated from version 10 to version 100

--- a/test/functional/update/re-update-bad-os-release/lines-checked
+++ b/test/functional/update/re-update-bad-os-release/lines-checked
@@ -13,6 +13,6 @@ Finishing download of update content...
 Staging file content
 Applying update
 Update was applied.
-Update successful. System updated from version 10 to version 20
 2 files were not in a pack
+Update successful. System updated from version 10 to version 20
 ERROR: Inconsistency between version files, exiting now.

--- a/test/functional/update/re-update-required/lines-checked
+++ b/test/functional/update/re-update-required/lines-checked
@@ -13,8 +13,8 @@ Finishing download of update content...
 Staging file content
 Applying update
 Update was applied.
-Update successful. System updated from version 10 to version 20
 3 files were not in a pack
+Update successful. System updated from version 10 to version 20
 Update started.
 Preparing to update from 100 to 110
 Statistics for going from version 100 to version 110:
@@ -30,5 +30,5 @@ Finishing download of update content...
 Staging file content
 Applying update
 Update was applied.
-Update successful. System updated from version 100 to version 110
 1 files were not in a pack
+Update successful. System updated from version 100 to version 110

--- a/test/functional/update/skip-scripts/lines-checked
+++ b/test/functional/update/skip-scripts/lines-checked
@@ -14,5 +14,5 @@ Staging file content
 Applying update
 Update was applied.
 WARNING: post-update helper scripts skipped due to --no-scripts argument
-Update successful. System updated from version 10 to version 100
 1 files were not in a pack
+Update successful. System updated from version 10 to version 100

--- a/test/functional/update/statedir-bad-hash/lines-checked
+++ b/test/functional/update/statedir-bad-hash/lines-checked
@@ -13,5 +13,5 @@ Finishing download of update content...
 Staging file content
 Applying update
 Update was applied.
-Update successful. System updated from version 10 to version 100
 1 files were not in a pack
+Update successful. System updated from version 10 to version 100

--- a/test/functional/update/use-full-file/lines-checked
+++ b/test/functional/update/use-full-file/lines-checked
@@ -13,5 +13,5 @@ Finishing download of update content...
 Staging file content
 Applying update
 Update was applied.
-Update successful. System updated from version 10 to version 100
 1 files were not in a pack
+Update successful. System updated from version 10 to version 100

--- a/test/functional/update/verify-fix-path-hash-mismatch/lines-checked
+++ b/test/functional/update/verify-fix-path-hash-mismatch/lines-checked
@@ -16,5 +16,5 @@ Hash did not match for path : /usr ... fixing
 Path /usr/bin is missing on the file system ... fixing
 Applying update
 Update was applied.
-Update successful. System updated from version 10 to version 100
 1 files were not in a pack
+Update successful. System updated from version 10 to version 100

--- a/test/functional/update/verify-fix-path-missing-dir/lines-checked
+++ b/test/functional/update/verify-fix-path-missing-dir/lines-checked
@@ -15,5 +15,5 @@ REGEXP:^Update target directory does not exist: .*/target-dir/usr/bin. Trying to
 Path /usr/bin is missing on the file system ... fixing
 Applying update
 Update was applied.
-Update successful. System updated from version 10 to version 100
 1 files were not in a pack
+Update successful. System updated from version 10 to version 100


### PR DESCRIPTION
Message informing that the system was successfully updated should be
the last message. Having a message that looks like an error as the
last message in an update can be confusing for users.