### PR TITLE
clean: use ctime instead of mtime

### DIFF
--- a/src/clean.c
+++ b/src/clean.c
@@ -141,7 +141,7 @@ static int remove_if(const char *path, remove_predicate_func pred)
 		}
 
 		if (!options.all) {
-			if (now.tv_sec - stat.st_mtime <= seconds) {
+			if (now.tv_sec - stat.st_ctime <= seconds) {
 				continue;
 			}
 		}


### PR DESCRIPTION
The ctime will represent the time the files were downloaded, instead
of the mtime generated at build time (which sometimes is the time of
build, but sometimes is not).

Fixes an issue reported by Otavio.