### PR TITLE
fix file descriptor leak check.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
         - pushd bsdiff-1.0.2 && ./configure --prefix=/usr --disable-tests && make -j48 && sudo make install && popd
         - wget https://curl.haxx.se/download/curl-7.51.0.tar.gz
         - tar -xvf curl-7.51.0.tar.gz
-        - pushd curl-7.51.0 && ./configure --prefix=/usr && make -j48 && sudo make install && popd
+        - pushd curl-7.51.0 && ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu && make -j48 && sudo make install && popd
         - wget https://download.clearlinux.org/releases/13010/clear/Swupd_Root.pem
         - sudo install -D -m0644 Swupd_Root.pem /usr/share/clear/update-ca/Swupd_Root.pem
         - wget https://github.com/libarchive/libarchive/archive/v3.3.1.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
         - sudo install -D -m0644 Swupd_Root.pem /usr/share/clear/update-ca/Swupd_Root.pem
         - wget https://github.com/libarchive/libarchive/archive/v3.3.1.tar.gz
         - tar -xvf v3.3.1.tar.gz
-        - pushd libarchive-3.3.1 && autoreconf -fi && ./configure --prefix=/usr && make && sudo make install && popd
+        - pushd libarchive-3.3.1 && autoreconf -fi && ./configure --prefix=/usr && make -j48 && sudo make install && popd
         - sudo apt-get install python3-docutils
         - sudo ln -s /usr/share/docutils/scripts/python3/rst2man /usr/bin/rst2man.py
 

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -534,6 +534,7 @@ int swupd_init(int *lock_fd)
 	int ret = 0;
 
 	check_root();
+	close_fds();
 
 	/* Check that our system time is reasonably valid before continuing,
 	 * or the certificate verification will fail with invalid time */

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -534,7 +534,7 @@ int swupd_init(int *lock_fd)
 	int ret = 0;
 
 	check_root();
-	close_fds();
+	record_fds();
 
 	/* Check that our system time is reasonably valid before continuing,
 	 * or the certificate verification will fail with invalid time */

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -329,7 +329,6 @@ extern bool verify_file(struct file *file, char *filename);
 extern bool verify_file_lazy(char *filename);
 extern int verify_bundle_hash(struct manifest *manifest, struct file *bundle);
 extern void unlink_all_staged_content(struct file *file);
-extern void dump_file_descriptor_leaks(void);
 extern int rm_staging_dir_contents(const char *rel_path);
 void free_file_data(void *data);
 void free_manifest_data(void *data);
@@ -345,6 +344,10 @@ extern bool is_under_mounted_directory(const char *filename);
 
 extern void run_scripts(bool block);
 extern void run_preupdate_scripts(struct manifest *manifest);
+
+/* filedesc.c */
+extern void dump_file_descriptor_leaks(void);
+extern void close_fds(void);
 
 /* lock.c */
 int p_lockfile(void);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -347,7 +347,7 @@ extern void run_preupdate_scripts(struct manifest *manifest);
 
 /* filedesc.c */
 extern void dump_file_descriptor_leaks(void);
-extern void close_fds(void);
+extern void record_fds(void);
 
 /* lock.c */
 int p_lockfile(void);

--- a/test/functional/ignore-list
+++ b/test/functional/ignore-list
@@ -6,5 +6,4 @@
 ^Update took .* seconds$
 ^sh: .*/usr/bin/clr-boot-manager: No such file or directory$
 ^sh: .*/usr/bin/clr-boot-manager: not found$
-^Possible filedescriptor leak: .*$
 ^\.+$


### PR DESCRIPTION
The readlink call was being used inefficiently (it has a lousy api).
Close extra file descriptors that are passed in to us, so we don't
complain if they are open at the end.

Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>