### PR TITLE
configure: Remove trailing ]

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -251,7 +251,7 @@ AS_IF(
   [unitpath=/usr/lib/systemd/system]
 )
 AC_SUBST(SYSTEMD_UNITDIR, [${unitpath}])
-AC_DEFINE_UNQUOTED([SYSTEMD_UNITDIR_VAR], ["${unitpath}"], [systemdsystemunitdir])]
+AC_DEFINE_UNQUOTED([SYSTEMD_UNITDIR_VAR], ["${unitpath}"], [systemdsystemunitdir])
 
 AC_ARG_WITH(
   [pre-update],


### PR DESCRIPTION
Configure was printing the error:

14:13:44 ./configure: line 14047: ]: command not found

It was harmless though.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>