### PR TITLE
Re-enable manpage tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -111,6 +111,7 @@ BATS_LOG_DRIVER = $(tap_driver)
 TESTS = $(dist_check_SCRIPTS)
 
 BATS = \
+	test/documentation/manpages/test.bats \
 	test/functional/bundleadd/add-directory/test.bats \
 	test/functional/bundleadd_v2/add-directory.bats \
 	test/functional/bundleadd/add-existing/test.bats \

--- a/test/documentation/manpages/test.bats
+++ b/test/documentation/manpages/test.bats
@@ -22,7 +22,7 @@ setup() {
   do
     [ -f "$nroff" ] || continue
     echo "$nroff"
-    git diff-index --quiet HEAD "$nroff"
+    git diff --exit-code HEAD "$nroff"
   done
 }
 

--- a/test/documentation/manpages/test.bats
+++ b/test/documentation/manpages/test.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+setup() {
+  # Ensure that we have the conversion program
+  type -t rst2man.py > /dev/null
+  # Change to the toplevel git directory
+  type -t git >/dev/null || skip
+  cd "$(git rev-parse --show-toplevel)"
+}
+
+@test "Check manual pages are up to date" {
+  for rst in docs/*.[1-9].rst
+  do
+    [ -f "$rst" ] || continue	# Could use shopt -s nullglob
+    echo "$rst"
+    rst2man.py "$rst" | cmp  "${rst%.rst}" -
+  done
+}
+
+@test "Check manual pages are clean" {
+  for nroff in docs/*.[1-9]
+  do
+    [ -f "$nroff" ] || continue
+    echo "$nroff"
+    git diff-index --quiet HEAD "$nroff"
+  done
+}
+
+# vi: ft=sh ts=8 sw=2 sts=2 et tw=80


### PR DESCRIPTION
The manpage tests were recently removed due to occasional test failures that were raised. I spent some time debugging the issue and root caused the issue.

So, I've reverted the commit that the removed the tests and fixed the problem in the second commit.