### PR TITLE
Improvements for DEBUG_TEST in test library

### DIFF
--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -192,8 +192,6 @@ to *true*.
 ```bash
 $ DEBUG_TEST=true bats <theme_directory>/<test_script>.bats
 ```
-Note: Remember you will have to delete this test environment manually before running
-the test again or it could have unexpected effects.
 
 ## Test Fixtures
 ### Test Environment

--- a/test/functional/update/update-slow-server.bats
+++ b/test/functional/update/update-slow-server.bats
@@ -48,9 +48,9 @@ global_teardown() {
 		Update started.
 		Preparing to update from 10 to 100
 		Downloading packs...
-		Error for .*update-slow-server/state/pack-test-bundle-from-10-to-100.tar download: Response 206 - No error
+		Error for .*/state/pack-test-bundle-from-10-to-100.tar download: Response 206 - No error
 		Starting download retry #1 for .*100/pack-test-bundle-from-10.tar
-		Error for .*update-slow-server/state/pack-test-bundle-from-10-to-100.tar download: Response 200 - Requested range was not delivered by the server
+		Error for .*/state/pack-test-bundle-from-10-to-100.tar download: Response 200 - Requested range was not delivered by the server
 		Range command not supported by server, download resume disabled.
 		Starting download retry #2 for .*100/pack-test-bundle-from-10.tar
 		Extracting test-bundle pack for version 100


### PR DESCRIPTION
When running tests, there is the possibility of preserving your
test environment for debugging purposes.

We were preserving the environment by skipping the execution of
the destroy_test_environment function when the DEBUG_TEST env
variable was set. This had one limitation, this was being done in
the default teardown function, so if the user would define his own
teardown then the DEBUG_TEST had no effect, the same if the user
used global_teardown instead. Another limitation the current
implementation had was that when an environment had been preserved
if the user would forget to clean it up manually before re-running
the test it would cause unexpected results in the test.

This commit removes both limitations by looking for the DEBUG_TEST
variable directly within the destroy_test_environment function so
the env will be preserved regardless of where the function is called
from and removes the environment at the beginning of the test if it
exists.

Closes #651

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>