### PR TITLE
manpages: add return-code documentation

### DIFF
--- a/docs/swupd.1
+++ b/docs/swupd.1
@@ -532,6 +532,54 @@ return value higher than \fB1\fP signals a failure.
 .sp
 If the subcommand was \fBautoupdate\fP without options, then the program
 returns \fB0\fP if automatic updating is enabled.
+.sp
+The non\-zero return codes for other operations are listed here:
+.INDENT 0.0
+.INDENT 3.5
+.INDENT 0.0
+.IP \(bu 2
+\fB2\fP: At least one local bundle could not be found in the MoM manifest
+.IP \(bu 2
+\fB3\fP: Unable to delete bundle
+.IP \(bu 2
+\fB4\fP: Unable to download or read MoM manifest
+.IP \(bu 2
+\fB5\fP, \fB6\fP, \fB7\fP: File staging error
+.IP \(bu 2
+\fB8\fP: Unable to recursively load included manifests
+.IP \(bu 2
+\fB9\fP: Unable to obtain lock on state directory
+.IP \(bu 2
+\fB11\fP: Unable to initialize curl agent
+.IP \(bu 2
+\fB12\fP: Initialization error
+.IP \(bu 2
+\fB13\fP: Bundle not tracked on system
+.IP \(bu 2
+\fB14\fP: Unable to load manifest into memory
+.IP \(bu 2
+\fB15\fP: Invalid command\-line option
+.IP \(bu 2
+\fB16\fP: Unable to connect to update server
+.IP \(bu 2
+\fB16\fP, \fB17\fP, \fB404\fP: File download issue
+.IP \(bu 2
+\fB18\fP: Unable to install bundles
+.IP \(bu 2
+\fB19\fP: Unable to create required directories
+.IP \(bu 2
+\fB20\fP: Unable to determine current version of the OS
+.IP \(bu 2
+\fB21\fP: Unable to initialize signature verification
+.IP \(bu 2
+\fB22\fP: System time is off by a large margin
+.IP \(bu 2
+\fB23\fP: Pack download issue
+.IP \(bu 2
+\fB24\fP: Unable to verify server SSL certificate
+.UNINDENT
+.UNINDENT
+.UNINDENT
 .SS SEE ALSO
 .INDENT 0.0
 .IP \(bu 2

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -373,6 +373,30 @@ return value higher than ``1`` signals a failure.
 If the subcommand was ``autoupdate`` without options, then the program
 returns ``0`` if automatic updating is enabled.
 
+The non-zero return codes for other operations are listed here:
+
+  - **2**: At least one local bundle could not be found in the MoM manifest
+  - **3**: Unable to delete bundle
+  - **4**: Unable to download or read MoM manifest
+  - **5**, **6**, **7**: File staging error
+  - **8**: Unable to recursively load included manifests
+  - **9**: Unable to obtain lock on state directory
+  - **11**: Unable to initialize curl agent
+  - **12**: Initialization error
+  - **13**: Bundle not tracked on system
+  - **14**: Unable to load manifest into memory
+  - **15**: Invalid command-line option
+  - **16**: Unable to connect to update server
+  - **16**, **17**, **404**: File download issue
+  - **18**: Unable to install bundles
+  - **19**: Unable to create required directories
+  - **20**: Unable to determine current version of the OS
+  - **21**: Unable to initialize signature verification
+  - **22**: System time is off by a large margin
+  - **23**: Pack download issue
+  - **24**: Unable to verify server SSL certificate
+
+
 SEE ALSO
 --------
 

--- a/src/swupd-error.h
+++ b/src/swupd-error.h
@@ -9,7 +9,6 @@
 #define EDOTFILE_WRITE 7	/* do_staging() couldn't create a dotfile */
 #define ERECURSE_MANIFEST 8     /* error while recursing a manifest */
 #define ELOCK_FILE 9		/* cannot get the lock */
-#define EPREP_MOUNT 10		/* failed to prepare mount points */
 #define ECURL_INIT 11		/* cannot initialize curl agent */
 #define EINIT_GLOBALS 12	/* cannot initialize globals */
 #define EBUNDLE_NOT_TRACKED 13  /* bundle is not tracked on the system */


### PR DESCRIPTION
Additionally remove the unused EPREP_MOUNT error code.
Fixes #296

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>