### PR TITLE
verifytime: modify set_time() to take single argument

### DIFF
--- a/src/verifytime.c
+++ b/src/verifytime.c
@@ -65,13 +65,13 @@ static unsigned long int get_versionstamp(void)
 	return version_num;
 }
 
-static bool set_time(time_t mtime, char *time)
+static bool set_time(time_t mtime)
 {
 	if (stime(&mtime) != 0) {
 		fprintf(stderr, "Failed to set system time");
 		return false;
 	}
-	fprintf(stderr, "Set system time to %s\n", time);
+	fprintf(stderr, "Set system time to %s\n", ctime(&mtime));
 	return true;
 }
 
@@ -96,7 +96,7 @@ int main()
 		 * and fallback to using versionstamp time if it does not work or seem reasonable.
 		 * The system time wasn't sane, so set it here and try again */
 		fprintf(stderr, "Warning: Current time is %s\nAttempting to fix...", asctime(timeinfo));
-		if (set_time(versiontime, asctime(timeinfo)) == false) {
+		if (set_time(versiontime) == false) {
 			return 1;
 		}
 	}


### PR DESCRIPTION
Modify the set_time() function used in verifytime.c to take a single
argument instead of two. The second argument that was previously used
can easily be derived from the first and it avoids situations where
these two are not coherent (which happens to the case in the current
version of verifytime.c)

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>