### PR TITLE
Fixing a bunch of memory leaks

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -533,7 +533,7 @@ int remove_bundles(char **bundles)
 				fprintf(stderr, "%s", bundle);
 			}
 
-			list_free_list(reqd_by);
+			list_free_list_and_data(reqd_by, free);
 			ret = EBUNDLE_REMOVE;
 			bad++;
 			goto out_free_mom;

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -992,6 +992,7 @@ clean_and_exit:
 		  current_version,
 		  ret);
 
+	free_string(&bundles_list_str);
 	swupd_deinit(lock_fd, &subs);
 
 	return ret;

--- a/src/globals.c
+++ b/src/globals.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 #include "config.h"
 #include "swupd.h"
@@ -239,7 +240,9 @@ int get_version_from_path(const char *abs_path)
 
 	ret = get_value_from_path(&ret_str, abs_path, true);
 	if (ret == 0) {
-		return strtoull(ret_str, NULL, 10);
+		int val = strtoimax(ret_str, NULL, 10);
+		free_string(&ret_str);
+		return val;
 	}
 
 	return -1;

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -716,6 +716,10 @@ int verify_fix_path(char *targetpath, struct manifest *target_MoM)
 		path = list1->data;
 		list1 = list1->next;
 
+		free_string(&target);
+		free_string(&tar_dotfile);
+		free_string(&url);
+
 		target = mk_full_filename(path_prefix, path);
 
 		/* Search for the file in the manifest, to get the hash for the file */

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -211,10 +211,6 @@ static struct manifest *manifest_from_file(int version, char *component, bool he
 	}
 
 	manifest = alloc_manifest(version, component);
-	if (manifest == NULL) {
-		goto err_close;
-	}
-
 	manifest->filecount = filecount;
 	manifest->contentsize = contentsize;
 	manifest->manifest_version = manifest_enc_version;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1121,6 +1121,7 @@ struct list *filter_out_existing_files(struct list *files)
 {
 	struct list *list, *next, *ret;
 	struct file *file;
+	char *filename;
 
 	ret = files;
 
@@ -1130,9 +1131,11 @@ struct list *filter_out_existing_files(struct list *files)
 
 		file = list->data;
 
-		if (verify_file_lazy(mk_full_filename(path_prefix, file->filename))) {
+		filename = mk_full_filename(path_prefix, file->filename);
+		if (verify_file_lazy(filename)) {
 			ret = list_free_item(list, NULL);
 		}
+		free_string(&filename);
 
 		list = next;
 	}

--- a/src/packs.c
+++ b/src/packs.c
@@ -77,6 +77,7 @@ static int download_pack(int oldversion, int newversion, char *module, int is_mi
 			free_string(&filename);
 			return err;
 		}
+		free_string(&url);
 	}
 
 	fprintf(stderr, "\nExtracting %s pack for version %i\n", module, newversion);

--- a/src/search.c
+++ b/src/search.c
@@ -164,7 +164,8 @@ static void free_bundle_result_data(void *data)
 		return;
 	}
 
-	list_free_list(br->files);
+	list_free_list_and_data(br->files, free);
+	list_free_list_and_data(br->includes, free);
 	free(br);
 }
 
@@ -719,6 +720,7 @@ static void do_search(struct manifest *MoM, char search_type, char *search_term)
 	if (display_size) {
 		apply_size_penalty(bundle_info);
 	}
+	list_free_list_and_data(bundle_info, free_bundle_result_data);
 
 	if (num_results != INT_MAX) {
 		sort_results();

--- a/src/verify.c
+++ b/src/verify.c
@@ -378,6 +378,7 @@ static int check_files_hash(struct list *files)
 
 		fullname = mk_full_filename(path_prefix, f->filename);
 		valid = cmdline_option_quick ? verify_file_lazy(fullname) : verify_file(f, fullname);
+		free_string(&fullname);
 		if (valid) {
 			f->do_not_update = 1;
 		} else {

--- a/src/verify.c
+++ b/src/verify.c
@@ -889,7 +889,6 @@ load_submanifests:
 		fprintf(stderr, "Verifying files\n");
 		deal_with_hash_mismatches(official_manifest, repair);
 	}
-	free_manifest(official_manifest);
 
 brick_the_system_and_clean_curl:
 	/* clean up */
@@ -946,6 +945,7 @@ brick_the_system_and_clean_curl:
 	/* this concludes the critical section, after this point it's clean up time, the disk content is finished and final */
 
 clean_and_exit:
+	free_manifest(official_manifest);
 	telemetry(ret ? TELEMETRY_CRIT : TELEMETRY_INFO,
 		  "verify",
 		  "fix=%d\nret=%d\n"


### PR DESCRIPTION
Some people were complaining about memory leaks in swupd. I fixed the ones I found using -fsanitize=address and running the tests.