### PR TITLE
Adding functions to update bundles and bump format

### DIFF
--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -723,6 +723,117 @@ update_hashes_in_mom() {
 
 }
 
+# Update all manifests after a format bump
+# Parameters:
+# ENVIRONMENT_NAME: the name of the test environment
+bump_format() {
+
+	local env_name=$1
+	local format
+	local version
+	local previous_version
+	local new_version
+	local middle_version
+	local new_version_path
+	local middle_version_path
+	local mom
+	local manifest
+	local bundles
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    bump_format <environment_name>
+			EOM
+		return
+	fi
+	validate_path "$env_name"
+
+	# find the latest version and MoM
+	version="$(ls "$env_name"/web-dir | grep -E '^[0-9]+$' | sort -rn | head -n1)"
+	middle_version="$((version+10))"
+	middle_version_path="$env_name"/web-dir/"$middle_version"
+	new_version="$((version+20))"
+	new_version_path="$env_name"/web-dir/"$new_version"
+	format="$(cat "$env_name"/web-dir/"$version"/format)"
+	mom="$new_version_path"/Manifest.MoM
+
+	# create two new versions for the format bump, each version separated by 10
+	# from each other and from the current latest version
+	create_version "$env_name" "$middle_version" "$version" "$format"
+	create_version -r "$env_name" "$new_version" "$middle_version" "$((format+1))"
+	# regardless of where we found the previous version of os-core, update
+	# the previous version to $middle_version
+	update_manifest -p "$new_version_path"/Manifest.os-core previous "$middle_version"
+
+	# update the new version
+	# copy all manifests in MoM to new version
+	bundles=($(cat "$mom" | grep -x "M\.\.\..*" | awk '{ print $4 }'))
+	IFS=$'\n'
+	for bundle in ${bundles[*]}; do
+		# search for the latest manifest version for the bundle
+		manifest="$new_version_path"/Manifest."$bundle"
+		if [ ! -e "$manifest" ]; then
+			previous_version="$new_version"
+			while [ "$previous_version" -gt 0 ] && [ ! -e "$manifest" ]; do
+				previous_version="$(awk '/previous/ { print $2 }' "$mom")"
+				manifest="$env_name"/web-dir/"$previous_version"/Manifest."$bundle"
+				mom="$env_name"/web-dir/"$previous_version"/Manifest.MoM
+			done
+			sudo cp "$manifest" "$env_name"/web-dir/"$new_version"/Manifest."$bundle"
+			manifest="$env_name"/web-dir/"$new_version"/Manifest."$bundle"
+			mom="$env_name"/web-dir/"$new_version"/Manifest.MoM
+			# copy the zero pack also from the old version to the new one
+			sudo cp "$env_name"/web-dir/"$previous_version"/pack-"$bundle"-from-0.tar "$env_name"/web-dir/"$new_version"/pack-"$bundle"-from-0.tar
+			# extract the content of the zero pack in the files directory so we have
+			# all files available to create future delta packs
+			sudo tar -xf "$env_name"/web-dir/"$new_version"/pack-"$bundle"-from-0.tar --strip-components 1 --directory "$env_name"/web-dir/"$new_version"/files
+			files=("$(ls -I "*.tar" "$env_name"/web-dir/"$new_version"/files)")
+			for bundle_file in ${files[*]}; do
+				if [ ! -e "$env_name"/web-dir/"$new_version"/files/"$bundle_file".tar ]; then
+					create_tar "$env_name"/web-dir/"$new_version"/files/"$bundle_file"
+				fi
+			done
+			update_manifest -p "$manifest" version "$new_version"
+			update_manifest -p "$manifest" previous "$previous_version"
+		fi
+		update_manifest -p "$manifest" format "$((format+1))"
+		# update manifest content with latest version
+		sudo sed -i "/....\\t.*\\t.*\\t.*$/s/\(....\\t.*\\t\).*\(\\t\)/\1$new_version\2/g" "$manifest"
+		sudo rm -rf "$manifest".tar
+		create_tar "$manifest"
+	done
+	unset IFS
+	update_hashes_in_mom "$mom"
+
+	# update the middle version
+	sudo rm -rf "$middle_version_path"/files/*
+	sudo rm -f "$middle_version_path"/Manifest*
+	sudo rm -f "$middle_version_path"/pack*
+	sudo cp -r "$new_version_path"/files/* "$middle_version_path"/files/
+	sudo cp "$new_version_path"/Manifest.* "$middle_version_path"/
+	sudo cp "$new_version_path"/pack* "$middle_version_path"/
+	mom="$middle_version_path"/Manifest.MoM
+	update_manifest -p "$mom" format "$((format))"
+	update_manifest -p "$mom" version "$middle_version"
+	update_manifest -p "$mom" previous "$version"
+	sudo sed -i "/....\\t.*\\t.*\\t.*$/s/\(....\\t.*\\t\).*\(\\t\)/\1$middle_version\2/g" "$mom"
+	bundles=($(cat "$mom" | grep -x "M\.\.\..*" | awk '{ print $4 }'))
+	IFS=$'\n'
+	for bundle in ${bundles[*]}; do
+		manifest="$middle_version_path"/Manifest."$bundle"
+		update_manifest -p "$manifest" format "$((format))"
+		update_manifest -p "$manifest" version "$middle_version"
+		update_manifest -p "$manifest" previous "$version"
+		sudo sed -i "/....\\t.*\\t.*\\t.*$/s/\(....\\t.*\\t\).*\(\\t\)/\1$middle_version\2/g" "$manifest"
+		sudo rm -rf "$manifest".tar
+		create_tar "$manifest"
+	done
+	unset IFS
+	update_hashes_in_mom "$mom"
+
+}
+
 # Signs a manifest with a PEM key and generates the signed manifest in the same location
 # Parameters:
 # - MANIFEST: the path to the manifest to be signed

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -755,7 +755,7 @@ bump_format() {
 	middle_version_path="$env_name"/web-dir/"$middle_version"
 	new_version="$((version+20))"
 	new_version_path="$env_name"/web-dir/"$new_version"
-	format="$(cat "$env_name"/web-dir/"$version"/format)"
+	format="$(< "$env_name"/web-dir/"$version"/format)"
 	mom="$new_version_path"/Manifest.MoM
 
 	# create two new versions for the format bump, each version separated by 10
@@ -768,7 +768,7 @@ bump_format() {
 
 	# update the new version
 	# copy all manifests in MoM to new version
-	bundles=($(cat "$mom" | grep -x "M\.\.\..*" | awk '{ print $4 }'))
+	bundles=($(awk '/^M\.\.\./ { print $4 }' "$mom"))
 	IFS=$'\n'
 	for bundle in ${bundles[*]}; do
 		# search for the latest manifest version for the bundle
@@ -818,7 +818,7 @@ bump_format() {
 	update_manifest -p "$mom" version "$middle_version"
 	update_manifest -p "$mom" previous "$version"
 	sudo sed -i "/....\\t.*\\t.*\\t.*$/s/\(....\\t.*\\t\).*\(\\t\)/\1$middle_version\2/g" "$mom"
-	bundles=($(cat "$mom" | grep -x "M\.\.\..*" | awk '{ print $4 }'))
+	bundles=($(awk '/^M\.\.\./ { print $4 }' "$mom"))
 	IFS=$'\n'
 	for bundle in ${bundles[*]}; do
 		manifest="$middle_version_path"/Manifest."$bundle"

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -431,11 +431,11 @@ add_to_manifest() {
 	name=$(basename "$item")
 	version=$(basename "$(dirname "$manifest")")
 	# add to filecount
-	filecount=$(awk '/filecount/ { print $2}' "$manifest")
+	filecount=$(awk '/^filecount/ { print $2}' "$manifest")
 	filecount=$((filecount + 1))
-	sudo sed -i "s/filecount:.*/filecount:\\t$filecount/" "$manifest"
+	sudo sed -i "s/^filecount:.*/filecount:\\t$filecount/" "$manifest"
 	# add to contentsize 
-	contentsize=$(awk '/contentsize/ { print $2}' "$manifest")
+	contentsize=$(awk '/^contentsize/ { print $2}' "$manifest")
 	contentsize=$((contentsize + item_size))
 	# get the item type
 	if [ "$(basename "$manifest")" = Manifest.MoM ]; then
@@ -469,7 +469,7 @@ add_to_manifest() {
 	if [ "$(dirname "$item_path")" = "/usr/lib/kernel" ] || [ "$(dirname "$item_path")" = "/usr/lib/modules/" ]; then
 		boot_type="b"
 	fi
-	sudo sed -i "s/contentsize:.*/contentsize:\\t$contentsize/" "$manifest"
+	sudo sed -i "s/^contentsize:.*/contentsize:\\t$contentsize/" "$manifest"
 	# add to manifest content
 	write_to_protected_file -a "$manifest" "$item_type.$boot_type.\\t$name\\t$version\\t$item_path\\n"
 	# If a manifest tar already exists for that manifest, renew the manifest tar unless specified otherwise
@@ -524,14 +524,14 @@ add_dependency_to_manifest() {
 	if [ ! -e "$path"/"$version"/"$manifest_name" ]; then
 		pre_version="$version"
 		while [ "$pre_version" -gt 0 ] && [ ! -e "$path"/"$pre_version"/"$manifest_name" ]; do
-				pre_version=$(awk '/previous/ { print $2 }' "$path"/"$pre_version"/Manifest.MoM)
+				pre_version=$(awk '/^previous/ { print $2 }' "$path"/"$pre_version"/Manifest.MoM)
 		done
 		sudo cp "$path"/"$pre_version"/"$manifest_name" "$path"/"$version"/"$manifest_name"
 		update_manifest -p "$manifest" version "$version"
 		update_manifest -p "$manifest" previous "$pre_version"
 	fi
 	update_manifest -p "$manifest" timestamp "$(date +"%s")"
-	sudo sed -i "/contentsize:.*/a includes:\\t$dependency" "$manifest"
+	sudo sed -i "/^contentsize:.*/a includes:\\t$dependency" "$manifest"
 	# If a manifest tar already exists for that manifest, renew the manifest tar
 	# unless specified otherwise
 	if [ "$partial" = false ]; then
@@ -577,11 +577,11 @@ remove_from_manifest() {
 	# replace every / with \/ in item (if any)
 	item="${item////\\/}"
 	# decrease filecount and contentsize
-	filecount=$(awk '/filecount/ { print $2}' "$manifest")
+	filecount=$(awk '/^filecount/ { print $2}' "$manifest")
 	filecount=$((filecount - 1))
 	update_manifest -p "$manifest" filecount "$filecount"
 	if [ "$(basename "$manifest")" != Manifest.MoM ]; then
-		contentsize=$(awk '/contentsize/ { print $2}' "$manifest")
+		contentsize=$(awk '/^contentsize/ { print $2}' "$manifest")
 		item_hash=$(get_hash_from_manifest "$manifest" "$item")
 		item_size=$(stat -c "%s" "$(dirname "$manifest")"/files/"$item_hash")
 		contentsize=$((contentsize - item_size))
@@ -638,7 +638,7 @@ update_manifest() {
 
 	case "$key" in
 	format)
-		sudo sed -i "s/MANIFEST.*/MANIFEST\\t$var/" "$manifest"
+		sudo sed -i "s/^MANIFEST.*/MANIFEST\\t$var/" "$manifest"
 		;;
 	version | previous | filecount | timestamp | contentsize)
 		sudo sed -i "s/$key.*/$key:\\t$var/" "$manifest"
@@ -1038,7 +1038,7 @@ create_version() {
 		if [ "$release_files" = true ]; then
 			oldversion="$version"
 			while [ "$oldversion" -gt 0 ] && [ ! -e "$env_name"/web-dir/"$oldversion"/Manifest.os-core ]; do
-				oldversion=$(awk '/previous/ { print $2 }' "$env_name"/web-dir/"$oldversion"/Manifest.MoM)
+				oldversion=$(awk '/^previous/ { print $2 }' "$env_name"/web-dir/"$oldversion"/Manifest.MoM)
 			done
 			# if no os-core manifest was found, nothing else needs to be done
 			if [ -e "$env_name"/web-dir/"$oldversion"/Manifest.os-core ]; then
@@ -1614,12 +1614,12 @@ update_bundle() {
 	# find the previous version of this bundle manifest
 	oldversion="$version"
 	while [ "$oldversion" -gt 0 ] && [ ! -e "$env_name"/web-dir/"$oldversion"/Manifest."$bundle" ]; do
-		oldversion=$(awk '/previous/ { print $2 }' "$env_name"/web-dir/"$oldversion"/Manifest.MoM)
+		oldversion=$(awk '/^previous/ { print $2 }' "$env_name"/web-dir/"$oldversion"/Manifest.MoM)
 	done
 	if [ "$oldversion" = "$version" ]; then
 		# if old version and new version are the same it means this bundle has already
 		# been modified in this version, so look for the real old version
-		oldversion=$(awk '/previous/ { print $2}' "$env_name"/web-dir/"$oldversion"/Manifest."$bundle")
+		oldversion=$(awk '/^previous/ { print $2}' "$env_name"/web-dir/"$oldversion"/Manifest."$bundle")
 	fi
 	oldversion_path="$env_name"/web-dir/"$oldversion"
 	bundle_manifest="$version_path"/Manifest."$bundle"
@@ -1643,7 +1643,7 @@ update_bundle() {
 			fi
 		done
 	fi
-	contentsize=$(awk '/contentsize/ { print $2 }' "$bundle_manifest")
+	contentsize=$(awk '/^contentsize/ { print $2 }' "$bundle_manifest")
 
 	# these actions apply to all operations except when adding a new file or updating the header only
 	if [ "$option" != "--add" ] && [ "$option" != "--add-dir" ] && [ "$option" != "--add-file" ] && [ "$option" != "--header-only" ]; then
@@ -1684,7 +1684,7 @@ update_bundle() {
 		add_to_manifest -p "$bundle_manifest" "$new_file" "$fname"
 		# contentsize is automatically added by the add_to_manifest function so
 		# all we need is to get the updated value for now
-		contentsize=$(awk '/contentsize/ { print $2 }' "$bundle_manifest")
+		contentsize=$(awk '/^contentsize/ { print $2 }' "$bundle_manifest")
 		# Add the file to the zero pack of the bundle
 		add_to_pack "$bundle" "$new_file"
 		# Add the file also to the delta-pack
@@ -1707,7 +1707,7 @@ update_bundle() {
 			add_to_pack "$bundle" "$new_dir"
 			add_to_pack "$bundle" "$new_dir" "$oldversion"
 		fi
-		contentsize=$(awk '/contentsize/ { print $2 }' "$bundle_manifest")
+		contentsize=$(awk '/^contentsize/ { print $2 }' "$bundle_manifest")
 		;;
 	--delete | --ghost)
 		# replace the first character of the line that matches with "."

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1403,6 +1403,279 @@ install_bundle() {
 
 }
 
+# Updates one file or directory from a bundle, the update will be created in whatever version
+# is the latest one (from web-dir/formatstaging/latest)
+# Parameters:
+# - -p: if the p (partial) flag is set the function skips updating the hashes
+#       in the MoM, and re-creating the bundle's tar, this is useful if more changes are to be done
+#       in order to reduce time
+# - ENVIRONMENT_NAME: the name of the test environment
+# - BUNDLE_NAME: the name of the bundle to be updated
+# - OPTION: the kind of update to be performed { --add, --add-dir, --delete, --ghost, --rename, --rename-legacy, --update }
+# - FILE_NAME: file or directory of the bundle to add or update
+# - NEW_NAME: when --rename is chosen this parameter receives the new name to assign
+update_bundle() {
+
+	local partial=false
+	[ "$1" = "-p" ] && { partial=true ; shift ; }
+	local env_name=$1
+	local bundle=$2
+	local option=$3
+	local fname=$4
+	local new_name=$5
+	local version
+	local version_path
+	local oldversion
+	local oldversion_path
+	local bundle_manifest
+	local fdir
+	local new_dir
+	local new_file
+	local contentsize
+	local fsize
+	local fhash
+	local fname
+	local new_fhash
+	local new_fsize
+	local new_fname
+	local delta_name
+	local format
+	local files
+	local bundle_file
+
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    update_bundle [-p] <environment_name> <bundle_name> --add <file_name>[:<path_to_existing_file>]
+			    update_bundle [-p] <environment_name> <bundle_name> --add-dir <directory_name>
+			    update_bundle [-p] <environment_name> <bundle_name> --delete <file_name>
+			    update_bundle [-p] <environment_name> <bundle_name> --ghost <file_name>
+			    update_bundle [-p] <environment_name> <bundle_name> --update <file_name>
+			    update_bundle [-p] <environment_name> <bundle_name> --rename[-legacy] <file_name> <new_name>
+			    update_bundle [-p] <environment_name> <bundle_name> --header-only
+
+			Options:
+			    -p    If set (partial), the bundle will be updated, but the manifest's tar won't
+			          be re-created nor the hash will be updated in the MoM. Use this flag when more
+			          updates or changes will be done to the bundle to save time.
+			EOM
+		return
+	fi
+
+	if [ "$option" = "--header-only" ]; then
+		fname="dummy"
+	fi
+	validate_path "$env_name"
+	validate_param "$bundle"
+	validate_param "$option"
+	validate_param "$fname"
+
+	# make sure fname starts with a slash
+	if [[ "$fname" != "/"* ]]; then
+		fname=/"$fname"
+	fi
+	# the version where the update will be created is the latest version
+	version="$(ls "$env_name"/web-dir | grep -E '^[0-9]+$' | sort -rn | head -n1)"
+	version_path="$env_name"/web-dir/"$version"
+	format=$(cat "$version_path"/format)
+	# find the previous version of this bundle manifest
+	oldversion="$version"
+	while [ "$oldversion" -gt 0 ] && [ ! -e "$env_name"/web-dir/"$oldversion"/Manifest."$bundle" ]; do
+		oldversion=$(awk '/previous/ { print $2 }' "$env_name"/web-dir/"$oldversion"/Manifest.MoM)
+	done
+	if [ "$oldversion" = "$version" ]; then
+		# if old version and new version are the same it means this bundle has already
+		# been modified in this version, so look for the real old version
+		oldversion=$(awk '/previous/ { print $2}' "$env_name"/web-dir/"$oldversion"/Manifest."$bundle")
+	fi
+	oldversion_path="$env_name"/web-dir/"$oldversion"
+	bundle_manifest="$version_path"/Manifest."$bundle"
+	# since we are going to be making updates to the bundle, copy its manifest
+	# from the old version directory to the new one (if not copied already)
+	if [ ! -e "$bundle_manifest" ]; then
+		sudo cp "$oldversion_path"/Manifest."$bundle" "$bundle_manifest"
+	fi
+	update_manifest -p "$bundle_manifest" format "$format"
+	update_manifest -p "$bundle_manifest" version "$version"
+	update_manifest -p "$bundle_manifest" previous "$oldversion"
+	# copy also the bundle's zero pack, untar it the files directory in the new version
+	# and create a tar per file (full files)
+	if [ ! -e "$version_path"/pack-"$bundle"-from-0.tar ]; then
+		sudo cp "$oldversion_path"/pack-"$bundle"-from-0.tar "$version_path"/
+		sudo tar -xf "$version_path"/pack-"$bundle"-from-0.tar --strip-components 1 --directory "$version_path"/files
+		files=("$(ls -I "*.tar" "$version_path"/files)")
+		for bundle_file in ${files[*]}; do
+			if [ ! -e "$version_path"/files/"$bundle_file".tar ]; then
+				create_tar "$version_path"/files/"$bundle_file"
+			fi
+		done
+	fi
+	contentsize=$(awk '/contentsize/ { print $2 }' "$bundle_manifest")
+
+	# these actions apply to all operations except when adding a new file or updating the header only
+	if [ "$option" != "--add" ] && [ "$option" != "--add-dir" ] && [ "$option" != "--add-file" ] && [ "$option" != "--header-only" ]; then
+		fhash=$(get_hash_from_manifest "$bundle_manifest" "$fname")
+		fsize=$(stat -c "%s" "$oldversion_path"/files/"$fhash")
+		# update the version of the file to be updated in the manifest
+		update_manifest -p "$bundle_manifest" file-version "$fname" "$version"
+	fi
+
+	case "$option" in
+	--add | --add-file)
+		# if the directories the file is don't exist, add them to the bundle
+		fdir=$(dirname "${fname%:*}")
+		if [ ! "$(sudo cat "$bundle_manifest" | grep -x "D\\.\\.\\..*$fdir")" ] && [ "$fdir" != "/" ]; then
+			new_dir=$(create_dir "$version_path"/files)
+			add_to_manifest -p "$bundle_manifest" "$new_dir" "$fdir"
+			# add each one of the directories of the path if they are not in the manifest already
+			while [ "$(dirname "$fdir")" != "/" ]; do
+				fdir=$(dirname "$fdir")
+				if [ ! "$(sudo cat "$bundle_manifest" | grep -x "D\\.\\.\\..*$fdir")" ]; then
+					add_to_manifest -p "$bundle_manifest" "$new_dir" "$fdir"
+				fi
+			done
+			# Add the dir to the delta-pack
+			add_to_pack "$bundle" "$new_dir" "$oldversion"
+		fi
+		# if the user wants to use an existing file, use it, else create a new one
+		if [[ "$fname" = *":"* ]]; then
+			new_file="${fname#*:}"
+			validate_item "$new_file"
+			sudo rsync -aq "$new_file" "$version_path"/files/"$(basename "$new_file")"
+			sudo rsync -aq "$new_file".tar "$version_path"/files/"$(basename "$new_file")".tar
+			new_file="$version_path"/files/"$(basename "$new_file")"
+			fname="${fname%:*}"
+		else
+			new_file=$(create_file "$version_path"/files)
+		fi
+		add_to_manifest -p "$bundle_manifest" "$new_file" "$fname"
+		# contentsize is automatically added by the add_to_manifest function so
+		# all we need is to get the updated value for now
+		contentsize=$(awk '/contentsize/ { print $2 }' "$bundle_manifest")
+		# Add the file to the zero pack of the bundle
+		add_to_pack "$bundle" "$new_file"
+		# Add the file also to the delta-pack
+		add_to_pack "$bundle" "$new_file" "$oldversion"
+		;;
+	--add-dir)
+		# if the directories the file is don't exist, add them to the bundle
+		fdir="$fname"
+		if [ ! "$(sudo cat "$bundle_manifest" | grep -x "D\\.\\.\\..*$fdir")" ] && [ "$fdir" != "/" ]; then
+			new_dir=$(create_dir "$version_path"/files)
+			add_to_manifest -p "$bundle_manifest" "$new_dir" "$fdir"
+			# add each one of the directories of the path if they are not in the manifest already
+			while [ "$(dirname "$fdir")" != "/" ]; do
+				fdir=$(dirname "$fdir")
+				if [ ! "$(sudo cat "$bundle_manifest" | grep -x "D\\.\\.\\..*$fdir")" ]; then
+					add_to_manifest -p "$bundle_manifest" "$new_dir" "$fdir"
+				fi
+			done
+			# Add the dir to the delta-pack
+			add_to_pack "$bundle" "$new_dir"
+			add_to_pack "$bundle" "$new_dir" "$oldversion"
+		fi
+		contentsize=$(awk '/contentsize/ { print $2 }' "$bundle_manifest")
+		;;
+	--delete | --ghost)
+		# replace the first character of the line that matches with "."
+		sudo sed -i "/\\t${fname////\\/}$/s/./\./1" "$bundle_manifest"
+		sudo sed -i "/\\t${fname////\\/}\\t/s/./\./1" "$bundle_manifest"
+		if [ "$option" = "--delete" ]; then
+			# replace the second character of the line that matches with "d"
+			sudo sed -i "/\\t${fname////\\/}$/s/./d/2" "$bundle_manifest"
+			sudo sed -i "/\\t${fname////\\/}\\t/s/./d/2" "$bundle_manifest"
+			# remove the related file(s) from the version dir (if there)
+			sudo rm -f "$version_path"/files/"$fhash"
+			sudo rm -f "$version_path"/files/"$fhash".tar
+		else
+			# replace the second character of the line that matches with "g"
+			sudo sed -i "/\\t${fname////\\/}$/s/./g/2" "$bundle_manifest"
+			sudo sed -i "/\\t${fname////\\/}\\t/s/./g/2" "$bundle_manifest"
+		fi
+		# replace the hash with 0s
+		update_manifest -p "$bundle_manifest" file-hash "$fname" "$zero_hash"
+		# calculate new contentsize (NOTE: filecount is not decreased)
+		contentsize=$((contentsize - fsize))
+		;;
+	--update)
+		# append random content to the file
+		generate_random_content 1 20 | sudo tee -a "$version_path"/files/"$fhash" > /dev/null
+		# recalculate hash and update file names
+		new_fhash=$(sudo "$SWUPD" hashdump "$version_path"/files/"$fhash" 2> /dev/null)
+		sudo mv "$version_path"/files/"$fhash" "$version_path"/files/"$new_fhash"
+		create_tar "$version_path"/files/"$new_fhash"
+		sudo rm -f "$oldversion_path"/files/"$fhash".tar
+		# update the manifest with the new hash
+		update_manifest -p "$bundle_manifest" file-hash "$fname" "$new_fhash"
+		# calculate new contentsize
+		new_fsize=$(stat -c "%s" "$version_path"/files/"$new_fhash")
+		contentsize=$((contentsize + (new_fsize - fsize)))
+		# update the zero-pack with the new file
+		add_to_pack "$bundle" "$version_path"/files/"$new_fhash"
+		# create the delta-file
+		delta_name="$oldversion-$version-$fhash-$new_fhash"
+		sudo bsdiff "$oldversion_path"/files/"$fhash" "$version_path"/files/"$new_fhash" "$version_path"/delta/"$delta_name"
+		# create or add to the delta-pack
+		add_to_pack "$bundle" "$version_path"/delta/"$delta_name" "$oldversion"
+		;;
+	--rename | --rename-legacy)
+		validate_param "$new_name"
+		# make sure new_name starts with a slash
+		if [[ "$new_name" != "/"* ]]; then
+			new_name=/"$new_name"
+		fi
+		new_fname="${new_name////\\/}"
+		# renames need two records in the manifest, one with the
+		# new name (F...) and one with the old one (.d..)
+		# replace the first character of the old record with "."
+		sudo sed -i "/\\t${fname////\\/}$/s/./\./1" "$bundle_manifest"
+		sudo sed -i "/\\t${fname////\\/}\\t/s/./\./1" "$bundle_manifest"
+		# replace the second character of the old record with "d"
+		sudo sed -i "/\\t${fname////\\/}$/s/./d/2" "$bundle_manifest"
+		sudo sed -i "/\\t${fname////\\/}\\t/s/./d/2" "$bundle_manifest"
+		# add the new name to the manifest
+		add_to_manifest -p "$bundle_manifest" "$oldversion_path"/files/"$fhash" "$new_name"
+		if [ "$option" = "--rename" ]; then
+			# replace the hash of the old record with 0s
+			update_manifest -p "$bundle_manifest" file-hash "$fname" "$zero_hash"
+		else
+			# replace the fourth character of the old record with "r"
+			sudo sed -i "/\\t${fname////\\/}$/s/./r/4" "$bundle_manifest"
+			sudo sed -i "/\\t${fname////\\/}\\t/s/./r/4" "$bundle_manifest"
+			# replace the fourth character of the new record with "r"
+			sudo sed -i "/\\t$new_fname$/s/./r/4" "$bundle_manifest"
+		fi
+		# create the delta-file
+		delta_name="$oldversion-$version-$fhash-$fhash"
+		sudo bsdiff "$oldversion_path"/files/"$fhash" "$oldversion_path"/files/"$fhash" "$version_path"/delta/"$delta_name"
+		# create or add to the delta-pack
+		add_to_pack "$bundle" "$version_path"/delta/"$delta_name" "$oldversion"
+		;;
+	--header-only)
+		# do nothing
+		;;
+	*)
+		terminate "Please select a valid option for updating the bundle: --add, --delete, --ghost, --rename, --update, --header-only"
+		;;
+	esac
+
+	# re-order items on the manifest so they are in the correct order based on version
+	sudo sort -t$'\t' -k3 -s -h -o "$bundle_manifest" "$bundle_manifest"
+
+	update_manifest -p "$bundle_manifest" contentsize "$contentsize"
+	update_manifest -p "$bundle_manifest" timestamp "$(date +"%s")"
+
+	# renew the manifest tar
+	if [ "$partial" = false ]; then
+		sudo rm -f "$bundle_manifest".tar
+		create_tar "$bundle_manifest"
+		# update the mom
+		update_hashes_in_mom "$version_path"/Manifest.MoM
+	fi
+
+}
+
 # Adds the specified file to the zero or delta pack for the bundle
 # Parameters:
 # - BUNDLE: the name of the bundle


### PR DESCRIPTION
This PR adds a couple of function which are very useful when working with tests that require multiple update versions of a bundle.
- update_bundle: allow users to create different kind of updates for a bundle between two versions in the server side content.
- bump_format: automatically creates an increase in the format version used in manifests, this requires two versions to be created with an update is os-core, os-core will update the os-release and format files.