### PR TITLE
Add systemd unitdir to swupd --version output

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -251,6 +251,7 @@ AS_IF(
   [unitpath=/usr/lib/systemd/system]
 )
 AC_SUBST(SYSTEMD_UNITDIR, [${unitpath}])
+AC_DEFINE_UNQUOTED([SYSTEMD_UNITDIR_VAR], ["${unitpath}"], [systemdsystemunitdir])]
 
 AC_ARG_WITH(
   [pre-update],

--- a/src/swupd-build-opts.h
+++ b/src/swupd-build-opts.h
@@ -94,19 +94,26 @@
 #define OPT_POST "no default set"
 #endif
 
+#ifdef SYSTEMD_UNITDIR_VAR
+#define OPT_SYSTEMD_UNITDIR SYSTEMD_UNITDIR_VAR
+#else
+#define OPT_SYSTEMD_UNITDIR "no default set"
+#endif
+
 #define BUILD_OPTS \
 	OPT_BZIP2 " " OPT_SIGNATURES " " OPT_COVERAGE " " OPT_BSDTAR " " OPT_XATTRS " " OPT_SELINUX " " OPT_STATELESS
 
-#define BUILD_CONFIGURE                                       \
-	"mount point                  " MOUNT_POINT "\n"      \
-	"state directory              " STATE_DIR "\n"        \
-	"bundles directory            " BUNDLES_DIR "\n"      \
-	"certificate path             " CERT_PATH "\n"        \
-	"fallback certificate path    " FALLBACK_CAPATHS "\n" \
-	"content URL                  " OPT_C_URL "\n"        \
-	"version URL                  " OPT_V_URL "\n"        \
-	"format ID                    " OPT_FORMAT "\n"       \
-	"pre-update hook              " OPT_PRE "\n"          \
+#define BUILD_CONFIGURE                                          \
+	"mount point                  " MOUNT_POINT "\n"         \
+	"state directory              " STATE_DIR "\n"           \
+	"bundles directory            " BUNDLES_DIR "\n"         \
+	"certificate path             " CERT_PATH "\n"           \
+	"fallback certificate path    " FALLBACK_CAPATHS "\n"    \
+	"systemd unitdir              " OPT_SYSTEMD_UNITDIR "\n" \
+	"content URL                  " OPT_C_URL "\n"           \
+	"version URL                  " OPT_V_URL "\n"           \
+	"format ID                    " OPT_FORMAT "\n"          \
+	"pre-update hook              " OPT_PRE "\n"             \
 	"post-update hook             " OPT_POST "\n"
 
 #endif


### PR DESCRIPTION
Print the compile-time configuration systemdsystemunitdir.

Option was incorrectly removed on 74b2d526 so it didn't get into commit
that added extra information to --version (204e2a4b)

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>