### PR TITLE
clean: separate into callable function and use in update

### DIFF
--- a/src/swupd.h
+++ b/src/swupd.h
@@ -411,6 +411,8 @@ extern void print_update_conf_info(void);
 
 extern void handle_mirror_if_stale(void);
 
+extern int clean_statedir(bool all, bool dry_run);
+
 /* some disk sizes constants for the various features:
  *   ...consider adding build automation to catch at build time
  *      if the build's artifacts are larger than these thresholds */

--- a/src/update.c
+++ b/src/update.c
@@ -547,6 +547,9 @@ clean_curl:
 	} else {
 		free_subscriptions(&current_subs);
 	}
+	/* clean up our cached content from the update. It is likely much more than
+	 * we need and the clean helps us prevent cache bloat. */
+	clean_statedir(false, false);
 	swupd_deinit(lock_fd, &latest_subs);
 
 	if (nonpack > 0) {


### PR DESCRIPTION
Separate the main statedir clean functionality into a callable function
and call it after performing an update. This helps clean up unused
files that bloat the state directory on a regular basis and helps
prevent the state directory from getting into a weird state over
updates.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

Fixes #378 