### PR TITLE
time: record time of scripts execution on verify and bundle-add

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -970,7 +970,9 @@ download_subscribed_packs:
 	sync();
 	timelist_timer_stop(global_times);
 	/* step 5: Run any scripts that are needed to complete update */
+	timelist_timer_start(global_times, "Run Scripts");
 	run_scripts(false);
+	timelist_timer_stop(global_times);
 
 	ret = 0;
 	timelist_print_stats(global_times);

--- a/src/verify.c
+++ b/src/verify.c
@@ -966,7 +966,9 @@ brick_the_system_and_clean_curl:
 		// always run in a fix or install case
 		need_update_boot = true;
 		need_update_bootloader = true;
+		timelist_timer_start(global_times, "Run Scripts");
 		run_scripts(false);
+		timelist_timer_stop(global_times);
 	}
 
 	sync();


### PR DESCRIPTION
Add a timer counter to print how long run_scripts() take on verify and
bundle-add commands. Note that this is already in place for update.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>