### PR TITLE
Avoid print time stats if the queue is empty.

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -131,7 +131,7 @@ void grabtime_stop(timelist *head)
 
 void print_time_stats(timelist *head)
 {
-	if (verbose_time == false) {
+	if (verbose_time == false || TAILQ_FIRST(head) == NULL) {
 		return;
 	}
 


### PR DESCRIPTION
If the -t parameter is set for a given empty directory, then
the time queue will be empty causing that the `TAILQ_FOREACH_REVERSE`
macro segfaults.

The proposed solution is to check if the head is NULL at the beginning
of the `print_time_stats` function.

Fixes #600

Signed-off-by: Erich Cordoba <erich.cm@yandex.com>