### PR TITLE
Remove manifest delta support

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -642,7 +642,7 @@ static void do_search(struct manifest *MoM, char search_type, char *search_term)
 		done_with_bundle = false;
 
 		/* Load sub-manifest */
-		subman = load_manifest(file->last_change, file->last_change, file, MoM, false);
+		subman = load_manifest(file->last_change, file, MoM, false);
 		if (!subman) {
 			fprintf(stderr, "Failed to load manifest %s\n", file->filename);
 			man_load_failures = true;
@@ -834,7 +834,7 @@ static int download_manifests(struct manifest **MoM, struct list **subs)
 
 		if (access(untard_file, F_OK) == -1) {
 			/* Do download */
-			subMan = load_manifest(current_version, file->last_change, file, *MoM, false);
+			subMan = load_manifest(file->last_change, file, *MoM, false);
 			if (!subMan) {
 				fprintf(stderr, "Cannot load official manifest MoM for version %i\n", current_version);
 			} else {

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -202,7 +202,7 @@ extern bool set_state_dir(char *path);
 extern void check_root(void);
 extern void increment_retries(int *retries, int *timeout);
 
-extern int add_included_manifests(struct manifest *mom, int current, struct list **subs);
+extern int add_included_manifests(struct manifest *mom, struct list **subs);
 extern int main_verify(int current_version);
 extern int walk_tree(struct manifest *, const char *, bool, const regex_t *);
 
@@ -218,7 +218,7 @@ extern int file_sort_filename(const void *a, const void *b);
 extern int file_sort_filename_reverse(const void *a, const void *b);
 extern struct manifest *load_mom_err(int version, bool latest, bool mix_exists, int *err);
 extern struct manifest *load_mom(int version, bool latest, bool mix_exists);
-extern struct manifest *load_manifest(int current, int version, struct file *file, struct manifest *mom, bool header_only);
+extern struct manifest *load_manifest(int version, struct file *file, struct manifest *mom, bool header_only);
 extern struct manifest *load_manifest_full(int version, bool mix);
 extern struct list *create_update_list(struct manifest *server);
 extern void link_manifests(struct manifest *m1, struct manifest *m2);
@@ -395,7 +395,7 @@ extern int show_bundle_reqd_by(const char *bundle_name, bool server);
 extern int show_included_bundles(char *bundle_name);
 extern int list_installable_bundles();
 extern int install_bundles_frontend(char **bundles);
-extern int add_subscriptions(struct list *bundles, struct list **subs, int current_version, struct manifest *mom, bool find_all, int recursion);
+extern int add_subscriptions(struct list *bundles, struct list **subs, struct manifest *mom, bool find_all, int recursion);
 int list_local_bundles();
 extern int link_or_rename(const char *orig, const char *dest);
 

--- a/src/update.c
+++ b/src/update.c
@@ -148,7 +148,7 @@ static int update_loop(struct list *updates, struct manifest *server_manifest)
 	return ret;
 }
 
-int add_included_manifests(struct manifest *mom, int current, struct list **subs)
+int add_included_manifests(struct manifest *mom, struct list **subs)
 {
 	struct list *subbed = NULL;
 	struct list *iter;
@@ -162,7 +162,7 @@ int add_included_manifests(struct manifest *mom, int current, struct list **subs
 
 	/* Pass the current version here, not the new, otherwise we will never
 	 * hit the Manifest delta path. */
-	if (add_subscriptions(subbed, subs, current, mom, false, 0) & (add_sub_ERR | add_sub_BADNAME)) {
+	if (add_subscriptions(subbed, subs, mom, false, 0) & (add_sub_ERR | add_sub_BADNAME)) {
 		ret = -1;
 	} else {
 		ret = 0;
@@ -396,7 +396,7 @@ load_current_submanifests:
 	/* The new subscription is seeded from the list of currently installed bundles
 	 * This calls add_subscriptions which recurses for new includes */
 	grabtime_start(&times, "Add Included Manifests");
-	ret = add_included_manifests(server_manifest, current_version, &latest_subs);
+	ret = add_included_manifests(server_manifest, &latest_subs);
 	grabtime_stop(&times);
 	if (ret) {
 		ret = EMANIFEST_LOAD;

--- a/src/verify.c
+++ b/src/verify.c
@@ -817,7 +817,7 @@ int verify_main(int argc, char **argv)
 		}
 	}
 
-	ret = add_included_manifests(official_manifest, version, &subs);
+	ret = add_included_manifests(official_manifest, &subs);
 	if (ret) {
 		ret = EMANIFEST_LOAD;
 		goto clean_and_exit;


### PR DESCRIPTION
Delta manifests are no longer used, so removing support for them. This
change removes the try_delta_manifest_download function which was used
to download manifest deltas. After removing this function, the 'current'
and 'file' parameters were no longer used by the retrieve_manifests
function. This had a ripple effect that removed unused parameters from
a variety of other functions.

Signed-off-by: John Akre <john.w.akre@intel.com>