### PR TITLE
helpers: Don't enforce umask on mkdir_p, just force that when needed

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -428,7 +428,7 @@ static void track_installed(const char *bundle_name)
 	 * user installed themselves just copy the entire system tracking directory
 	 * into the state tracking directory. */
 	if (!is_populated_dir(dst)) {
-		ret = mkdir_p(dst);
+		ret = mkdir(dst, S_IRWXU);
 		if (ret) {
 			goto out;
 		}


### PR DESCRIPTION
Swupd state dir should be masked as 700, but we can't mask all subfolders
as 700. This is particularly a problem because /var and /var/lib/ shoudn't
be 700, but /var/lib/swupd should. So creating all folders with current
umask and using chmod syscall to set only the swupd statedir diretory to
root only

Also, stop using mkdir_p where are no longer needed

Fixes #655

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>