### PR TITLE
Adding a missing line break in the verify command

### DIFF
--- a/src/verify.c
+++ b/src/verify.c
@@ -554,7 +554,7 @@ static void check_and_fix_one(struct file *file, struct manifest *official_manif
 	}
 	counts.mismatch++;
 	/* Log to stdout, so we can post-process it */
-	printf("Hash mismatch for file: %s\n", fullname);
+	printf("\nHash mismatch for file: %s\n", fullname);
 
 	/* if not repairing, we're done */
 	if (!repair) {

--- a/test/functional/verify/verify-boot-file-mismatch-fix.bats
+++ b/test/functional/verify/verify-boot-file-mismatch-fix.bats
@@ -22,7 +22,7 @@ test_setup() {
 		Finishing download of update content...
 		Adding any missing files
 		Fixing modified files
-		.Hash mismatch for file: .*/target-dir/usr/lib/kernel/testfile
+		Hash mismatch for file: .*/target-dir/usr/lib/kernel/testfile
 		.fixed
 		Inspected 7 files
 		  0 files were missing

--- a/test/functional/verify/verify-boot-file-mismatch.bats
+++ b/test/functional/verify/verify-boot-file-mismatch.bats
@@ -18,7 +18,7 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Verifying version 10
 		Verifying files
-		.Hash mismatch for file: .*/target-dir/usr/lib/kernel/testfile
+		Hash mismatch for file: .*/target-dir/usr/lib/kernel/testfile
 		Inspected 7 files
 		  1 files did not match
 		Verify successful

--- a/test/functional/verify/verify-check-missing-directory.bats
+++ b/test/functional/verify/verify-check-missing-directory.bats
@@ -18,7 +18,7 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Verifying version 10
 		Verifying files
-		.Hash mismatch for file: .*/target-dir/foo
+		Hash mismatch for file: .*/target-dir/foo
 		Inspected 4 files
 		  1 files did not match
 		Verify successful

--- a/test/functional/verify/verify-format-mismatch-override.bats
+++ b/test/functional/verify/verify-format-mismatch-override.bats
@@ -27,9 +27,9 @@ test_setup() {
 		Missing file: .*/target-dir/usr/bin
 		.fixed
 		Fixing modified files
-		.Hash mismatch for file: .*/target-dir/usr/lib/os-release
+		Hash mismatch for file: .*/target-dir/usr/lib/os-release
 		.fixed
-		.Hash mismatch for file: .*/target-dir/usr/share/defaults/swupd/format
+		Hash mismatch for file: .*/target-dir/usr/share/defaults/swupd/format
 		.fixed
 		Inspected 12 files
 		  1 files were missing

--- a/test/functional/verify/verify-picky-downgrade.bats
+++ b/test/functional/verify/verify-picky-downgrade.bats
@@ -49,8 +49,8 @@ test_setup() {
 		Finishing download of update content...
 		Adding any missing files
 		Fixing modified files
-		.Hash mismatch for file: .*/target-dir/usr/lib/os-release
-		.*fixed
+		Hash mismatch for file: .*/target-dir/usr/lib/os-release
+		.fixed
 		--picky removing extra files under .*/target-dir/usr
 		REMOVING /usr/share/clear/bundles/test-bundle2
 		REMOVING /usr/foo/file_3
@@ -93,8 +93,8 @@ test_setup() {
 		Finishing download of update content...
 		Adding any missing files
 		Fixing modified files
-		.Hash mismatch for file: .*/target-dir/usr/lib/os-release
-		.*fixed
+		Hash mismatch for file: .*/target-dir/usr/lib/os-release
+		.fixed
 		--picky removing extra files under .*/target-dir/bar
 		REMOVING /bar/file_5
 		REMOVING /bar/file_4


### PR DESCRIPTION
There is a missing line break that shows up When running
the "swupd verify" command and there is a hash mismatch.

The output looks like this:
```
$ sudo swupd verify
Verifying version 25590
Verifying files
   ...1%Hash mismatch for file: /usr/bin/tmux
   ...100%
Inspected 292278 files
  1 files did not match
Verify successful
```

This commit fixes the issue by adding a line break at the 
beginning of the output.

This PR depends on PR #670  as soon as that one merges I will rebase this one.