### PR TITLE
Remove #warnings from code. Use TODO instead

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -601,7 +601,7 @@ CURLcode swupd_curl_set_basic_options(CURL *curl, const char *url)
 	}
 
 	if (strncmp(url, "https://", 8) == 0) {
-#warning "SECURITY HOLE since we can't SSL pin arbitrary servers"
+		//TODO: Fix "SECURITY HOLE since we can't SSL pin arbitrary servers"
 		curl_ret = swupd_curl_set_security_opts(curl);
 		if (curl_ret != CURLE_OK) {
 			goto exit;

--- a/src/staging.c
+++ b/src/staging.c
@@ -62,7 +62,7 @@ static int create_staging_renamedir(char *rename_tmpdir)
 }
 
 /* Do the staging of new files into the filesystem */
-#warning "do_staging is currently not able to be run in parallel"
+//TODO: "do_staging is currently not able to be run in parallel"
 /* Consider adding a remove_leftovers() that runs in verify/fix in order to
  * allow this function to mkdtemp create folders for parallel build */
 int do_staging(struct file *file, struct manifest *MoM)

--- a/src/update.c
+++ b/src/update.c
@@ -682,12 +682,12 @@ static void print_help(const char *name)
 	fprintf(stderr, "Application Options:\n");
 	fprintf(stderr, "   -m, --manifest=M        Update to version M, also accepts 'latest' (default)\n");
 	fprintf(stderr, "   -d, --download          Download all content, but do not actually install the update\n");
-#warning "remove user configurable url when alternative exists"
+	//TODO: "remove user configurable url when alternative exists"
 	fprintf(stderr, "   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
 	fprintf(stderr, "   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
-#warning "remove user configurable content url when alternative exists"
+	//TODO: "remove user configurable content url when alternative exists"
 	fprintf(stderr, "   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
-#warning "remove user configurable version url when alternative exists"
+	//TODO: "remove user configurable version url when alternative exists"
 	fprintf(stderr, "   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
 	fprintf(stderr, "   -s, --status            Show current OS version and latest version available on server\n");
 	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");


### PR DESCRIPTION
All #warnings messages on swupd code were related to tasks to be performed
in the future and not real code warnings. Using the TODO comment, that is
already used for other tasks.

It's too annoying to see warning messages on compile time and having them
makes a bit harder to noticed when we are introducing real compiler warnings.