### PR TITLE
Output hints to check free space on download failures

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -448,6 +448,7 @@ exit:
 			break;
 		case CURLE_WRITE_ERROR:
 			fprintf(stderr, "Curl: Error downloading to local file - %s\n", filename);
+			fprintf(stderr, "Check free space for %s ?", state_dir);
 			err = -EIO;
 			break;
 		case CURLE_OPERATION_TIMEDOUT:

--- a/src/download.c
+++ b/src/download.c
@@ -283,6 +283,10 @@ static int perform_curl_io_and_complete(struct swupd_curl_parallel_handle *h, in
 				fprintf(stderr, "Error for %s download: Response %ld - %s\n",
 					file->file.path, response, curl_easy_strerror(msg->data.result));
 
+				if (curl_ret == CURLE_WRITE_ERROR) {
+					fprintf(stderr, "Check free space for %s ?\n", state_dir);
+				}
+
 				//Download resume isn't supported. Disabling it for next try
 				if (curl_ret == CURLE_RANGE_ERROR) {
 					fprintf(stderr, "Range command not supported by server, download resume disabled.\n");


### PR DESCRIPTION
Currently some of the output from swupd can be cryptic when
files fail to download. Add a hint to the user to check
their free space if Curl returns write errors.

Closes #486

Signed-off-by: Brian J Lovin <brian.j.lovin@intel.com>