### PR TITLE
Enforce braces on single line ifs in make compliant

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -242,10 +242,16 @@ compliant:
 	git diff --quiet --exit-code src; ret=$$?; \
 	if [ $$ret -eq 1 ]; then \
 		echo "Code style issues found. Run 'git diff' to view issues."; \
+	fi; \
+	OUT=$$(git grep if\ \(.*\)$$ -- '*.c'); ret2=$$?; \
+	if [ $$ret2 -eq 0 ]; then \
+		echo "Missing brackets in single line if:"; \
+		echo "$$OUT"; \
 	elif [ $$ret -eq 0 ]; then \
 		echo "No code style issues found."; \
+		exit 0; \
 	fi; \
-	exit $$ret
+	exit 1
 
 release:
 	@git rev-parse v$(PACKAGE_VERSION) &> /dev/null; \

--- a/src/curl.c
+++ b/src/curl.c
@@ -128,8 +128,9 @@ int swupd_curl_check_network(void)
 	CURL *c;
 	static int has_network = 0;
 
-	if (has_network)
+	if (has_network) {
 		return 0;
+	}
 
 	if (!curl) {
 		return -1;

--- a/src/delta.c
+++ b/src/delta.c
@@ -158,8 +158,9 @@ void apply_deltas(struct manifest *current_manifest)
 
 		for (; ll && !found; ll = ll->next) {
 			struct file *file = ll->data;
-			if (file->is_deleted || file->is_ghosted || !file->is_file || !hash_equal(file->hash, from))
+			if (file->is_deleted || file->is_ghosted || !file->is_file || !hash_equal(file->hash, from)) {
 				continue;
+			}
 
 			/* Verify the actual file in the disk matches our expectations. */
 			char hash[SWUPD_HASH_LEN];


### PR DESCRIPTION
There's no way to inforce braces on single line ifs using clang-format.
Adding a grep to look for ifs without a bracket so we can at least
warn users about that.