### PR TITLE
bundle-add to return 0 if bundle already installed

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -766,8 +766,7 @@ static int install_bundles(struct list *bundles, struct list **subs, struct mani
 	/* Use a bitwise AND with the add_sub_NEW mask to determine if at least
 	 * one new bundle was subscribed */
 	if (!(ret & add_sub_NEW)) {
-		/* something went wrong, print a message and exit */
-		ret = EBUNDLE_INSTALL;
+		/* something went wrong, nothing will be installed */
 		goto out;
 	}
 
@@ -1009,7 +1008,6 @@ out:
 		fprintf(stderr, "Successfully installed %i bundle%s\n", bundles_installed, (bundles_installed > 1 ? "s" : ""));
 	}
 	if (already_installed) {
-		ret = EBUNDLE_INSTALL;
 		fprintf(stderr, "%i bundle%s already installed\n", already_installed, (already_installed > 1 ? "s were" : " was"));
 	}
 

--- a/test/functional/bundleadd/add-existing.bats
+++ b/test/functional/bundleadd/add-existing.bats
@@ -13,7 +13,7 @@ test_setup() {
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
-	assert_status_is "$EBUNDLE_INSTALL"
+	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Warning: Bundle "test-bundle" is already installed, skipping it...
 		1 bundle was already installed

--- a/test/functional/bundleadd/add-rc.bats
+++ b/test/functional/bundleadd/add-rc.bats
@@ -82,7 +82,7 @@ global_teardown() {
 @test "bundle-add output: adding one bundle that is already added" {
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle3"
-	assert_status_is "$EBUNDLE_INSTALL"
+	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Warning: Bundle "test-bundle3" is already installed, skipping it...
 		1 bundle was already installed
@@ -122,7 +122,7 @@ global_teardown() {
 @test "bundle-add output: adding multiple bundles, all invalid, both already added" {
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle3 test-bundle4"
-	assert_status_is "$EBUNDLE_INSTALL"
+	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Warning: Bundle "test-bundle4" is already installed, skipping it...
 		Warning: Bundle "test-bundle3" is already installed, skipping it...
@@ -155,7 +155,7 @@ global_teardown() {
 @test "bundle-add output: adding multiple bundles, one valid, one already added" {
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1 test-bundle3"
-	assert_status_is "$EBUNDLE_INSTALL"
+	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Warning: Bundle "test-bundle3" is already installed, skipping it...
 		Starting download of remaining update content. This may take a while...


### PR DESCRIPTION
Previously, the only way to get a return code of 0 (success) during
a bundle-add operation was if everything that was attempted to be
added had been successful. That means that bundle-add command was
returning EBUNDLE_INSTALL whenever it would try to add a bundle that
was already installed.

This commit changes the return code of such operation since it was
determined that it is a more appropriate behavior to consider an
attempt to add a bundle that is already added as successful, even when
no bundle was added during the operation.

Closes #510

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>