### PR TITLE
Use verify --fix --picky with older versions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -206,6 +206,7 @@ BATS = \
 	test/functional/verify/verify-install-directory.bats \
 	test/functional/verify/verify-install-latest-directory.bats \
 	test/functional/verify/verify-latest-missing.bats \
+	test/functional/verify/verify-picky-downgrade.bats \
 	test/functional/verify/verify-picky-ghosted.bats \
 	test/functional/verify/verify-picky-ghosted-missing.bats \
 	test/functional/verify/verify-skip-scripts.bats

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -164,6 +164,19 @@ struct time {
 	times;
 };
 
+struct file_counts {
+	int checked;
+	int missing;
+	int replaced;
+	int not_replaced;
+	int mismatch;
+	int fixed;
+	int not_fixed;
+	int extraneous;
+	int deleted;
+	int not_deleted;
+};
+
 typedef TAILQ_HEAD(timelist, time) timelist;
 
 extern bool download_only;
@@ -206,7 +219,7 @@ extern void increment_retries(int *retries, int *timeout);
 
 extern int add_included_manifests(struct manifest *mom, struct list **subs);
 extern int main_verify(int current_version);
-extern int walk_tree(struct manifest *, const char *, bool, const regex_t *);
+extern int walk_tree(struct manifest *, const char *, bool, const regex_t *, struct file_counts *);
 
 extern int get_latest_version(char *v_url);
 extern int read_versions(int *current_version, int *server_version, char *path_prefix);

--- a/src/update.c
+++ b/src/update.c
@@ -163,8 +163,9 @@ int add_included_manifests(struct manifest *mom, struct list **subs)
 
 	/* Pass the current version here, not the new, otherwise we will never
 	 * hit the Manifest delta path. */
-	if (add_subscriptions(subbed, subs, mom, false, 0) & (add_sub_ERR | add_sub_BADNAME)) {
-		ret = -1;
+	ret = add_subscriptions(subbed, subs, mom, false, 0);
+	if (ret & (add_sub_ERR | add_sub_BADNAME)) {
+		ret = -ret;
 	} else {
 		ret = 0;
 	}

--- a/src/verify.c
+++ b/src/verify.c
@@ -809,6 +809,26 @@ int verify_main(int argc, char **argv)
 	}
 
 	ret = add_included_manifests(official_manifest, &subs);
+	/* if one or more of the installed bundles were not found in the manifest,
+	 * continue only if --force was used since the bundles could be removed */
+	if (ret == -add_sub_BADNAME) {
+		if (force) {
+			if (cmdline_option_picky && cmdline_option_fix) {
+				fprintf(stderr, "WARNING: One or more installed bundles that are not "
+						"available at version %d will be removed.\n",
+					version);
+			} else if (cmdline_option_picky && !cmdline_option_fix) {
+				fprintf(stderr, "WARNING: One or more installed bundles are not "
+						"available at version %d.\n",
+					version);
+			}
+			ret = 0;
+		} else {
+			fprintf(stderr, "Unable to verify, one or more currently installed bundles "
+					"are not available at version %d. Use --force to override.\n",
+				version);
+		}
+	}
 	if (ret) {
 		ret = EMANIFEST_LOAD;
 		goto clean_and_exit;

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1341,7 +1341,7 @@ create_test_environment() { # swupd_function
 	# added by default to every test environment unless specified otherwise
 	if [ "$empty" = false ]; then
 		if [ "$release_files" = true ]; then
-			create_bundle -L -n os-core -v "$version" -f /core,/usr/lib/os-release:"$OS_RELEASE",/usr/share/defaults/swupd/format:"$FORMAT" "$env_name"
+			create_bundle -L -n os-core -v "$version" -d /usr/share/clear/bundles -f /core,/usr/lib/os-release:"$OS_RELEASE",/usr/share/defaults/swupd/format:"$FORMAT" "$env_name"
 		else
 			create_bundle -L -n os-core -v "$version" -f /core "$env_name"
 		fi

--- a/test/functional/update/update-re-update-bad-os-release.bats
+++ b/test/functional/update/update-re-update-bad-os-release.bats
@@ -28,7 +28,7 @@ test_setup() {
 		    changed bundles   : 1
 		    new bundles       : 0
 		    deleted bundles   : 0
-		    changed files     : 8
+		    changed files     : 10
 		    new files         : 0
 		    deleted files     : 0
 		Starting download of remaining update content. This may take a while...

--- a/test/functional/update/update-re-update-required.bats
+++ b/test/functional/update/update-re-update-required.bats
@@ -23,7 +23,7 @@ test_setup() {
 		    changed bundles   : 1
 		    new bundles       : 0
 		    deleted bundles   : 0
-		    changed files     : 9
+		    changed files     : 11
 		    new files         : 0
 		    deleted files     : 0
 		Starting download of remaining update content. This may take a while...

--- a/test/functional/verify/verify-picky-downgrade.bats
+++ b/test/functional/verify/verify-picky-downgrade.bats
@@ -1,0 +1,153 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment -r "$TEST_NAME"
+	create_bundle -L -n test-bundle1 -f /file_1 "$TEST_NAME"
+	create_version "$TEST_NAME" 20 10
+	create_bundle -L -n test-bundle2 -f /usr/foo/file_2,/usr/foo/file_3,/bar/file_4,/bar/file_5 "$TEST_NAME"
+	set_current_version "$TEST_NAME" 20
+
+}
+
+@test "Verify using an older version won't remove an installed bundle that was not available then" {
+
+	run sudo sh -c "$SWUPD verify --fix --picky -m 10 $SWUPD_OPTS"
+
+	assert_status_is "$EMANIFEST_LOAD"
+	expected_output=$(cat <<-EOM
+		Verifying version 10
+		WARNING: the force or picky option is specified; ignoring version mismatch for verify --fix
+		Warning: Bundle "test-bundle2" is invalid, skipping it...
+		Unable to verify, one or more currently installed bundles are not available at version 10. Use --force to override.
+		Error: Fix did not fully succeed
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/usr/foo/file_2
+	assert_file_exists "$TARGETDIR"/usr/foo/file_3
+	assert_file_exists "$TARGETDIR"/bar/file_4
+	assert_file_exists "$TARGETDIR"/bar/file_5
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
+
+}
+
+@test "Verify can be forced to remove installed bundles that were not available in a previous version" {
+
+	run sudo sh -c "$SWUPD verify --fix --picky --force -m 10 $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Verifying version 10
+		WARNING: the force or picky option is specified; ignoring version mismatch for verify --fix
+		Warning: Bundle "test-bundle2" is invalid, skipping it...
+		WARNING: One or more installed bundles that are not available at version 10 will be removed.
+		Verifying files
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Adding any missing files
+		Fixing modified files
+		.Hash mismatch for file: .*/target-dir/usr/lib/os-release
+		.*fixed
+		--picky removing extra files under .*/target-dir/usr
+		REMOVING /usr/share/clear/bundles/test-bundle2
+		REMOVING /usr/foo/file_3
+		REMOVING /usr/foo/file_2
+		REMOVING DIR /usr/foo/
+		Inspected 15 files
+		  0 files were missing
+		  1 files did not match
+		    1 of 1 files were fixed
+		    0 of 1 files were not fixed
+		  4 files found which should be deleted
+		    4 of 4 files were deleted
+		    0 of 4 files were not deleted
+		Calling post-update helper scripts.
+		Fix successful
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+	assert_file_not_exists "$TARGETDIR"/usr/foo/file_2
+	assert_file_not_exists "$TARGETDIR"/usr/foo/file_3
+	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
+	# these files should still exist in the target system since they were not in /usr
+	assert_file_exists "$TARGETDIR"/bar/file_4
+	assert_file_exists "$TARGETDIR"/bar/file_5
+
+}
+
+@test "Verify can remove files in a specified location that were not available in a previous version" {
+
+	run sudo sh -c "$SWUPD verify --fix --picky --picky-tree=/bar --force -m 10 $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Verifying version 10
+		WARNING: the force or picky option is specified; ignoring version mismatch for verify --fix
+		Warning: Bundle "test-bundle2" is invalid, skipping it...
+		WARNING: One or more installed bundles that are not available at version 10 will be removed.
+		Verifying files
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Adding any missing files
+		Fixing modified files
+		.Hash mismatch for file: .*/target-dir/usr/lib/os-release
+		.*fixed
+		--picky removing extra files under .*/target-dir/bar
+		REMOVING /bar/file_5
+		REMOVING /bar/file_4
+		REMOVING DIR /bar/
+		Inspected 3 files
+		  0 files were missing
+		  1 files did not match
+		    1 of 1 files were fixed
+		    0 of 1 files were not fixed
+		  3 files found which should be deleted
+		    3 of 3 files were deleted
+		    0 of 3 files were not deleted
+		Calling post-update helper scripts.
+		Fix successful
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+	assert_file_not_exists "$TARGETDIR"/bar/file_4
+	assert_file_not_exists "$TARGETDIR"/bar/file_5
+	# these files should still exist in the target system since we specified /bar
+	# as the dir to look into
+	assert_file_exists "$TARGETDIR"/usr/foo/file_2
+	assert_file_exists "$TARGETDIR"/usr/foo/file_3
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
+
+}
+
+@test "Verify can show files that would be removed if not available in a previous version" {
+
+	run sudo sh -c "$SWUPD verify --picky --force -m 10 $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Verifying version 10
+		Warning: Bundle "test-bundle2" is invalid, skipping it...
+		WARNING: One or more installed bundles are not available at version 10.
+		Generating list of extra files under .*/target-dir/usr
+		/usr/share/clear/bundles/test-bundle2
+		/usr/foo/file_3
+		/usr/foo/file_2
+		/usr/foo/
+		Inspected 15 files
+		  4 files found which should be deleted
+		    0 of 4 files were deleted
+		    4 of 4 files were not deleted
+		Verify successful
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/usr/foo/file_2
+	assert_file_exists "$TARGETDIR"/usr/foo/file_3
+	assert_file_exists "$TARGETDIR"/bar/file_4
+	assert_file_exists "$TARGETDIR"/bar/file_5
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
+
+}


### PR DESCRIPTION
When you do a "verify --fix --picky -m older_version", and one
or more of the currently installed bundles didn't exist back then,
a non useful error message was being used, and the verify operation
would fail.

This commit makes the following changes.

1) With this commit, if the mentioned situation happens, the verify
operation will still be stopped, but a useful message will now be
displayed to inform the user of the situation, and he/she will be
presented with an alternative to proceed using the --force option.

2) If the user uses the --force option, the user will still be warned
but the verify operation will continue and the offending bundles will
be removed from the system.

3) Fixes a bug when using verify --picky. Only files that were orphaned
were being counted as files being removed from the system, files removed
because of the picky options were not being counted. This commit fixes
that.

Closes #608

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>