### PR TITLE
Add consistency between verify and verify --fix

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -199,6 +199,7 @@ BATS = \
 	test/functional/verify/verify-client-certificate.bats \
 	test/functional/verify/verify-directory-tree-deleted.bats \
 	test/functional/verify/verify-empty-dir-deleted.bats \
+	test/functional/verify/verify-fix.bats \
 	test/functional/verify/verify-fix-version-mismatch.bats \
 	test/functional/verify/verify-fix-version-mismatch-override.bats \
 	test/functional/verify/verify-format-mismatch.bats \

--- a/src/extra_files.c
+++ b/src/extra_files.c
@@ -154,6 +154,8 @@ int walk_tree(struct manifest *manifest, const char *start, bool fix, const rege
 		int skip_len; /* Length of directory name we are skipping
 			       * could have used strlen(skip_dir), but speed! */
 		if (!F[i].in_manifest) {
+			/* Account for these files not in the manifest as inspected also */
+			counts->checked++;
 			counts->extraneous++;
 			/* Logic to avoid printing out all the files in a
 			 * directory when the directory itself is not present */
@@ -180,7 +182,6 @@ int walk_tree(struct manifest *manifest, const char *start, bool fix, const rege
 			skip_dir = NULL;
 		}
 	}
-	counts->checked = nF;
 tidy:
 	for (int i = 0; i < nF; i++) {
 		free_string(&F[i].filename);

--- a/test/functional/verify/verify-add-missing-directory.bats
+++ b/test/functional/verify/verify-add-missing-directory.bats
@@ -25,10 +25,9 @@ test_setup() {
 		.fixed
 		Fixing modified files
 		Inspected 5 files
-		  1 files were missing
+		  1 file was missing
 		    1 of 1 missing files were replaced
 		    0 of 1 missing files were not replaced
-		  0 files found which should be deleted
 		Calling post-update helper scripts.
 		Fix successful
 	EOM

--- a/test/functional/verify/verify-add-missing-include-old.bats
+++ b/test/functional/verify/verify-add-missing-include-old.bats
@@ -33,7 +33,6 @@ test_setup() {
 		  2 files were missing
 		    2 of 2 missing files were replaced
 		    0 of 2 missing files were not replaced
-		  0 files found which should be deleted
 		Calling post-update helper scripts.
 		Fix successful
 	EOM

--- a/test/functional/verify/verify-add-missing-include.bats
+++ b/test/functional/verify/verify-add-missing-include.bats
@@ -34,7 +34,6 @@ test_setup() {
 		  3 files were missing
 		    3 of 3 missing files were replaced
 		    0 of 3 missing files were not replaced
-		  0 files found which should be deleted
 		Calling post-update helper scripts.
 		Fix successful
 	EOM

--- a/test/functional/verify/verify-boot-file-deleted.bats
+++ b/test/functional/verify/verify-boot-file-deleted.bats
@@ -20,9 +20,7 @@ test_setup() {
 		Verifying files
 		Adding any missing files
 		Fixing modified files
-		Inspected 4 files
-		  0 files were missing
-		  0 files found which should be deleted
+		Inspected 5 files
 		Calling post-update helper scripts.
 		Fix successful
 	EOM

--- a/test/functional/verify/verify-boot-file-mismatch-fix.bats
+++ b/test/functional/verify/verify-boot-file-mismatch-fix.bats
@@ -25,11 +25,9 @@ test_setup() {
 		Hash mismatch for file: .*/target-dir/usr/lib/kernel/testfile
 		.fixed
 		Inspected 7 files
-		  0 files were missing
-		  1 files did not match
+		  1 file did not match
 		    1 of 1 files were fixed
 		    0 of 1 files were not fixed
-		  0 files found which should be deleted
 		Calling post-update helper scripts.
 		Fix successful
 	EOM

--- a/test/functional/verify/verify-boot-file-mismatch.bats
+++ b/test/functional/verify/verify-boot-file-mismatch.bats
@@ -20,7 +20,7 @@ test_setup() {
 		Verifying files
 		Hash mismatch for file: .*/target-dir/usr/lib/kernel/testfile
 		Inspected 7 files
-		  1 files did not match
+		  1 file did not match
 		Verify successful
 	EOM
 	)

--- a/test/functional/verify/verify-boot-skip.bats
+++ b/test/functional/verify/verify-boot-skip.bats
@@ -20,9 +20,7 @@ test_setup() {
 		Verifying files
 		Adding any missing files
 		Fixing modified files
-		Inspected 4 files
-		  0 files were missing
-		  0 files found which should be deleted
+		Inspected 5 files
 		Calling post-update helper scripts.
 		WARNING: boot files update skipped due to --no-boot-update argument
 		Fix successful

--- a/test/functional/verify/verify-check-missing-directory.bats
+++ b/test/functional/verify/verify-check-missing-directory.bats
@@ -18,9 +18,9 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Verifying version 10
 		Verifying files
-		Hash mismatch for file: .*/target-dir/foo
+		Missing file: .*/target-dir/foo
 		Inspected 4 files
-		  1 files did not match
+		  1 file was missing
 		Verify successful
 	EOM
 	)

--- a/test/functional/verify/verify-directory-tree-deleted.bats
+++ b/test/functional/verify/verify-directory-tree-deleted.bats
@@ -25,11 +25,13 @@ test_setup() {
 		Verifying files
 		Adding any missing files
 		Fixing modified files
-		Deleted .*/target-dir/testdir1/testdir2/testfile
-		Deleted .*/target-dir/testdir1/testdir2
-		Deleted .*/target-dir/testdir1
-		Inspected 1 files
-		  0 files were missing
+		File that should be deleted: .*/target-dir/testdir1/testdir2/testfile
+		.deleted
+		File that should be deleted: .*/target-dir/testdir1/testdir2
+		.deleted
+		File that should be deleted: .*/target-dir/testdir1
+		.deleted
+		Inspected 4 files
 		  3 files found which should be deleted
 		    3 of 3 files were deleted
 		    0 of 3 files were not deleted

--- a/test/functional/verify/verify-empty-dir-deleted.bats
+++ b/test/functional/verify/verify-empty-dir-deleted.bats
@@ -20,10 +20,10 @@ test_setup() {
 		Verifying files
 		Adding any missing files
 		Fixing modified files
-		Deleted .*/target-dir/testdir
-		Inspected 1 files
-		  0 files were missing
-		  1 files found which should be deleted
+		File that should be deleted: .*/target-dir/testdir
+		.deleted
+		Inspected 2 files
+		  1 file found which should be deleted
 		    1 of 1 files were deleted
 		    0 of 1 files were not deleted
 		Calling post-update helper scripts.

--- a/test/functional/verify/verify-fix-version-mismatch-override.bats
+++ b/test/functional/verify/verify-fix-version-mismatch-override.bats
@@ -29,10 +29,9 @@ test_setup() {
 		.fixed
 		Fixing modified files
 		Inspected 3 files
-		  1 files were missing
+		  1 file was missing
 		    1 of 1 missing files were replaced
 		    0 of 1 missing files were not replaced
-		  0 files found which should be deleted
 		Calling post-update helper scripts.
 		Fix successful
 	EOM

--- a/test/functional/verify/verify-fix.bats
+++ b/test/functional/verify/verify-fix.bats
@@ -1,0 +1,226 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment -r "$TEST_NAME" 10 1
+	create_bundle -L -n test-bundle1 -f /foo/file_1,/bar/file_2 "$TEST_NAME"
+	create_version "$TEST_NAME" 20 10 1
+	update_bundle -p "$TEST_NAME" test-bundle1 --update /foo/file_1
+	update_bundle -p "$TEST_NAME" test-bundle1 --delete /bar/file_2
+	update_bundle "$TEST_NAME" test-bundle1 --add /baz/file_3
+	set_current_version "$TEST_NAME" 20
+	# adding an untracked files into an untracked directory (/bat)
+	sudo mkdir "$TARGETDIR"/bat
+	sudo touch "$TARGETDIR"/bat/untracked_file1
+	# adding an untracked file into tracked directory (/bar)
+	sudo touch "$TARGETDIR"/bar/untracked_file2
+	# adding an untracked file into /usr
+	sudo touch "$TARGETDIR"/usr/untracked_file3
+
+}
+
+@test "Verify shows modified files, new files and deleted files" {
+
+	# verify should show tracked files with a hash mismatch,
+	# it should also show tracked files that were marked to be removed,
+	# and it should show files that were added to bundles.
+	# verify should not show any of these changes in untracked files
+
+	run sudo sh -c "$SWUPD verify $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Verifying version 20
+		Verifying files
+		Missing file: .*/target-dir/baz
+		Missing file: .*/target-dir/baz/file_3
+		Hash mismatch for file: .*/target-dir/foo/file_1
+		Hash mismatch for file: .*/target-dir/usr/lib/os-release
+		File that should be deleted: .*/target-dir/bar/file_2
+		Inspected 18 files
+		  2 files were missing
+		  2 files did not match
+		  1 file found which should be deleted
+		Verify successful
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+	# tracked files
+	assert_file_exists "$TARGETDIR"/foo/file_1
+	assert_file_exists "$TARGETDIR"/bar/file_2
+	assert_file_not_exists "$TARGETDIR"/baz/file_3
+	# untracked files
+	assert_file_exists "$TARGETDIR"/bat/untracked_file1
+	assert_file_exists "$TARGETDIR"/bar/untracked_file2
+	assert_file_exists "$TARGETDIR"/usr/untracked_file3
+
+}
+
+@test "Verify fixes modified files, new files and deleted files" {
+
+	# verify --fix should fix tracked files with a hash mismatch,
+	# it should also delete tracked files that were marked to be removed,
+	# and it should add files that were added to bundles.
+	# verify --fix should not delete any untracked files
+
+	run sudo sh -c "$SWUPD verify --fix $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Verifying version 20
+		Verifying files
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Adding any missing files
+		Missing file: .*/target-dir/baz
+		.fixed
+		Missing file: .*/target-dir/baz/file_3
+		.fixed
+		Fixing modified files
+		Hash mismatch for file: .*/target-dir/foo/file_1
+		.fixed
+		Hash mismatch for file: .*/target-dir/usr/lib/os-release
+		.fixed
+		File that should be deleted: .*/target-dir/bar/file_2
+		.deleted
+		Inspected 18 files
+		  2 files were missing
+		    2 of 2 missing files were replaced
+		    0 of 2 missing files were not replaced
+		  2 files did not match
+		    2 of 2 files were fixed
+		    0 of 2 files were not fixed
+		  1 file found which should be deleted
+		    1 of 1 files were deleted
+		    0 of 1 files were not deleted
+		Calling post-update helper scripts.
+		Fix successful
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+	# tracked files
+	assert_file_exists "$TARGETDIR"/foo/file_1
+	assert_file_not_exists "$TARGETDIR"/bar/file_2
+	assert_file_exists "$TARGETDIR"/baz/file_3
+	# untracked files
+	assert_file_exists "$TARGETDIR"/bat/untracked_file1
+	assert_file_exists "$TARGETDIR"/bar/untracked_file2
+	assert_file_exists "$TARGETDIR"/usr/untracked_file3
+
+}
+
+@test "Verify fixes modified files, new files, deleted files, and removes untracked files" {
+
+	# verify --fix --picky should fix tracked files with a hash mismatch,
+	# it should also delete tracked files that were marked to be removed,
+	# and it should add files that were added to bundles.
+	# verify --fix --picky should delete any untracked files within /usr
+
+	run sudo sh -c "$SWUPD verify --fix --picky $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Verifying version 20
+		Verifying files
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Adding any missing files
+		Missing file: .*/target-dir/baz
+		.fixed
+		Missing file: .*/target-dir/baz/file_3
+		.fixed
+		Fixing modified files
+		Hash mismatch for file: .*/target-dir/foo/file_1
+		.fixed
+		Hash mismatch for file: .*/target-dir/usr/lib/os-release
+		.fixed
+		File that should be deleted: .*/target-dir/bar/file_2
+		.deleted
+		--picky removing extra files under .*/target-dir/usr
+		REMOVING /usr/untracked_file3
+		Inspected 19 files
+		  2 files were missing
+		    2 of 2 missing files were replaced
+		    0 of 2 missing files were not replaced
+		  2 files did not match
+		    2 of 2 files were fixed
+		    0 of 2 files were not fixed
+		  2 files found which should be deleted
+		    2 of 2 files were deleted
+		    0 of 2 files were not deleted
+		Calling post-update helper scripts.
+		Fix successful
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+	# tracked files
+	assert_file_exists "$TARGETDIR"/foo/file_1
+	assert_file_not_exists "$TARGETDIR"/bar/file_2
+	assert_file_exists "$TARGETDIR"/baz/file_3
+	# untracked files
+	assert_file_exists "$TARGETDIR"/bat/untracked_file1
+	assert_file_exists "$TARGETDIR"/bar/untracked_file2
+	assert_file_not_exists "$TARGETDIR"/usr/untracked_file3
+
+}
+
+@test "Verify fixes modified files, new files, deleted files, and removes untracked files from a specified location" {
+
+	# verify --fix --picky should fix tracked files with a hash mismatch,
+	# it should also delete tracked files that were marked to be removed,
+	# and it should add files that were added to bundles.
+	# verify --fix --picky-tree=/bat should delete any untracked files within /bat
+
+	run sudo sh -c "$SWUPD verify --fix --picky --picky-tree=/bat $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Verifying version 20
+		Verifying files
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Adding any missing files
+		Missing file: .*/target-dir/baz
+		.fixed
+		Missing file: .*/target-dir/baz/file_3
+		.fixed
+		Fixing modified files
+		Hash mismatch for file: .*/target-dir/foo/file_1
+		.fixed
+		Hash mismatch for file: .*/target-dir/usr/lib/os-release
+		.fixed
+		File that should be deleted: .*/target-dir/bar/file_2
+		.deleted
+		--picky removing extra files under .*/target-dir/bat
+		REMOVING /bat/untracked_file1
+		REMOVING DIR /bat/
+		Inspected 20 files
+		  2 files were missing
+		    2 of 2 missing files were replaced
+		    0 of 2 missing files were not replaced
+		  2 files did not match
+		    2 of 2 files were fixed
+		    0 of 2 files were not fixed
+		  3 files found which should be deleted
+		    3 of 3 files were deleted
+		    0 of 3 files were not deleted
+		Calling post-update helper scripts.
+		Fix successful
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+	# tracked files
+	assert_file_exists "$TARGETDIR"/foo/file_1
+	assert_file_not_exists "$TARGETDIR"/bar/file_2
+	assert_file_exists "$TARGETDIR"/baz/file_3
+	# untracked files
+	assert_file_not_exists "$TARGETDIR"/bat/untracked_file1
+	assert_file_exists "$TARGETDIR"/bar/untracked_file2
+	assert_file_exists "$TARGETDIR"/usr/untracked_file3
+
+}

--- a/test/functional/verify/verify-format-mismatch-override.bats
+++ b/test/functional/verify/verify-format-mismatch-override.bats
@@ -32,13 +32,12 @@ test_setup() {
 		Hash mismatch for file: .*/target-dir/usr/share/defaults/swupd/format
 		.fixed
 		Inspected 12 files
-		  1 files were missing
+		  1 file was missing
 		    1 of 1 missing files were replaced
 		    0 of 1 missing files were not replaced
 		  2 files did not match
 		    2 of 2 files were fixed
 		    0 of 2 files were not fixed
-		  0 files found which should be deleted
 		Calling post-update helper scripts.
 		Fix successful
 	EOM

--- a/test/functional/verify/verify-ghosted.bats
+++ b/test/functional/verify/verify-ghosted.bats
@@ -19,9 +19,7 @@ test_setup() {
 		Verifying files
 		Adding any missing files
 		Fixing modified files
-		Inspected 1 files
-		  0 files were missing
-		  0 files found which should be deleted
+		Inspected 2 files
 		Calling post-update helper scripts.
 		Fix successful
 	EOM

--- a/test/functional/verify/verify-install-directory.bats
+++ b/test/functional/verify/verify-install-directory.bats
@@ -25,7 +25,7 @@ test_setup() {
 		Finishing download of update content...
 		Adding any missing files
 		Inspected 5 files
-		  1 files were missing
+		  1 file was missing
 		    1 of 1 missing files were replaced
 		    0 of 1 missing files were not replaced
 		Calling post-update helper scripts.

--- a/test/functional/verify/verify-install-latest-directory.bats
+++ b/test/functional/verify/verify-install-latest-directory.bats
@@ -25,7 +25,7 @@ test_setup() {
 		Finishing download of update content...
 		Adding any missing files
 		Inspected 6 files
-		  1 files were missing
+		  1 file was missing
 		    1 of 1 missing files were replaced
 		    0 of 1 missing files were not replaced
 		Calling post-update helper scripts.

--- a/test/functional/verify/verify-picky-downgrade.bats
+++ b/test/functional/verify/verify-picky-downgrade.bats
@@ -56,9 +56,8 @@ test_setup() {
 		REMOVING /usr/foo/file_3
 		REMOVING /usr/foo/file_2
 		REMOVING DIR /usr/foo/
-		Inspected 15 files
-		  0 files were missing
-		  1 files did not match
+		Inspected 17 files
+		  1 file did not match
 		    1 of 1 files were fixed
 		    0 of 1 files were not fixed
 		  4 files found which should be deleted
@@ -99,9 +98,8 @@ test_setup() {
 		REMOVING /bar/file_5
 		REMOVING /bar/file_4
 		REMOVING DIR /bar/
-		Inspected 3 files
-		  0 files were missing
-		  1 files did not match
+		Inspected 16 files
+		  1 file did not match
 		    1 of 1 files were fixed
 		    0 of 1 files were not fixed
 		  3 files found which should be deleted
@@ -136,10 +134,8 @@ test_setup() {
 		/usr/foo/file_3
 		/usr/foo/file_2
 		/usr/foo/
-		Inspected 15 files
+		Inspected 17 files
 		  4 files found which should be deleted
-		    0 of 4 files were deleted
-		    4 of 4 files were not deleted
 		Verify successful
 	EOM
 	)

--- a/test/functional/verify/verify-picky-ghosted-missing.bats
+++ b/test/functional/verify/verify-picky-ghosted-missing.bats
@@ -21,10 +21,8 @@ test_setup() {
 		Verifying files
 		Adding any missing files
 		Fixing modified files
-		--picky removing extra files under .*
-		Inspected 11 files
-		  0 files were missing
-		  0 files found which should be deleted
+		--picky removing extra files under .*/target-dir/usr
+		Inspected 13 files
 		Calling post-update helper scripts.
 		Fix successful
 	EOM

--- a/test/functional/verify/verify-picky-ghosted.bats
+++ b/test/functional/verify/verify-picky-ghosted.bats
@@ -19,10 +19,8 @@ test_setup() {
 		Verifying files
 		Adding any missing files
 		Fixing modified files
-		--picky removing extra files under .*
-		Inspected 12 files
-		  0 files were missing
-		  0 files found which should be deleted
+		--picky removing extra files under .*/target-dir/usr
+		Inspected 13 files
 		Calling post-update helper scripts.
 		Fix successful
 	EOM

--- a/test/functional/verify/verify-skip-scripts.bats
+++ b/test/functional/verify/verify-skip-scripts.bats
@@ -22,9 +22,7 @@ test_setup() {
 		Verifying files
 		Adding any missing files
 		Fixing modified files
-		Inspected 6 files
-		  0 files were missing
-		  0 files found which should be deleted
+		Inspected 7 files
 		WARNING: post-update helper scripts skipped due to --no-scripts argument
 		Fix successful
 	EOM


### PR DESCRIPTION
Running "swupd verify" should be a dry-run of running
"swupd verify --fix", meaning that "swupd verify" should find
the same issues to be resolved than "swupd verify --fix" but it
should just inform about them while --fix should inform + fix them.
In occasions this does not happen, for example when there are
tracked files that need to be removed from the system.

Closes #607
Closes #536 

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>