### PR TITLE
verify: When --install is specified, warn on disk full

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,7 @@ swupd_SOURCES = \
 	src/download.c \
 	src/extra_files.c \
 	src/filedesc.c \
+	src/fs.c \
 	src/fullfile.c \
 	src/globals.c \
 	src/hash.c \

--- a/src/fs.c
+++ b/src/fs.c
@@ -1,0 +1,47 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright (c) 2012-2018 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "swupd.h"
+#include <sys/statvfs.h>
+
+long get_available_space(const char *path)
+{
+	struct statvfs stat;
+
+	if (statvfs(path, &stat) != 0) {
+		return -1;
+	}
+
+	return stat.f_bsize * stat.f_bavail;
+}
+
+long get_manifest_list_contentsize(struct list *manifests)
+{
+	long total_size = 0;
+
+	struct list *ptr = NULL;
+	for (ptr = list_head(manifests); ptr; ptr = ptr->next) {
+		struct manifest *subman;
+		subman = ptr->data;
+
+		total_size += subman->contentsize;
+	}
+
+	return total_size;
+}

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -395,6 +395,11 @@ typedef enum telem_prio_t {
 } telem_prio_t;
 extern void telemetry(telem_prio_t level, const char *class, const char *fmt, ...);
 
+/* fs.c */
+extern long get_available_space(const char *path);
+/* Calculate the total contentsize of a manifest list */
+extern long get_manifest_list_contentsize(struct list *manifests);
+
 extern struct file **manifest_files_to_array(struct manifest *manifest);
 extern int enforce_compliant_manifest(struct file **a, struct file **b, int searchsize, int size);
 extern void free_manifest_array(struct file **array);


### PR DESCRIPTION
This change adds some simple space checking on the new 'bundles' to
install when using verify.

This assumes that if you pass --install to verify you intend
to install all bundles to a 'new' folder (no other bundles installed).
This could warn erroneously if there are previously installed bundles or partially
installed bundles, because 'contentsize' could be more than the size
that's actually required to install those files.

Fixes #328

Signed-off-by: Brian J Lovin <brian.j.lovin@intel.com>