### PR TITLE
Fixing a bug in the test list in Makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -196,7 +196,7 @@ BATS = \
 	test/functional/verify/verify-boot-file-mismatch-fix.bats \
 	test/functional/verify/verify-boot-skip.bats \
 	test/functional/verify/verify-check-missing-directory.bats \
-	test/functional/verify/verify-client-certificate.bats
+	test/functional/verify/verify-client-certificate.bats \
 	test/functional/verify/verify-directory-tree-deleted.bats \
 	test/functional/verify/verify-empty-dir-deleted.bats \
 	test/functional/verify/verify-fix-version-mismatch.bats \

--- a/test/functional/verify/verify-format-mismatch-override.bats
+++ b/test/functional/verify/verify-format-mismatch-override.bats
@@ -24,14 +24,14 @@ test_setup() {
 		Starting download of remaining update content. This may take a while...
 		Finishing download of update content...
 		Adding any missing files
-		Missing file: .+/target-dir/usr/bin
+		Missing file: .*/target-dir/usr/bin
 		.fixed
 		Fixing modified files
 		.Hash mismatch for file: .*/target-dir/usr/lib/os-release
 		.fixed
-		Hash mismatch for file: .*/target-dir/usr/share/defaults/swupd/format
+		.Hash mismatch for file: .*/target-dir/usr/share/defaults/swupd/format
 		.fixed
-		Inspected 10 files
+		Inspected 12 files
 		  1 files were missing
 		    1 of 1 missing files were replaced
 		    0 of 1 missing files were not replaced

--- a/test/functional/verify/verify-latest-missing.bats
+++ b/test/functional/verify/verify-latest-missing.bats
@@ -28,6 +28,6 @@ test_teardown() {
 		Failed verify initialization, exiting now.
 	EOM
 	)
-	assert_regex_is_output "$expected_output"
+	assert_regex_in_output "$expected_output"
 	
 }


### PR DESCRIPTION
The list is missing a "\" at the end of one test which is causing
a group of tests to be ignored by the makefile, therefore they are
not being run.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>