### PR TITLE
Testlib partial updates for manifests

### DIFF
--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1305,7 +1305,7 @@ remove_bundle() {
 
 	# if the bundle's manifest is not found just return
 	if [ ! -e "$bundle_manifest" ]; then
-		echo "$(basename $bundle_manifest) not found, maybe the bundle was already removed"
+		echo "$(basename "$bundle_manifest") not found, maybe the bundle was already removed"
 		return
 	fi
 
@@ -1326,17 +1326,15 @@ remove_bundle() {
 		sudo rmdir --ignore-fail-on-non-empty "$target_path$dname" 2> /dev/null
 	done
 	if [ "$remove_local" = false ]; then
-		# remove all files that are in the manifest from web-dir
-		file_names=($(awk '/^[FL]...\t/ { print $2 }' "$bundle_manifest"))
-		for fname in ${file_names[@]}; do
-			sudo rm "$version_path"/files/"$fname"
-			sudo rm "$version_path"/files/"$fname".tar
-		done
-		# remove zero pack
-		sudo rm "$version_path"/pack-"$bundle_name"-from-0.tar
-		# finally remove the manifest
-		sudo rm "$version_path"/"$manifest_file"
-		sudo rm "$version_path"/"$manifest_file".tar
+		# there is no need to remove the files and tars from web-dir/<ver>/files
+		# as long as we remove the manifest from the bundle from all versions
+		# where it shows up and from the MoM, the files may be used by another bundle
+		sudo rm -f "$version_path"/"$manifest_file"
+		sudo rm -f "$version_path"/"$manifest_file".tar
+		# remove packs
+		sudo rm "$version_path"/pack-"$bundle_name"-from-*.tar
+		# finally remove it from the MoM
+		remove_from_manifest "$version_path"/Manifest.MoM "$bundle_name"
 	fi
 
 }


### PR DESCRIPTION
Some functions from the test library can be used by end users to modify some object from their test environment, for example using the add_dependency_to_manifest they can add one or many dependencies to a bundle's manifest.

After modifying a bundle's manifest, a few subsequent actions need to occur in order for the objects to still be valid, the manifest's tar needs to be re-created, since the manifest's hash has changed, the MoM needs to be updated with this new hash, etc. 

To minimize the actions an end user needs to do, most of these activities are automatically performed by most library functions. However if the function is being called by another function which expects to perform many updates to the same object, it may not be the best option to be re-creating those tars and updating the MoM many times for the same object since it could affect the performance.

This PR adds a -p flag to some functions that allow them to run a partial update in a manifest, meaning that you plan on making more changes to the manifest so all those unnecessary changes are not performed.