### PR TITLE
Use release os-core manifest for update boot tests

### DIFF
--- a/test/functional/update/update-boot-file.bats
+++ b/test/functional/update/update-boot-file.bats
@@ -4,7 +4,7 @@ load "../testlib"
 
 test_setup() {
 
-	create_test_environment "$TEST_NAME"
+	create_test_environment -r "$TEST_NAME"
 	create_version -p "$TEST_NAME" 100 10
 	update_bundle "$TEST_NAME" os-core --add /usr/lib/kernel/testfile
 
@@ -24,7 +24,7 @@ test_setup() {
 		    new bundles       : 0
 		    deleted bundles   : 0
 		    changed files     : 0
-		    new files         : 4
+		    new files         : 2
 		    deleted files     : 0
 		Starting download of remaining update content. This may take a while...
 		Finishing download of update content...

--- a/test/functional/update/update-boot-skip.bats
+++ b/test/functional/update/update-boot-skip.bats
@@ -4,7 +4,7 @@ load "../testlib"
 
 test_setup() {
 
-	create_test_environment "$TEST_NAME"
+	create_test_environment -r "$TEST_NAME"
 	create_version -p "$TEST_NAME" 100 10
 	update_bundle "$TEST_NAME" os-core --add /usr/lib/kernel/testfile
 
@@ -24,7 +24,7 @@ test_setup() {
 		    new bundles       : 0
 		    deleted bundles   : 0
 		    changed files     : 0
-		    new files         : 4
+		    new files         : 2
 		    deleted files     : 0
 		Starting download of remaining update content. This may take a while...
 		Finishing download of update content...


### PR DESCRIPTION
When creating the test environment, some files and directories, like
/usr/lib, are created without corresponding entries in the os-core
manifest. This is a problem for update tests that add boot files, like
/usr/lib/kernel/file. Without an entry for /usr/lib in the FROM os-core
manifest, an update will consider /usr and /usr/lib new files even when
they already exist on the system. The '-r' argument can be passed to
create_test_environment to create a more complete os-core manifest.

Signed-off-by: John Akre <john.w.akre@intel.com>