### PR TITLE
configure.ac: detect openssl version (1.0 vs. 1.1)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,10 @@ PKG_CHECK_MODULES([bsdiff], [bsdiff])
 PKG_CHECK_MODULES([lzma], [liblzma])
 PKG_CHECK_MODULES([zlib], [zlib])
 PKG_CHECK_MODULES([curl], [libcurl])
-PKG_CHECK_MODULES([openssl], [libcrypto >= 1.0.1])
+PKG_CHECK_MODULES([openssl], [libcrypto >= 1.1.0],
+  [AC_DEFINE([HAVE_OPENSSL11], [1], [Use OpenSSL 1.1])],
+  [PKG_CHECK_MODULES([openssl10], [libcrypto < 1.1.0])]
+)
 PKG_CHECK_MODULES([libarchive], [libarchive])
 
 


### PR DESCRIPTION
This defines HAVE_OPENSSL11 if openssl is >= 1.1.x. This can be used
later in the code to implement support for 1.0 and 1.1 OpenSSL APIs
at the same time.