### PR TITLE
Fix a bug in some verify tests

### DIFF
--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1366,7 +1366,15 @@ destroy_test_environment() { # swupd_function
 			EOM
 		return
 	fi
-	validate_path "$env_name"
+	validate_param "$env_name"
+
+	# if the test environment doesn't exist warn the user but don't terminate script
+	# execution, this function could be called from a test teardown and terminating
+	# at that point will cause incorrect test reporting
+	if [ ! -d "$env_name" ]; then
+		echo "Warning: test environment \"$env_name\" doesn't exist, nothing to destroy."
+		return 1
+	fi
 
 	# since the action to be performed is very destructive, at least
 	# make sure the directory does look like a test environment

--- a/test/functional/verify/verify-format-mismatch-override.bats
+++ b/test/functional/verify/verify-format-mismatch-override.bats
@@ -4,9 +4,9 @@ load "../testlib"
 
 test_setup() {
 
-	create_test_environment -u "$TEST_NAME" 10 1
+	create_test_environment -r "$TEST_NAME" 10 1
 	bump_format "$TEST_NAME"
-	create_version -u "$TEST_NAME" 40 30 2
+	create_version -r "$TEST_NAME" 40 30 2
 	update_bundle "$TEST_NAME" os-core --add-dir /usr/bin
 
 }

--- a/test/functional/verify/verify-format-mismatch.bats
+++ b/test/functional/verify/verify-format-mismatch.bats
@@ -4,9 +4,9 @@ load "../testlib"
 
 test_setup() {
 
-	create_test_environment -u "$TEST_NAME" 10 1
+	create_test_environment -r "$TEST_NAME" 10 1
 	bump_format "$TEST_NAME"
-	create_version -u "$TEST_NAME" 40 30 2
+	create_version -r "$TEST_NAME" 40 30 2
 
 }
 

--- a/test/functional/verify/verify-picky-ghosted-missing.bats
+++ b/test/functional/verify/verify-picky-ghosted-missing.bats
@@ -4,7 +4,7 @@ load "../testlib"
 
 test_setup() {
 
-	create_test_environment -u "$TEST_NAME"
+	create_test_environment -r "$TEST_NAME"
 	create_bundle -L -n test-bundle -f /usr/foo -d/usr/share/clear/bundles "$TEST_NAME"
 	update_manifest "$WEBDIR"/10/Manifest.test-bundle file-status /usr/foo .g..
 	# since the files must have been installed by the -L option, remove /usr/foo

--- a/test/functional/verify/verify-picky-ghosted.bats
+++ b/test/functional/verify/verify-picky-ghosted.bats
@@ -4,7 +4,7 @@ load "../testlib"
 
 test_setup() {
 
-	create_test_environment -u "$TEST_NAME"
+	create_test_environment -r "$TEST_NAME"
 	create_bundle -L -n test-bundle -f /usr/foo -d/usr/share/clear/bundles "$TEST_NAME"
 	update_manifest "$WEBDIR"/10/Manifest.test-bundle file-status /usr/foo .g..
 


### PR DESCRIPTION
Some time ago the "-u" option of the create_test_environment and
create_version functions was renamed to "-r". Four of the verify
tests were not updated, so they were crashing during the setup,
while trying to create the test environment, so the test would not
be run since the setup failed but the teardown would still run and
the teardown would attempt to delete a non existant test environment
which would cause the destroy_test_environment to exit the script
causing an inconclusive test result.

This commit fixes the issue by doing the following actions:
- Fixes the tests by using the correct option "-r".
- Modifies the destroy_test_environment function so it does not exit
if a test environment doesn't exist, but instead it just returns a non
zero code and warns the user so the teardown works as expected.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>