### PR TITLE
Refactor bundle-remove to handle multiple bundles

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -399,7 +399,11 @@ out:
 /*  This function is a fresh new implementation for a bundle
  *  remove without being tied to verify loop, this means
  *  improved speed and space as well as more roubustness and
- *  flexibility. What it does is basically:
+ *  flexibility. The function removes one ore more bundles
+ *  passed in the bundles param.
+ *
+ *  For each one of the bundles to be removed what it does
+ *  is basically:
  *
  *  1) Read MoM and load all submanifests except the one to be
  *  	removed and then consolidate them.
@@ -572,7 +576,7 @@ int remove_bundles(char **bundles)
 	}
 
 	if (bad > 0) {
-		fprintf(stderr, "%i bundle(s) of %i failed to remove\n", bad, total);
+		fprintf(stderr, "%i bundle(s) of %i failed to be removed\n", bad, total);
 	} else {
 		fprintf(stderr, "%i bundle(s) were removed successfully\n", total);
 	}

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -419,7 +419,7 @@ int remove_bundles(char **bundles)
 {
 	int lock_fd;
 	int ret = 0;
-	int retCode = 0;
+	int ret_code = 0;
 	int bad = 0;
 	int total = 0;
 	int current_version = CURRENT_OS_VERSION;
@@ -573,7 +573,7 @@ int remove_bundles(char **bundles)
 			  ret);
 		if (ret) {
 			fprintf(stderr, "Error: Bundle remove failed\n");
-			retCode = ret;
+			ret_code = ret;
 		}
 	}
 
@@ -585,7 +585,7 @@ int remove_bundles(char **bundles)
 
 	swupd_deinit(lock_fd, &subs);
 
-	return retCode;
+	return ret_code;
 }
 
 /* bitmapped return

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -36,22 +36,6 @@
 
 #define VERIFY_PICKY 1
 
-/* this is a temp container to save parsed
- * options so if more than one bundle to remove
- * then we can restore the parsed options into
- * globals
- */
-static struct opts {
-	char *path_prefix;
-	char *version_url;
-	char *content_url;
-	char *format_string;
-	char *state_dir;
-	char *cert_path;
-	bool force;
-	bool sigcheck;
-} curopts = { NULL, NULL, NULL, NULL, NULL, NULL, false, true };
-
 static char **bundles;
 
 static void print_help(const char *name)
@@ -105,7 +89,6 @@ static bool parse_options(int argc, char **argv)
 				fprintf(stderr, "Invalid --path argument\n\n");
 				goto err;
 			}
-			string_or_die(&curopts.path_prefix, "%s", optarg);
 			break;
 		case 'u':
 			if (!optarg) {
@@ -114,8 +97,6 @@ static bool parse_options(int argc, char **argv)
 			}
 			set_version_url(optarg);
 			set_content_url(optarg);
-			string_or_die(&curopts.version_url, "%s", optarg);
-			string_or_die(&curopts.content_url, "%s", optarg);
 			break;
 		case 'c':
 			if (!optarg) {
@@ -123,7 +104,6 @@ static bool parse_options(int argc, char **argv)
 				goto err;
 			}
 			set_content_url(optarg);
-			string_or_die(&curopts.content_url, "%s", optarg);
 			break;
 		case 'v':
 			if (!optarg) {
@@ -131,7 +111,6 @@ static bool parse_options(int argc, char **argv)
 				goto err;
 			}
 			set_version_url(optarg);
-			string_or_die(&curopts.version_url, "%s", optarg);
 			break;
 		case 'P':
 			if (sscanf(optarg, "%ld", &update_server_port) != 1) {
@@ -144,22 +123,18 @@ static bool parse_options(int argc, char **argv)
 				fprintf(stderr, "Invalid --format argument\n\n");
 				goto err;
 			}
-			string_or_die(&curopts.format_string, "%s", optarg);
 			break;
 		case 'S':
 			if (!optarg || !set_state_dir(optarg)) {
 				fprintf(stderr, "Invalid --statedir argument\n\n");
 				goto err;
 			}
-			string_or_die(&curopts.state_dir, "%s", optarg);
 			break;
 		case 'x':
 			force = true;
-			curopts.force = true;
 			break;
 		case 'n':
 			sigcheck = false;
-			curopts.sigcheck = false;
 			break;
 		case 'I':
 			timecheck = false;
@@ -170,7 +145,6 @@ static bool parse_options(int argc, char **argv)
 				goto err;
 			}
 			set_cert_path(optarg);
-			string_or_die(&curopts.cert_path, "%s", optarg);
 			break;
 		default:
 			fprintf(stderr, "error: unrecognized option\n\n");

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -67,7 +67,7 @@ static void print_help(const char *name)
 	fprintf(stderr, "   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
 	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	fprintf(stderr, "   -x, --force             Attempt to proceed even if non-critical errors found\n");
-	fprintf(stderr, "   -n, --nosigcheck       Do not attempt to enforce certificate or signature checks\n");
+	fprintf(stderr, "   -n, --nosigcheck        Do not attempt to enforce certificate or signature checks\n");
 	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
 	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");
 	fprintf(stderr, "   -C, --certpath          Specify alternate path to swupd certificates\n");
@@ -191,84 +191,11 @@ err:
 	return false;
 }
 
-static void reload_parsed_opts(void)
-{
-	if (curopts.path_prefix) {
-		set_path_prefix(curopts.path_prefix);
-	}
-
-	if (curopts.version_url) {
-		set_version_url(curopts.version_url);
-	}
-
-	if (curopts.content_url) {
-		set_content_url(curopts.content_url);
-	}
-
-	if (curopts.format_string) {
-		set_format_string(curopts.format_string);
-	}
-
-	if (curopts.state_dir) {
-		set_state_dir(curopts.state_dir);
-	}
-
-	if (curopts.cert_path) {
-		set_cert_path(curopts.cert_path);
-	}
-
-	force = curopts.force;
-	sigcheck = curopts.sigcheck;
-}
-
-static void free_saved_opts(void)
-{
-	free_string(&curopts.path_prefix);
-	free_string(&curopts.version_url);
-	free_string(&curopts.content_url);
-	free_string(&curopts.format_string);
-	free_string(&curopts.state_dir);
-	free_string(&curopts.cert_path);
-}
-
 int bundle_remove_main(int argc, char **argv)
 {
-	int ret = 0;
-	int total = 0;
-	int bad = 0;
-
 	if (!parse_options(argc, argv)) {
 		return EINVALID_OPTION;
 	}
 
-	for (; *bundles; ++bundles, total++) {
-		fprintf(stderr, "Removing bundle: %s\n", *bundles);
-
-		if (remove_bundle(*bundles) != 0) {
-			/* At least one bundle failed to be removed
-			 * then for consistency return an error
-			 * indicating that
-			 */
-			ret = EBUNDLE_REMOVE;
-			bad++;
-		}
-		/* if we have more than one bundle to process then
-		 * make sure to reload the parsed options since all
-		 * globals are cleaned up at swupd_deinit()
-		 */
-		if (*bundles) {
-			reload_parsed_opts();
-		}
-	}
-	/* print some statistics */
-	if (ret) {
-		fprintf(stderr, "%i bundle(s) of %i failed to remove\n", bad, total);
-	} else {
-		fprintf(stderr, "%i bundle(s) were removed successfully\n", total);
-	}
-
-	/* free any parsed opt saved for reloading */
-	free_saved_opts();
-
-	return ret;
+	return remove_bundles(bundles);
 }

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -377,7 +377,7 @@ extern void create_and_append_subscription(struct list **subs, const char *compo
 
 /* bundle.c */
 extern bool is_tracked_bundle(const char *bundle_name);
-extern int remove_bundle(const char *bundle_name);
+extern int remove_bundles(char **bundles);
 extern int show_bundle_reqd_by(const char *bundle_name, bool server);
 extern int show_included_bundles(char *bundle_name);
 extern int list_installable_bundles();

--- a/test/functional/bundleremove/include-nested/lines-checked
+++ b/test/functional/bundleremove/include-nested/lines-checked
@@ -8,4 +8,4 @@ format:
   * test-bundle2
     |-- test-bundle3
 Error: Bundle remove failed
-1 bundle(s) of 1 failed to remove
+1 bundle(s) of 1 failed to be removed

--- a/test/functional/bundleremove/include/lines-checked
+++ b/test/functional/bundleremove/include/lines-checked
@@ -7,4 +7,4 @@ format:
  # ...
   * test-bundle2
 Error: Bundle remove failed
-1 bundle(s) of 1 failed to remove
+1 bundle(s) of 1 failed to be removed

--- a/test/functional/bundleremove/remove-file/test.bats
+++ b/test/functional/bundleremove/remove-file/test.bats
@@ -25,4 +25,20 @@ teardown() {
   [ ! -f "$DIR/target-dir/test-file" ]
 }
 
+@test "bundle-remove remove bundle os-core" {
+  run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS os-core"
+
+  # EBUNDLE_NOT_TRACKED == 13
+  echo "$status"
+  [ "$status" -eq 13 ]
+}
+
+@test "bundle-remove remove untracked bundle" {
+  run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS os-core"
+
+  # EBUNDLE_NOT_TRACKED == 13
+  echo "$status"
+  [ "$status" -eq 13 ]
+}
+
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80

--- a/test/functional/bundleremove/remove-multiple/test.bats
+++ b/test/functional/bundleremove/remove-multiple/test.bats
@@ -32,9 +32,19 @@ teardown() {
 }
 
 @test "bundle-remove remove multiple bundles one exist and one that dont" {
-  run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle3 fake-bundle"
+  run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS fake-bundle test-bundle3"
 
-  [ ! -f "$DIR/target-dir/test-file3" ] && [ $status -eq 3 ]
+  # EBUNDLE_NOT_TRACKED == 13
+  echo "Status: $status"
+  [ ! -f "$DIR/target-dir/test-file3" ] && [ $status -eq 13 ]
+}
+
+@test "bundle-remove remove multiple bundles two exist and one is os-core" {
+  run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle1 os-core test-bundle2"
+
+  # EBUNDLE_NOT_TRACKED == 13
+  echo "Status: $status"
+  [ ! -f "$DIR/target-dir/test-file1" ] && [ ! -f "$DIR/target-dir/test-file2" ] && [ $status -eq 13 ]
 }
 
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
The current remove_bundle() function was designed to only be called
once, but for multiple bundle removals, it is currently called
multiple times.

This commit refactors this function so the bundle removal code can
handle multiple bundles at once.

Fixes #449