### PR TITLE
testlib: Add guards to sed to avoid incorrect replaces

### DIFF
--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -739,7 +739,7 @@ update_manifest() {
 		sudo sed -i "s/^MANIFEST.*/MANIFEST\\t$var/" "$manifest"
 		;;
 	version | previous | filecount | timestamp | contentsize)
-		sudo sed -i "s/$key.*/$key:\\t$var/" "$manifest"
+		sudo sed -i "s/^$key:.*/$key:\\t$var/" "$manifest"
 		;;
 	file-status)
 		validate_param "$value"


### PR DESCRIPTION
When updating the manifest version we were replacing any line with the word
version to "version: new_version". This is a problem now that we are adding
a minversion field to the manifest. That could be a problem too when there
was a file named version.

This pull request fixes one problem that is going to be introduced by #580 and #585. If you use both commits minversions of all MoMs created used create_version will have minversion == version, unless you explicitly set the minversion