### PR TITLE
Safely convert strings to numbers

### DIFF
--- a/src/filedesc.c
+++ b/src/filedesc.c
@@ -54,6 +54,7 @@ static void foreach_open_fd(void(pf)(int, void *), void *arg)
 	DIR *dir;
 	struct dirent *entry;
 	int dir_fd;
+	int err;
 
 	dir = opendir("/proc/self/fd");
 	if (!dir) {
@@ -72,7 +73,10 @@ static void foreach_open_fd(void(pf)(int, void *), void *arg)
 			continue;
 		}
 
-		n = strtol(entry->d_name, &ep, 10);
+		err = strtoi_err(entry->d_name, &ep, &n);
+		if (err != 0) {
+			fprintf(stderr, "Warning: invalid fd\n");
+		}
 		if (*ep) {
 			continue; /* Trailing non digits */
 		}

--- a/src/globals.c
+++ b/src/globals.c
@@ -228,13 +228,19 @@ fail:
 int get_version_from_path(const char *abs_path)
 {
 	int ret = -1;
+	int val;
 	char *ret_str;
 
 	ret = get_value_from_path(&ret_str, abs_path, true);
 	if (ret == 0) {
-		int val = strtoimax(ret_str, NULL, 10);
+		int err = strtoi_err(ret_str, NULL, &val);
 		free_string(&ret_str);
-		return val;
+
+		if (err != 0) {
+			fprintf(stderr, "Error: Invalid version\n");
+		} else {
+			return val;
+		}
 	}
 
 	return -1;
@@ -326,7 +332,7 @@ static bool is_valid_integer_format(char *str)
 	errno = 0;
 
 	version = strtoull(str, &endptr, 10);
-	if ((errno < 0) || (version == 0) || (endptr && *endptr != '\0')) {
+	if ((errno != 0) || (version == 0) || (endptr && *endptr != '\0')) {
 		return false;
 	}
 

--- a/src/search.c
+++ b/src/search.c
@@ -381,6 +381,7 @@ static const struct option prog_opts[] = {
 static bool parse_options(int argc, char **argv)
 {
 	int opt;
+	int err;
 
 	while ((opt = getopt_long(argc, argv, "hu:c:v:P:p:F:s:t:mlbinIdS:C:", prog_opts, NULL)) != -1) {
 		switch (opt) {
@@ -436,9 +437,8 @@ static bool parse_options(int argc, char **argv)
 
 			break;
 		case 't':
-			errno = 0;
-			num_results = strtol(optarg, NULL, 10);
-			if (errno != 0) {
+			err = strtoi_err(optarg, NULL, &num_results);
+			if (err != 0) {
 				fprintf(stderr, "Invalid --top argument\n\n");
 				goto err;
 			}

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -369,6 +369,7 @@ extern int rm_bundle_file(const char *bundle);
 extern void print_manifest_files(struct manifest *m);
 extern void swupd_deinit(void);
 extern int swupd_init(void);
+extern int strtoi_err(const char *str, char **endptr, int *value);
 extern void string_or_die(char **strp, const char *fmt, ...);
 char *strdup_or_die(const char *const str);
 extern void free_string(char **s);

--- a/src/verifytime.c
+++ b/src/verifytime.c
@@ -19,6 +19,7 @@
  *         Tudor Marcu <tudor.marcu@intel.com>
  *
  */
+#include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -34,6 +35,7 @@ static unsigned long int get_versionstamp(void)
 	FILE *fp = NULL;
 	char data[11];
 	const char *filename = "/usr/share/clear/versionstamp";
+	unsigned long int version_num;
 
 	if (stat(filename, &statt) == -1) {
 		fprintf(stderr, "%s does not exist!\n", filename);
@@ -53,13 +55,15 @@ static unsigned long int get_versionstamp(void)
 	}
 
 	/* If we read a 0 the versionstamp is wrong/corrupt */
-	if (strtoul(data, NULL, 10) == 0) {
+	errno = 0;
+	version_num = strtoul(data, NULL, 10);
+	if (version_num == 0 || errno != 0) {
 		fclose(fp);
 		return 0;
 	}
 
 	fclose(fp);
-	return strtoul(data, NULL, 10);
+	return version_num;
 }
 
 static bool set_time(time_t mtime, char *time)

--- a/src/version.c
+++ b/src/version.c
@@ -46,6 +46,7 @@ int get_latest_version(char *v_url)
 
 	char *url = NULL;
 	int ret = 0;
+	int err;
 	char version_str[MAX_VERSION_STR_SIZE];
 	struct curl_file_data tmp_version = {
 		MAX_VERSION_STR_SIZE, 0,
@@ -68,7 +69,11 @@ int get_latest_version(char *v_url)
 		goto out;
 	} else {
 		tmp_version.data[tmp_version.len] = '\0';
-		ret = strtol(tmp_version.data, NULL, MAX_VERSION_CHARS);
+		err = strtoi_err(tmp_version.data, NULL, &ret);
+
+		if (err != 0) {
+			ret = -1;
+		}
 	}
 
 out:
@@ -82,6 +87,7 @@ int get_current_version(char *path_prefix)
 	char line[LINE_MAX];
 	FILE *file;
 	int v = -1;
+	int err;
 	char *buildstamp;
 	char *src, *dest;
 
@@ -117,7 +123,10 @@ int get_current_version(char *path_prefix)
 			}
 			*dest = 0;
 
-			v = strtoull(&line[11], NULL, 10);
+			err = strtoi_err(&line[11], NULL, &v);
+			if (err != 0) {
+				v = -1;
+			}
 			break;
 		}
 	}
@@ -172,6 +181,7 @@ int read_mix_version_file(char *filename, char *path_prefix)
 	char line[LINE_MAX];
 	FILE *file;
 	int v = -1;
+	int err;
 	char *buildstamp;
 
 	string_or_die(&buildstamp, "%s%s", path_prefix, filename);
@@ -193,7 +203,10 @@ int read_mix_version_file(char *filename, char *path_prefix)
 			*c = '\0';
 		}
 
-		v = strtoull(line, NULL, 10);
+		err = strtoi_err(line, NULL, &v);
+		if (err != 0) {
+			v = -1;
+		}
 	}
 	free_string(&buildstamp);
 	fclose(file);


### PR DESCRIPTION
Various functions, like strtol, were used to convert strings to numbers.
Frequently, the results of these conversion functions were stored in
variables with types that did not match the function return value. As a
result, there was a potential risk that an overflow would occur when
type casting the string conversion function result to store it in a
mismatched type.

The most common case is to convert a string to an int, so this commit
creates the strtoi_err function which converts a string to an int and
provides error handling. Also, the error checking for other string to
number conversions was improved by adding error handling with errno.

Fixes #601

Signed-off-by: John Akre <john.w.akre@intel.com>