### PR TITLE
Adding new assertions to the test library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -181,17 +181,23 @@ BATS = \
 	test/functional/checkupdate/version-match/test.bats \
 	test/functional/checkupdate_v2/chk-update-version-match.bats \
 	test/functional/completion/basic/test.bats \
+	test/functional/completion_v2/completion-basic.bats \
 	test/functional/hashdump/file-hash/test.bats \
 	test/functional/hashdump/file-hash-no-path-prefix/test.bats \
+	test/functional/hashdump_v2/hashdump-file-hash.bats \
 	test/functional/mirror/createdir/test.bats \
+	test/functional/mirror_v2/mirror-createdir.bats \
 	test/functional/mirror/createdir-negative/test.bats \
+	test/functional/mirror_v2/mirror-createdir-negative.bats \
 	test/functional/search/content-check-negfull-path/test.bats \
 	test/functional/search/content-check-neglibtest/test.bats \
+	test/functional/search_v2/search-content-check-negative.bats \
 	test/functional/search/content-check-posbin/test.bats \
 	test/functional/search/content-check-posebin/test.bats \
 	test/functional/search/content-check-posfull-path/test.bats \
 	test/functional/search/content-check-poslib32/test.bats \
 	test/functional/search/content-check-poslib64/test.bats \
+	test/functional/search_v2/search-content-check-positive.bats \
 	test/functional/update/apply-full-file-delta/test.bats \
 	test/functional/update/boot-file/test.bats \
 	test/functional/update/boot-skip/test.bats \

--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -302,44 +302,97 @@ run <some_command>
 assert_file_not_exists /some/file
 ```
 
-*assert_in_output*  
-passes if the provided text is included in the command output, fails otherwise  
+*assert_is_output*  
+passes if the provided text matches the whole command output, fails otherwise  
 Examples:  
 ```bash
 # one line strings
 run <some_command>
-assert_in_output "Successfully installed 1 bundle"
+assert_is_output "Some output"
 
 # multi-line strings
+run <some_command>
+expected_output=$(cat <<-EOM
+  Some text that needs
+  to match exactly with
+  the whole command output
+EOM
+)
+assert_is_output "$expected_output"
+```
+
+*assert_is_not_output*  
+passes if the provided text does not match the whole command output, fails otherwise  
+Examples:  
+```bash
+run <some_command>
+assert_is_not_output "This should not be the command output"
+```
+
+*assert_in_output*  
+passes if the provided text is included in the command output (partial match), fails otherwise  
+Examples:  
+```bash
 run <other_command>
 expected_output=$(cat <<-EOM
-  Some multi-ine text that needs to be present
-  in the exact order
-  some more lines, bla bla
+  Some multi-line output
+  some more lines,
+  bla bla
 EOM
 )
 assert_in_output "$expected_output"
-
-# combination of both
-run <yet_another_command>
-expected_output=$(cat <<-EOM
-  Some multi-ine text that needs to be present
-  in the exact order
-  some more lines, bla bla
-EOM
-)
-assert_in_output "some literall text"
-assert_in_output "$expected_output"
-assert_in_output "more text to be checked"
 ```
 
 *assert_not_in_output*  
-passes if the provided text is not included in the command output, fails otherwise  
+passes if the provided text is not included in the command output (partial match), fails otherwise  
 Examples:  
 ```bash
-# one line strings
 run <some_command>
 assert_not_in_output "Error"
+```
+
+*assert_regex_is_output*  
+similar to assert_is_output but this assertion receives a regular expression, passes
+if the provided regular expression matches the whole command output, fails otherwise  
+Examples:  
+```bash
+# remember to skip characters that are part of the expected
+# output that match special regex characters like .*?()[] 
+run <some_command>
+expected_output=$(cat <<-EOM
+  Some expected text that can have
+  regex characters like .* in it
+  \(skipping these pharenteses\)\.
+EOM
+)
+assert_regex_is_output "$expected_output"
+```
+
+*assert_regex_is_not_output*  
+similar to assert_is_not_output but this assertion receives a regular expression, passes
+if the provided regular expression does not match the command output, fails otherwise  
+Examples:  
+```bash
+run <some_command>
+assert_regex_is_not_output "Error .?"
+```
+
+*assert_regex_in_output*  
+similar to assert_in_output but this assertion receives a regular expression, passes
+if the provided regular expression is part of the command output (partial match), fails otherwise  
+Examples:  
+```bash
+run <some_command>
+assert_regex_in_output "This is part .* of the output"
+```
+
+*assert_regex_not_in_output*  
+similar to assert_not_in_output but this assertion receives a regular expression, passes
+if the provided regular expression is not part of the command output (partial match), fails otherwise  
+Examples:  
+```bash
+run <some_command>
+assert_regex_not_in_output "Error."
 ```
 
 *assert_equal*  

--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -304,6 +304,8 @@ assert_file_not_exists /some/file
 
 *assert_is_output*  
 passes if the provided text matches the whole command output, fails otherwise  
+**NOTE:** dots and blank lines are removed by default from the output before comparing it to the expected output,
+if you want to disable this behavior use the assertion with the *--identical* option   
 Examples:  
 ```bash
 # one line strings
@@ -319,6 +321,19 @@ expected_output=$(cat <<-EOM
 EOM
 )
 assert_is_output "$expected_output"
+
+# multi-line strings with dots and blank lines
+run <some_command>
+expected_output=$(cat <<-EOM
+  Some text that has dots
+  ..
+  and some empty lines
+  
+  and you want those to be included when
+  comparing the output
+EOM
+)
+assert_is_output --identical "$expected_output"
 ```
 
 *assert_is_not_output*  
@@ -362,7 +377,7 @@ run <some_command>
 expected_output=$(cat <<-EOM
   Some expected text that can have
   regex characters like .* in it
-  \(skipping these pharenteses\)\.
+  \(skipping these parentheses\)\.
 EOM
 )
 assert_regex_is_output "$expected_output"
@@ -409,4 +424,27 @@ Example:
 ```bash
 run <some_command>
 assert_not_equal "$variable1" "$variable2"
+```
+
+### Ignore lists
+When using assertions that compare the command output to an expected output (for example
+assert_is_output, assert_in_output, etc.), blank lines and lines containing only
+dots are removed by default before comparing outputs.  
+Besides removing empty lines and lines with dots from the output, it is also possible to
+use an *ignore list* to remove other patterns that are not important for a test when using these assertions.  
+
+There are three different ignore list files that can be used (but only one can be used at a time):
+- <functional_tests_directory>/<test_theme_directory>/<test_name>.ignore-list: this file is intended
+to specify an ignore-list for only one particular test.
+- <functional_tests_directory>/<test_theme_directory>/ignore-list: this file is intended to
+be used as an ignore-list for a group of test cases that are similar (the same theme).
+- <functional_tests_directory>/ignore-list.global: this is a global ignore-list intended to be
+used as a fallback for all tests.
+
+To disable the use of ignore lists you can use the *--identical* option with every assertion
+that checks a command output.  
+Example:  
+```bash
+assert_is_output --identical "$expected_output"
+assert_regex_not_in_output --identical "$some_other_output"
 ```

--- a/test/functional/bundleadd_v2/add-bad-hash-state.bats
+++ b/test/functional/bundleadd_v2/add-bad-hash-state.bats
@@ -28,10 +28,8 @@ test_setup() {
 	assert_not_equal "$hash_before" "$hash_after"
 	expected_output=$(cat <<-EOM
 		Starting download of remaining update content. This may take a while...
-		.
 		Finishing download of update content...
 		Installing bundle(s) files...
-		.
 		Calling post-update helper scripts.
 		Successfully installed 1 bundle
 	EOM

--- a/test/functional/bundleadd_v2/add-bad-hash-state.bats
+++ b/test/functional/bundleadd_v2/add-bad-hash-state.bats
@@ -36,6 +36,6 @@ test_setup() {
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundleadd_v2/add-bad-hash.bats
+++ b/test/functional/bundleadd_v2/add-bad-hash.bats
@@ -32,7 +32,6 @@ test_setup() {
 	assert_file_not_exists "$TEST_NAME"/target-dir/usr/bin/file1
 	expected_output=$(cat <<-EOM
 		Starting download of remaining update content. This may take a while...
-		.
 		Finishing download of update content...
 		Error: File content hash mismatch for $TEST_DIRNAME/state/staged/e6d85023c5e619eb43d5cfbfdbdec784afef5a82ffa54e8c93bda3e0883360a3 (bad server data?)
 	EOM

--- a/test/functional/bundleadd_v2/add-bad-hash.bats
+++ b/test/functional/bundleadd_v2/add-bad-hash.bats
@@ -37,7 +37,7 @@ test_setup() {
 		Error: File content hash mismatch for $TEST_DIRNAME/state/staged/e6d85023c5e619eb43d5cfbfdbdec784afef5a82ffa54e8c93bda3e0883360a3 (bad server data?)
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 

--- a/test/functional/bundleadd_v2/add-bad-manifest.bats
+++ b/test/functional/bundleadd_v2/add-bad-manifest.bats
@@ -27,6 +27,6 @@ test_setup() {
 		Failed to install 1 of 1 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundleadd_v2/add-boot-file.bats
+++ b/test/functional/bundleadd_v2/add-boot-file.bats
@@ -18,10 +18,8 @@ test_setup() {
 	assert_file_exists "$TEST_NAME/target-dir/usr/lib/kernel/test-file"
 	expected_output=$(cat <<-EOM
 		Starting download of remaining update content. This may take a while\.\.\.
-		\.
 		Finishing download of update content\.\.\.
 		Installing bundle\(s\) files\.\.\.
-		\.
 		Calling post-update helper scripts\.
 		.*
 		Successfully installed 1 bundle

--- a/test/functional/bundleadd_v2/add-boot-file.bats
+++ b/test/functional/bundleadd_v2/add-boot-file.bats
@@ -17,15 +17,16 @@ test_setup() {
 	assert_status_is 0
 	assert_file_exists "$TEST_NAME/target-dir/usr/lib/kernel/test-file"
 	expected_output=$(cat <<-EOM
-		Starting download of remaining update content. This may take a while...
-		.
-		Finishing download of update content...
-		Installing bundle(s) files...
-		.
-		Calling post-update helper scripts.
+		Starting download of remaining update content. This may take a while\.\.\.
+		\.
+		Finishing download of update content\.\.\.
+		Installing bundle\(s\) files\.\.\.
+		\.
+		Calling post-update helper scripts\.
+		.*
+		Successfully installed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
-	assert_in_output "Successfully installed 1 bundle"
+	assert_regex_is_output "$expected_output"
 
 }

--- a/test/functional/bundleadd_v2/add-boot-skip.bats
+++ b/test/functional/bundleadd_v2/add-boot-skip.bats
@@ -18,10 +18,8 @@ test_setup() {
 	assert_file_exists "$TEST_NAME/target-dir/usr/lib/kernel/test-file"
 	expected_output=$(cat <<-EOM
 		Starting download of remaining update content. This may take a while...
-		.
 		Finishing download of update content...
 		Installing bundle(s) files...
-		.
 		Calling post-update helper scripts.
 		WARNING: boot files update skipped due to --no-boot-update argument
 		Successfully installed 1 bundle

--- a/test/functional/bundleadd_v2/add-boot-skip.bats
+++ b/test/functional/bundleadd_v2/add-boot-skip.bats
@@ -27,6 +27,6 @@ test_setup() {
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundleadd_v2/add-directory.bats
+++ b/test/functional/bundleadd_v2/add-directory.bats
@@ -17,10 +17,8 @@ test_setup() {
 	assert_dir_exists "$TEST_NAME/target-dir/usr/bin/test"
 	expected_output=$(cat <<-EOM
 		Starting download of remaining update content. This may take a while...
-		.
 		Finishing download of update content...
 		Installing bundle(s) files...
-		.
 		Calling post-update helper scripts.
 		Successfully installed 1 bundle
 	EOM

--- a/test/functional/bundleadd_v2/add-directory.bats
+++ b/test/functional/bundleadd_v2/add-directory.bats
@@ -25,6 +25,6 @@ test_setup() {
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 } 

--- a/test/functional/bundleadd_v2/add-existing.bats
+++ b/test/functional/bundleadd_v2/add-existing.bats
@@ -19,6 +19,6 @@ test_setup() {
 		1 bundle was already installed
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundleadd_v2/add-include.bats
+++ b/test/functional/bundleadd_v2/add-include.bats
@@ -23,10 +23,8 @@ test_setup() {
 	assert_file_exists "$TEST_NAME"/target-dir/bar/test-file2
 	expected_output=$(cat <<-EOM
 		Starting download of remaining update content. This may take a while...
-		.
 		Finishing download of update content...
 		Installing bundle(s) files...
-		..
 		Calling post-update helper scripts.
 		Successfully installed 1 bundle
 	EOM

--- a/test/functional/bundleadd_v2/add-include.bats
+++ b/test/functional/bundleadd_v2/add-include.bats
@@ -31,6 +31,6 @@ test_setup() {
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundleadd_v2/add-multiple.bats
+++ b/test/functional/bundleadd_v2/add-multiple.bats
@@ -22,16 +22,11 @@ test_setup() {
 	assert_file_exists "$TEST_NAME/target-dir/media/lib/file2"
 	expected_output=$(cat <<-EOM
 		Downloading packs...
-
 		Extracting test-bundle1 pack for version 10
-		.
 		Extracting test-bundle2 pack for version 10
-
 		Starting download of remaining update content. This may take a while...
-		..
 		Finishing download of update content...
 		Installing bundle(s) files...
-		...
 		Calling post-update helper scripts.
 		Successfully installed 2 bundles
 	EOM

--- a/test/functional/bundleadd_v2/add-multiple.bats
+++ b/test/functional/bundleadd_v2/add-multiple.bats
@@ -36,6 +36,6 @@ test_setup() {
 		Successfully installed 2 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundleadd_v2/add-rc.bats
+++ b/test/functional/bundleadd_v2/add-rc.bats
@@ -52,7 +52,7 @@ global_teardown() {
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }
 
@@ -70,7 +70,7 @@ global_teardown() {
 		Successfully installed 2 bundles
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }
 
@@ -88,7 +88,7 @@ global_teardown() {
 		1 bundle was already installed
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }
 
@@ -101,7 +101,7 @@ global_teardown() {
 		Failed to install 1 of 1 bundles
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }
 
@@ -115,7 +115,7 @@ global_teardown() {
 		Failed to install 2 of 2 bundles
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }
 
@@ -129,7 +129,7 @@ global_teardown() {
 		2 bundles were already installed
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }
 
@@ -144,7 +144,7 @@ global_teardown() {
 		1 bundle was already installed
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }
 
@@ -168,7 +168,7 @@ global_teardown() {
 		1 bundle was already installed
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }
 
@@ -187,7 +187,7 @@ global_teardown() {
 		Failed to install 1 of 2 bundles
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }
 
@@ -208,7 +208,7 @@ global_teardown() {
 		1 bundle was already installed
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }
 
@@ -235,6 +235,6 @@ global_teardown() {
 		1 bundle was already installed
 	EOM
 	)
-	assert_regex_is_output "$expected_output"
+	assert_regex_is_output --identical "$expected_output"
 
 }

--- a/test/functional/bundleadd_v2/add-rc.bats
+++ b/test/functional/bundleadd_v2/add-rc.bats
@@ -52,7 +52,7 @@ global_teardown() {
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 
@@ -70,7 +70,7 @@ global_teardown() {
 		Successfully installed 2 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 
@@ -88,7 +88,7 @@ global_teardown() {
 		1 bundle was already installed
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 
@@ -101,7 +101,7 @@ global_teardown() {
 		Failed to install 1 of 1 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 
@@ -115,7 +115,7 @@ global_teardown() {
 		Failed to install 2 of 2 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 
@@ -129,7 +129,7 @@ global_teardown() {
 		2 bundles were already installed
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 
@@ -144,7 +144,7 @@ global_teardown() {
 		1 bundle was already installed
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 
@@ -168,7 +168,7 @@ global_teardown() {
 		1 bundle was already installed
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 
@@ -187,7 +187,7 @@ global_teardown() {
 		Failed to install 1 of 2 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 
@@ -208,7 +208,7 @@ global_teardown() {
 		1 bundle was already installed
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 
@@ -222,21 +222,19 @@ global_teardown() {
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1 test-bundle2 fake-bundle test-bundle3"
 	assert_status_is "$EBUNDLE_INSTALL"
 	expected_output=$(cat <<-EOM
-		Warning: Bundle "fake-bundle" is invalid, skipping it...
-		Warning: Bundle "test-bundle3" is already installed, skipping it...
-		Starting download of remaining update content. This may take a while...
-		.
-		Finishing download of update content...
-		Error for $file_hash tarfile extraction
-	EOM
-	)
-	assert_in_output "$expected_output"
-	expected_output=$(cat <<-EOM
+		Warning: Bundle "fake-bundle" is invalid, skipping it\.\.\.
+		Warning: Bundle "test-bundle3" is already installed, skipping it\.\.\.
+		Starting download of remaining update content\. This may take a while\.\.\.
+		\.
+		Finishing download of update content\.\.\.
+		Error for $file_hash tarfile extraction, .*
+		Installing bundle\(s\) files\.\.\.
+		.Path /bar/test-file2 is missing on the file system \.\.\. fixing
 		Error: Failed to download file /bar/test-file2 in verify_fix_path
 		Failed to install 3 of 3 bundles
 		1 bundle was already installed
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_regex_is_output "$expected_output"
 
 }

--- a/test/functional/bundleadd_v2/add-skip-scripts.bats
+++ b/test/functional/bundleadd_v2/add-skip-scripts.bats
@@ -17,10 +17,8 @@ test_setup() {
 	assert_file_exists "$TEST_NAME/target-dir/usr/lib/kernel/test-file"
 	expected_output=$(cat <<-EOM
 		Starting download of remaining update content. This may take a while...
-		.
 		Finishing download of update content...
 		Installing bundle(s) files...
-		.
 		WARNING: post-update helper scripts skipped due to --no-scripts argument
 		Successfully installed 1 bundle
 	EOM

--- a/test/functional/bundleadd_v2/add-skip-scripts.bats
+++ b/test/functional/bundleadd_v2/add-skip-scripts.bats
@@ -25,6 +25,6 @@ test_setup() {
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundleadd_v2/add-verify-fix-path.bats
+++ b/test/functional/bundleadd_v2/add-verify-fix-path.bats
@@ -28,13 +28,11 @@ test_setup() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Starting download of remaining update content. This may take a while...
-		.
 		Finishing download of update content...
 		Installing bundle(s) files...
 		Update target directory does not exist: $TEST_DIRNAME/target-dir/foo/bar. Auto-fix disabled
 		Path /foo/bar is missing on the file system ... fixing
 		Path /foo/bar/test-file1 is missing on the file system ... fixing
-		.
 		Calling post-update helper scripts.
 		Successfully installed 1 bundle
 	EOM

--- a/test/functional/bundleadd_v2/add-verify-fix-path.bats
+++ b/test/functional/bundleadd_v2/add-verify-fix-path.bats
@@ -39,6 +39,6 @@ test_setup() {
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundlelist_v2/list-all.bats
+++ b/test/functional/bundlelist_v2/list-all.bats
@@ -20,6 +20,6 @@ test_setup() {
 		test-bundle2
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundlelist_v2/list-deps-flat.bats
+++ b/test/functional/bundlelist_v2/list-deps-flat.bats
@@ -21,7 +21,6 @@ test_setup() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Bundles included by test-bundle1:
-
 		test-bundle2
 		test-bundle3
 	EOM

--- a/test/functional/bundlelist_v2/list-deps-flat.bats
+++ b/test/functional/bundlelist_v2/list-deps-flat.bats
@@ -26,6 +26,6 @@ test_setup() {
 		test-bundle3
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundlelist_v2/list-deps-invalid-bundle.bats
+++ b/test/functional/bundlelist_v2/list-deps-invalid-bundle.bats
@@ -11,6 +11,6 @@ load "../testlib"
 		Error: Bad bundle name detected - Aborting
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundlelist_v2/list-deps-nested.bats
+++ b/test/functional/bundlelist_v2/list-deps-nested.bats
@@ -21,7 +21,6 @@ test_setup() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Bundles included by test-bundle1:
-
 		test-bundle2
 		test-bundle3
 	EOM

--- a/test/functional/bundlelist_v2/list-deps-nested.bats
+++ b/test/functional/bundlelist_v2/list-deps-nested.bats
@@ -26,6 +26,6 @@ test_setup() {
 		test-bundle3
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundlelist_v2/list-has-dep-nested-not-installed.bats
+++ b/test/functional/bundlelist_v2/list-has-dep-nested-not-installed.bats
@@ -25,6 +25,6 @@ test_setup() {
 		Error: Bundle list failed
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundlelist_v2/list-has-dep-nested-server.bats
+++ b/test/functional/bundlelist_v2/list-has-dep-nested-server.bats
@@ -26,7 +26,6 @@ test_setup() {
 		 #   |-- is-required-by
 		 # * is-also-required-by
 		 # ...
-
 		  * test-bundle2
 		    |-- test-bundle3
 	EOM

--- a/test/functional/bundlelist_v2/list-has-dep-nested-server.bats
+++ b/test/functional/bundlelist_v2/list-has-dep-nested-server.bats
@@ -31,6 +31,6 @@ test_setup() {
 		    |-- test-bundle3
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundlelist_v2/list-has-dep-nested.bats
+++ b/test/functional/bundlelist_v2/list-has-dep-nested.bats
@@ -26,7 +26,6 @@ test_setup() {
 		 #   |-- is-required-by
 		 # * is-also-required-by
 		 # ...
-
 		  * test-bundle2
 		    |-- test-bundle3
 	EOM

--- a/test/functional/bundlelist_v2/list-has-dep-nested.bats
+++ b/test/functional/bundlelist_v2/list-has-dep-nested.bats
@@ -31,6 +31,6 @@ test_setup() {
 		    |-- test-bundle3
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundlelist_v2/list-no-deps.bats
+++ b/test/functional/bundlelist_v2/list-no-deps.bats
@@ -18,6 +18,6 @@ test_setup() {
 		No included bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundlelist_v2/list-none-has-deps.bats
+++ b/test/functional/bundlelist_v2/list-none-has-deps.bats
@@ -18,6 +18,6 @@ test_setup() {
 		No bundles have test-bundle1 as a dependency
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundleremove_v2/remove-boot-file.bats
+++ b/test/functional/bundleremove_v2/remove-boot-file.bats
@@ -20,6 +20,6 @@ test_setup() {
 		Successfully removed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundleremove_v2/remove-file.bats
+++ b/test/functional/bundleremove_v2/remove-file.bats
@@ -20,6 +20,6 @@ test_setup() {
 		Successfully removed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundleremove_v2/remove-include-nested.bats
+++ b/test/functional/bundleremove_v2/remove-include-nested.bats
@@ -29,7 +29,6 @@ test_setup() {
 		 #   |-- is-required-by
 		 # * is-also-required-by
 		 # ...
-
 		  * test-bundle2
 		    |-- test-bundle3
 		Failed to remove 1 of 1 bundles

--- a/test/functional/bundleremove_v2/remove-include-nested.bats
+++ b/test/functional/bundleremove_v2/remove-include-nested.bats
@@ -35,6 +35,6 @@ test_setup() {
 		Failed to remove 1 of 1 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundleremove_v2/remove-include.bats
+++ b/test/functional/bundleremove_v2/remove-include.bats
@@ -26,7 +26,6 @@ test_setup() {
 		 #   |-- is-required-by
 		 # * is-also-required-by
 		 # ...
-
 		  * test-bundle2
 		Failed to remove 1 of 1 bundles
 	EOM

--- a/test/functional/bundleremove_v2/remove-include.bats
+++ b/test/functional/bundleremove_v2/remove-include.bats
@@ -31,6 +31,6 @@ test_setup() {
 		Failed to remove 1 of 1 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundleremove_v2/remove-multiple.bats
+++ b/test/functional/bundleremove_v2/remove-multiple.bats
@@ -36,6 +36,6 @@ test_setup() {
 		Successfully removed 3 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"  
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundleremove_v2/remove-os-core.bats
+++ b/test/functional/bundleremove_v2/remove-os-core.bats
@@ -12,6 +12,6 @@ load "../testlib"
 		Failed to remove 1 of 1 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundleremove_v2/remove-rc.bats
+++ b/test/functional/bundleremove_v2/remove-rc.bats
@@ -46,7 +46,7 @@ global_teardown() {
 		Successfully removed 1 bundle
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }
 
@@ -64,7 +64,7 @@ global_teardown() {
 		Successfully removed 2 bundles
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }
 
@@ -81,7 +81,7 @@ global_teardown() {
 		Failed to remove 1 of 1 bundles
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }
 
@@ -94,7 +94,7 @@ global_teardown() {
 		Failed to remove 1 of 1 bundles
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }
 
@@ -108,7 +108,7 @@ global_teardown() {
 		Failed to remove 2 of 2 bundles
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }
 
@@ -129,6 +129,6 @@ global_teardown() {
 		Failed to remove 2 of 3 bundles
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }

--- a/test/functional/bundleremove_v2/remove-rc.bats
+++ b/test/functional/bundleremove_v2/remove-rc.bats
@@ -46,7 +46,7 @@ global_teardown() {
 		Successfully removed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 
@@ -64,7 +64,7 @@ global_teardown() {
 		Successfully removed 2 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 
@@ -81,7 +81,7 @@ global_teardown() {
 		Failed to remove 1 of 1 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 
@@ -94,7 +94,7 @@ global_teardown() {
 		Failed to remove 1 of 1 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 
@@ -108,7 +108,7 @@ global_teardown() {
 		Failed to remove 2 of 2 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 
@@ -129,6 +129,6 @@ global_teardown() {
 		Failed to remove 2 of 3 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/checkupdate_v2/chk-update-new-version.bats
+++ b/test/functional/checkupdate_v2/chk-update-new-version.bats
@@ -22,6 +22,6 @@ test_setup() {
 		There is a new OS version available: 100
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/checkupdate_v2/chk-update-no-server-content.bats
+++ b/test/functional/checkupdate_v2/chk-update-no-server-content.bats
@@ -14,6 +14,6 @@ test_setup() {
 
 	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS_NO_CERT"
 	assert_status_is_not 0
-	assert_in_output "Error: server does not report any version"
+	assert_is_output "Error: server does not report any version"
 
 }

--- a/test/functional/checkupdate_v2/chk-update-no-target-content.bats
+++ b/test/functional/checkupdate_v2/chk-update-no-target-content.bats
@@ -14,6 +14,6 @@ test_setup() {
 
 	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS_NO_CERT"
 	assert_status_is_not 0
-	assert_in_output "Unable to determine current OS version"
+	assert_is_output "Unable to determine current OS version"
 
 }

--- a/test/functional/checkupdate_v2/chk-update-slow-server.bats
+++ b/test/functional/checkupdate_v2/chk-update-slow-server.bats
@@ -29,7 +29,7 @@ test_teardown() {
 		There is a new OS version available: 99990
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 

--- a/test/functional/checkupdate_v2/chk-update-version-match.bats
+++ b/test/functional/checkupdate_v2/chk-update-version-match.bats
@@ -11,6 +11,6 @@ load "../testlib"
 		There are no updates available
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/completion_v2/completion-basic.bats
+++ b/test/functional/completion_v2/completion-basic.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+test_setup() {
+
+	# do nothing
+	return
+
+}
+
+test_teardown() {
+
+	# do nothing
+	return
+
+}
+
+@test "autocomplete exists" {
+
+	assert_file_exists "$SWUPD_DIR"/swupd.bash
+
+}
+
+@test "autocomplete syntax" {
+
+	bash "$SWUPD_DIR"/swupd.bash
+
+}
+
+@test "autocomplete has autoupdate" {
+
+	grep -q  '("autoupdate")' "$SWUPD_DIR"/swupd.bash
+
+}
+
+@test "autocomplete has expected hashdump opts" {
+
+	grep -q  'opts="--help --no-xattrs --path "' "$SWUPD_DIR"/swupd.bash
+
+}

--- a/test/functional/hashdump_v2/hashdump-file-hash.bats
+++ b/test/functional/hashdump_v2/hashdump-file-hash.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+	printf "test-data" | sudo tee "$TEST_NAME"/target-dir/test-hash > /dev/null
+
+}
+
+test_setup() {
+
+	return
+
+}
+
+test_teardown() {
+
+	return
+
+}
+
+global_teardown() {
+
+	destroy_test_environment "$TEST_NAME"
+
+}
+
+@test "hashdump with prefix" {
+
+	run sudo sh -c "$SWUPD hashdump --path=$TEST_NAME/target-dir /test-hash"
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Calculating hash with xattrs for: .*/target-dir/test-hash
+		8286279c93f45c7ffa6b9ed440066de09716527346d9dd0239f50948e0e554f0
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}
+
+@test "hashdump with no prefix" {
+
+	run sudo sh -c "$SWUPD hashdump $TEST_NAME/target-dir/test-hash"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Calculating hash with xattrs for: .*/target-dir/test-hash
+		8286279c93f45c7ffa6b9ed440066de09716527346d9dd0239f50948e0e554f0
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}

--- a/test/functional/mirror_v2/mirror-createdir-negative.bats
+++ b/test/functional/mirror_v2/mirror-createdir-negative.bats
@@ -36,7 +36,6 @@ global_teardown() {
 	expected_output=$(cat <<-EOM
 		.*/etc/swupd: not a directory
 		Unable to set mirror url
-
 		Default version URL not found. Use the -v option instead.
 	EOM
 	)
@@ -53,7 +52,6 @@ global_teardown() {
 	expected_output=$(cat <<-EOM
 		.*/etc/swupd: not a directory
 		Unable to set mirror url
-
 		Default version URL not found. Use the -v option instead.
 	EOM
 	)

--- a/test/functional/mirror_v2/mirror-createdir-negative.bats
+++ b/test/functional/mirror_v2/mirror-createdir-negative.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+
+}
+
+test_setup() {
+
+	# do nothing
+	return
+
+}
+
+test_teardown() {
+
+	sudo rm -rf "$TEST_NAME"/target-dir/etc/swupd
+
+}
+
+global_teardown() {
+
+	destroy_test_environment "$TEST_NAME"
+
+}
+
+@test "mirror /etc/swupd is a file" {
+
+	sudo touch "$TEST_NAME"/target-dir/etc/swupd
+
+	run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+	assert_status_is_not 0
+	expected_output=$(cat <<-EOM
+		.*/etc/swupd: not a directory
+		Unable to set mirror url
+
+		Default version URL not found. Use the -v option instead.
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}
+
+@test "mirror /etc/swupd is a symlink to a file" {
+
+	sudo touch "$TEST_NAME"/target-dir/foo
+	sudo ln -s $(realpath "$TEST_NAME"/target-dir/foo) "$TEST_NAME"/target-dir/etc/swupd
+	run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+	assert_status_is_not 0
+	expected_output=$(cat <<-EOM
+		.*/etc/swupd: not a directory
+		Unable to set mirror url
+
+		Default version URL not found. Use the -v option instead.
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}

--- a/test/functional/mirror_v2/mirror-createdir.bats
+++ b/test/functional/mirror_v2/mirror-createdir.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+
+}
+
+test_setup() {
+
+	# do nothing
+	return
+
+}
+
+test_teardown() {
+
+	sudo rm -rf "$TEST_NAME"/target-dir/etc/swupd
+
+}
+
+global_teardown() {
+
+	destroy_test_environment "$TEST_NAME"
+
+}
+
+@test "mirror /etc/swupd does not exist" {
+
+	run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Set upstream mirror to http://example.com/swupd-file
+		Installed version: 10
+		Version URL:       http://example.com/swupd-file
+		Content URL:       http://example.com/swupd-file
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_equal "http://example.com/swupd-file" $(<$TEST_NAME/target-dir/etc/swupd/mirror_contenturl)
+	assert_equal "http://example.com/swupd-file" $(<$TEST_NAME/target-dir/etc/swupd/mirror_versionurl)
+
+}
+
+@test "mirror /etc/swupd already exists" {
+
+	sudo mkdir -p "$TEST_NAME"/target-dir/etc/swupd
+	run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Set upstream mirror to http://example.com/swupd-file
+		Installed version: 10
+		Version URL:       http://example.com/swupd-file
+		Content URL:       http://example.com/swupd-file
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_equal "http://example.com/swupd-file" $(<$TEST_NAME/target-dir/etc/swupd/mirror_contenturl)
+	assert_equal "http://example.com/swupd-file" $(<$TEST_NAME/target-dir/etc/swupd/mirror_versionurl)
+
+}
+
+@test "mirror /etc/swupd is a symlink to a directory" {
+
+	sudo mkdir "$TEST_NAME"/target-dir/foo
+	sudo ln -s $(realpath "$TEST_NAME"/target-dir/foo) "$TEST_NAME"/target-dir/etc/swupd
+	run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Set upstream mirror to http://example.com/swupd-file
+		Installed version: 10
+		Version URL:       http://example.com/swupd-file
+		Content URL:       http://example.com/swupd-file
+	EOM
+	)
+	assert_is_output "$expected_output"
+  
+  	! [[ -L "$TEST_NAME/target-dir/etc/swupd" ]]
+	assert_equal "http://example.com/swupd-file" $(<$TEST_NAME/target-dir/etc/swupd/mirror_contenturl)
+	assert_equal "http://example.com/swupd-file" $(<$TEST_NAME/target-dir/etc/swupd/mirror_versionurl)
+
+}

--- a/test/functional/search_v2/search-content-check-negative.bats
+++ b/test/functional/search_v2/search-content-check-negative.bats
@@ -37,9 +37,7 @@ global_teardown() {
 	expected_output=$(cat <<-EOM
 		Downloading Clear Linux manifests
 		   .* MB total\.\.\.
-
 		Completed manifests download\.
-
 		Search term not found\.
 	EOM
 	)
@@ -53,7 +51,6 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Searching for 'libtest-nohit'
-
 		Search term not found.
 	EOM
 	)

--- a/test/functional/search_v2/search-content-check-negative.bats
+++ b/test/functional/search_v2/search-content-check-negative.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n test-bundle -f /foo/test-file1,/usr/lib/test-lib32,/libtest-nohit "$TEST_NAME"
+
+}
+
+test_setup() {
+
+	# do nothing
+	return
+
+}
+
+test_teardown() {
+
+	# do nothing
+	return
+
+}
+
+global_teardown() {
+
+	destroy_test_environment "$TEST_NAME"
+
+}
+
+@test "search with non existant file, specifying full path" {
+
+	run sudo sh -c "$SWUPD search $SWUPD_OPTS /usr/lib64/test-lib100"
+	assert_status_is 0
+	assert_in_output "Searching for '/usr/lib64/test-lib100'"
+	expected_output=$(cat <<-EOM
+		Downloading Clear Linux manifests
+		   .* MB total\.\.\.
+
+		Completed manifests download\.
+
+		Search term not found\.
+	EOM
+	)
+	assert_regex_in_output "$expected_output"
+
+}
+
+@test "search with non existant library" {
+
+	run sudo sh -c "$SWUPD search $SWUPD_OPTS -l libtest-nohit"
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Searching for 'libtest-nohit'
+
+		Search term not found.
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+

--- a/test/functional/search_v2/search-content-check-positive.bats
+++ b/test/functional/search_v2/search-content-check-positive.bats
@@ -51,7 +51,6 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Searching for 'test-bin'
-
 		Bundle test-bundle	\(.* MB to install\)
 		./usr/bin/test-bin
 	EOM
@@ -66,7 +65,6 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Searching for '/usr/lib64/test-lib64'
-
 		Bundle test-bundle2	\(.* MB to install\)
 		./usr/lib64/test-lib64
 	EOM
@@ -82,7 +80,6 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Searching for 'test-lib32'
-
 		Bundle test-bundle	\(.* MB to install\)
 		./usr/lib/test-lib32
 	EOM
@@ -97,7 +94,6 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Searching for 'test-lib64'
-
 		Bundle test-bundle2	\(.* MB to install\)
 		./usr/lib64/test-lib64
 	EOM

--- a/test/functional/search_v2/search-content-check-positive.bats
+++ b/test/functional/search_v2/search-content-check-positive.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n test-bundle -f /foo/test-file1,/usr/bin/test-bin,/usr/lib/test-lib32 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /bar/test-file2,/usr/lib64/test-lib64 "$TEST_NAME"
+
+}
+
+test_setup() {
+
+	# do nothing
+	return
+
+}
+
+test_teardown() {
+
+	# do nothing
+	return
+
+}
+
+global_teardown() {
+
+	destroy_test_environment "$TEST_NAME"
+
+}
+
+@test "search for a binary" {
+
+	run sudo sh -c "$SWUPD search $SWUPD_OPTS -b test-bin"
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Searching for 'test-bin'
+		.*
+		Bundle test-bundle	\(.* MB to install\)
+		./usr/bin/test-bin
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}
+
+@test "search for a file everywhere" {
+
+	run sudo sh -c "$SWUPD search $SWUPD_OPTS test-bin"
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Searching for 'test-bin'
+
+		Bundle test-bundle	\(.* MB to install\)
+		./usr/bin/test-bin
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}
+
+@test "search for a file specifying the full path" {
+
+	run sudo sh -c "$SWUPD search $SWUPD_OPTS /usr/lib64/test-lib64"
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Searching for '/usr/lib64/test-lib64'
+
+		Bundle test-bundle2	\(.* MB to install\)
+		./usr/lib64/test-lib64
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}
+
+@test "search for a library in lib32" {
+
+	run sudo sh -c "$SWUPD search $SWUPD_OPTS -l test-lib32"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Searching for 'test-lib32'
+
+		Bundle test-bundle	\(.* MB to install\)
+		./usr/lib/test-lib32
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}
+
+@test "search for a library in lib64" {
+
+	run sudo sh -c "$SWUPD search $SWUPD_OPTS -l test-lib64"
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Searching for 'test-lib64'
+
+		Bundle test-bundle2	\(.* MB to install\)
+		./usr/lib64/test-lib64
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}


### PR DESCRIPTION
This pull request include two parts.

1) It adds 6 new assertions to the test library:
- assert_is_output
- assert_is_not_output
- assert_regex_is_output
- assert_regex_is_not_output
- assert_regex_in_output
- assert_regex_not_in_output

2) It migrates the tests from the following categories to use the
new library:
- completion
- hashdump
- mirror
- search

Finally this commit changes a few test cases so they use
"assert_is_output" instead of "assert_in_output", that way
we can have a tighter control of the output we want since
assert_is_output requires the whole output to match to a
specific text instead of doing a partial match.