### PR TITLE
Add minversion support to testlib

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -170,6 +170,7 @@ BATS = \
 	test/functional/update/update-include.bats \
 	test/functional/update/update-include-old-bundle.bats \
 	test/functional/update/update-include-old-bundle-with-tracked-file.bats \
+	test/functional/update/update-minversion.bats \
 	test/functional/update/update-missing-os-core.bats \
 	test/functional/update/update-newest-deleted.bats \
 	test/functional/update/update-newest-ghosted.bats \
@@ -178,7 +179,6 @@ BATS = \
 	test/functional/update/update-re-update-bad-os-release.bats \
 	test/functional/update/update-re-update-required.bats \
 	test/functional/update/update-skip-scripts.bats \
-	test/functional/update/update-skip-verified-fullfiles.bats \
 	test/functional/update/update-slow-server.bats \
 	test/functional/update/update-statedir-bad-hash.bats \
 	test/functional/update/update-status.bats \

--- a/test/functional/update/update-minversion.bats
+++ b/test/functional/update/update-minversion.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME" 10
+	create_bundle -L -n bundle1 -v 10 -f /file1 "$TEST_NAME"
+
+	create_version "$TEST_NAME" 20 10 staging
+	update_minversion 20
+
+	sudo rm -f "$WEBDIR"/20/files/*
+}
+
+@test "skip fullfile download for unchanged file in minversion update " {
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+	assert_status_is 0
+
+	expected_output=$(cat <<-EOM
+		Update started.
+		Preparing to update from 10 to 20
+		Downloading packs...
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 2
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 4
+		    new files         : 0
+		    deleted files     : 0
+		Staging file content
+		Applying update
+		Update was applied.
+		Calling post-update helper scripts.
+		Update successful. System updated from version 10 to version 20
+	EOM
+	)
+	assert_in_output "$expected_output"
+}


### PR DESCRIPTION
Soon, a minversion header field will be included in the MoM. This change
updates the test library to add a minversion header field to MoMs and adds
functions to create a minversion update. Also, the skip-verified-fullfiles
test was replaced by the update-minversion test. The update-minversion test
verifies that unchanged files with a version bump caused by a minversion
update are skipped during an update.

Signed-off-by: John Akre <john.w.akre@intel.com>