### PR TITLE
verifytime: Fix TOCTOU problem

### DIFF
--- a/src/verifytime.c
+++ b/src/verifytime.c
@@ -31,20 +31,19 @@
 
 static unsigned long int get_versionstamp(void)
 {
-	struct stat statt;
 	FILE *fp = NULL;
 	char data[11];
 	const char *filename = "/usr/share/clear/versionstamp";
 	unsigned long int version_num;
 
-	if (stat(filename, &statt) == -1) {
-		fprintf(stderr, "%s does not exist!\n", filename);
-		return 0;
-	}
-
+	errno = 0;
 	fp = fopen(filename, "r");
 	if (fp == NULL) {
-		fprintf(stderr, "Failed to open %s\n", filename);
+		if (errno == ENOENT) {
+			fprintf(stderr, "%s does not exist!\n", filename);
+		} else {
+			fprintf(stderr, "Failed to open %s\n", filename);
+		}
 		return 0;
 	}
 


### PR DESCRIPTION
We can't assume that the file wasn't deleted between the execution of a
stat and a fopen. Printing error only when fopen fails.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>