### PR TITLE
[RFC] - Update signature verification for OpenSSL 1.1

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -150,7 +150,6 @@ void terminate_signature(void)
 	if (cert) {
 		cert = NULL;
 	}
-	ERR_remove_thread_state(NULL);
 	CRYPTO_cleanup_all_ex_data();
 }
 
@@ -396,14 +395,14 @@ error:
 		X509_STORE_CTX_free(verify_ctx);
 	}
 
-	return verify_ctx->error;
+	return X509_STORE_CTX_get_error(verify_ctx);
 }
 
 int verify_callback(int ok, X509_STORE_CTX *stor)
 {
 	if (!ok) {
 		fprintf(stderr, "Certificate verification error: %s\n",
-			X509_verify_cert_error_string(stor->error));
+			X509_verify_cert_error_string(X509_STORE_CTX_get_error(stor)));
 	}
 	return ok;
 }

--- a/src/signature.c
+++ b/src/signature.c
@@ -36,6 +36,7 @@
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/pem.h>
+#include <openssl/x509v3.h>
 
 #include "config.h"
 #include "signature.h"
@@ -339,6 +340,11 @@ static int validate_certificate(void)
 
 	X509_STORE_set_verify_cb_func(store, verify_callback);
 
+	if (X509_STORE_set_purpose(store, X509_PURPOSE_ANY) != 1) {
+		fprintf(stderr, "Failed X509_STORE_set_purpose() for %s\n", CERTNAME);
+		goto error;
+	}
+
 	/* Add the certificates to be verified to the store */
 	if (!(lookup = X509_STORE_add_lookup(store, X509_LOOKUP_file()))) {
 		fprintf(stderr, "Failed X509_STORE_add_lookup() for %s\n", CERTNAME);
@@ -371,7 +377,6 @@ static int validate_certificate(void)
 		fprintf(stderr, "Failed X509_STORE_CTX_init() for %s\n", CERTNAME);
 		goto error;
 	}
-
 	/* Specify which cert to validate in the verify context.
 	 * This is required because we may add multiple certs to the X509 store,
 	 * but we want to validate a specific one out of the group/chain. */


### PR DESCRIPTION
The ERR_remove_thread_state() function is deprecated as the thread
handling and many memory management operatoins have been re-written to
be internally handled by the API. The error code should be retrieved
by the proper function now from X509 store contexts.

Signed-off-by: Tudor Marcu <tudor.marcu@intel.com>