### PR TITLE
Fixing memory leak in retrieve_manifests

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -447,7 +447,7 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 {
 	char *url = NULL;
 	char *filename;
-	char *dir;
+	char *dir = NULL;
 	char *basedir;
 	int ret = 0;
 	struct stat sb;
@@ -504,7 +504,6 @@ static int retrieve_manifests(int current, int version, char *component, struct 
 
 untar:
 	ret = extract_to(filename, dir);
-	free_string(&dir);
 	if (ret != 0) {
 		goto out;
 	} else {
@@ -514,6 +513,7 @@ untar:
 	}
 
 out:
+	free_string(&dir);
 	free_string(&filename);
 	free_string(&url);
 	return ret;


### PR DESCRIPTION
This commit fixes a memory leak with the dir variable in the retrieve_manifests function.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>