### PR TITLE
test: add localhost for no_proxy if not present

### DIFF
--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1433,6 +1433,14 @@ start_web_server() { # swupd_function
 
 	echo "$server_pid" > "$SERVER_PID_FILE"
 
+	# make sure localhost is present in no_proxy settings
+	if [ -n "$no_proxy" ] && grep -v 'localhost' <<< "$no_proxy"; then
+		no_proxy="${no_proxy},localhost"
+	elif [ -z "$no_proxy" ]; then
+		no_proxy="localhost"
+	fi
+	export no_proxy
+
 	# wait for server to be available
 	for i in $(seq 1 100); do
 		if [ -f "$PORT_FILE" ]; then


### PR DESCRIPTION
I see the checkupdate/chk-update-slow-server test fail when the `http_proxy` env variable is set, but `no_proxy` is not set.

Resolve the issue by adding "localhost" to `no_proxy` if needed, since the test web servers run on localhost.