### PR TITLE
Testlib usability improvements

### DIFF
--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1510,3 +1510,30 @@ assert_not_equal() {
 	fi
 
 }
+
+assert_files_equal() {
+
+	local val1=$1
+	local val2=$2
+	validate_item "$val1"
+	validate_item "$val2"
+
+	diff -q "$val1" "$val2"
+
+}
+
+assert_files_not_equal() {
+
+	local val1=$1
+	local val2=$2
+	validate_item "$val1"
+	validate_item "$val2"
+
+	if diff -q "$val1" "$val2" > /dev/null; then
+		echo "Files $val1 and $val2 are equal"
+		return 1
+	else
+		return 0
+	fi
+
+}

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1238,7 +1238,7 @@ use_ignore_list() {
 assert_status_is() {
 
 	local expected_status=$1
-	validate_param expected_status
+	validate_param "$expected_status"
 
 	if [ -z "$status" ]; then
 		echo "The \$status environment variable is empty."
@@ -1263,7 +1263,7 @@ assert_status_is() {
 assert_status_is_not() {
 
 	local not_expected_status=$1
-	validate_param not_expected_status
+	validate_param "$not_expected_status"
 
 	if [ -z "$status" ]; then
 		echo "The \$status environment variable is empty."
@@ -1288,7 +1288,7 @@ assert_status_is_not() {
 assert_dir_exists() {
 
 	local vdir=$1
-	validate_param vdir
+	validate_param "$vdir"
 
 	if [ ! -d "$vdir" ]; then
 		print_assert_failure "Directory $vdir should exist, but it does not"
@@ -1300,7 +1300,7 @@ assert_dir_exists() {
 assert_dir_not_exists() {
 
 	local vdir=$1
-	validate_param vdir
+	validate_param "$vdir"
 
 	if [ -d "$vdir" ]; then
 		print_assert_failure "Directory $vdir should not exist, but it does"
@@ -1312,7 +1312,7 @@ assert_dir_not_exists() {
 assert_file_exists() {
 
 	local vfile=$1
-	validate_param vfile
+	validate_param "$vfile"
 
 	if [ ! -f "$vfile" ]; then
 		print_assert_failure "File $vfile should exist, but it does not"
@@ -1324,7 +1324,7 @@ assert_file_exists() {
 assert_file_not_exists() {
 
 	local vfile=$1
-	validate_param vfile
+	validate_param "$vfile"
 
 	if [ -f "$vfile" ]; then
 		print_assert_failure "File $vfile should not exist, but it does"
@@ -1489,8 +1489,8 @@ assert_equal() {
 
 	local val1=$1
 	local val2=$2
-	validate_param val1
-	validate_param val2
+	validate_param "$val1"
+	validate_param "$val2"
 
 	if [ "$val1" != "$val2" ]; then
 		return 1
@@ -1502,8 +1502,8 @@ assert_not_equal() {
 
 	local val1=$1
 	local val2=$2
-	validate_param val1
-	validate_param val2
+	validate_param "$val1"
+	validate_param "$val2"
 
 	if [ "$val1" = "$val2" ]; then
 		return 1

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1175,7 +1175,9 @@ test_setup() {
 # Default test_teardown
 test_teardown() {
 
-	destroy_test_environment "$TEST_NAME"
+	if [ "$DEBUG_TEST" != true ]; then
+		destroy_test_environment "$TEST_NAME"
+	fi
 
 }
 

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -123,11 +123,22 @@ validate_param() {
 # - STREAM: the content to be written
 write_to_protected_file() {
 
-        local arg
-        [ "$1" = "-a" ] && { arg=-a ; shift ; }
-        local file=${1?Missing output file in write_to_protected_file}
-        shift
-        printf "$@" | sudo tee $arg "$file" >/dev/null
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    write_to_protected_file [-a] <file> <stream>
+
+			Options:
+			    -a    If used the text will be appeneded to the file, otherwise it will be overwritten
+			EOM
+		return
+	fi
+	local arg
+	[ "$1" = "-a" ] && { arg=-a ; shift ; }
+	local file=${1?Missing output file in write_to_protected_file}
+	shift
+	printf "%s" "$@" | sudo tee $arg "$file" >/dev/null
 
 }
 
@@ -138,6 +149,14 @@ set_env_variables() {
 
 	local env_name=$1
 	local path
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    set_env_variables <environment_name>
+			EOM
+		return
+	fi
 	validate_path "$env_name"
 	path=$(dirname "$(realpath "$env_name")")
 
@@ -157,6 +176,15 @@ create_dir() {
 	local path=$1
 	local hashed_name
 	local directory
+
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    create_dir <path>
+			EOM
+		return
+	fi
 	validate_path "$path"
 	
 	# most directories have the same hash, so we only need one directory
@@ -181,6 +209,15 @@ create_file() {
  
 	local path=$1
 	local hashed_name
+
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    create_file <path>
+			EOM
+		return
+	fi
 	validate_path "$path"
 
 	generate_random_content | sudo tee "$path/testfile" > /dev/null
@@ -204,6 +241,15 @@ create_link() {
 	local path=$1
 	local pfile=$2
 	local hashed_name
+
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    create_link <path> [file_to_point_to]
+			EOM
+		return
+	fi
 	validate_path "$path"
 	
 	# if no file is specified, create one
@@ -228,6 +274,17 @@ create_tar() {
 	local path
 	local item_name
 	local skip_param_validation=false
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    create_tar [--skip-validation] <item>
+
+			Options:
+			    --skip-validation    If set, the function parameters will not be validated
+			EOM
+		return
+	fi
 	[ "$1" = "--skip-validation" ] && { skip_param_validation=true ; shift ; }
 	local item=$1
 
@@ -255,6 +312,15 @@ create_manifest() {
 	local path=$1
 	local name=$2
 	local version
+
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    create_manifest <path> <bundle_name>
+			EOM
+		return
+	fi
 	validate_path "$path"
 	validate_param "$name"
 
@@ -295,6 +361,18 @@ add_to_manifest() {
 	local manifest=$1
 	local item=$2
 	local item_path=$3
+
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    add_to_manifest [--skip-validation] <manifest> <item> <item_path_in_fs>
+
+			Options:
+			    --skip-validation    If set, the validation of parameters will be skipped
+			EOM
+		return
+	fi
 
 	if [ "$skip_param_validation" = false ]; then
 		validate_item "$manifest"
@@ -369,6 +447,14 @@ add_dependency_to_manifest() {
 	local path
 	local manifest_name
 	local bundle_name
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    add_dependency_to_manifest <manifest> <dependency>
+			EOM
+		return
+	fi
 	validate_item "$manifest"
 	path=$(dirname "$manifest")
 	manifest_name=$(basename "$manifest")
@@ -389,6 +475,14 @@ remove_from_manifest() {
 
 	local manifest=$1
 	local item=$2
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    remove_from_manifest <manifest> <item>
+			EOM
+		return
+	fi
 	validate_item "$manifest"
 	validate_param "$item"
 
@@ -445,6 +539,15 @@ update_hashes_in_mom() {
 sign_manifest() {
 
 	local manifest=$1
+
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    sign_manifest <manifest>
+			EOM
+		return
+	fi
 	validate_item "$manifest"
 
 	sudo openssl smime -sign -binary -in "$manifest" \
@@ -461,6 +564,15 @@ get_hash_from_manifest() {
 
 	local manifest=$1
 	local item=$2
+
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    get_hash_from_manifest <manifest> <name_in_fs>
+			EOM
+		return
+	fi
 	validate_item "$manifest"
 	validate_param "$item"
 
@@ -477,6 +589,16 @@ set_current_version() {
 
 	local env_name=$1
 	local new_version=$2
+
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		echo "$(cat <<-EOM
+			Usage:
+			    set_current_version <environment_name> <new_version>
+			EOM
+		)"
+		return
+	fi
 	validate_path "$env_name"
 
 	sudo sed -i "s/VERSION_ID=.*/VERSION_ID=$new_version/" "$env_name"/target-dir/usr/lib/os-release
@@ -554,6 +676,15 @@ create_test_environment() {
 destroy_test_environment() { 
 
 	local env_name=$1
+
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    destroy_test_environment <environment_name>
+			EOM
+		return
+	fi
 	validate_path "$env_name"
 
 	# since the action to be performed is very destructive, at least
@@ -572,7 +703,7 @@ destroy_test_environment() {
 create_bundle() { 
 
 	cb_usage() { 
-		echo $(cat <<-EOF
+		cat <<-EOM
 		Usage:
 		    create_bundle [-L] [-n] <bundle_name> [-v] <version> [-d] <list of dirs> [-f] <list of files> [-l] <list of links> ENV_NAME
 
@@ -599,8 +730,7 @@ create_bundle() {
 
 		    create_bundle -n test-bundle -f /usr/bin/test-1,/usr/bin/test-2,/etc/systemd/test-3 -l /etc/test-link my_test_env
 
-		EOF
-		)
+		EOM
 	}
 	
 	local OPTIND
@@ -617,6 +747,11 @@ create_bundle() {
 	local manifest
 	local local_bundle=false
 
+	# If no parameters are received show help
+	if [ $# -eq 0 ]; then
+		create_bundle -h
+		return
+	fi
 	set -f  # turn off globbing
 	while getopts :v:d:f:l:b:n:L opt; do
 		case "$opt" in
@@ -792,6 +927,18 @@ create_bundle() {
 # - BUNDLE_MANIFEST: the manifest of the bundle to be removed
 remove_bundle() {
 
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    remove_bundle [-L] <bundle_manifest>
+
+			Options:
+			    -L   If set, the bundle will be removed from the target-dir only,
+			         otherwise it is removed from both target-dir and web-dir
+			EOM
+		return
+	fi
 	local remove_local=false
 	[ "$1" = "-L" ] && { remove_local=true ; shift ; }
 	local bundle_manifest=$1
@@ -857,6 +1004,14 @@ install_bundle() {
 	local manifest_file
 	local bundle_name
 
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    install_bundle <bundle_manifest>
+			EOM
+		return
+	fi
 	validate_item "$bundle_manifest"
 	target_path=$(dirname "$bundle_manifest" | cut -d "/" -f1)/target-dir
 	files_path=$(dirname "$bundle_manifest")/files
@@ -902,6 +1057,14 @@ install_bundle() {
 clean_state_dir() {
 
 	local env_name=$1
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    clean_state_dir <environment_name>
+			EOM
+		return
+	fi
 	validate_path "$env_name"
 
 	sudo rm -rf "$env_name"/state/{staged,download,delta,telemetry}
@@ -917,6 +1080,15 @@ generate_test() {
 
 	local name=$1
 	local path
+
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    generate_test <test_name>
+			EOM
+		return
+	fi
 	validate_param "$name"
 
 	path=$(dirname "$name")/

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -58,6 +58,18 @@ generate_random_name() {
 
 }
 
+print_stack() {
+
+	echo "An error occurred"
+	echo "Function stack (most recent on top):"
+	for func in ${FUNCNAME[*]}; do
+		if [ "$func" != "print_stack" ] && [ "$func" != "terminate" ]; then
+			echo -e "\\t$func"
+		fi
+	done
+
+}
+
 terminate() {
 
 	# since the library could be sourced and run from an interactive shell
@@ -67,8 +79,10 @@ terminate() {
 	local msg=$1
 	local param
 	case "$-" in
-		*i*)	: ${param:?"$msg, exiting..."} ;;
-		*)		echo "$msg, exiting..."
+		*i*)	print_stack
+				: "${param:?"$msg, exiting..."}" ;;
+		*)		print_stack
+				echo "$msg, exiting..."
 				exit 1;;
 	esac
 


### PR DESCRIPTION
This pull request add some usability improvements to the test library.

- Print the function stack when the script fails due to missing or bad parameters.
- Print information about function usage when executing the function without any parameter in the command line.
- Allow users to skip the deletion of a test environment temporarily so they can debug what is wrong with its test, and or to verify the environment is correct as they built it.
- Adds two more assertions for validating file equality in tests.

Besides the usability improvements the PR includes a fix for some variables that were being used incorrectly (without the $ character).