### PR TITLE
Fixing typos and orthography errors on docs and codebase

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -36,7 +36,7 @@ At the time of writing,
 the current image for the `default` target is
 `travisci/ci-garnet:packer-1512502276-986baf0`
 
-Start a detatched image running /sbin/init (i.e. a system that is
+Start a detached image running /sbin/init (i.e. a system that is
 booted normally). You probably will want this to be privileged, so you can use tools like gdb or strace.
 
    docker run --name travis-debug -dit --privileged travisci/ci-garnet:packer-1512502276-986baf0 /sbin/init

--- a/docs/swupd.1
+++ b/docs/swupd.1
@@ -202,7 +202,7 @@ are blocking removal.
 \fBbundle\-list\fP
 .INDENT 0.0
 .INDENT 3.5
-List all installed sofware bundles in the local system. Bundles available
+List all installed software bundles in the local system. Bundles available
 can be listed with the \fI\-\-all\fP option.
 .INDENT 0.0
 .IP \(bu 2

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -155,7 +155,7 @@ SUBCOMMANDS
 
 ``bundle-list``
 
-    List all installed sofware bundles in the local system. Bundles available
+    List all installed software bundles in the local system. Bundles available
     can be listed with the `--all` option.
 
     -  `-a, --all`

--- a/src/autoupdate.c
+++ b/src/autoupdate.c
@@ -71,7 +71,7 @@ static bool parse_options(int argc, char **argv)
 	}
 
 	if (argc > optind) {
-		fprintf(stderr, "Error: unexpected arguements\n\n");
+		fprintf(stderr, "Error: unexpected arguments\n\n");
 		goto err;
 	}
 

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -819,7 +819,7 @@ static int install_bundles(struct list *bundles, struct list **subs, int current
 		}
 	}
 
-	/* step 2: download neccessary packs */
+	/* step 2: download necessary packs */
 	grabtime_start(&times, "Download packs");
 	(void)rm_staging_dir_contents("download");
 

--- a/src/curl.c
+++ b/src/curl.c
@@ -30,7 +30,7 @@
  * NOTE NOTE NOTE
  *
  * Only use these from the main thread of the program. For multithreaded
- * use, you need to manage your own curl mutli environment.
+ * use, you need to manage your own curl multi environment.
  */
 
 #define _GNU_SOURCE

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -202,7 +202,7 @@ static int create_required_dirs(void)
 #define STATE_DIR_COUNT (sizeof(state_dirs) / sizeof(state_dirs[0]))
 	const char *state_dirs[] = { "delta", "staged", "download", "telemetry" };
 
-	// check for existance
+	// check for existence
 	ensure_root_owned_dir(state_dir);
 
 	for (i = 0; i < STATE_DIR_COUNT; i++) {

--- a/src/heuristics.c
+++ b/src/heuristics.c
@@ -64,7 +64,7 @@ static bool is_state(char *filename)
 	}
 
 	/* Compare the first part of the path, first all the entries inside
-	 * kernel directory, then only the kernel directoy */
+	 * kernel directory, then only the kernel directory */
 	if ((strncmp(filename, "/usr/src/kernel/", 16) == 0) ||
 	    ((strlen(filename) == 15) && (strncmp(filename, "/usr/src/kernel", 15) == 0))) {
 		return false;

--- a/src/search.c
+++ b/src/search.c
@@ -881,7 +881,7 @@ int search_main(int argc, char **argv)
 	}
 
 	if (init) {
-		fprintf(stderr, "Successfully retreived manifests. Exiting\n");
+		fprintf(stderr, "Successfully retrieved manifests. Exiting\n");
 		ret = 0;
 		goto clean_exit;
 	}

--- a/src/verify.c
+++ b/src/verify.c
@@ -406,7 +406,7 @@ static int get_required_files(struct manifest *official_manifest, struct list *s
 
 	ret = download_fullfiles(official_manifest->files, NULL);
 	if (ret) {
-		fprintf(stderr, "Error: Unable to download neccessary files for this OS release\n");
+		fprintf(stderr, "Error: Unable to download necessary files for this OS release\n");
 	}
 
 	return ret;

--- a/src/xattrs.c
+++ b/src/xattrs.c
@@ -151,7 +151,7 @@ static const char **get_sorted_xattr_name_table(const char *names, int n)
 /* copy an xattr blob from a file to another file or to a buffer
  *
  * returned blob_len==0 indicates the blob pointer does not
- * contain valid data.  Given quirks in xattr implemenations (or lack there
+ * contain valid data.  Given quirks in xattr implementations (or lack there
  * of on some kernels or filesystems or OS's) and SSL quirks (the blob and
  * blob length are passed to a hasing function) the blob pointer is set to a
  * canary instead of being left as NULL, simplifying code elsewhere. */

--- a/src/xattrs.h
+++ b/src/xattrs.h
@@ -18,7 +18,7 @@ void xattrs_copy(const char *src_filename, const char *dst_filename);
  * Attempt to pack into a data blob the extended attributes of the given file.
  * The data blob will be allocated and possibly filled with first the sorted
  * list of all the extended attributes names, and then their values.
- * The values will be NUL terminated, but the encoding is not reversable so
+ * The values will be NUL terminated, but the encoding is not reversible so
  * is only suitable to use as input to a hashing function.
  * @param filename - The file from which the extended attributes will be
  * read and packed into the data blob.


### PR DESCRIPTION
Errors reported by codespell (https://github.com/codespell-project/codespell)