### PR TITLE
Test: file cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
 script:
         - sudo find test/functional -exec chmod g-w {} \;
         - autoreconf --verbose --warnings=none --install --force &&
-          ./configure CFLAGS="$CFLAGS -fsanitize=address -Werror" --prefix=/usr --with-fallback-capaths=/tmp/swupd_test_certificates --enable-signature-verification --with-systemdsystemunitdir=/usr/lib/systemd/system &&
+          ./configure CFLAGS="$CFLAGS -fsanitize=address -Werror" --prefix=/usr --with-fallback-capaths=$TRAVIS_BUILD_DIR/swupd_test_certificates --enable-signature-verification --with-systemdsystemunitdir=/usr/lib/systemd/system &&
           make -j48 &&
           sudo sh -c 'umask 0022 && make -j48 check' &&
           sudo sh -c 'umask 0022 && make install' &&

--- a/autogen.sh
+++ b/autogen.sh
@@ -6,9 +6,13 @@ autoreconf --force --install --symlink --warnings=all
 
 # The client certificate tests are skipped by default, but require an
 # alternative trust store for the test web server's public key. To enable
-# the trust store for the client certificate tests, the following configuration
-# argument must be added to args:
-# --with-fallback-capaths=/tmp/swupd_test_certificates
+# the trust store for the client certificate tests, the SCRIPT_PATH variable
+# must be uncommented and the following configuration argument must be added
+# to args:
+#
+# --with-fallback-capaths=$SCRIPT_PATH/swupd_test_certificates
+#
+#SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 args="\
 --sysconfdir=/etc \
 --localstatedir=/var \

--- a/test/functional/bundleadd/add-client-certificate.bats
+++ b/test/functional/bundleadd/add-client-certificate.bats
@@ -2,15 +2,15 @@
 
 load "../testlib"
 
-server_pub="/tmp/$TEST_NAME-server-pub.pem"
-server_key="/tmp/$TEST_NAME-server-key.pem"
-client_pub="/tmp/$TEST_NAME-client-pub.pem"
-client_key="/tmp/$TEST_NAME-client-key.pem"
+server_pub="$PWD/$TEST_NAME"_1/server-pub.pem
+server_key="$PWD/$TEST_NAME"_1/server-key.pem
+client_pub="$PWD/$TEST_NAME"_1/client-pub.pem
+client_key="$PWD/$TEST_NAME"_1/client-key.pem
 
 global_setup() {
 
-	# Skip this test for local development because it takes a long time. To run this
-	# test locally, configure swupd with --with-fallback-capaths=/tmp/swup_test_certificates
+	# Skip this test for local development because it takes a long time. To run this test locally,
+	# configure swupd with --with-fallback-capaths=<path to top level of repo>/swupd_test_certificates
 	# and run: TRAVIS=true make check
 	if [ -z "${TRAVIS}" ]; then
 		return
@@ -61,11 +61,6 @@ global_teardown() {
 
 	destroy_web_server
 	destroy_trusted_cacert
-
-	rm -f "$client_key"
-	rm -f "$client_pub"
-	rm -f "$server_key"
-	rm -f "$server_pub"
 
 	destroy_test_environment "$TEST_NAME"
 }

--- a/test/functional/bundleadd/add-client-certificate.bats
+++ b/test/functional/bundleadd/add-client-certificate.bats
@@ -59,8 +59,6 @@ global_teardown() {
 		return
 	fi
 
-	destroy_web_server
-	destroy_trusted_cacert
 
 	destroy_test_environment "$TEST_NAME"
 }

--- a/test/functional/bundlelist/list-client-certificate.bats
+++ b/test/functional/bundlelist/list-client-certificate.bats
@@ -57,8 +57,6 @@ global_teardown() {
 		return
 	fi
 
-	destroy_web_server
-	destroy_trusted_cacert
 
 	destroy_test_environment "$TEST_NAME"
 }

--- a/test/functional/bundlelist/list-client-certificate.bats
+++ b/test/functional/bundlelist/list-client-certificate.bats
@@ -2,15 +2,15 @@
 
 load "../testlib"
 
-server_pub="/tmp/$TEST_NAME-server-pub.pem"
-server_key="/tmp/$TEST_NAME-server-key.pem"
-client_pub="/tmp/$TEST_NAME-client-pub.pem"
-client_key="/tmp/$TEST_NAME-client-key.pem"
+server_pub="$PWD/$TEST_NAME"_1/server-pub.pem
+server_key="$PWD/$TEST_NAME"_1/server-key.pem
+client_pub="$PWD/$TEST_NAME"_1/client-pub.pem
+client_key="$PWD/$TEST_NAME"_1/client-key.pem
 
 global_setup() {
 
-	# Skip this test for local development because it takes a long time. To run this
-	# test locally, configure swupd with --with-fallback-capaths=/tmp/swup_test_certificates
+	# Skip this test for local development because it takes a long time. To run this test locally,
+	# configure swupd with --with-fallback-capaths=<path to top level of repo>/swupd_test_certificates
 	# and run: TRAVIS=true make check
 	if [ -z "${TRAVIS}" ]; then
 		return
@@ -59,11 +59,6 @@ global_teardown() {
 
 	destroy_web_server
 	destroy_trusted_cacert
-
-	rm -f "$client_key"
-	rm -f "$client_pub"
-	rm -f "$server_key"
-	rm -f "$server_pub"
 
 	destroy_test_environment "$TEST_NAME"
 }

--- a/test/functional/bundleremove/remove-client-certificate.bats
+++ b/test/functional/bundleremove/remove-client-certificate.bats
@@ -2,15 +2,15 @@
 
 load "../testlib"
 
-server_pub="/tmp/$TEST_NAME-server-pub.pem"
-server_key="/tmp/$TEST_NAME-server-key.pem"
-client_pub="/tmp/$TEST_NAME-client-pub.pem"
-client_key="/tmp/$TEST_NAME-client-key.pem"
+server_pub="$PWD/$TEST_NAME"_1/server-pub.pem
+server_key="$PWD/$TEST_NAME"_1/server-key.pem
+client_pub="$PWD/$TEST_NAME"_1/client-pub.pem
+client_key="$PWD/$TEST_NAME"_1/client-key.pem
 
 global_setup() {
 
-	# Skip this test for local development because it takes a long time. To run this
-	# test locally, configure swupd with --with-fallback-capaths=/tmp/swup_test_certificates
+	# Skip this test for local development because it takes a long time. To run this test locally,
+	# configure swupd with --with-fallback-capaths=<path to top level of repo>/swupd_test_certificates
 	# and run: TRAVIS=true make check
 	if [ -z "${TRAVIS}" ]; then
 		return
@@ -62,11 +62,6 @@ global_teardown() {
 
 	destroy_web_server
 	destroy_trusted_cacert
-
-	rm -f "$client_key"
-	rm -f "$client_pub"
-	rm -f "$server_key"
-	rm -f "$server_pub"
 
 	destroy_test_environment "$TEST_NAME"
 }

--- a/test/functional/bundleremove/remove-client-certificate.bats
+++ b/test/functional/bundleremove/remove-client-certificate.bats
@@ -60,8 +60,6 @@ global_teardown() {
 		return
 	fi
 
-	destroy_web_server
-	destroy_trusted_cacert
 
 	destroy_test_environment "$TEST_NAME"
 }

--- a/test/functional/checkupdate/chk-update-client-certificate.bats
+++ b/test/functional/checkupdate/chk-update-client-certificate.bats
@@ -2,15 +2,15 @@
 
 load "../testlib"
 
-server_pub="/tmp/$TEST_NAME-server-pub.pem"
-server_key="/tmp/$TEST_NAME-server-key.pem"
-client_pub="/tmp/$TEST_NAME-client-pub.pem"
-client_key="/tmp/$TEST_NAME-client-key.pem"
+server_pub="$PWD/$TEST_NAME"_1/server-pub.pem
+server_key="$PWD/$TEST_NAME"_1/server-key.pem
+client_pub="$PWD/$TEST_NAME"_1/client-pub.pem
+client_key="$PWD/$TEST_NAME"_1/client-key.pem
 
 global_setup() {
 
-	# Skip this test for local development because it takes a long time. To run this
-	# test locally, configure swupd with --with-fallback-capaths=/tmp/swup_test_certificates
+	# Skip this test for local development because it takes a long time. To run this test locally,
+	# configure swupd with --with-fallback-capaths=<path to top level of repo>/swupd_test_certificates
 	# and run: TRAVIS=true make check
 	if [ -z "${TRAVIS}" ]; then
 		return
@@ -62,11 +62,6 @@ global_teardown() {
 
 	destroy_web_server
 	destroy_trusted_cacert
-
-	rm -f "$client_key"
-	rm -f "$client_pub"
-	rm -f "$server_key"
-	rm -f "$server_pub"
 
 	destroy_test_environment "$TEST_NAME"
 }

--- a/test/functional/checkupdate/chk-update-client-certificate.bats
+++ b/test/functional/checkupdate/chk-update-client-certificate.bats
@@ -60,8 +60,6 @@ global_teardown() {
 		return
 	fi
 
-	destroy_web_server
-	destroy_trusted_cacert
 
 	destroy_test_environment "$TEST_NAME"
 }

--- a/test/functional/checkupdate/chk-update-slow-server.bats
+++ b/test/functional/checkupdate/chk-update-slow-server.bats
@@ -23,7 +23,6 @@ test_teardown() {
 
 global_teardown() {
 
-	destroy_web_server
 	destroy_test_environment "$TEST_NAME"
 }
 

--- a/test/functional/search/search-client-certificate.bats
+++ b/test/functional/search/search-client-certificate.bats
@@ -2,15 +2,15 @@
 
 load "../testlib"
 
-server_pub="/tmp/$TEST_NAME-server-pub.pem"
-server_key="/tmp/$TEST_NAME-server-key.pem"
-client_pub="/tmp/$TEST_NAME-client-pub.pem"
-client_key="/tmp/$TEST_NAME-client-key.pem"
+server_pub="$PWD/$TEST_NAME"_1/server-pub.pem
+server_key="$PWD/$TEST_NAME"_1/server-key.pem
+client_pub="$PWD/$TEST_NAME"_1/client-pub.pem
+client_key="$PWD/$TEST_NAME"_1/client-key.pem
 
 global_setup() {
 
-	# Skip this test for local development because it takes a long time. To run this
-	# test locally, configure swupd with --with-fallback-capaths=/tmp/swup_test_certificates
+	# Skip this test for local development because it takes a long time. To run this test locally,
+	# configure swupd with --with-fallback-capaths=<path to top level of repo>/swupd_test_certificates
 	# and run: TRAVIS=true make check
 	if [ -z "${TRAVIS}" ]; then
 		return
@@ -60,11 +60,6 @@ global_teardown() {
 
 	destroy_web_server
 	destroy_trusted_cacert
-
-	rm -f "$client_key"
-	rm -f "$client_pub"
-	rm -f "$server_key"
-	rm -f "$server_pub"
 
 	destroy_test_environment "$TEST_NAME"
 }

--- a/test/functional/search/search-client-certificate.bats
+++ b/test/functional/search/search-client-certificate.bats
@@ -58,8 +58,6 @@ global_teardown() {
 		return
 	fi
 
-	destroy_web_server
-	destroy_trusted_cacert
 
 	destroy_test_environment "$TEST_NAME"
 }

--- a/test/functional/server.py
+++ b/test/functional/server.py
@@ -65,6 +65,9 @@ if __name__ == '__main__':
                              fail with partial download error and succeed on 2nd \
                              download.')
 
+    parser.add_argument('--pid_file',
+                        help='File path to write pid used by web server')
+
     parser.add_argument('--port_file',
                         help='File path to write port used by web server')
 
@@ -91,6 +94,12 @@ if __name__ == '__main__':
         request_handler = server.SimpleHTTPRequestHandler
 
     httpd = server.HTTPServer(addr, request_handler)
+
+    # write pid to file to be read by other processes
+    if args.pid_file:
+        pid = os.getpid()
+        with open (args.pid_file, "w") as f:
+            f.write(str(pid))
 
     # write port to file which can be read by other processes
     if args.port_file:

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -82,7 +82,7 @@ generate_certificate() { # swupd_function
 
 	# generate self-signed public and private key
 	if [ -z "$config" ]; then
-		openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 \
+		sudo openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 \
 			-keyout "$key_path" -out "$cert_path" \
 			-subj "/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost"
 	else
@@ -271,9 +271,9 @@ set_env_variables() { # swupd_function
 
 	export CLIENT_CERT_DIR="$TEST_NAME/target-dir/etc/swupd"
 	export CLIENT_CERT="$CLIENT_CERT_DIR/client.pem"
-	export CACERT_DIR="/tmp/swupd_test_certificates" # trusted key store path
-	export PORT_FILE="/tmp/$TEST_NAME-port_file.txt" # stores web server port
-	export SERVER_PID_FILE="/tmp/$TEST_NAME-pid_file.txt" # stores web server pid
+	export CACERT_DIR="$SWUPD_DIR/swupd_test_certificates" # trusted key store path
+	export PORT_FILE="$TEST_NAME/port_file.txt" # stores web server port
+	export SERVER_PID_FILE="$TEST_NAME/pid_file.txt" # stores web server pid
 
 	# Add environment variables for PORT and SERVER_PID when web server used
 	if [ -f "$PORT_FILE" ]; then
@@ -1447,10 +1447,7 @@ start_web_server() { # swupd_function
 	done
 
 	# start web server and write port/pid numbers to their respective files
-	python3 "$FUNC_DIR"/server.py $server_args --port_file "$PORT_FILE" &
-	server_pid=$!
-
-	echo "$server_pid" > "$SERVER_PID_FILE"
+	sudo python3 "$FUNC_DIR"/server.py $server_args --port_file "$PORT_FILE" --pid_file "$SERVER_PID_FILE" &
 
 	# make sure localhost is present in no_proxy settings
 	if [ -n "$no_proxy" ] && grep -v 'localhost' <<< "$no_proxy"; then
@@ -1497,11 +1494,7 @@ destroy_web_server() { # swupd_function
 	local server_pid
 
 	if [ -f "$SERVER_PID_FILE" ]; then
-		server_pid=$(cat "$SERVER_PID_FILE")
-
-		kill "$server_pid"
-		rm -f "$SERVER_PID_FILE"
-		rm -f "$PORT_FILE"
+		sudo kill "$(<$SERVER_PID_FILE)"
 	fi
 
 }

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1312,7 +1312,10 @@ create_test_environment() { # swupd_function
 		return
 	fi
 	validate_param "$env_name"
-	
+
+	# clean test environment when test interrupted
+	trap "destroy_test_environment $TEST_NAME" INT
+
 	# create all the files and directories needed
 	# web-dir files & dirs
 	sudo mkdir -p "$env_name"
@@ -1371,6 +1374,9 @@ destroy_test_environment() { # swupd_function
 		return
 	fi
 	validate_param "$env_name"
+
+	destroy_web_server
+	destroy_trusted_cacert
 
 	# if the test environment doesn't exist warn the user but don't terminate script
 	# execution, this function could be called from a test teardown and terminating

--- a/test/functional/update/update-client-certificate.bats
+++ b/test/functional/update/update-client-certificate.bats
@@ -2,15 +2,15 @@
 
 load "../testlib"
 
-server_pub="/tmp/$TEST_NAME-server-pub.pem"
-server_key="/tmp/$TEST_NAME-server-key.pem"
-client_pub="/tmp/$TEST_NAME-client-pub.pem"
-client_key="/tmp/$TEST_NAME-client-key.pem"
+server_pub="$PWD/$TEST_NAME"_1/server-pub.pem
+server_key="$PWD/$TEST_NAME"_1/server-key.pem
+client_pub="$PWD/$TEST_NAME"_1/client-pub.pem
+client_key="$PWD/$TEST_NAME"_1/client-key.pem
 
 global_setup() {
 
-	# Skip this test for local development because it takes a long time. To run this
-	# test locally, configure swupd with --with-fallback-capaths=/tmp/swup_test_certificates
+	# Skip this test for local development because it takes a long time. To run this test locally,
+	# configure swupd with --with-fallback-capaths=<path to top level of repo>/swupd_test_certificates
 	# and run: TRAVIS=true make check
 	if [ -z "${TRAVIS}" ]; then
 		return
@@ -64,11 +64,6 @@ global_teardown() {
 
 	destroy_web_server
 	destroy_trusted_cacert
-
-	rm -f "$client_key"
-	rm -f "$client_pub"
-	rm -f "$server_key"
-	rm -f "$server_pub"
 
 	destroy_test_environment "$TEST_NAME"
 }

--- a/test/functional/update/update-client-certificate.bats
+++ b/test/functional/update/update-client-certificate.bats
@@ -62,8 +62,6 @@ global_teardown() {
 		return
 	fi
 
-	destroy_web_server
-	destroy_trusted_cacert
 
 	destroy_test_environment "$TEST_NAME"
 }

--- a/test/functional/update/update-slow-server.bats
+++ b/test/functional/update/update-slow-server.bats
@@ -33,7 +33,6 @@ global_teardown() {
 
 	# teardown only if in travis CI
 	if [ -n "${TRAVIS}" ]; then
-		destroy_web_server
 		destroy_test_environment "$TEST_NAME"
 	fi
 

--- a/test/functional/verify/verify-client-certificate.bats
+++ b/test/functional/verify/verify-client-certificate.bats
@@ -57,8 +57,6 @@ global_teardown() {
 		return
 	fi
 
-	destroy_web_server
-	destroy_trusted_cacert
 
 	destroy_test_environment "$TEST_NAME"
 }

--- a/test/functional/verify/verify-client-certificate.bats
+++ b/test/functional/verify/verify-client-certificate.bats
@@ -2,15 +2,15 @@
 
 load "../testlib"
 
-server_pub="/tmp/$TEST_NAME-server-pub.pem"
-server_key="/tmp/$TEST_NAME-server-key.pem"
-client_pub="/tmp/$TEST_NAME-client-pub.pem"
-client_key="/tmp/$TEST_NAME-client-key.pem"
+server_pub="$PWD/$TEST_NAME"_1/server-pub.pem
+server_key="$PWD/$TEST_NAME"_1/server-key.pem
+client_pub="$PWD/$TEST_NAME"_1/client-pub.pem
+client_key="$PWD/$TEST_NAME"_1/client-key.pem
 
 global_setup() {
 
-	# Skip this test for local development because it takes a long time. To run this
-	# test locally, configure swupd with --with-fallback-capaths=/tmp/swup_test_certificates
+	# Skip this test for local development because it takes a long time. To run this test locally,
+	# configure swupd with --with-fallback-capaths=<path to top level of repo>/swupd_test_certificates
 	# and run: TRAVIS=true make check
 	if [ -z "${TRAVIS}" ]; then
 		return
@@ -59,11 +59,6 @@ global_teardown() {
 
 	destroy_web_server
 	destroy_trusted_cacert
-
-	rm -f "$client_key"
-	rm -f "$client_pub"
-	rm -f "$server_key"
-	rm -f "$server_pub"
 
 	destroy_test_environment "$TEST_NAME"
 }


### PR DESCRIPTION
Some tests (tests using web servers) wrote files to /tmp which were hard to clean up. This change moves the files/directories that were written to /tmp to more obvious locations. The trusted certificate store is now written to the top level directory of the repo and the other files are written to their corresponding test environment directories. Also this change adds a trap to clean up tests when they are interrupted.

Fixes #650