### PR TITLE
Add more compile options to info and --version

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -81,18 +81,6 @@ EXTRA_DIST += \
 	data/swupd-update.timer \
 	data/verifytime.service
 
-DISTCHECK_CONFIGURE_FLAGS = \
-	--with-systemdsystemunitdir=$$dc_install_base/$(systemdunitdir)
-
-systemdunitdir = @SYSTEMD_UNITDIR@
-
-systemdunit_DATA = \
-	data/check-update.service \
-	data/check-update.timer \
-	data/swupd-update.service \
-	data/swupd-update.timer \
-	data/verifytime.service
-
 distclean-local:
 	rm -rf aclocal.m4 ar-lib autom4te.cache config.guess config.h.in config.h.in~ config.sub configure depcomp install-sh ltmain.sh m4 Makefile.in missing compile
 

--- a/configure.ac
+++ b/configure.ac
@@ -241,18 +241,6 @@ AS_IF(
 )
 
 AC_ARG_WITH(
-  [systemdsystemunitdir],
-  [AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [path to systemd system service dir @<:@default=/usr/lib/systemd/system@:>@])],
-  [unitpath=${withval}],
-  [unitpath="$($PKG_CONFIG --variable=systemdsystemunitdir systemd)"]
-)
-AS_IF(
-  [test -z "${unitpath}"],
-  [unitpath=/usr/lib/systemd/system]
-)
-AC_SUBST(SYSTEMD_UNITDIR, [${unitpath}])
-
-AC_ARG_WITH(
   [pre-update],
   [AS_HELP_STRING([--with-pre-update=EXE], [Path to the pre-update executable])],
   [AC_DEFINE_UNQUOTED([PRE_UPDATE], ["$withval"], [pre-update])],

--- a/src/main.c
+++ b/src/main.c
@@ -83,6 +83,12 @@ static void copyright_header(void)
 	fprintf(stderr, "\n");
 }
 
+static void print_compile_opts(void)
+{
+	printf("Compile-time options: %s\n", BUILD_OPTS);
+	printf("Compile-time configuration:\n%s\n", BUILD_CONFIGURE);
+}
+
 static int subcmd_index(char *arg)
 {
 	struct subcmd *entry = commands;
@@ -115,7 +121,7 @@ static int parse_options(int argc, char **argv, int *index)
 			exit(EXIT_SUCCESS);
 		case 'v':
 			copyright_header();
-			fprintf(stderr, "Compile-time options: %s\n", BUILD_OPTS);
+			print_compile_opts();
 			exit(EXIT_SUCCESS);
 		case '\01':
 			/* found a subcommand, or a random non-option argument */

--- a/src/swupd-build-opts.h
+++ b/src/swupd-build-opts.h
@@ -46,7 +46,67 @@
 #define OPT_BSDTAR "-BSDTAR"
 #endif
 
+#ifdef SWUPD_WITH_XATTRS
+#define OPT_XATTRS "+XATTRS"
+#else
+#define OPT_XATTRS "-XATTRS"
+#endif
+
+#ifdef SWUPD_TAR_SELINUX
+#define OPT_SELINUX "+TAR_SELINUX"
+#else
+#define OPT_SELINUX "-TAR_SELINUX"
+#endif
+
+#ifdef OS_IS_STATELESS
+#define OPT_STATELESS "+STATELESS"
+#else
+#define OPT_STATELESS "-STATELESS"
+#endif
+
+#ifdef CONTENTURL
+#define OPT_C_URL CONTENTURL
+#else
+#define OPT_C_URL "no default set"
+#endif
+
+#ifdef VERSIONURL
+#define OPT_V_URL VERSIONURL
+#else
+#define OPT_V_URL "no default set"
+#endif
+
+#ifdef FORMATID
+#define OPT_FORMAT FORMATID
+#else
+#define OPT_FORMAT "no default set"
+#endif
+
+#ifdef PRE_UPDATE
+#define OPT_PRE PRE_UPDATE
+#else
+#define OPT_PRE "no default set"
+#endif
+
+#ifdef POST_UPDATE
+#define OPT_POST POST_UPDATE
+#else
+#define OPT_POST "no default set"
+#endif
+
 #define BUILD_OPTS \
-	OPT_BZIP2 " " OPT_SIGNATURES " " OPT_COVERAGE " " OPT_BSDTAR
+	OPT_BZIP2 " " OPT_SIGNATURES " " OPT_COVERAGE " " OPT_BSDTAR " " OPT_XATTRS " " OPT_SELINUX " " OPT_STATELESS
+
+#define BUILD_CONFIGURE                                       \
+	"mount point                  " MOUNT_POINT "\n"      \
+	"state directory              " STATE_DIR "\n"        \
+	"bundles directory            " BUNDLES_DIR "\n"      \
+	"certificate path             " CERT_PATH "\n"        \
+	"fallback certificate path    " FALLBACK_CAPATHS "\n" \
+	"content URL                  " OPT_C_URL "\n"        \
+	"version URL                  " OPT_V_URL "\n"        \
+	"format ID                    " OPT_FORMAT "\n"       \
+	"pre-update hook              " OPT_PRE "\n"          \
+	"post-update hook             " OPT_POST "\n"
 
 #endif

--- a/test/functional/ignore-list
+++ b/test/functional/ignore-list
@@ -1,3 +1,15 @@
 sh: .*/usr/bin/clr-boot-manager: No such file or directory
 sh: .*/usr/bin/clr-boot-manager: not found
 Update took .* seconds
+Compile-time options:.*
+Compile-time configuration:
+mount point.*
+state directory.*
+bundles directory.*
+certificate path.*
+fallback certificate path.*
+content URL.*
+version URL.*
+format ID.*
+pre-update hook.*
+post-update hook.*


### PR DESCRIPTION
When invoking swupd info or swupd --version print more information about
compile-time configuration. This feature was requested after a bug was
introduced to an unreleased Clear Linux build when swupd was built with
the wrong format ID. This allows QA to determine exactly which
compile-time options were set during runtime without inspecting the
binary.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>