### PR TITLE
Make parallel downloads flag global, used for fullfile downloads too.

### DIFF
--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -57,7 +57,7 @@ static void print_help(const char *name)
 	fprintf(stderr, "   -t, --time              Show verbose time output for swupd operations\n");
 	fprintf(stderr, "   -N, --no-scripts        Do not run the post-update scripts and boot update tool\n");
 	fprintf(stderr, "   -b, --no-boot-update    Do not update the boot files using clr-boot-manager\n");
-	fprintf(stderr, "   -D, --max-parallel-pack-downloads=[n] Set the maximum number of parallel pack downloads\n");
+	fprintf(stderr, "   -D, --max-parallel-downloads=[n] Set the maximum number of parallel downloads\n");
 	fprintf(stderr, "   --skip-diskspace-check  Do not check free disk space before adding bundle\n");
 	fprintf(stderr, "\n");
 }
@@ -79,7 +79,7 @@ static const struct option prog_opts[] = {
 	{ "time", no_argument, 0, 't' },
 	{ "no-scripts", no_argument, 0, 'N' },
 	{ "no-boot-update", no_argument, 0, 'b' },
-	{ "max-parallel-pack-downloads", required_argument, 0, 'D' },
+	{ "max-parallel-downloads", required_argument, 0, 'D' },
 	{ "skip-diskspace-check", no_argument, &skip_diskspace_check, 1 },
 	{ 0, 0, 0, 0 }
 };
@@ -170,8 +170,8 @@ static bool parse_options(int argc, char **argv)
 			set_cert_path(optarg);
 			break;
 		case 'D':
-			if (sscanf(optarg, "%d", &max_parallel_pack_downloads) != 1) {
-				fprintf(stderr, "Invalid --max-parallel-pack-downloads argument\n\n");
+			if (sscanf(optarg, "%d", &max_parallel_downloads) != 1) {
+				fprintf(stderr, "Invalid --max-parallel-downloads argument\n\n");
 				goto err;
 			}
 			break;

--- a/src/fullfile.c
+++ b/src/fullfile.c
@@ -27,6 +27,7 @@
 #include "swupd.h"
 
 /* hysteresis thresholds */
+//FIXME #562
 #define MAX_XFER 25
 
 static void download_mix_file(struct file *file)
@@ -129,7 +130,7 @@ int download_fullfiles(struct list *files, int *num_downloads)
 		return 0;
 	}
 
-	download_handle = swupd_curl_parallel_download_start(MAX_XFER);
+	download_handle = swupd_curl_parallel_download_start(get_max_xfer(MAX_XFER));
 	swupd_curl_parallel_download_set_callbacks(download_handle, download_successful, download_error, NULL);
 	fprintf(stderr, "Starting download of remaining update content. This may take a while...\n");
 	if (!download_handle) {

--- a/src/globals.c
+++ b/src/globals.c
@@ -70,7 +70,7 @@ char *content_url = NULL;
 bool content_url_is_local = false;
 char *cert_path = NULL;
 long update_server_port = -1;
-int max_parallel_pack_downloads = -1;
+int max_parallel_downloads = -1;
 char *swupd_cmd = NULL;
 
 timelist init_timelist(void)
@@ -606,4 +606,13 @@ void save_cmd(char **argv)
 		strcat(swupd_cmd, argv[i]);
 		strcat(swupd_cmd, " ");
 	}
+}
+
+size_t get_max_xfer(size_t default_max_xfer)
+{
+	if (max_parallel_downloads > 0) {
+		return max_parallel_downloads;
+	}
+
+	return default_max_xfer;
 }

--- a/src/packs.c
+++ b/src/packs.c
@@ -160,15 +160,6 @@ static int download_pack(void *download_handle, int oldversion, int newversion, 
 	return err;
 }
 
-size_t get_max_xfer()
-{
-	if (max_parallel_pack_downloads > 0) {
-		return max_parallel_pack_downloads;
-	}
-
-	return MAX_XFER;
-}
-
 /* pull in packs for base and any subscription */
 int download_subscribed_packs(struct list *subs, struct manifest *mom, bool required)
 {
@@ -181,7 +172,7 @@ int download_subscribed_packs(struct list *subs, struct manifest *mom, bool requ
 	void *download_handle;
 
 	fprintf(stderr, "Downloading packs...\n");
-	download_handle = swupd_curl_parallel_download_start(get_max_xfer());
+	download_handle = swupd_curl_parallel_download_start(get_max_xfer(MAX_XFER));
 
 	swupd_curl_parallel_download_set_callbacks(download_handle, download_successful, download_error, download_free_data);
 	iter = list_head(subs);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -191,7 +191,7 @@ extern char *content_url;
 extern bool content_url_is_local;
 extern char *cert_path;
 extern long update_server_port;
-extern int max_parallel_pack_downloads;
+extern int max_parallel_downloads;
 extern char *default_format_path;
 extern bool set_path_prefix(char *path);
 extern int set_content_url(char *url);
@@ -295,6 +295,8 @@ extern int rename_all_files_to_final(struct list *updates);
 extern int rename_staged_file_to_final(struct file *file);
 
 extern int update_device_latest_version(int version);
+
+extern size_t get_max_xfer(size_t default_max_xfer);
 
 /* curl.c */
 

--- a/src/update.c
+++ b/src/update.c
@@ -596,7 +596,7 @@ static const struct option prog_opts[] = {
 	{ "time", no_argument, 0, 't' },
 	{ "no-scripts", no_argument, 0, 'N' },
 	{ "no-boot-update", no_argument, 0, 'b' },
-	{ "max-parallel-pack-downloads", required_argument, 0, 'D' },
+	{ "max-parallel-downloads", required_argument, 0, 'D' },
 	{ "migrate", no_argument, 0, 'T' },
 	{ "allow-mix-collisions", no_argument, 0, 'a' },
 	{ 0, 0, 0, 0 }
@@ -630,7 +630,7 @@ static void print_help(const char *name)
 	fprintf(stderr, "   -t, --time              Show verbose time output for swupd operations\n");
 	fprintf(stderr, "   -N, --no-scripts        Do not run the post-update scripts and boot update tool\n");
 	fprintf(stderr, "   -b, --no-boot-update    Do not update the boot files using clr-boot-manager\n");
-	fprintf(stderr, "   -D, --max-parallel-pack-downloads=[n] Set the maximum number of parallel pack downloads\n");
+	fprintf(stderr, "   -D, --max-parallel-downloads=[n] Set the maximum number of parallel downloads\n");
 	fprintf(stderr, "   -T, --migrate           Migrate to augmented upstream/mix content\n");
 	fprintf(stderr, "   -a, --allow-mix-collisions	Ignore and continue if custom user content conflicts with upstream provided content\n");
 	fprintf(stderr, "\n");
@@ -739,8 +739,8 @@ static bool parse_options(int argc, char **argv)
 			set_cert_path(optarg);
 			break;
 		case 'D':
-			if (sscanf(optarg, "%d", &max_parallel_pack_downloads) != 1) {
-				fprintf(stderr, "Invalid --max-parallel-pack-downloads argument\n\n");
+			if (sscanf(optarg, "%d", &max_parallel_downloads) != 1) {
+				fprintf(stderr, "Invalid --max-parallel-downloads argument\n\n");
 				goto err;
 			}
 			break;

--- a/src/verify.c
+++ b/src/verify.c
@@ -87,7 +87,7 @@ static const struct option prog_opts[] = {
 	{ "time", no_argument, 0, 't' },
 	{ "no-scripts", no_argument, 0, 'N' },
 	{ "no-boot-update", no_argument, 0, 'b' },
-	{ "max-parallel-pack-downloads", required_argument, 0, 'D' },
+	{ "max-parallel-downloads", required_argument, 0, 'D' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -119,7 +119,7 @@ static void print_help(const char *name)
 	fprintf(stderr, "   -t, --time              Show verbose time output for swupd operations\n");
 	fprintf(stderr, "   -N, --no-scripts        Do not run the post-update scripts and boot update tool\n");
 	fprintf(stderr, "   -b, --no-boot-update    Do not install boot files to the boot partition (containers)\n");
-	fprintf(stderr, "   -D, --max-parallel-pack-downloads=[n] Set the maximum number of parallel pack downloads\n");
+	fprintf(stderr, "   -D, --max-parallel-downloads=[n] Set the maximum number of parallel downloads\n");
 	fprintf(stderr, "\n");
 }
 
@@ -276,8 +276,8 @@ static bool parse_options(int argc, char **argv)
 			cmdline_option_picky_whitelist = optarg;
 			break;
 		case 'D':
-			if (sscanf(optarg, "%d", &max_parallel_pack_downloads) != 1) {
-				fprintf(stderr, "Invalid --max-parallel-pack-downloads argument\n\n");
+			if (sscanf(optarg, "%d", &max_parallel_downloads) != 1) {
+				fprintf(stderr, "Invalid --max-parallel-downloads argument\n\n");
 				goto err;
 			}
 			break;


### PR DESCRIPTION
Adjust getopts, since this is relatively new. -D stays the same
and now applies to fullfiles too.