### PR TITLE
Adding the --keepcache option when doing updates

### DIFF
--- a/docs/swupd.1
+++ b/docs/swupd.1
@@ -432,6 +432,14 @@ Ignore and continue if custom user content conflicts with upstream
 provided content.
 .UNINDENT
 .UNINDENT
+.IP \(bu 2
+\fI\-k, \-\-keepcache\fP
+.INDENT 2.0
+.INDENT 3.5
+Do not delete the swupd state directory content after updating the
+system.
+.UNINDENT
+.UNINDENT
 .UNINDENT
 .UNINDENT
 .UNINDENT

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -302,6 +302,11 @@ SUBCOMMANDS
         Ignore and continue if custom user content conflicts with upstream
         provided content.
 
+    - `-k, --keepcache`
+
+        Do not delete the swupd state directory content after updating the
+        system.
+
 ``verify``
 
     Perform system software installation verification. The program will

--- a/src/globals.c
+++ b/src/globals.c
@@ -55,6 +55,7 @@ char *bundle_to_add = NULL;
 struct timeval start_time;
 char *state_dir = NULL;
 int skip_diskspace_check = 0;
+bool keepcache = false;
 
 /* NOTE: Today the content and version server urls are the same in
  * all cases.  It is highly likely these will eventually differ, eg:

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -104,6 +104,7 @@ extern bool need_update_boot;
 extern bool need_update_bootloader;
 extern bool need_systemd_reexec;
 extern struct list *post_update_actions;
+extern bool keepcache;
 
 struct update_stat {
 	uint64_t st_mode;

--- a/src/update.c
+++ b/src/update.c
@@ -545,7 +545,9 @@ clean_curl:
 	}
 	/* clean up our cached content from the update. It is likely much more than
 	 * we need and the clean helps us prevent cache bloat. */
-	clean_statedir(false, false);
+	if (!keepcache) {
+		clean_statedir(false, false);
+	}
 	free_subscriptions(&latest_subs);
 	swupd_deinit();
 
@@ -589,6 +591,7 @@ static const struct option prog_opts[] = {
 	{ "nosigcheck", no_argument, 0, 'n' },
 	{ "ignore-time", no_argument, 0, 'I' },
 	{ "statedir", required_argument, 0, 'S' },
+	{ "keepcache", no_argument, 0, 'k' },
 	{ "certpath", required_argument, 0, 'C' },
 	{ "time", no_argument, 0, 't' },
 	{ "no-scripts", no_argument, 0, 'N' },
@@ -622,6 +625,7 @@ static void print_help(const char *name)
 	fprintf(stderr, "   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
 	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
 	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");
+	fprintf(stderr, "   -k, --keepcache         Do not delete the swupd state directory content after updating the system\n");
 	fprintf(stderr, "   -C, --certpath          Specify alternate path to swupd certificates\n");
 	fprintf(stderr, "   -t, --time              Show verbose time output for swupd operations\n");
 	fprintf(stderr, "   -N, --no-scripts        Do not run the post-update scripts and boot update tool\n");
@@ -636,7 +640,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hm:xnIdtNbTau:P:c:v:sF:p:S:C:D:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hm:xnIdtNbTau:P:c:v:sF:p:S:C:D:k", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -739,6 +743,9 @@ static bool parse_options(int argc, char **argv)
 				fprintf(stderr, "Invalid --max-parallel-pack-downloads argument\n\n");
 				goto err;
 			}
+			break;
+		case 'k':
+			keepcache = true;
 			break;
 		default:
 			fprintf(stderr, "Unrecognized option\n\n");

--- a/swupd.bash
+++ b/swupd.bash
@@ -45,7 +45,7 @@ _swupd()
 		opts="--help --no-xattrs --path "
 		break;;
 	    ("update")
-		opts="--help --download --url --port --contenturl --versionurl --status --format --path --force --nosigcheck --ignore-time --statedir --certpath --time --no-scripts --no-boot-update --migrate --allow-mix-collisions --max-parallel-pack-downloads "
+		opts="--help --download --url --port --contenturl --versionurl --status --format --path --force --nosigcheck --ignore-time --statedir --certpath --time --no-scripts --no-boot-update --migrate --allow-mix-collisions --max-parallel-pack-downloads --keepcache "
 		break;;
 	    ("verify")
 		opts="--help --manifest --path --url --port --contenturl --versionurl --fix --picky --picky-tree --picky-whitelist --install --format --quick --force --nosigcheck --ignore-time --statedir --certpath --time --no-scripts --no-boot-update --max-parallel-pack-downloads "


### PR DESCRIPTION
After running an update, the state directory is cleaned up.
Sometimes it is useful to be able to peek at the state directory
after an update, this is specially true when testing updates,
this way tests can verify what manifests were downloaded during
the update.

This commit adds the --keepcache option to swupd update so it can
be used when writing tests for updates.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>