### PR TITLE
Bug fixes and improvements for the test library

### DIFF
--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -221,7 +221,7 @@ necessary for the bundle like files, directories, manifests, packs, etc.
 Use the following command to create a bundle with two files called "test-bundle" in
 the "my_env" test environment.
 ```bash
-create_bundle -n test-bundle -f /foo/bar/test-file1,/baz/test-file2 my_env
+$ create_bundle -n test-bundle -f /foo/bar/test-file1,/baz/test-file2 my_env
 ```
 By creating that bundle the following objects will also be created:
 * A hashed directory (to be used for the /foo, /foo/bar and /baz directories)
@@ -235,7 +235,7 @@ randomly generated so hashes are different)
 
 Another example:
 ```bash
-create_bundle -L -n another-bundle -d /some_dir -f /baz/test-file -l /test-link my_env
+$ create_bundle -L -n another-bundle -d /some_dir -f /baz/test-file -l /test-link my_env
 ```
 This bundle, besides having characteristics similar to the previous bundle will
 have this new characteristics:
@@ -245,6 +245,18 @@ symbolic link is pointing to
 * Since the -L flag was used, the bundle will not only be created in the directory
 for content download, but it will also be installed in the target file system, this
 is useful for tests that need a pre-installed bundle as prerequisite
+
+Sometimes it is useful to create a bundle using an existing file in your system
+instead of letting the helper functions create a random file for you. This can be
+achieved by using the ':' character and specifying the file you want to use.  
+For example:  
+```bash
+$ create_bundle -L -n test-bundle -f /foo/bar/test-file:"$WEBDIR"/10/files/"$hashed_name" my_env
+```
+This will create a bundle that has the file */foo/bar/test-file* in the manifest and
+will refer to the file specified by you. Note that it is your responsibility to copy
+that file to the appropriate directory first (*"$WEBDIR"/\<version\>/files*), and to
+name it properly according to its hash.
 
 The following are some of the functions provided by the test library to create and
 handle test objects:

--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -468,6 +468,7 @@ Example:
 ```bash
 run <some_command>
 assert_files_not_equal foo/bar foo/baz
+```
 
 ### Ignore lists
 When using assertions that compare the command output to an expected output (for example

--- a/test/functional/bundleadd_v2/add-boot-file.bats
+++ b/test/functional/bundleadd_v2/add-boot-file.bats
@@ -17,14 +17,13 @@ test_setup() {
 	assert_status_is 0
 	assert_file_exists "$TEST_NAME/target-dir/usr/lib/kernel/test-file"
 	expected_output=$(cat <<-EOM
-		Starting download of remaining update content. This may take a while\.\.\.
-		Finishing download of update content\.\.\.
-		Installing bundle\(s\) files\.\.\.
-		Calling post-update helper scripts\.
-		.*
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Installing bundle(s) files...
+		Calling post-update helper scripts.
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_regex_is_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundleadd_v2/add-include.bats
+++ b/test/functional/bundleadd_v2/add-include.bats
@@ -9,8 +9,6 @@ test_setup() {
 	create_bundle -n test-bundle2 -f /bar/test-file2 "$TEST_NAME"
 	# add test-bundle2 as a dependency of test-bundle1
 	add_dependency_to_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle1 test-bundle2
-	# since we modified one manifest we need to update that in MoM too, so re add the bundle manifest
-	update_hashes_in_mom "$TEST_NAME"/web-dir/10/Manifest.MoM
 
 }
 

--- a/test/functional/bundleadd_v2/add-verify-fix-path.bats
+++ b/test/functional/bundleadd_v2/add-verify-fix-path.bats
@@ -10,11 +10,8 @@ test_setup() {
 	# bundles created with the testlib add all needed directories to the
 	# manifest by default, so we need to remove the directory from test-bundle1
 	# so its missing the path to the file.
-	# also, because the change on Manifest.test-bundle1 its hash will change, so
-	# update the hash in the MoM
 	remove_from_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle1 /foo
 	remove_from_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle1 /foo/bar
-	update_hashes_in_mom "$TEST_NAME"/web-dir/10/Manifest.MoM
 	# since test-bundle2 is already installed, both directories defined
 	# there already exist, so we need to delete one of the /foo/bar so it
 	# can be fixed using verify_fix_path

--- a/test/functional/bundlelist_v2/list-deps-flat.bats
+++ b/test/functional/bundlelist_v2/list-deps-flat.bats
@@ -11,7 +11,6 @@ test_setup() {
 	# add bundle2 and 3 as dependencies of bundle1
 	add_dependency_to_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle1 test-bundle2
 	add_dependency_to_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle1 test-bundle3
-	update_hashes_in_mom "$TEST_NAME"/web-dir/10/Manifest.MoM
 
 }
 

--- a/test/functional/bundlelist_v2/list-deps-nested.bats
+++ b/test/functional/bundlelist_v2/list-deps-nested.bats
@@ -11,7 +11,6 @@ test_setup() {
 	# add bundle2 as dependencies of bundle1 and bundle 3 as dependency of bundle2
 	add_dependency_to_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle1 test-bundle2
 	add_dependency_to_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle2 test-bundle3
-	update_hashes_in_mom "$TEST_NAME"/web-dir/10/Manifest.MoM
 
 }
 

--- a/test/functional/bundlelist_v2/list-has-dep-nested-not-installed.bats
+++ b/test/functional/bundlelist_v2/list-has-dep-nested-not-installed.bats
@@ -11,7 +11,6 @@ test_setup() {
 	# add bundle1 as dependencies of bundle2 and bundle 2 as dependency of bundle3
 	add_dependency_to_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle2 test-bundle1
 	add_dependency_to_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle3 test-bundle2
-	update_hashes_in_mom "$TEST_NAME"/web-dir/10/Manifest.MoM
 
 }
 

--- a/test/functional/bundlelist_v2/list-has-dep-nested-server.bats
+++ b/test/functional/bundlelist_v2/list-has-dep-nested-server.bats
@@ -11,7 +11,6 @@ test_setup() {
 	# add bundle1 as dependencies of bundle2 and bundle 2 as dependency of bundle3
 	add_dependency_to_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle2 test-bundle1
 	add_dependency_to_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle3 test-bundle2
-	update_hashes_in_mom "$TEST_NAME"/web-dir/10/Manifest.MoM
 
 }
 

--- a/test/functional/bundlelist_v2/list-has-dep-nested.bats
+++ b/test/functional/bundlelist_v2/list-has-dep-nested.bats
@@ -11,7 +11,6 @@ test_setup() {
 	# add bundle1 as dependencies of bundle2 and bundle 2 as dependency of bundle3
 	add_dependency_to_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle2 test-bundle1
 	add_dependency_to_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle3 test-bundle2
-	update_hashes_in_mom "$TEST_NAME"/web-dir/10/Manifest.MoM
 
 }
 

--- a/test/functional/bundleremove_v2/remove-boot-file.bats
+++ b/test/functional/bundleremove_v2/remove-boot-file.bats
@@ -13,10 +13,10 @@ test_setup() {
 
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle"
 	assert_status_is 0
-	assert_file_not_exists "$TEST_NAME"/target-dir/usr/lib/kernel/testfile
+	assert_file_not_exists "$TARGETDIR"/usr/lib/kernel/testfile
 	expected_output=$(cat <<-EOM
 		Deleting bundle files...
-		Total deleted files: 2
+		Total deleted files: 1
 		Successfully removed 1 bundle
 	EOM
 	)

--- a/test/functional/bundleremove_v2/remove-include-nested.bats
+++ b/test/functional/bundleremove_v2/remove-include-nested.bats
@@ -11,7 +11,6 @@ test_setup() {
 	# add dependencies
 	add_dependency_to_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle2 test-bundle1
 	add_dependency_to_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle3 test-bundle2
-	update_hashes_in_mom "$TEST_NAME"/web-dir/10/Manifest.MoM
 
 }
 

--- a/test/functional/bundleremove_v2/remove-include.bats
+++ b/test/functional/bundleremove_v2/remove-include.bats
@@ -9,7 +9,6 @@ test_setup() {
 	create_bundle -L -n test-bundle2 -f /bar/test-file2 "$TEST_NAME"
 	# add test-bundle1 as dependency of test-bundle2
 	add_dependency_to_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle2 test-bundle1
-	update_hashes_in_mom "$TEST_NAME"/web-dir/10/Manifest.MoM
 
 }
 

--- a/test/functional/bundleremove_v2/remove-os-core.bats
+++ b/test/functional/bundleremove_v2/remove-os-core.bats
@@ -6,7 +6,7 @@ load "../testlib"
 
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS os-core"
 	assert_status_is "$EBUNDLE_NOT_TRACKED"
-	assert_file_exists "$TEST_NAME"/target-dir/usr/bin/core
+	assert_file_exists "$TARGETDIR"/core
 	expected_output=$(cat <<-EOM
 		Warning: Bundle "os-core" not allowed to be removed
 		Failed to remove 1 of 1 bundles

--- a/test/functional/ignore-list.global
+++ b/test/functional/ignore-list.global
@@ -1,0 +1,3 @@
+sh: .*/usr/bin/clr-boot-manager: No such file or directory
+sh: .*/usr/bin/clr-boot-manager: not found
+Update took .* seconds

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -808,6 +808,8 @@ create_bundle() {
 		    - for every symlink created a related file will be created and added to the bundle as well (except for dangling links)
 		    - if the '-f' or '-l' options are used, and the directories where the files live don't exist,
 		      they will be automatically created and added to the bundle for each file
+		    - if instead of creating a new file you want to reuse an existing one, you can do this by adding ':' followed by the
+		      path to the file, for example '-f /usr/bin/test-1:my_environment/web-dir/10/files/\$file_hash'
 
 		Example of usage:
 
@@ -924,7 +926,14 @@ create_bundle() {
 	# 3) Create the requested file(s)
 	for val in "${file_list[@]}"; do
 		add_dirs
-		bundle_file=$(create_file "$files_path")
+		# if the user wants to use an existing file, use it, else create a new one
+		if [[ "$val" = *":"* ]]; then
+			bundle_file="${val#*:}"
+			val="${val%:*}"
+			validate_item "$bundle_file"
+		else
+			bundle_file=$(create_file "$files_path")
+		fi
 		if [ "$DEBUG" == true ]; then
 			echo "file -> $bundle_file"
 		fi

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -692,13 +692,28 @@ set_latest_version() {
 # Creates a test environment with the basic directory structure needed to
 # validate the swupd client
 # Parameters:
+# - -e: if this option is set the test environment is created empty (withouth bundle os-core)
 # - ENVIRONMENT_NAME: the name of the test environment, this should be typically the test name
 # - VERSION: the version to use for the test environment, if not specified the default is 10
 create_test_environment() { 
 
+	local empty=false
+	[ "$1" = "-e" ] && { empty=true ; shift ; }
 	local env_name=$1 
 	local version=${2:-10}
 	local mom
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    create_test_environment [-e] <environment_name> [initial_version]
+
+			Options:
+			    -e    If set, the test environment is created empty, otherwise it will have
+			          bundle os-core in the web-dir and installed by default.
+			EOM
+		return
+	fi
 	validate_param "$env_name"
 	
 	# create all the files and directories needed
@@ -735,8 +750,10 @@ create_test_environment() {
 	set_env_variables "$env_name"
 
 	# every environment needs to have at least the os-core bundle so this should be
-	# added by default to every test environment
-	create_bundle -L -n os-core -v "$version" -f /usr/bin/core "$env_name"
+	# added by default to every test environment unless specified otherwise
+	if [ "$empty" = false ]; then
+		create_bundle -L -n os-core -v "$version" -f /core "$env_name"
+	fi
 
 }
 

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1172,8 +1172,13 @@ generate_test() {
 		printf '\t# global cleanup\n\n'
 		printf '}\n\n'
 		printf '@test "<test description>" {\n\n'
-		printf '\trun sudo sh -c "$SWUPD <swupd_command> $SWUPD_OPTS <command_options>"\n'
-		printf '\t# <validations>\n\n'
+		printf '\trun sudo sh -c "$SWUPD <swupd_command> $SWUPD_OPTS <command_options>"\n\n'
+		printf '\t# assert_status_is 0\n'
+		printf '\t# expected_output=$(cat <<-EOM\n'
+		printf '\t# \t<expected output>\n'
+		printf '\t# EOM\n'
+		printf '\t# )\n'
+		printf '\t# assert_is_output "$expected_output"\n\n'
 		printf '}\n\n'
 	} > "$path$name".bats
 	# make the test script executable

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -163,7 +163,11 @@ set_env_variables() {
 	export SWUPD_OPTS="-S $path/$env_name/state -p $path/$env_name/target-dir -F staging -u file://$path/$env_name/web-dir -C $FUNC_DIR/Swupd_Root.pem -I"
 	export SWUPD_OPTS_NO_CERT="-S $path/$env_name/state -p $path/$env_name/target-dir -F staging -u file://$path/$env_name/web-dir"
 	export SWUPD_OPTS_MIRROR="-p $path/$env_name/target-dir"
+	export SWUPD_OPTS_NO_FMT="-S $path/$env_name/state -p $path/$env_name/target-dir -u file://$path/$env_name/web-dir -C $FUNC_DIR/Swupd_Root.pem -I"
 	export TEST_DIRNAME="$path"/"$env_name"
+	export WEBDIR="$env_name"/web-dir
+	export TARGETDIR="$env_name"/target-dir
+	export STATEDIR="$env_name"/state
 
 }
 

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -348,7 +348,7 @@ create_manifest() {
 #                      are not validated, so use this option carefully
 # - MANIFEST: the relative path to the manifest file
 # - ITEM: the relative path to the item (file, directory, symlink) to be added
-# - ITEM_PATH: the absolute path of the item in the target system when installed
+# - PATH_IN_FS: the absolute path of the item in the target system when installed
 add_to_manifest() { 
 
 	local item_type
@@ -392,7 +392,7 @@ add_to_manifest() {
 	filecount=$((filecount + 1))
 	sudo sed -i "s/filecount:.*/filecount:\\t$filecount/" "$manifest"
 	# add to contentsize 
-	contentsize=$(sudo cat "$manifest" | grep contentsize | awk '{ print $2 }')
+	contentsize=$(awk '/contentsize/ { print $2}' "$manifest")
 	contentsize=$((contentsize + item_size))
 	# get the item type
 	if [ "$(basename "$manifest")" = Manifest.MoM ]; then
@@ -422,7 +422,7 @@ add_to_manifest() {
 	elif [ -d "$item" ]; then
 		item_type=D
 	fi
-	# if the file is in the /usr/lib/kernel dir then it is a boot file
+	# if the file is in the /usr/lib/{kernel, modules} dir then it is a boot file
 	if [ "$(dirname "$item_path")" = "/usr/lib/kernel" ] || [ "$(dirname "$item_path")" = "/usr/lib/modules/" ]; then
 		boot_type="b"
 	fi

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -626,7 +626,6 @@ get_hash_from_manifest() {
 
 	local manifest=$1
 	local item=$2
-
 	# If no parameters are received show usage
 	if [ $# -eq 0 ]; then
 		cat <<-EOM
@@ -638,7 +637,7 @@ get_hash_from_manifest() {
 	validate_item "$manifest"
 	validate_param "$item"
 
-	hash=$(sudo cat "$manifest" | grep "$item" | awk '{ print $2 }')
+	hash=$(sudo cat "$manifest" | grep $'\t'"$item"$ | awk '{ print $2 }')
 	echo "$hash"
 
 }

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1079,7 +1079,7 @@ remove_bundle() {
 	# may be used by another bundle)
 	dir_names=($(awk '/^D...\t/ { print $4 }' "$bundle_manifest"))
 	for dname in ${dir_names[@]}; do
-		sudo rmdir "$target_path$dname" 2> /dev/null
+		sudo rmdir --ignore-fail-on-non-empty "$target_path$dname" 2> /dev/null
 	done
 	if [ "$remove_local" = false ]; then
 		# remove all files that are in the manifest from web-dir

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -884,11 +884,6 @@ create_bundle() {
 	# set default values
 	bundle_name=${bundle_name:-$(generate_random_name test-bundle-)}
 	version=${version:-10}
-	if [ -z "$dir_list" ] && [ -z "$file_list" ] && [ -z "$link_list" ] && [ -z "$dangling_link_list" ] ; then
-		# if nothing was specified to be created, at least create
-		# one directory which is the bare minimum for a bundle
-		dir_list=(/usr/bin)
-	fi
 	# all bundles should include their own tracking file, so append it to the
 	# list of files to be created in the bundle
 	file_list+=(/usr/share/clear/bundles/"$bundle_name")

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -674,6 +674,15 @@ set_latest_version() {
 
 	local env_name=$1
 	local new_version=$2
+
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    set_latest_version <environment_name> <new_version>
+			EOM
+		return
+	fi
 	validate_path "$env_name"
 
 	write_to_protected_file "$env_name"/web-dir/version/formatstaging/latest "$new_version"


### PR DESCRIPTION
This pull request includes several bug fixes in the test library and also makes a few improvements in it.

Improvements:

- Export some more variables that are useful for some tests.
- Improves on how content size is read from a manifest.
- Allows adding dependencies to newer versions not only version 10 (default one).
- Decrease the file count and content size when removing something from a manifest.
- Updates the test template generated by the test generator with a more common output.
- Adds usage info in a couple of functions that were missing it.
- Adds the capability of creating empty test environment (with no os-core bundle).
- Removes an unnecessary directory in the creation of "default" bundles.
- Adds the capability of using existing files in the test bundles.
