### PR TITLE
Remove 404 from the list of possible swupd return codes

### DIFF
--- a/docs/swupd.1
+++ b/docs/swupd.1
@@ -590,7 +590,7 @@ The non\-zero return codes for other operations are listed here:
 .IP \(bu 2
 \fB16\fP: Unable to connect to update server
 .IP \(bu 2
-\fB16\fP, \fB17\fP, \fB404\fP: File download issue
+\fB16\fP, \fB17\fP: File download issue
 .IP \(bu 2
 \fB18\fP: Unable to install bundles
 .IP \(bu 2

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -404,7 +404,7 @@ The non-zero return codes for other operations are listed here:
   - **14**: Unable to load manifest into memory
   - **15**: Invalid command-line option
   - **16**: Unable to connect to update server
-  - **16**, **17**, **404**: File download issue
+  - **16**, **17**: File download issue
   - **18**: Unable to install bundles
   - **19**: Unable to create required directories
   - **20**: Unable to determine current version of the OS

--- a/src/swupd-error.h
+++ b/src/swupd-error.h
@@ -1,6 +1,8 @@
 #ifndef __INCLUDE_GUARD_SWUPD_ERROR_H
 #define __INCLUDE_GUARD_SWUPD_ERROR_H
 
+/* error codes to be used as swupd exit status */
+
 #define EBUNDLE_MISMATCH 2      /* at least one local bundle mismatches from MoM */
 #define EBUNDLE_REMOVE 3	/* cannot delete local bundle filename */
 #define EMOM_NOTFOUND 4		/* MoM cannot be loaded into memory (this could imply network issue) */
@@ -16,7 +18,6 @@
 #define EINVALID_OPTION 15      /* invalid command option */
 #define ENOSWUPDSERVER 16       /* no net connection to swupd server */
 #define EFULLDOWNLOAD 17	/* full_download problem */
-#define ENET404 404		/* download 404'd */
 #define EBUNDLE_INSTALL 18      /* Cannot install bundles */
 #define EREQUIRED_DIRS 19       /* Cannot create required dirs */
 #define ECURRENT_VERSION 20     /* Cannot determine current OS version */

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -56,6 +56,8 @@ extern "C" {
 #define add_sub_NEW 2
 #define add_sub_BADNAME 4
 
+/* download 404'd error code used by curl */
+#define ENET404 404
 struct sub {
 	/* name of bundle/component/subscription */
 	char *component;

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -27,7 +27,6 @@ export EMANIFEST_LOAD=14  # cannot load manifest into memory
 export EINVALID_OPTION=15  # invalid command option
 export ENOSWUPDSERVER=16  # no net connection to swupd server
 export EFULLDOWNLOAD=17  # full_download problem
-export ENET404=404  # download 404'd
 export EBUNDLE_INSTALL=18  # Cannot install bundles
 export EREQUIRED_DIRS=19  # Cannot create required dirs
 export ECURRENT_VERSION=20  # Cannot determine current OS version


### PR DESCRIPTION
Linux programs return code should be a number between 0 and 255, so 404 is an
invalid return code. Removing it from docs and from swupd-error.h file.

As it wasn't being used, this won't be a problem.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>