### PR TITLE
Download

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,8 @@ swupd_SOURCES = \
 	src/globals.c \
 	src/hash.c \
 	src/hashdump.c \
+	src/hashmap.c \
+	src/hashmap.h \
 	src/helpers.c \
 	src/heuristics.c \
 	src/info.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -63,8 +63,7 @@ swupd_LDADD = \
 	$(openssl_LIBS) \
 	$(curl_LIBS) \
 	$(bsdiff_LIBS) \
-	$(libarchive_LIBS) \
-	$(pthread_LIBS)
+	$(libarchive_LIBS)
 
 verifytime_SOURCES = src/verifytime.c
 bin_PROGRAMS += verifytime

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,6 @@ PKG_CHECK_MODULES([zlib], [zlib])
 PKG_CHECK_MODULES([curl], [libcurl])
 PKG_CHECK_MODULES([openssl], [libcrypto >= 1.0.1])
 PKG_CHECK_MODULES([libarchive], [libarchive])
-AC_CHECK_LIB([pthread], [pthread_create])
 
 
 # Program checks

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -53,12 +53,6 @@ int list_installable_bundles()
 	int current_version;
 	bool mix_exists;
 
-	int ret = swupd_curl_check_network();
-	if (ret) {
-		fprintf(stderr, "Error: Network issue, unable to download manifest\n");
-		return ret;
-	}
-
 	current_version = get_current_version(path_prefix);
 	if (current_version < 0) {
 		fprintf(stderr, "Error: Unable to determine current OS version\n");

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -139,12 +139,6 @@ static int check_update()
 	}
 	swupd_curl_init();
 
-	int ret = swupd_curl_check_network();
-	if (ret) {
-		fprintf(stderr, "Error: Network issue, unable to check for update\n");
-		return ret;
-	}
-
 	read_versions(&current_version, &server_version, path_prefix);
 
 	if (server_version < 0) {

--- a/src/curl.c
+++ b/src/curl.c
@@ -160,7 +160,7 @@ static size_t filesize_from_header_cb(void UNUSED_PARAM *func, size_t size, size
 	return (size_t)(size * nmemb);
 }
 
-double swupd_query_url_content_size(char *url)
+double swupd_curl_query_content_size(char *url)
 {
 	CURLcode curl_ret;
 	double content_size;

--- a/src/curl.c
+++ b/src/curl.c
@@ -288,7 +288,7 @@ int swupd_curl_get_file_full(const char *url, char *filename,
 	bool local_download = strncmp(url, "file://", 7) == 0;
 
 	if (!curl) {
-		abort();
+		return -1;
 	}
 restart_download:
 	curl_easy_reset(curl);

--- a/src/curl.c
+++ b/src/curl.c
@@ -48,10 +48,8 @@
 
 static CURL *curl = NULL;
 
-/* these are used to handle alternative trust locations */
-static char *capath;
-static char **fallback_capaths;
-static char fallback_capaths_no;
+/* alternative CA Path */
+static char *capath = NULL;
 
 /* Pretty print curl return status */
 static void swupd_curl_strerror(CURLcode curl_ret)
@@ -59,9 +57,50 @@ static void swupd_curl_strerror(CURLcode curl_ret)
 	fprintf(stderr, "Curl error: (%d) %s\n", curl_ret, curl_easy_strerror(curl_ret));
 }
 
+static int check_connection(const char *test_capath)
+{
+	CURLcode curl_ret;
+
+	curl_ret = curl_easy_setopt(curl, CURLOPT_URL, version_url);
+	if (curl_ret != CURLE_OK) {
+		return -1;
+	}
+
+	curl_ret = curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
+	if (curl_ret != CURLE_OK) {
+		return -1;
+	}
+
+	if (test_capath) {
+		curl_ret = curl_easy_setopt(curl, CURLOPT_CAPATH, test_capath);
+		if (curl_ret != CURLE_OK) {
+			return -1;
+		}
+	}
+
+	curl_ret = curl_easy_perform(curl);
+
+	switch (curl_ret) {
+	case CURLE_OK:
+		return 0;
+	case CURLE_SSL_CACERT:
+		fprintf(stderr, "Error: unable to verify server SSL certificate\n");
+		return -EBADCERT;
+	default:
+		swupd_curl_strerror(curl_ret);
+		/* something bad, stop */
+		return -1;
+	}
+}
+
 int swupd_curl_init(void)
 {
 	CURLcode curl_ret;
+	char *str;
+	char *tok;
+	char *ctx;
+	int ret;
+	struct stat st;
 
 	curl_ret = curl_global_init(CURL_GLOBAL_ALL);
 	if (curl_ret != CURLE_OK) {
@@ -76,20 +115,13 @@ int swupd_curl_init(void)
 		return -1;
 	}
 
-#ifdef FALLBACK_CAPATHS
-	/* parse and initialize CA paths. */
-	{
-		char *str = strdup(FALLBACK_CAPATHS);
-		char *tok;
-		char *ctx;
-		struct stat st;
-		int i;
-		int sz = 1;
+	ret = check_connection(NULL);
+	if (ret == 0) {
+		return 0;
+	}
 
-		fallback_capaths = (char **)malloc(sz * sizeof(char *));
-		fallback_capaths[0] = NULL;
-		i = 1;
-
+	if (FALLBACK_CAPATHS[0]) {
+		str = strdup_or_die(FALLBACK_CAPATHS);
 		for (tok = strtok_r(str, ":", &ctx); tok; tok = strtok_r(NULL, ":", &ctx)) {
 			if (stat(tok, &st)) {
 				continue;
@@ -97,87 +129,16 @@ int swupd_curl_init(void)
 			if ((st.st_mode & S_IFMT) != S_IFDIR) {
 				continue;
 			}
-			if (i == sz) {
-				sz <<= 1;
-				fallback_capaths = (char **)realloc(fallback_capaths, sz * sizeof(char *));
-			}
-			fallback_capaths[i] = strdup(tok);
-			i++;
-		}
-		fallback_capaths_no = i;
-		free_string(&str);
-	}
-#else
-	fallback_capaths = (char **)malloc(sizeof(char *));
-	fallback_capaths[0] = NULL;
-	fallback_capaths_no = 1;
-#endif
 
-	return 0;
-}
-
-int swupd_curl_check_network(void)
-{
-	CURLcode curl_ret;
-	int ret = -1;
-	int i;
-	CURL *c;
-	static int has_network = 0;
-
-	if (has_network) {
-		return 0;
-	}
-
-	if (!curl) {
-		return -1;
-	}
-
-	c = curl_easy_duphandle(curl);
-	if (!c) {
-		return -1;
-	}
-
-	for (i = 0; i < fallback_capaths_no; i++) {
-		curl_easy_reset(c);
-
-		curl_ret = curl_easy_setopt(c, CURLOPT_URL, version_url);
-		if (curl_ret != CURLE_OK) {
-			goto cleanup;
-		}
-
-		curl_ret = curl_easy_setopt(c, CURLOPT_NOBODY, 1L);
-		if (curl_ret != CURLE_OK) {
-			goto cleanup;
-		}
-
-		if (i) { /* first element represents default CApath, means no explicit setting */
-			curl_ret = curl_easy_setopt(c, CURLOPT_CAPATH, fallback_capaths[i]);
-			if (curl_ret != CURLE_OK) {
+			ret = check_connection(tok);
+			if (ret == 0) {
+				capath = strdup_or_die(tok);
 				break;
 			}
 		}
-
-		curl_ret = curl_easy_perform(c);
-
-		switch (curl_ret) {
-		case CURLE_OK:
-			capath = fallback_capaths[i];
-			ret = 0;
-			has_network = 1;
-			goto cleanup;
-		case CURLE_SSL_CACERT:
-			fprintf(stderr, "Error: unable to verify server SSL certificate\n");
-			ret = EBADCERT;
-			break;
-		default:
-			swupd_curl_strerror(curl_ret);
-			/* something bad, stop */
-			goto cleanup;
-		}
+		free_string(&str);
 	}
 
-cleanup:
-	curl_easy_cleanup(c);
 	return ret;
 }
 
@@ -187,6 +148,9 @@ void swupd_curl_deinit(void)
 		curl_easy_cleanup(curl);
 	}
 	curl = NULL;
+
+	free_string(&capath);
+
 	curl_global_cleanup();
 }
 

--- a/src/datatypes.h
+++ b/src/datatypes.h
@@ -1,0 +1,16 @@
+#ifndef __INCLUDE_GUARD_DATATYPE_H
+#define __INCLUDE_GUARD_DATATYPE_H
+
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*free_data_fn_t)(void *data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/download.c
+++ b/src/download.c
@@ -135,7 +135,7 @@ static size_t file_hash_value(const void *data)
 	return HASH_VALUE(((struct file *)data)->hash[0]);
 }
 
-int start_full_download(bool pipelining)
+int start_full_download()
 {
 	if (swupd_curl_hashmap) {
 		return -1;
@@ -149,17 +149,7 @@ int start_full_download(bool pipelining)
 		return -1;
 	}
 
-	/*
-	 * we want to not do HTTP pipelining once things have failed once.. in case some transpoxy in the middle
-	 * is even more broken than average. This at least will allow the user to update, albeit slowly.
-	 */
-	if (pipelining) {
-		curl_multi_setopt(mcurl, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX | CURLPIPE_HTTP1);
-	} else {
-		/* survival: don't go too parallel in verify/fix loop */
-		MAX_XFER = 1;
-		MAX_XFER_BOTTOM = 1;
-	}
+	curl_multi_setopt(mcurl, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX | CURLPIPE_HTTP1);
 
 	fprintf(stderr, "Starting download of remaining update content. This may take a while...\n");
 

--- a/src/download.c
+++ b/src/download.c
@@ -58,9 +58,21 @@ static struct list *failed = NULL;
  * traversing a manifest, doing hash comparisons, and (re)staging any files
  * whose hash miscompares.
  *
- * file->hash[0] acts as index into the arrays
+ * file->hash[0:1] acts as index into the arrays
  */
 #define SWUPD_CURL_HASH_BUCKETS 256
+
+/*
+ * Converts a character to its hexadecimal value (0 to 15 assuming that the
+ * input was from the set 0123456789abcdef).
+ */
+#define HASH_VALUE(h) (h >= 'a' ? h - 'a' + 10 : h - '0')
+
+/*
+ * converts two characters to a value in the range 0 to 255.
+ */
+#define HASH_TO_KEY(hash) (HASH_VALUE(hash[0]) << 4 | HASH_VALUE(hash[1]))
+
 static struct list *swupd_curl_hashmap[SWUPD_CURL_HASH_BUCKETS];
 
 /* try to insert the file into the hashmap download queue
@@ -74,7 +86,7 @@ static int swupd_curl_hashmap_insert(struct file *file)
 	char *tar_dotfile;
 	char *targetfile;
 	struct stat stat;
-	int hashmap_index = file->hash[0];
+	int hashmap_index = HASH_TO_KEY(file->hash);
 	struct list **bucket;
 
 	bucket = &swupd_curl_hashmap[hashmap_index];

--- a/src/fullfile.c
+++ b/src/fullfile.c
@@ -90,7 +90,7 @@ int download_fullfiles(struct list *files, int num_retries, int timeout)
 	int retries = 0;
 
 	while (files) {
-		ret = start_full_download(true);
+		ret = start_full_download();
 		if (ret != 0) {
 			/* If we hit this point, the network is accessible but we were
 			 * unable to download the needed files. This is a terminal error

--- a/src/fullfile.c
+++ b/src/fullfile.c
@@ -110,7 +110,6 @@ int download_fullfiles(struct list *files, int num_retries, int timeout)
 
 			increment_retries(&retries, &timeout);
 			fprintf(stderr, "Starting download retry #%d\n", retries);
-			clean_curl_multi_queue();
 		}
 	}
 

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -1,0 +1,139 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2012-2016 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Authors:
+ *         Otavio Pontes <otavio.pontes@intel.com>
+ *
+ */
+
+#define _GNU_SOURCE
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hashmap.h"
+#include "list.h"
+
+#define HASH_MASK(bits) (HASH_SIZE(bits) - 1)
+
+static inline struct list **get_hashmap_list(struct hashmap *hashmap, const void *data)
+{
+	return &hashmap->map[hashmap->hash(data) || HASH_MASK(hashmap->mask_bits)];
+}
+
+static unsigned int calc_bits(size_t capacity)
+{
+	unsigned int bits = 0;
+
+	if (!capacity) {
+		return 0;
+	}
+
+	capacity--;
+	while (capacity) {
+		capacity >>= 1;
+		bits++;
+	}
+
+	return bits;
+}
+
+struct hashmap *hashmap_new(size_t capacity, hash_equal_fn_t equal, hash_fn_t hash)
+{
+	struct hashmap *hashmap;
+	unsigned int mask_bits = calc_bits(capacity);
+	size_t real_capacity = HASH_SIZE(mask_bits);
+
+	hashmap = calloc(1, sizeof(struct hashmap) + real_capacity * sizeof(struct list *));
+	if (!hashmap) {
+		return NULL;
+	}
+	hashmap->mask_bits = mask_bits;
+	hashmap->hash = hash;
+	hashmap->equal = equal;
+
+	return hashmap;
+}
+
+void hashmap_free_hash_and_data(struct hashmap *hashmap, free_data_fn_t free_data)
+{
+	int i;
+
+	for (i = 0; i < HASH_SIZE(hashmap->mask_bits); i++) {
+		list_free_list_and_data(hashmap->map[i], free_data);
+	}
+
+	free(hashmap);
+}
+
+void hashmap_free(struct hashmap *hashmap)
+{
+	hashmap_free_hash_and_data(hashmap, NULL);
+}
+
+bool hashmap_put(struct hashmap *hashmap, void *data)
+{
+	struct list **items, *i;
+
+	items = get_hashmap_list(hashmap, data);
+	for (i = *items; i; i = i->next) {
+		if (hashmap->equal(data, i->data)) {
+			return false;
+		}
+	}
+	*items = list_prepend_data(*items, data);
+
+	return true;
+}
+
+static struct list *hashmap_get_internal(struct hashmap *hashmap, const void *key, bool remove)
+{
+	struct list **items, *i;
+
+	items = get_hashmap_list(hashmap, key);
+	for (i = *items; i; i = i->next) {
+		if (hashmap->equal(key, i->data) == 0) {
+			void *data = i->data;
+			if (remove) {
+				//If it's the first element of the list, update head
+				if (i == *items) {
+					*items = i->next;
+				}
+				list_free_item(i, NULL);
+			}
+			return data;
+		}
+	}
+
+	return NULL;
+}
+
+void *hashmap_get(struct hashmap *hashmap, const void *key)
+{
+	return hashmap_get_internal(hashmap, key, false);
+}
+
+void *hashmap_pop(struct hashmap *hashmap, const void *key)
+{
+	return hashmap_get_internal(hashmap, key, true);
+}
+
+bool hashmap_contains(struct hashmap *hashmap, const void *key)
+{
+	return hashmap_get_internal(hashmap, key, false) != NULL;
+}

--- a/src/hashmap.h
+++ b/src/hashmap.h
@@ -1,0 +1,84 @@
+#ifndef __INCLUDE_GUARD_HASH_H
+#define __INCLUDE_GUARD_HASH_H
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define HASH_SIZE(bits) (1 << bits)
+
+typedef void (*free_data_fn_t)(void *data);
+typedef size_t (*hash_fn_t)(const void *data);
+typedef bool (*hash_equal_fn_t)(const void *a, const void *b);
+
+struct hashmap {
+	unsigned int mask_bits;
+	hash_equal_fn_t equal;
+	hash_fn_t hash;
+	struct list *map[];
+};
+
+/*
+ * Create a new hashmap. Size of the hashmap will be the closest power of 2 number
+ * greater than capacity.
+ * Function hash will be used as a hash function and equal to compare elements.
+ */
+struct hashmap *hashmap_new(size_t capacity, hash_equal_fn_t equal, hash_fn_t hash);
+
+/*
+ * Put an element into the hashmap, if it isn't already in the hashmap.
+ *
+ * Return true if the element was added or false if the element was already
+ * in the hashmap.
+ */
+bool hashmap_put(struct hashmap *hashmap, void *data);
+
+/*
+ * Retrieve an element from the hashmap.
+ *
+ * Return the element or NULL if not found.
+ */
+void *hashmap_get(struct hashmap *hashmap, const void *key);
+
+/*
+ * Remove and element from the hashmap.
+ *
+ * Return the removed element or NULL if not found.
+ */
+void *hashmap_pop(struct hashmap *hashmap, const void *key);
+
+/*
+ * Check if the hashmap contains a specific element.
+ */
+bool hashmap_contains(struct hashmap *hashmap, const void *key);
+
+/*
+ * Free the hashmap.
+ */
+void hashmap_free(struct hashmap *hashmap);
+
+/*
+ * Free the hashmap and all data using free_data() function.
+ */
+void hashmap_free_hash_and_data(struct hashmap *hashmap, free_data_fn_t free_data);
+
+/*
+ * Loop through all elements in the hashmap.
+ *
+ * i will be set with the current position on the hash table.
+ * l will be set with the current list element.
+ * data will be set with the data of the current element.
+ */
+#define HASHMAP_FOREACH(hashmap, i, l, data)                         \
+	for (i = 0; i < HASH_SIZE(hashmap->mask_bits); i++)          \
+		for (l = hashmap->map[i], data = l ? l->data : NULL; \
+		     l && (data = l->data); l = l->next)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -584,6 +584,21 @@ out_fds:
 	return ret;
 }
 
+/* Return a duplicated copy of the string using strdup().
+ * Abort if there's no memory to allocate the new string.
+*/
+char *strdup_or_die(const char *const str)
+{
+	char *result;
+
+	result = strdup(str);
+	if (!result) {
+		abort();
+	}
+
+	return result;
+}
+
 void string_or_die(char **strp, const char *fmt, ...)
 {
 	va_list ap;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -472,12 +472,6 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 	}
 	free_string(&filename);
 
-	ret = swupd_curl_check_network();
-	if (ret) {
-		ret = -ret;
-		goto out;
-	}
-
 	string_or_die(&dir, "%s/%i", state_dir, version);
 	ret = mkdir(dir, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 	if ((ret != 0) && (errno != EEXIST)) {

--- a/src/packs.c
+++ b/src/packs.c
@@ -109,11 +109,6 @@ int download_subscribed_packs(struct list *subs, struct manifest *mom, bool requ
 	unsigned int list_length = list_len(subs);
 	unsigned int complete = 0;
 
-	int ret = swupd_curl_check_network();
-	if (ret) {
-		return -ret;
-	}
-
 	fprintf(stderr, "Downloading packs...\n");
 	iter = list_head(subs);
 	while (iter) {

--- a/src/search.c
+++ b/src/search.c
@@ -870,12 +870,6 @@ int search_main(int argc, char **argv)
 		return ret;
 	}
 
-	ret = swupd_curl_check_network();
-	if (ret) {
-		fprintf(stderr, "Error: Network issue, unable to proceed with update\n");
-		goto clean_exit;
-	}
-
 	if (!init) {
 		fprintf(stderr, "Searching for '%s'\n\n", search_string);
 	}

--- a/src/search.c
+++ b/src/search.c
@@ -756,7 +756,7 @@ static double query_total_download_size(struct list *list)
 			string_or_die(&url, "%s/%i/Manifest.%s.tar", content_url,
 				      file->last_change, file->filename);
 
-			ret = swupd_query_url_content_size(url);
+			ret = swupd_curl_query_content_size(url);
 			free_string(&url);
 			if (ret != -1) {
 				/* Convert file size from bytes to MB */

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -199,7 +199,6 @@ extern void set_cert_path(char *path);
 extern bool set_state_dir(char *path);
 
 extern void check_root(void);
-extern void clean_curl_multi_queue(void);
 extern void increment_retries(int *retries, int *timeout);
 
 extern int add_included_manifests(struct manifest *mom, int current, struct list **subs);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -362,6 +362,7 @@ extern void print_manifest_files(struct manifest *m);
 extern void swupd_deinit(int lock_fd, struct list **subs);
 extern int swupd_init(int *lock_fd);
 extern void string_or_die(char **strp, const char *fmt, ...);
+char *strdup_or_die(const char *const str);
 extern void free_string(char **s);
 void update_motd(int new_release);
 void delete_motd(void);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -300,7 +300,6 @@ extern int update_device_latest_version(int version);
 
 extern int swupd_curl_init(void);
 extern void swupd_curl_deinit(void);
-extern int swupd_curl_check_network(void);
 extern double swupd_query_url_content_size(char *url);
 extern CURLcode swupd_download_file_start(struct file *file);
 extern CURLcode swupd_download_file_complete(CURLcode curl_ret, struct file *file);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -300,7 +300,7 @@ extern int update_device_latest_version(int version);
 
 extern int swupd_curl_init(void);
 extern void swupd_curl_deinit(void);
-extern double swupd_query_url_content_size(char *url);
+extern double swupd_curl_query_content_size(char *url);
 extern CURLcode swupd_download_file_start(struct file *file);
 extern CURLcode swupd_download_file_complete(CURLcode curl_ret, struct file *file);
 extern int swupd_curl_get_file(const char *url, char *filename);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -288,7 +288,7 @@ extern int download_subscribed_packs(struct list *subs, struct manifest *mom, bo
 
 extern void apply_deltas(struct manifest *current_manifest);
 extern void full_download(struct file *file);
-extern int start_full_download(bool pipelining);
+extern int start_full_download();
 extern struct list *end_full_download(void);
 extern int untar_full_download(void *data);
 

--- a/src/update.c
+++ b/src/update.c
@@ -236,12 +236,6 @@ static int main_update()
 	clock_gettime(CLOCK_MONOTONIC_RAW, &ts_start);
 	grabtime_start(&times, "Main Update");
 
-	ret = swupd_curl_check_network();
-	if (ret) {
-		fprintf(stderr, "Error: Network issue, unable to proceed with update\n");
-		goto clean_curl;
-	}
-
 	mix_exists = check_mix_exists();
 
 	fprintf(stderr, "Update started.\n");

--- a/src/verify.c
+++ b/src/verify.c
@@ -706,12 +706,6 @@ int verify_main(int argc, char **argv)
 
 	fprintf(stderr, "Verifying version %i\n", version);
 
-	ret = swupd_curl_check_network();
-	if (ret) {
-		fprintf(stderr, "Error: Network issue, unable to download manifest\n");
-		goto clean_and_exit;
-	}
-
 	read_subscriptions(&subs);
 
 	/*

--- a/src/version.c
+++ b/src/version.c
@@ -147,11 +147,6 @@ int check_versions(int *current_version,
 		   int requested_version,
 		   char *path_prefix)
 {
-
-	if (swupd_curl_check_network()) {
-		return -1;
-	}
-
 	read_versions(current_version, server_version, path_prefix);
 
 	if (*current_version < 0) {

--- a/test/functional/verify/latest-missing/lines-checked
+++ b/test/functional/verify/latest-missing/lines-checked
@@ -1,2 +1,2 @@
-Unable to get latest version for install
-Error: Fix did not fully succeed
+Curl error: (37) Couldn't read a file:// file
+Failed verify initialization, exiting now.

--- a/test/functional/verify/latest-missing/test.bats
+++ b/test/functional/verify/latest-missing/test.bats
@@ -5,7 +5,7 @@ load "../../swupdlib"
 @test "verify install using latest with missing version file on server" {
   run sudo sh -c "$SWUPD verify $SWUPD_OPTS --install -m latest"
 
-  check_lines "$output"
+  check_lines "$(echo "$output" | uniq)"
 }
 
 # vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
Pull request with some fixes and some preparation to the fix of #298.

Please, consider a careful review of "5322aff: download: remove mutex lock in single thread code" because I don't know the reason the mutex lock was added to that file and I may have missed something.

Another point I'd like to be carefully reviewed is the "curl: Set fallback CA paths in swupd_curl_init()" commit. Is there any reason we needed to check the connection using swupd_curl_check_network() in a moment different from when we called swupd_curl_init()?