### PR TITLE
Add os-core index to mixin state

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1325,7 +1325,8 @@ static int is_version_data(const char *filename)
 	    strcmp(filename, "/usr/share/defaults/swupd/contenturl") == 0 ||
 	    strcmp(filename, "/usr/share/defaults/swupd/format") == 0 ||
 	    strcmp(filename, "/usr/share/clear/update-ca/Swupd_Root.pem") == 0 ||
-	    strcmp(filename, "/usr/share/clear/os-core-update-index") == 0) {
+	    strcmp(filename, "/usr/share/clear/os-core-update-index") == 0 ||
+	    strcmp(filename, "/usr/share/clear/allbundles/os-core") == 0) {
 		return 1;
 	}
 	return 0;


### PR DESCRIPTION
Mixin re-creates the os-core bundle when creating a local mix. This
causes the corresponding os-core-update-index bundle-info file to have
changes to the metadata listed inside. Treate this as mixin state and do
not check hashes for this file.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>