### PR TITLE
manifest: ignore I flag in manifest

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -254,6 +254,10 @@ static struct manifest *manifest_from_file(int version, char *component, bool he
 			file->is_link = 1;
 		} else if (c[0] == 'M') {
 			file->is_manifest = 1;
+		} else if (c[0] == 'I') {
+			/* ignore this file for future iterative manifest feature */
+			free(file);
+			continue;
 		} else if (c[0] != '.') { /* unknown file type */
 			free(file);
 			goto err;


### PR DESCRIPTION
The 'I' flag will be used to represent iterative manifests once the
feature becomes available. For now we need to ignore this flag so the
feature can be implemented in mixer before implementation here. Before
this patch manifest parsing would fail if it encountered an 'I' flag.
The iterative manifests will be published and included in the
Manifest.MoM before actually being used by client, which is why it is
important to ignore and not fail here.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>