### PR TITLE
Add free space check before adding bundles

### DIFF
--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -57,6 +57,7 @@ static void print_help(const char *name)
 	fprintf(stderr, "   -t, --time              Show verbose time output for swupd operations\n");
 	fprintf(stderr, "   -N, --no-scripts        Do not run the post-update scripts and boot update tool\n");
 	fprintf(stderr, "   -b, --no-boot-update    Do not update the boot files using clr-boot-manager\n");
+	fprintf(stderr, "   --skip-diskspace-check  Do not check free disk space before adding bundle\n");
 	fprintf(stderr, "\n");
 }
 
@@ -77,6 +78,7 @@ static const struct option prog_opts[] = {
 	{ "time", no_argument, 0, 't' },
 	{ "no-scripts", no_argument, 0, 'N' },
 	{ "no-boot-update", no_argument, 0, 'b' },
+	{ "skip-diskspace-check", no_argument, &skip_diskspace_check, 1 },
 	{ 0, 0, 0, 0 }
 };
 
@@ -164,6 +166,8 @@ static bool parse_options(int argc, char **argv)
 				goto err;
 			}
 			set_cert_path(optarg);
+			break;
+		case 0:
 			break;
 		default:
 			fprintf(stderr, "error: unrecognized option\n\n");

--- a/src/globals.c
+++ b/src/globals.c
@@ -54,6 +54,7 @@ char *mounted_dirs = NULL;
 char *bundle_to_add = NULL;
 struct timeval start_time;
 char *state_dir = NULL;
+int skip_diskspace_check = 0;
 
 /* NOTE: Today the content and version server urls are the same in
  * all cases.  It is highly likely these will eventually differ, eg:

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -184,6 +184,7 @@ extern char *swupd_cmd;
 extern char *bundle_to_add;
 extern struct timeval start_time;
 extern char *state_dir;
+extern int skip_diskspace_check;
 
 extern char *version_url;
 extern char *content_url;


### PR DESCRIPTION
Prevoiusly, when running bundle-add there was no check in
place to verify free storage before attempting to add the
new bundle.

Added this check, a warning message, and a flag to ignore
the message if desired.

Some functionality from search was moved out and is re-used
for calculating bundle sizes.

related to issue #266

Signed-off-by: Brian J Lovin <brian.j.lovin@intel.com>