### PR TITLE
migrate: read format from file system

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -213,8 +213,12 @@ int read_mix_version_file(char *filename, char *path_prefix)
 void check_mix_versions(int *current_version, int *server_version, char *path_prefix)
 {
 	*current_version = read_mix_version_file("/usr/share/clear/version", path_prefix);
-	*server_version = read_mix_version_file(MIX_STATE_DIR "version/format1/latest", path_prefix);
+	char *format_file;
+	string_or_die(&format_file, MIX_STATE_DIR "version/format%s/latest", format_string);
+	*server_version = read_mix_version_file(format_file, path_prefix);
+	free_string(&format_file);
 }
+
 int update_device_latest_version(int version)
 {
 	FILE *file = NULL;


### PR DESCRIPTION
Fixes #539
To find the latest version in the MIX_STATE_DIR swupd must look under
the correct directory versioned after the format number of the current
system. This is a change to mixer that auto-populates the format to the
system on which it is running if the mixer.state file does not exist.
Since mixer.state is not managed by the user when interacting with mixin
we need to use the format number on the system to find the latest
version. Old mixer behaviour was to default to 1 for the format.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>