### PR TITLE
Ability to create environment with complex bundle

### DIFF
--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -227,6 +227,20 @@ $ create_test_environment my_env 2
 # create a new version 20 based on version 10, format 2
 $ create_version my_env 20 10 2
 ```
+In occasions you may want to create a test environment that has an os-core
+bundle that includes the os-release and format files tracked in the bundle's
+manifest, this is particularly useful for upgrade related tests. To create
+this kind of test environment you can use the *-r* (release) option.
+bash```
+# test environment with a more complete os-core bundle
+$ create_test_environment -r my_env
+```
+In a similar manner is possible to create a test environment with no bundle using
+the *-e* (empty) option.
+bash```
+# empty test environment
+$ create_test_environment -e my_env
+```
 
 The test library provides the following functions for handling test environments:
 * create_test_environment

--- a/test/functional/bundleremove_v2/remove-boot-file.bats
+++ b/test/functional/bundleremove_v2/remove-boot-file.bats
@@ -4,7 +4,7 @@ load "../testlib"
 
 test_setup() {
 
-	create_test_environment "$TEST_NAME"
+	create_test_environment -r "$TEST_NAME"
 	create_bundle -L -n test-bundle -f /usr/lib/kernel/test-file "$TEST_NAME"
 
 }
@@ -16,7 +16,7 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/usr/lib/kernel/testfile
 	expected_output=$(cat <<-EOM
 		Deleting bundle files...
-		Total deleted files: 1
+		Total deleted files: 2
 		Successfully removed 1 bundle
 	EOM
 	)


### PR DESCRIPTION
Normal test environments come with a minimal version of os-core
bundle by default (only one file and the tracking file). Users
also have the option of not having os-core at all with the -e
"empty" option.

This commit adds another option "-r" for creating a test environment
that includes a more complete version of the os-core bundle,
with a couple of useful files: os-release and format. This type
of bundle can be useful when working with some type of tests like
updates.