### PR TITLE
Return error if adding subscriptions fails

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -36,10 +36,6 @@
 
 #define MODE_RW_O (S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)
 
-#define add_sub_ERR 1
-#define add_sub_NEW 2
-#define add_sub_BADNAME 4
-
 /*
 * list_installable_bundles()
 * Parse the full manifest for the current version of the OS and print

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -51,6 +51,11 @@ extern "C" {
 
 #define DEFAULT_CONTENTURL "https://cdn.download.clearlinux.org/update/"
 
+/* Return codes for adding subscriptions */
+#define add_sub_ERR 1
+#define add_sub_NEW 2
+#define add_sub_BADNAME 4
+
 struct sub {
 	/* name of bundle/component/subscription */
 	char *component;

--- a/src/update.c
+++ b/src/update.c
@@ -162,10 +162,10 @@ int add_included_manifests(struct manifest *mom, int current, struct list **subs
 
 	/* Pass the current version here, not the new, otherwise we will never
 	 * hit the Manifest delta path. */
-	if (add_subscriptions(subbed, subs, current, mom, false, 0) >= 0) {
-		ret = 0;
-	} else {
+	if (add_subscriptions(subbed, subs, current, mom, false, 0) & (add_sub_ERR | add_sub_BADNAME)) {
 		ret = -1;
+	} else {
+		ret = 0;
 	}
 	list_free_list(subbed);
 


### PR DESCRIPTION
When adding included manifests during an update the add_subscriptions
function is used, this function returns a value of either add_sub_ERR=1,
or add_sub_BADNAME=4 when it fails to add a subscription, and the code
is currently considering any value > 0 to be a successful value.

This commit fixes the issue by making sure the add_subscriptions
function doesn't return a code of 1 or 4 which would mean it failed
adding a subscription.