### PR TITLE
Aborts and error handling

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1151,10 +1151,7 @@ int list_local_bundles()
 		}
 		/* Need to dup the strings as the directory
 		 * may be bigger than the size of the I/O buffer */
-		char *name = strdup(ent->d_name);
-		if (!name) {
-			abort();
-		}
+		char *name = strdup_or_die(ent->d_name);
 		bundles = list_append_data(bundles, name);
 	}
 

--- a/src/extra_files.c
+++ b/src/extra_files.c
@@ -73,9 +73,9 @@ static int record_filename(const char *name, const struct stat *stat __attribute
 		}
 	}
 
-	char *savedname = strdup(relname);     /* Only store name relative to top of area */
-	F = realloc(F, (nF + 1) * sizeof(*F)); /* TODO, check realloc is smart, so don't need to double myself */
-	if (!F || !savedname) {
+	char *savedname = strdup_or_die(relname); /* Only store name relative to top of area */
+	F = realloc(F, (nF + 1) * sizeof(*F));    /* TODO, check realloc is smart, so don't need to double myself */
+	if (!F) {
 		fprintf(stderr, "Out of memory allocating %d filenames\n", nF);
 		abort(); /* For consistency with string_or_die on out of memory*/
 		return -ENOMEM;

--- a/src/hashdump.c
+++ b/src/hashdump.c
@@ -105,10 +105,7 @@ int hashdump_main(int argc, char **argv)
 		exit(-1);
 	}
 
-	file->filename = strdup(argv[optind]);
-	if (!file->filename) {
-		abort();
-	}
+	file->filename = strdup_or_die(argv[optind]);
 
 	ret = set_path_prefix(NULL);
 	if (!ret) {
@@ -121,10 +118,7 @@ int hashdump_main(int argc, char **argv)
 	if (use_prefix) {
 		fullname = mk_full_filename(path_prefix, file->filename);
 	} else {
-		fullname = strdup(file->filename);
-		if (!fullname) {
-			abort();
-		}
+		fullname = strdup_or_die(file->filename);
 	}
 
 	fprintf(stderr, "Calculating hash %s xattrs for: %s\n",

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -291,12 +291,9 @@ char *mk_full_filename(const char *prefix, const char *path)
 	char *abspath;
 
 	if (path[0] == '/') {
-		abspath = strdup(path);
+		abspath = strdup_or_die(path);
 	} else {
 		string_or_die(&abspath, "/%s", path);
-	}
-	if (abspath == NULL) {
-		abort();
 	}
 
 	if (prefix == NULL) {
@@ -309,16 +306,10 @@ char *mk_full_filename(const char *prefix, const char *path)
 	if ((strcmp(prefix, "/") == 0) ||
 	    (strcmp(prefix, "") == 0)) {
 		// rootfs, use absolute path
-		fname = strdup(abspath);
-		if (fname == NULL) {
-			abort();
-		}
+		fname = strdup_or_die(abspath);
 	} else if (strcmp(&prefix[strlen(prefix) - 1], "/") == 0) {
 		// chroot and need to strip trailing "/" from prefix
-		char *tmp = strdup(prefix);
-		if (tmp == NULL) {
-			abort();
-		}
+		char *tmp = strdup_or_die(prefix);
 		tmp[strlen(tmp) - 1] = '\0';
 
 		string_or_die(&fname, "%s%s", tmp, abspath);
@@ -370,10 +361,7 @@ bool is_under_mounted_directory(const char *filename)
 		return false;
 	}
 
-	dir = strdup(mounted_dirs);
-	if (dir == NULL) {
-		abort();
-	}
+	dir = strdup_or_die(mounted_dirs);
 
 	token = strtok(dir + 1, ":");
 	while (token != NULL) {
@@ -745,7 +733,7 @@ int verify_fix_path(char *targetpath, struct manifest *target_MoM)
 	}
 
 	/* Removing trailing '/' from the path */
-	path = strdup(targetpath);
+	path = strdup_or_die(targetpath);
 	if (path[strlen(path) - 1] == '/') {
 		path[strlen(path) - 1] = '\0';
 	}
@@ -754,8 +742,8 @@ int verify_fix_path(char *targetpath, struct manifest *target_MoM)
 	 * eg. Path /usr/bin/foo will be broken into /usr,/usr/bin and /usr/bin/foo
 	 */
 	while (strcmp(path, "/") != 0) {
-		path_list = list_prepend_data(path_list, strdup(path));
-		tmp = strdup(dirname(path));
+		path_list = list_prepend_data(path_list, strdup_or_die(path));
+		tmp = strdup_or_die(dirname(path));
 		free_string(&path);
 		path = tmp;
 	}

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -288,37 +288,26 @@ static void get_mounted_directories(void)
 char *mk_full_filename(const char *prefix, const char *path)
 {
 	char *fname = NULL;
-	char *abspath;
+	size_t len = 0;
 
+	if (!path) {
+		return NULL;
+	}
+
+	if (prefix) {
+		len = strlen(prefix);
+	}
+	//Remove trailing '/' at the end of prefix
+	while (len && prefix[len - 1] == '/') {
+		len--;
+	}
+
+	//make sure a '/' will always be added between prefix and path
 	if (path[0] == '/') {
-		abspath = strdup_or_die(path);
+		string_or_die(&fname, "%.*s%s", len, prefix, path);
 	} else {
-		string_or_die(&abspath, "/%s", path);
+		string_or_die(&fname, "%.*s/%s", len, prefix, path);
 	}
-
-	if (prefix == NULL) {
-		return abspath;
-	}
-
-	// The prefix is a minimum of "/" or "".  If the prefix is only that,
-	// just use abspath.  If the prefix is longer than the minimal, insure
-	// it ends in not "/" and append abspath.
-	if ((strcmp(prefix, "/") == 0) ||
-	    (strcmp(prefix, "") == 0)) {
-		// rootfs, use absolute path
-		fname = strdup_or_die(abspath);
-	} else if (strcmp(&prefix[strlen(prefix) - 1], "/") == 0) {
-		// chroot and need to strip trailing "/" from prefix
-		char *tmp = strdup_or_die(prefix);
-		tmp[strlen(tmp) - 1] = '\0';
-
-		string_or_die(&fname, "%s%s", tmp, abspath);
-		free_string(&tmp);
-	} else {
-		// chroot and no need to strip trailing "/" from prefix
-		string_or_die(&fname, "%s%s", prefix, abspath);
-	}
-	free_string(&abspath);
 	return fname;
 }
 

--- a/src/list.c
+++ b/src/list.c
@@ -56,11 +56,13 @@ static struct list *list_alloc_item(void *data)
 	struct list *item;
 
 	item = (struct list *)malloc(sizeof(struct list));
-	if (item) {
-		item->data = data;
-		item->next = NULL;
-		item->prev = NULL;
+	if (!item) {
+		abort();
 	}
+
+	item->data = data;
+	item->next = NULL;
+	item->prev = NULL;
 
 	return item;
 }
@@ -294,6 +296,9 @@ struct list *list_deep_clone_strs(struct list *list)
 	item = list_tail(list);
 	while (item) {
 		clone = list_prepend_data(clone, strdup(item->data));
+		if (!clone->data) {
+			abort();
+		}
 		item = item->prev;
 	}
 

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -87,7 +87,7 @@ static struct manifest *alloc_manifest(int version, char *component)
 	}
 
 	manifest->version = version;
-	manifest->component = strdup(component);
+	manifest->component = strdup_or_die(component);
 
 	return manifest;
 }
@@ -195,7 +195,7 @@ static struct manifest *manifest_from_file(int version, char *component, bool he
 		}
 		if (latest && strncmp(component, "MoM", 3) == 0) {
 			if (strncmp(line, "actions:", 8) == 0) {
-				post_update_actions = list_prepend_data(post_update_actions, strdup(c));
+				post_update_actions = list_prepend_data(post_update_actions, strdup_or_die(c));
 				if (!post_update_actions->data) {
 					fprintf(stderr, "WARNING: Unable to read post update action from Manifest.MoM. \
 							Another update or verify may be required.\n");
@@ -203,10 +203,7 @@ static struct manifest *manifest_from_file(int version, char *component, bool he
 			}
 		}
 		if (strncmp(line, "includes:", 9) == 0) {
-			includes = list_prepend_data(includes, strdup(c));
-			if (!includes->data) {
-				abort();
-			}
+			includes = list_prepend_data(includes, strdup_or_die(c));
 		}
 	}
 
@@ -325,10 +322,7 @@ static struct manifest *manifest_from_file(int version, char *component, bool he
 
 		c = c2;
 
-		file->filename = strdup(c);
-		if (!file->filename) {
-			abort();
-		}
+		file->filename = strdup_or_die(c);
 
 		/* Mark every file in a mix manifest as also being mix content since we do not
 		 * have another flag to check for like we do in the MoM */

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1306,6 +1306,9 @@ struct file **manifest_files_to_array(struct manifest *manifest)
 	numfiles = manifest->filecount;
 
 	array = malloc(sizeof(struct file *) * numfiles);
+	if (!array) {
+		abort();
+	}
 
 	iter = list_head(manifest->files);
 	while (iter) {

--- a/src/staging.c
+++ b/src/staging.c
@@ -78,8 +78,8 @@ int do_staging(struct file *file, struct manifest *MoM)
 	int ret;
 	struct stat s;
 
-	tmp = strdup(file->filename);
-	tmp2 = strdup(file->filename);
+	tmp = strdup_or_die(file->filename);
+	tmp2 = strdup_or_die(file->filename);
 
 	dir = dirname(tmp);
 	base = basename(tmp2);

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -172,10 +172,7 @@ void create_and_append_subscription(struct list **subs, const char *component)
 		abort();
 	}
 
-	sub->component = strdup(component);
-	if (sub->component == NULL) {
-		abort();
-	}
+	sub->component = strdup_or_die(component);
 
 	sub->version = 0;
 	sub->oldversion = 0;

--- a/src/update.c
+++ b/src/update.c
@@ -65,7 +65,7 @@ static int check_manifests_uniqueness(int clrver, int mixver)
 
 	if (clearfull == NULL || mixerfull == NULL) {
 		fprintf(stderr, "Could not convert full manifest to array\n");
-		abort();
+		return -1;
 	}
 
 	int ret = enforce_compliant_manifest(mixerfull, clearfull, mixer->filecount, clear->filecount);
@@ -282,12 +282,15 @@ version_check:
 			// new mix version
 			check_mix_versions(&mix_current_version, &mix_server_version, path_prefix);
 			ret = check_manifests_uniqueness(server_version, mix_server_version);
-			if (ret) {
+			if (ret > 0) {
 				printf("\n\t!! %i collisions were found between mix and upstream, please re-create mix !!\n", ret);
 				if (!allow_mix_collisions) {
 					ret = EXIT_FAILURE;
 					goto clean_curl;
 				}
+			} else if (ret < 0) {
+				ret = EXIT_FAILURE;
+				goto clean_curl;
 			}
 
 			goto version_check;

--- a/src/verify.c
+++ b/src/verify.c
@@ -436,9 +436,6 @@ static void add_missing_files(struct manifest *official_manifest)
 		}
 
 		fullname = mk_full_filename(path_prefix, file->filename);
-		if (fullname == NULL) {
-			abort();
-		}
 		memset(&local, 0, sizeof(struct file));
 		local.filename = file->filename;
 		populate_file_struct(&local, fullname);
@@ -511,9 +508,6 @@ static void check_and_fix_one(struct file *file, struct manifest *official_manif
 
 	/* compare the hash and report mismatch */
 	fullname = mk_full_filename(path_prefix, file->filename);
-	if (fullname == NULL) {
-		abort();
-	}
 	if (verify_file(file, fullname)) {
 		goto end;
 	}
@@ -600,9 +594,6 @@ static void remove_orphaned_files(struct manifest *official_manifest)
 		}
 
 		fullname = mk_full_filename(path_prefix, file->filename);
-		if (fullname == NULL) {
-			abort();
-		}
 
 		if (lstat(fullname, &sb) != 0) {
 			/* correctly, the file is not present */


### PR DESCRIPTION
 - Use strdup_or_die instead of strdup + abort when possible
 - Adding some aborts() on out of memory errors
 - Removing unnecessary aborts().
 - Improve error handling on check_manifests_uniqueness()
 - Improvements on mk_full_filename()
