### PR TITLE
curl: Don't warn about curl fd leaks

### DIFF
--- a/src/filedesc.c
+++ b/src/filedesc.c
@@ -106,7 +106,9 @@ static void dump_file_descriptor_leaks_int(int n, void *a)
 	string_or_die(&filename, "/proc/self/fd/%d", n);
 	if ((size = readlink(filename, buffer, PATH_MAXLEN)) != -1) {
 		buffer[size] = '\0'; /* Supply the terminator */
-		if (!strstr(buffer, "socket")) {
+		if (!strstr(buffer, "socket") &&
+		    !strstr(buffer, "/dev/random") &&
+		    !strstr(buffer, "/dev/urandom")) {
 			fprintf(stderr, "Possible filedescriptor leak: fd_number=\"%d\",fd_details=\"%s\"\n", n, buffer);
 		}
 	}


### PR DESCRIPTION
Curl isn't closing urandom and random when using openssl 1.1. As it's something
out of our control and this won't create any resource leak problems, we're not
reporting that anymore.

This fd leak report is triggered when any https download is performed by swupd

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>