### PR TITLE
Iterative manifest

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -172,6 +172,7 @@ BATS = \
 	test/functional/update/update-include-old-bundle-with-tracked-file.bats \
 	test/functional/update/update-iterative.bats \
 	test/functional/update/update-iterative-and-full.bats \
+	test/functional/update/update-iterative-bad-name.bats \
 	test/functional/update/update-iterative-download-fail.bats \
 	test/functional/update/update-iterative-has-dependency.bats \
 	test/functional/update/update-iterative-has-new-dependency.bats \

--- a/Makefile.am
+++ b/Makefile.am
@@ -170,6 +170,11 @@ BATS = \
 	test/functional/update/update-include.bats \
 	test/functional/update/update-include-old-bundle.bats \
 	test/functional/update/update-include-old-bundle-with-tracked-file.bats \
+	test/functional/update/update-iterative.bats \
+	test/functional/update/update-iterative-and-full.bats \
+	test/functional/update/update-iterative-download-fail.bats \
+	test/functional/update/update-iterative-has-dependency.bats \
+	test/functional/update/update-iterative-has-new-dependency.bats \
 	test/functional/update/update-minversion.bats \
 	test/functional/update/update-missing-os-core.bats \
 	test/functional/update/update-newest-deleted.bats \

--- a/src/globals.c
+++ b/src/globals.c
@@ -55,6 +55,7 @@ char *bundle_to_add = NULL;
 struct timeval start_time;
 char *state_dir = NULL;
 int skip_diskspace_check = 0;
+bool keepcache = false;
 
 /* NOTE: Today the content and version server urls are the same in
  * all cases.  It is highly likely these will eventually differ, eg:

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -609,6 +609,16 @@ char *strdup_or_die(const char *const str)
 	return result;
 }
 
+char *strndup_or_die(const char *const str, size_t size)
+{
+	char *result;
+
+	result = strndup(str, size);
+	ON_NULL_ABORT(result);
+
+	return result;
+}
+
 void string_or_die(char **strp, const char *fmt, ...)
 {
 	va_list ap;

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -512,6 +512,7 @@ void free_file_data(void *data)
 	/* peer is a pointer to file contained
 	 * in another list and must not be disposed */
 	free_string(&file->filename);
+	free_string(&file->bundlename);
 	free_string(&file->staging);
 
 	if (file->header) {

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -509,8 +509,8 @@ void free_file_data(void *data)
 		return;
 	}
 
-	/* peer is a pointer to file contained
-	 * in another list and must not be disposed */
+	/* peer and full_manifest are pointers to files contained
+	 * in other lists and must not be disposed */
 	free_string(&file->filename);
 	free_string(&file->bundlename);
 	free_string(&file->staging);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -330,7 +330,7 @@ static struct manifest *manifest_from_file(int version, char *component, bool he
 			if (ptr != NULL) {
 				/* Keep only the bundle name from the file name, the filename should be
 				 * something similar to bundle-name.I.20 */
-				file->bundlename = strndup(file->filename, ptr - file->filename - 2);
+				file->bundlename = strndup_or_die(file->filename, ptr - file->filename - 2);
 				file->from_version = atoi(ptr + 1);
 			}
 		} else {

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -460,7 +460,7 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 {
 	char *url = NULL;
 	char *filename;
-	char *dir;
+	char *dir = NULL;
 	char *basedir;
 	int ret = 0;
 	struct stat sb;
@@ -517,7 +517,6 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 
 untar:
 	ret = extract_to(filename, dir);
-	free_string(&dir);
 	if (ret != 0) {
 		goto out;
 	} else {
@@ -527,6 +526,7 @@ untar:
 	}
 
 out:
+	free_string(&dir);
 	free_string(&filename);
 	free_string(&url);
 	return ret;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -90,7 +90,7 @@ static struct manifest *alloc_manifest(int version, char *component)
 	return manifest;
 }
 
-static struct manifest *manifest_from_file(int version, char *component, bool header_only, bool latest, bool is_mix)
+static struct manifest *manifest_from_file(int version, char *component, bool header_only, bool latest, bool is_mix, bool load_iterative)
 {
 	FILE *infile;
 	char line[MANIFEST_LINE_MAXLEN], *c, *c2;
@@ -251,6 +251,11 @@ static struct manifest *manifest_from_file(int version, char *component, bool he
 		} else if (c[0] == 'M') {
 			file->is_manifest = 1;
 		} else if (c[0] == 'I') {
+			/* only load iterative manifests when enabled*/
+			if (!load_iterative) {
+				free(file);
+				continue;
+			}
 			file->is_manifest = 1;
 			file->is_iterative = 1;
 		} else if (c[0] != '.') { /* unknown file type */
@@ -327,12 +332,16 @@ static struct manifest *manifest_from_file(int version, char *component, bool he
 		if (file->is_iterative == 1) {
 			char *ptr;
 			ptr = strrchr(file->filename, '.');
-			if (ptr != NULL) {
-				/* Keep only the bundle name from the file name, the filename should be
-				 * something similar to bundle-name.I.20 */
-				file->bundlename = strndup_or_die(file->filename, ptr - file->filename - 2);
-				file->from_version = atoi(ptr + 1);
+			/* the filename should be something similar to bundle-name.I.20, if it is
+			 * not, drop the iterative manifest */
+			if (ptr == NULL || strncmp(ptr - 2, ".I", 2) != 0 || atoi(ptr + 1) == 0) {
+				free_string(&file->filename);
+				free(file);
+				continue;
 			}
+			/* Keep only the bundle name from the file name */
+			file->bundlename = strndup_or_die(file->filename, ptr - file->filename - 2);
+			file->from_version = atoi(ptr + 1);
 		} else {
 			file->bundlename = strdup_or_die(c);
 		}
@@ -574,7 +583,7 @@ static void remove_manifest_files(char *filename, int version, char *hash)
 
 struct manifest *load_mom(int version, bool latest, bool mix_exists)
 {
-	return load_mom_err(version, latest, mix_exists, NULL);
+	return load_mom_err(version, latest, mix_exists, NULL, false);
 }
 
 /* Loads the MoM (Manifest of Manifests) for VERSION.
@@ -589,7 +598,7 @@ struct manifest *load_mom(int version, bool latest, bool mix_exists)
  * loaded into memory, this function will return NULL. If err is passed, it is set
  * with the error code.
  */
-struct manifest *load_mom_err(int version, bool latest, bool mix_exists, int *err)
+struct manifest *load_mom_err(int version, bool latest, bool mix_exists, int *err, bool load_iterative)
 {
 	struct manifest *manifest = NULL;
 	int ret = 0;
@@ -610,7 +619,7 @@ verify_mom:
 		return NULL;
 	}
 
-	manifest = manifest_from_file(version, "MoM", false, latest, mix_exists);
+	manifest = manifest_from_file(version, "MoM", false, latest, mix_exists, load_iterative);
 
 	if (manifest == NULL) {
 		if (retried == false) {
@@ -704,9 +713,7 @@ retry_load:
 		if (file->is_iterative == 1 && file->full_manifest && !retried) {
 			/* Since the iterative manifest failed to be loaded,
 			 * fall back to using the full manifest */
-			file->full_manifest->peer = file->peer;
 			file = file->full_manifest;
-			file->peer->peer = file;
 			retried = true;
 			goto retry_load;
 		}
@@ -727,7 +734,7 @@ retry_load:
 		return NULL;
 	}
 
-	manifest = manifest_from_file(version, file->filename, header_only, false, file->is_mix);
+	manifest = manifest_from_file(version, file->filename, header_only, false, file->is_mix, false);
 
 	if (manifest == NULL) {
 		if (retried == false) {
@@ -756,7 +763,7 @@ struct manifest *load_manifest_full(int version, bool mix)
 		return NULL;
 	}
 
-	manifest = manifest_from_file(version, "full", false, false, false);
+	manifest = manifest_from_file(version, "full", false, false, false, false);
 
 	if (manifest == NULL) {
 		fprintf(stderr, "Failed to load %d Manifest.full\n", version);
@@ -1425,36 +1432,55 @@ int enforce_compliant_manifest(struct file **a, struct file **b, int searchsize,
 
 /* The function splits a list of manifests into two lists:
  * - full_manifests: this list will contain all the full manifests that were in the manifests list
- * - iterative_manifests: this list will contain all the valid iterative manifests from the manifests
+ * - consolidated_manifests: this list will contain all the valid iterative manifests from the manifests
  *   list, plus the full manifest of those bundles that didn't have a valid iterative manifest
  *   A valid iterative manifest is one that can be used during an update, meaning that the iterative
  *   manifest must match the "from version" provided, and that it belongs to an already installed bundle*/
-void filter_iterative_manifests(struct list *manifests, int version, struct list **full_manifests, struct list **iterative_manifests)
+void consolidate_manifests(struct list *manifests, int version, struct list **consolidated_manifests)
 {
-	/* Split the manifests into "iterative manifests" and "full manifests" */
+	struct list *full_manifests = NULL;
 	struct list *list;
 	struct file *file;
 
+	/* Split the manifests into "iterative manifests" and "full manifests" */
 	for (list = manifests; list; list = list->next) {
 		file = list->data;
 		/* Keep only iterative manifests that are from the specified version and that are
 		 * already installed */
-		if (file->is_iterative == 1 && file->from_version == version && is_tracked_bundle(file->bundlename)) {
-			*iterative_manifests = list_prepend_data(*iterative_manifests, file);
+		if (file->is_iterative == 1 && file->from_version <= version && is_tracked_bundle(file->bundlename)) {
+			*consolidated_manifests = list_prepend_data(*consolidated_manifests, file);
 		} else if (file->is_iterative != 1) {
-			*full_manifests = list_prepend_data(*full_manifests, file);
+			full_manifests = list_prepend_data(full_manifests, file);
 		}
 	}
 
 	/* Add the full manifest of those bundles that do not have a valid iterative manifest
-	* into the list of iterative_manifests */
-	for (list = *full_manifests; list; list = list->next) {
+	* into the list of consolidated_manifests */
+	for (list = full_manifests; list; list = list->next) {
 		file = list->data;
-		if (!search_bundle_in_manifests(*iterative_manifests, file->bundlename)) {
-			*iterative_manifests = list_prepend_data(*iterative_manifests, file);
+		if (!search_bundle_in_manifests(*consolidated_manifests, file->bundlename)) {
+			*consolidated_manifests = list_prepend_data(*consolidated_manifests, file);
 		}
 	}
 
 	/* link the iterative manifest with its related full manifest */
-	link_iterative_manifests(*iterative_manifests, *full_manifests);
+	link_iterative_manifests(*consolidated_manifests, full_manifests);
+
+	list_free_list(full_manifests);
+}
+
+/* filters a list of manifests so they only include manifests needed for an update */
+void filter_update_manifests(struct list *update_subs, struct list *manifests, struct list **update_manifests)
+{
+	struct list *list;
+	struct file *file;
+	struct sub *sub;
+
+	for (list = update_subs; list; list = list->next) {
+		sub = list->data;
+		file = search_bundle_in_manifests(manifests, sub->component);
+		if (file) {
+			*update_manifests = list_prepend_data(*update_manifests, file);
+		}
+	}
 }

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -251,9 +251,8 @@ static struct manifest *manifest_from_file(int version, char *component, bool he
 		} else if (c[0] == 'M') {
 			file->is_manifest = 1;
 		} else if (c[0] == 'I') {
-			/* ignore this file for future iterative manifest feature */
-			free(file);
-			continue;
+			file->is_manifest = 1;
+			file->is_iterative = 1;
 		} else if (c[0] != '.') { /* unknown file type */
 			free(file);
 			goto err;
@@ -323,6 +322,20 @@ static struct manifest *manifest_from_file(int version, char *component, bool he
 		c = c2;
 
 		file->filename = strdup_or_die(c);
+		/* If the file is an iterative manifest, copy the from_version and obtain the
+		 * bundle name based on the file name */
+		if (file->is_iterative == 1) {
+			char *ptr;
+			ptr = strrchr(file->filename, '.');
+			if (ptr != NULL) {
+				/* Keep only the bundle name from the file name, the filename should be
+				 * something similar to bundle-name.I.20 */
+				file->bundlename = strndup(file->filename, ptr - file->filename - 2);
+				file->from_version = atoi(ptr + 1);
+			}
+		} else {
+			file->bundlename = strdup_or_die(c);
+		}
 
 		/* Mark every file in a mix manifest as also being mix content since we do not
 		 * have another flag to check for like we do in the MoM */

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -119,9 +119,11 @@ struct update_stat {
 
 struct file {
 	char *filename;
+	char *bundlename;
 	char hash[SWUPD_HASH_LEN];
 	bool use_xattrs;
 	int last_change;
+	int from_version;
 	struct update_stat stat;
 
 	unsigned int is_dir : 1;
@@ -131,6 +133,7 @@ struct file {
 	unsigned int is_ghosted : 1;
 	unsigned int is_tracked : 1;
 	unsigned int is_manifest : 1;
+	unsigned int is_iterative : 1;
 
 	unsigned int is_config : 1;
 	unsigned int is_state : 1;

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -330,6 +330,7 @@ extern int compute_hash(struct file *file, char *filename) __attribute__((warn_u
 extern struct list *recurse_manifest(struct manifest *manifest, struct list *subs, const char *component, bool server);
 extern struct list *consolidate_files(struct list *files);
 extern struct list *filter_out_existing_files(struct list *files);
+extern void filter_iterative_manifests(struct list *manifests, int version, struct list **full_manifests, struct list **iterative_manifests);
 
 extern void populate_file_struct(struct file *file, char *filename);
 extern bool verify_file(struct file *file, char *filename);
@@ -342,6 +343,7 @@ void free_manifest_data(void *data);
 void remove_files_in_manifest_from_fs(struct manifest *m);
 void deduplicate_files_from_manifest(struct manifest **m1, struct manifest *m2);
 extern struct file *search_bundle_in_manifest(struct manifest *manifest, const char *bundlename);
+extern struct file *search_bundle_in_manifests(struct list *manifests, const char *bundlename);
 extern struct file *search_file_in_manifest(struct manifest *manifest, const char *filename);
 
 extern char *mounted_dirs;

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -376,6 +376,7 @@ extern void swupd_deinit(void);
 extern int swupd_init(void);
 extern void string_or_die(char **strp, const char *fmt, ...);
 char *strdup_or_die(const char *const str);
+char *strndup_or_die(const char *const str, size_t size);
 extern void free_string(char **s);
 void update_motd(int new_release);
 void delete_motd(void);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -220,7 +220,7 @@ extern void apply_heuristics(struct file *file);
 
 extern int file_sort_filename(const void *a, const void *b);
 extern int file_sort_filename_reverse(const void *a, const void *b);
-extern struct manifest *load_mom_err(int version, bool latest, bool mix_exists, int *err);
+extern struct manifest *load_mom_err(int version, bool latest, bool mix_exists, int *err, bool load_iterative);
 extern struct manifest *load_mom(int version, bool latest, bool mix_exists);
 extern struct manifest *load_manifest(int current, int version, struct file *file, struct manifest *mom, bool header_only);
 extern struct manifest *load_manifest_full(int version, bool mix);
@@ -333,7 +333,8 @@ extern int compute_hash(struct file *file, char *filename) __attribute__((warn_u
 extern struct list *recurse_manifest(struct manifest *manifest, struct list *subs, const char *component, bool server);
 extern struct list *consolidate_files(struct list *files);
 extern struct list *filter_out_existing_files(struct list *files);
-extern void filter_iterative_manifests(struct list *manifests, int version, struct list **full_manifests, struct list **iterative_manifests);
+extern void consolidate_manifests(struct list *manifests, int version, struct list **consolidated_manifests);
+extern void filter_update_manifests(struct list *update_subs, struct list *manifests, struct list **update_manifests);
 
 extern void populate_file_struct(struct file *file, char *filename);
 extern bool verify_file(struct file *file, char *filename);
@@ -394,6 +395,7 @@ extern bool on_new_format(void);
 struct list *free_list_file(struct list *item);
 struct list *free_bundle(struct list *item);
 extern void create_and_append_subscription(struct list **subs, const char *component);
+extern void filter_update_subscriptions(struct manifest *server_manifest, struct list *current_subs, int current_version, struct list **update_subs, struct list **nonupdate_subs);
 
 /* bundle.c */
 extern bool is_tracked_bundle(const char *bundle_name);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -142,7 +142,8 @@ struct file {
 	unsigned int is_mix : 1;
 	unsigned int do_not_update : 1;
 
-	struct file *peer; /* same file in another manifest */
+	struct file *peer;	  /* same file in another manifest */
+	struct file *full_manifest; /* pointer to the full manifest of an iterative manifest */
 	struct header *header;
 	char *staging;
 };
@@ -225,6 +226,7 @@ extern struct manifest *load_manifest_full(int version, bool mix);
 extern struct list *create_update_list(struct manifest *server);
 extern void link_manifests(struct manifest *m1, struct manifest *m2);
 extern void link_submanifests(struct manifest *m1, struct manifest *m2, struct list *subs1, struct list *subs2, bool server);
+extern void link_iterative_manifests(struct list *iterative_manifests, struct list *full_manifests);
 extern void free_manifest(struct manifest *manifest);
 
 extern void grabtime_start(timelist *list, const char *name);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -104,6 +104,7 @@ extern bool need_update_boot;
 extern bool need_update_bootloader;
 extern bool need_systemd_reexec;
 extern struct list *post_update_actions;
+extern bool keepcache;
 
 struct update_stat {
 	uint64_t st_mode;

--- a/src/update.c
+++ b/src/update.c
@@ -394,7 +394,6 @@ load_current_submanifests:
 
 	/* consolidate the current collective manifests down into one in memory */
 	current_manifest->files = files_from_bundles(current_manifest->submanifests);
-
 	current_manifest->files = consolidate_files(current_manifest->files);
 
 	latest_subs = list_clone(current_subs);

--- a/src/update.c
+++ b/src/update.c
@@ -556,7 +556,9 @@ clean_curl:
 	}
 	/* clean up our cached content from the update. It is likely much more than
 	 * we need and the clean helps us prevent cache bloat. */
-	clean_statedir(false, false);
+	if (!keepcache) {
+		clean_statedir(false, false);
+	}
 	free_subscriptions(&latest_subs);
 	swupd_deinit();
 
@@ -600,6 +602,7 @@ static const struct option prog_opts[] = {
 	{ "nosigcheck", no_argument, 0, 'n' },
 	{ "ignore-time", no_argument, 0, 'I' },
 	{ "statedir", required_argument, 0, 'S' },
+	{ "keepcache", no_argument, 0, 'k' },
 	{ "certpath", required_argument, 0, 'C' },
 	{ "time", no_argument, 0, 't' },
 	{ "no-scripts", no_argument, 0, 'N' },
@@ -633,6 +636,7 @@ static void print_help(const char *name)
 	fprintf(stderr, "   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
 	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
 	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");
+	fprintf(stderr, "   -k, --keepcache         Do not delete the swupd state directory after updating the system\n");
 	fprintf(stderr, "   -C, --certpath          Specify alternate path to swupd certificates\n");
 	fprintf(stderr, "   -t, --time              Show verbose time output for swupd operations\n");
 	fprintf(stderr, "   -N, --no-scripts        Do not run the post-update scripts and boot update tool\n");
@@ -647,7 +651,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hm:xnIdtNbTau:P:c:v:sF:p:S:C:D:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hm:xnIdtNbTau:P:c:v:sF:p:S:C:D:k", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -750,6 +754,9 @@ static bool parse_options(int argc, char **argv)
 				fprintf(stderr, "Invalid --max-parallel-pack-downloads argument\n\n");
 				goto err;
 			}
+			break;
+		case 'k':
+			keepcache = true;
 			break;
 		default:
 			fprintf(stderr, "Unrecognized option\n\n");

--- a/swupd.bash
+++ b/swupd.bash
@@ -45,7 +45,7 @@ _swupd()
 		opts="--help --no-xattrs --path "
 		break;;
 	    ("update")
-		opts="--help --download --url --port --contenturl --versionurl --status --format --path --force --nosigcheck --ignore-time --statedir --certpath --time --no-scripts --no-boot-update --migrate --allow-mix-collisions --max-parallel-pack-downloads "
+		opts="--help --download --url --port --contenturl --versionurl --status --format --path --force --nosigcheck --ignore-time --statedir --certpath --time --no-scripts --no-boot-update --migrate --allow-mix-collisions --max-parallel-pack-downloads --keepcache "
 		break;;
 	    ("verify")
 		opts="--help --manifest --path --url --port --contenturl --versionurl --fix --picky --picky-tree --picky-whitelist --install --format --quick --force --nosigcheck --ignore-time --statedir --certpath --time --no-scripts --no-boot-update --max-parallel-pack-downloads "

--- a/test/functional/bundleadd/add-with-iterative.bats
+++ b/test/functional/bundleadd/add-with-iterative.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n test-bundle-1 -f /foo,/baz/test-file1 "$TEST_NAME"
+	create_bundle -n test-bundle-2 -f /bar,/baz/test-file2 "$TEST_NAME"
+	create_version "$TEST_NAME" 20 10
+	update_bundle -i "$TEST_NAME" test-bundle-1 --update /baz/test-file1
+	create_version "$TEST_NAME" 30 20
+	update_bundle -i "$TEST_NAME" test-bundle-2 --delete /baz/test-file2
+
+}
+
+@test "bundle-add add bundle works fine when there are iterative manifests in other versions" {
+
+	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle-1 test-bundle-2"
+
+	assert_status_is 0
+
+	# verify target files
+	assert_file_exists "$TARGETDIR"/foo
+	assert_file_exists "$TARGETDIR"/bar
+	assert_file_exists "$TARGETDIR"/baz/test-file1
+	assert_file_exists "$TARGETDIR"/baz/test-file2
+	# verify downloaded manifests
+	assert_file_exists "$STATEDIR"/10/Manifest.test-bundle-1
+	assert_file_exists "$STATEDIR"/10/Manifest.test-bundle-2
+
+	expected_output=$(cat <<-EOM
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Installing bundle(s) files...
+		Calling post-update helper scripts.
+		Successfully installed 2 bundles
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "bundle-add add bundle does not use iterative manifests" {
+
+	# pre-requisiste
+	set_current_version "$TEST_NAME" 30
+
+	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle-1 test-bundle-2"
+
+	assert_status_is 0
+
+	# verify target files
+	assert_file_exists "$TARGETDIR"/foo
+	assert_file_exists "$TARGETDIR"/bar
+	assert_file_exists "$TARGETDIR"/baz/test-file1
+	assert_file_not_exists "$TARGETDIR"/baz/test-file2
+	# verify downloaded manifests
+	assert_file_exists "$STATEDIR"/20/Manifest.test-bundle-1
+	assert_file_exists "$STATEDIR"/30/Manifest.test-bundle-2
+	# verify not necessary manifests are not downloaded
+	assert_file_not_exists "$STATEDIR"/20/Manifest.test-bundle-1.I.10
+	assert_file_not_exists "$STATEDIR"/30/Manifest.test-bundle-2.I.10
+
+	expected_output=$(cat <<-EOM
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Installing bundle(s) files...
+		Calling post-update helper scripts.
+		Successfully installed 2 bundles
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -2058,7 +2058,7 @@ update_bundle() {
 		new_fhash=$(sudo "$SWUPD" hashdump "$version_path"/files/"$fhash" 2> /dev/null)
 		sudo mv "$version_path"/files/"$fhash" "$version_path"/files/"$new_fhash"
 		create_tar "$version_path"/files/"$new_fhash"
-		sudo rm -f "$oldversion_path"/files/"$fhash".tar
+		sudo rm -f "$version_path"/files/"$fhash".tar
 		# update the manifest with the new hash
 		update_manifest -p "$bundle_manifest" file-hash "$fname" "$new_fhash"
 		# calculate new contentsize
@@ -2437,6 +2437,40 @@ assert_status_is_not() {
 		echo "------------------------------------------------------------------" >&3
 		echo "$output" >&3
 		echo -e "------------------------------------------------------------------\\n" >&3
+	fi
+
+}
+
+assert_true() {
+
+	local value=$1
+	local message=$2
+
+	# no value or 0 is considered false
+	if [ -z "$value" ] || [ -eq 0 ]; then
+		if [ -n "$message" ]; then
+			print_assert_failure "$message"
+		else
+			print_assert_failure "The expression was expected to be true, but it is false"
+		fi
+		return 1
+	fi
+
+}
+
+assert_false() {
+
+	local value=$1
+	local message=$2
+
+	# no value or 0 is considered false
+	if [ -n "$value" ] || [ -ne 0 ]; then
+		if [ -n "$message" ]; then
+			print_assert_failure "$message"
+		else
+			print_assert_failure "The expression was expected to be false, but it is true"
+		fi
+		return 1
 	fi
 
 }

--- a/test/functional/update/update-include-old-bundle-with-tracked-file.bats
+++ b/test/functional/update/update-include-old-bundle-with-tracked-file.bats
@@ -26,8 +26,8 @@ test_setup() {
 		Update started.
 		Preparing to update from 20 to 30
 		Downloading packs...
-		Extracting os-core pack for version 30
 		Extracting test-bundle3 pack for version 30
+		Extracting os-core pack for version 30
 		Statistics for going from version 20 to version 30:
 		    changed bundles   : 3
 		    new bundles       : 0

--- a/test/functional/update/update-iterative-and-full.bats
+++ b/test/functional/update/update-iterative-and-full.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle-1 -f /foo/test-file1 "$TEST_NAME"
+	create_bundle -L -n test-bundle-2 -f /foo/test-file2 "$TEST_NAME"
+	create_version "$TEST_NAME" 20 10
+	update_bundle -i "$TEST_NAME" test-bundle-1 --update /foo/test-file1
+	create_version "$TEST_NAME" 30 20
+	update_bundle -i "$TEST_NAME" test-bundle-1 --update /foo/test-file1
+	update_bundle -i "$TEST_NAME" test-bundle-2 --update /foo/test-file2
+
+}
+
+@test "update works correctly using both full and iterative manifests in the same operation" {
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS_KEEPCACHE"
+
+	assert_status_is 0
+
+	# verify target files
+	assert_file_exists "$TARGETDIR"/foo/test-file1
+	assert_file_exists "$TARGETDIR"/foo/test-file2
+	# verify downloaded manifests
+	assert_file_exists "$STATEDIR"/10/Manifest.test-bundle-1
+	assert_file_exists "$STATEDIR"/10/Manifest.test-bundle-2
+	assert_file_exists "$STATEDIR"/30/Manifest.test-bundle-1
+	assert_file_exists "$STATEDIR"/30/Manifest.test-bundle-2.I.10
+	# verify not necessary manifests are not downloaded
+	assert_file_not_exists "$STATEDIR"/30/Manifest.test-bundle-1.I.10
+	assert_file_not_exists "$STATEDIR"/30/Manifest.test-bundle-1.I.20
+	assert_file_not_exists "$STATEDIR"/30/Manifest.test-bundle-2
+	assert_file_not_exists "$STATEDIR"/10/Manifest.os-core
+	assert_file_not_exists "$STATEDIR"/30/Manifest.os-core
+
+	expected_output=$(cat <<-EOM
+		Update started.
+		Preparing to update from 10 to 30
+		Downloading packs...
+		Extracting test-bundle-2 pack for version 30
+		Statistics for going from version 10 to version 30:
+		    changed bundles   : 2
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 2
+		    new files         : 0
+		    deleted files     : 0
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Staging file content
+		Applying update
+		Update was applied.
+		Calling post-update helper scripts.
+		1 files were not in a pack
+		Update successful. System updated from version 10 to version 30
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+

--- a/test/functional/update/update-iterative-bad-name.bats
+++ b/test/functional/update/update-iterative-bad-name.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle-1 -f /test-file1 "$TEST_NAME"
+	create_bundle -L -n test-bundle-2 -f /test-file2 "$TEST_NAME"
+	create_bundle -L -n test-bundle-3 -f /test-file3 "$TEST_NAME"
+	create_version "$TEST_NAME" 20 10
+	update_bundle -i "$TEST_NAME" test-bundle-1 --update /test-file1
+	update_bundle -i "$TEST_NAME" test-bundle-2 --update /test-file2
+	update_bundle -i "$TEST_NAME" test-bundle-3 --update /test-file3
+	# modify the iterative manifests so they have a bad name
+	sudo mv "$WEBDIR"/20/Manifest.test-bundle-1.I.10 "$WEBDIR"/20/Manifest.test-bundle-1.F.123
+	update_manifest -p "$WEBDIR"/20/Manifest.MoM file-name test-bundle-1.I.10 test-bundle-1.F.123
+	sudo mv "$WEBDIR"/20/Manifest.test-bundle-2.I.10 "$WEBDIR"/20/Manifest.test-bundle-2.I.1A0
+	update_manifest -p "$WEBDIR"/20/Manifest.MoM file-name test-bundle-2.I.10 test-bundle-2.I.1A0
+	sudo mv "$WEBDIR"/20/Manifest.test-bundle-3.I.10 "$WEBDIR"/20/Manifest.test-bundle-3I10
+	update_manifest "$WEBDIR"/20/Manifest.MoM file-name test-bundle-3.I.10 test-bundle-3I10
+
+}
+
+@test "update ignores iterative manifests with a bad name" {
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS_KEEPCACHE"
+
+	assert_status_is 0
+
+	# verify target files
+	assert_file_exists "$TARGETDIR"/test-file1
+	assert_file_exists "$TARGETDIR"/test-file2
+	assert_file_exists "$TARGETDIR"/test-file3
+	# verify downloaded manifests
+	assert_file_exists "$STATEDIR"/10/Manifest.test-bundle-1
+	assert_file_exists "$STATEDIR"/10/Manifest.test-bundle-2
+	assert_file_exists "$STATEDIR"/10/Manifest.test-bundle-3
+	assert_file_exists "$STATEDIR"/20/Manifest.test-bundle-1
+	assert_file_exists "$STATEDIR"/20/Manifest.test-bundle-2
+	assert_file_exists "$STATEDIR"/20/Manifest.test-bundle-3
+	# verify not necessary manifests are not downloaded
+	assert_file_not_exists "$STATEDIR"/20/Manifest.test-bundle-1.F.123
+	assert_file_not_exists "$STATEDIR"/20/Manifest.test-bundle-2.I.1A0
+	assert_file_not_exists "$STATEDIR"/20/Manifest.test-bundle-3I10
+	assert_file_not_exists "$STATEDIR"/10/Manifest.os-core
+	assert_file_not_exists "$STATEDIR"/20/Manifest.os-core
+
+	expected_output=$(cat <<-EOM
+		Update started.
+		Preparing to update from 10 to 20
+		Downloading packs...
+		Extracting test-bundle-3 pack for version 20
+		Extracting test-bundle-2 pack for version 20
+		Extracting test-bundle-1 pack for version 20
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 3
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 3
+		    new files         : 0
+		    deleted files     : 0
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Staging file content
+		Applying update
+		Update was applied.
+		Calling post-update helper scripts.
+		Update successful. System updated from version 10 to version 20
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/update/update-iterative-download-fail.bats
+++ b/test/functional/update/update-iterative-download-fail.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle -f /foo,/bar,/bat/baz "$TEST_NAME"
+	create_version "$TEST_NAME" 20 10
+	update_bundle -i "$TEST_NAME" test-bundle --update /foo
+	sudo rm -rf "$WEBDIR"/20/Manifest.test-bundle.I.10
+	sudo rm -rf "$WEBDIR"/20/Manifest.test-bundle.I.10.tar
+
+}
+
+@test "update falls back to full manifests when the iterative fails to download" {
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS_KEEPCACHE"
+
+	assert_status_is 0
+
+	# verify target files
+	assert_file_exists "$TARGETDIR"/foo
+	assert_file_exists "$TARGETDIR"/bar
+	assert_file_exists "$TARGETDIR"/bat/baz
+
+	# since the iterative manifest was deleted the full manifest should
+	# have been downloaded
+	assert_file_exists "$STATEDIR"/10/Manifest.test-bundle
+	assert_file_exists "$STATEDIR"/20/Manifest.test-bundle
+	# verify not necessary manifests are not downloaded
+	assert_file_not_exists "$STATEDIR"/10/Manifest.os-core
+	assert_file_not_exists "$STATEDIR"/20/Manifest.os-core
+	# verify the iterative manifest is in the MoM
+	iterative_manifest="$(get_hash_from_manifest "$WEBDIR"/20/Manifest.MoM test-bundle.I.10)"
+	assert_true "$iterative_manifest" "The iterative manifest was not found in the MoM"
+
+	expected_output=$(cat <<-EOM
+		Update started.
+		Preparing to update from 10 to 20
+		Downloading packs...
+		Extracting test-bundle pack for version 20
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 1
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 1
+		    new files         : 0
+		    deleted files     : 0
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Staging file content
+		Applying update
+		Update was applied.
+		Calling post-update helper scripts.
+		Update successful. System updated from version 10 to version 20
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/update/update-iterative-from-previous-version.bats
+++ b/test/functional/update/update-iterative-from-previous-version.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle-1 -f /test-file1 "$TEST_NAME"
+	create_version "$TEST_NAME" 20 10
+	create_version "$TEST_NAME" 30 20
+	create_version "$TEST_NAME" 40 30
+	update_bundle -i "$TEST_NAME" test-bundle-1 --update /test-file1
+	set_current_version "$TEST_NAME" 20
+
+}
+
+@test "update works correctly using iterative manifests when the bundle hadn't been updated in many versions" {
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS_KEEPCACHE"
+
+	assert_status_is 0
+
+	# verify target files
+	assert_file_exists "$TARGETDIR"/test-file1
+	# verify downloaded manifests
+	assert_file_exists "$STATEDIR"/40/Manifest.test-bundle-1.I.10
+	# verify not necessary manifests are not downloaded
+	assert_file_not_exists "$STATEDIR"/40/Manifest.test-bundle-1
+
+	expected_output=$(cat <<-EOM
+		Update started.
+		Preparing to update from 20 to 40
+		Downloading packs...
+		Extracting test-bundle-1 pack for version 40
+		Statistics for going from version 20 to version 40:
+		    changed bundles   : 1
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 1
+		    new files         : 0
+		    deleted files     : 0
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Staging file content
+		Applying update
+		Update was applied.
+		Calling post-update helper scripts.
+		Update successful. System updated from version 20 to version 40
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+

--- a/test/functional/update/update-iterative-has-dependency.bats
+++ b/test/functional/update/update-iterative-has-dependency.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle-1 -f /test-file1 "$TEST_NAME"
+	create_bundle -L -n test-bundle-2 -f /test-file2,/test-file3 "$TEST_NAME"
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle-1 test-bundle-2
+	create_version "$TEST_NAME" 20 10
+	update_bundle -i "$TEST_NAME" test-bundle-1 --update /test-file1
+	update_bundle -i "$TEST_NAME" test-bundle-2 --update /test-file2
+
+}
+
+@test "update works correctly using an iterative manifest that has an old dependency" {
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS_KEEPCACHE"
+
+	assert_status_is 0
+
+	# verify target files
+	assert_file_exists "$TARGETDIR"/test-file1
+	assert_file_exists "$TARGETDIR"/test-file2
+
+	expected_output=$(cat <<-EOM
+		Update started.
+		Preparing to update from 10 to 20
+		Downloading packs...
+		Extracting test-bundle-2 pack for version 20
+		Extracting test-bundle-1 pack for version 20
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 2
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 2
+		    new files         : 0
+		    deleted files     : 0
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Staging file content
+		Applying update
+		Update was applied.
+		Calling post-update helper scripts.
+		Update successful. System updated from version 10 to version 20
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+

--- a/test/functional/update/update-iterative-has-new-dependency.bats
+++ b/test/functional/update/update-iterative-has-new-dependency.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle-1 -f /test-file1 "$TEST_NAME"
+	create_bundle -n test-bundle-2 -f /test-file2,/test-file3 "$TEST_NAME"
+	create_version "$TEST_NAME" 20 10
+	update_bundle -p "$TEST_NAME" test-bundle-1 --header-only
+	add_dependency_to_manifest "$WEBDIR"/20/Manifest.test-bundle-1 test-bundle-2
+	update_bundle -i "$TEST_NAME" test-bundle-1 --update /test-file1
+	update_bundle -i "$TEST_NAME" test-bundle-2 --update /test-file2
+
+}
+
+@test "update works correctly using an iterative manifest that has a new dependency" {
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS_KEEPCACHE"
+
+	assert_status_is 0
+
+	# verify target files
+	assert_file_exists "$TARGETDIR"/test-file1
+	assert_file_exists "$TARGETDIR"/test-file2
+	assert_file_exists "$TARGETDIR"/test-file3
+	# verify downloaded manifests
+	# (test-bundle-2 was added in version 20 but it was not installed in the
+	# target system, so its iterative manifest should not be used)
+	assert_file_exists "$STATEDIR"/10/Manifest.test-bundle-1
+	assert_file_exists "$STATEDIR"/20/Manifest.test-bundle-1.I.10
+	assert_file_exists "$STATEDIR"/20/Manifest.test-bundle-2
+	# verify not necessary manifests are not downloaded
+	assert_file_not_exists "$STATEDIR"/10/Manifest.test-bundle-2
+	assert_file_not_exists "$STATEDIR"/20/Manifest.test-bundle-1
+	assert_file_not_exists "$STATEDIR"/20/Manifest.test-bundle-2.I.10
+	assert_file_not_exists "$STATEDIR"/10/Manifest.os-core
+	assert_file_not_exists "$STATEDIR"/20/Manifest.os-core
+
+	expected_output=$(cat <<-EOM
+		Update started.
+		Preparing to update from 10 to 20
+		Downloading packs...
+		Extracting test-bundle-2 pack for version 20
+		Extracting test-bundle-1 pack for version 20
+		Couldn.t use delta file .* no .from. file to apply was found
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 1
+		    new bundles       : 1
+		    deleted bundles   : 0
+		    changed files     : 1
+		    new files         : 3
+		    deleted files     : 0
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Staging file content
+		Applying update
+		Update was applied.
+		Calling post-update helper scripts.
+		3 files were not in a pack
+		Update successful. System updated from version 10 to version 20
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}
+

--- a/test/functional/update/update-iterative.bats
+++ b/test/functional/update/update-iterative.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle-1 -f /foo,/baz/test-file1 "$TEST_NAME"
+	create_bundle -L -n test-bundle-2 -f /bar,/baz/test-file2 "$TEST_NAME"
+	create_version "$TEST_NAME" 20 10
+	update_bundle -i "$TEST_NAME" test-bundle-1 --update /baz/test-file1
+	create_version "$TEST_NAME" 30 20
+	update_bundle -i "$TEST_NAME" test-bundle-2 --delete /baz/test-file2
+
+}
+
+@test "update works correctly using iterative manifests" {
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS_KEEPCACHE"
+
+	assert_status_is 0
+
+	# verify target files
+	assert_file_exists "$TARGETDIR"/foo
+	assert_file_exists "$TARGETDIR"/bar
+	assert_file_exists "$TARGETDIR"/baz/test-file1
+	assert_file_not_exists "$TARGETDIR"/baz/test-file2
+	# verify downloaded manifests
+	assert_file_exists "$STATEDIR"/10/Manifest.test-bundle-1
+	assert_file_exists "$STATEDIR"/10/Manifest.test-bundle-2
+	assert_file_exists "$STATEDIR"/20/Manifest.test-bundle-1.I.10
+	assert_file_exists "$STATEDIR"/30/Manifest.test-bundle-2.I.10
+	# verify not necessary manifests are not downloaded
+	assert_file_not_exists "$STATEDIR"/20/Manifest.test-bundle-1
+	assert_file_not_exists "$STATEDIR"/30/Manifest.test-bundle-2
+	assert_file_not_exists "$STATEDIR"/10/Manifest.os-core
+	assert_file_not_exists "$STATEDIR"/30/Manifest.os-core
+
+	expected_output=$(cat <<-EOM
+		Update started.
+		Preparing to update from 10 to 30
+		Downloading packs...
+		Extracting test-bundle-1 pack for version 20
+		Statistics for going from version 10 to version 30:
+		    changed bundles   : 2
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 1
+		    new files         : 0
+		    deleted files     : 1
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Staging file content
+		Applying update
+		Update was applied.
+		Calling post-update helper scripts.
+		Update successful. System updated from version 10 to version 30
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/update/update-missing-os-core.bats
+++ b/test/functional/update/update-missing-os-core.bats
@@ -21,8 +21,8 @@ test_setup() {
 		Update started.
 		Preparing to update from 10 to 100
 		Downloading packs...
-		Extracting os-core pack for version 100
 		Extracting test-bundle pack for version 100
+		Extracting os-core pack for version 100
 		Statistics for going from version 10 to version 100:
 		    changed bundles   : 2
 		    new bundles       : 0


### PR DESCRIPTION
This PR enables the use of an iterative to manifest in swupd client, which only contains the things that need to be updated, therefore reducing the download time, the amount of memory needed to load that manifest and the processing time for parsing it.

Closes #558 
