### PR TITLE
Continue check-update when time is not correct

### DIFF
--- a/test/functional/checkupdate/chk-update-client-certificate.bats
+++ b/test/functional/checkupdate/chk-update-client-certificate.bats
@@ -66,7 +66,7 @@ global_teardown() {
 
 @test "CHK006: Check for available updates over HTTPS with a valid client certificate" {
 
-	opts="-S $TEST_DIRNAME/state -p $TEST_DIRNAME/target-dir -F staging -u https://localhost:$PORT/$TEST_NAME/web-dir"
+	opts="-S $TEST_DIRNAME/state -p $TEST_DIRNAME/target-dir -F staging -u https://localhost:$PORT/$TEST_NAME/web-dir -I"
 
 	run sudo sh -c "$SWUPD check-update $opts"
 
@@ -75,7 +75,7 @@ global_teardown() {
 
 @test "CHK007: Try checking for available updates over HTTPS with no client certificate" {
 
-	opts="-S $TEST_DIRNAME/state -p $TEST_DIRNAME/target-dir -F staging -u https://localhost:$PORT/$TEST_NAME/web-dir"
+	opts="-S $TEST_DIRNAME/state -p $TEST_DIRNAME/target-dir -F staging -u https://localhost:$PORT/$TEST_NAME/web-dir -I"
 
 	# remove client certificate
 	sudo rm "$CLIENT_CERT"
@@ -92,7 +92,7 @@ global_teardown() {
 
 @test "CHK008: Try checking for available updates over HTTPS with an invalid client certificate" {
 
-	opts="-S $TEST_DIRNAME/state -p $TEST_DIRNAME/target-dir -F staging -u https://localhost:$PORT/$TEST_NAME/web-dir"
+	opts="-S $TEST_DIRNAME/state -p $TEST_DIRNAME/target-dir -F staging -u https://localhost:$PORT/$TEST_NAME/web-dir -I"
 
 	# make client certificate invalid
 	sudo sh -c "echo foo > $CLIENT_CERT"

--- a/test/functional/checkupdate/chk-update-new-version.bats
+++ b/test/functional/checkupdate/chk-update-new-version.bats
@@ -15,7 +15,7 @@ test_setup() {
 
 @test "CHK001: Check for available updates when there is a new version available" {
 
-	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS_NO_CERT"
+	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM

--- a/test/functional/checkupdate/chk-update-no-server-content.bats
+++ b/test/functional/checkupdate/chk-update-no-server-content.bats
@@ -12,7 +12,7 @@ test_setup() {
 
 @test "CHK004: Check for available updates with no server version file available" {
 
-	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS_NO_CERT"
+	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"
 
 	assert_status_is_not 0
 	assert_is_output "Error: Unable to determine the server version"

--- a/test/functional/checkupdate/chk-update-no-target-content.bats
+++ b/test/functional/checkupdate/chk-update-no-target-content.bats
@@ -12,7 +12,7 @@ test_setup() {
 
 @test "CHK005: Check for available updates with no target version file available" {
 
-	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS_NO_CERT"
+	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"
 
 	assert_status_is_not 0
 	assert_is_output "Error: Unable to determine current OS version"

--- a/test/functional/checkupdate/chk-update-slow-server.bats
+++ b/test/functional/checkupdate/chk-update-slow-server.bats
@@ -28,7 +28,7 @@ global_teardown() {
 
 @test "CHK003: Check for available updates with a slow server" {
 
-	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS_HTTP_NO_CERT"
+	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS_HTTP"
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Current OS version: 10

--- a/test/functional/checkupdate/chk-update-version-match.bats
+++ b/test/functional/checkupdate/chk-update-version-match.bats
@@ -4,7 +4,7 @@ load "../testlib"
 
 @test "CHK002: Check for available updates when we are at latest" {
 
-	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS_NO_CERT"
+	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"
 
 	assert_status_is 1
 	expected_output=$(cat <<-EOM


### PR DESCRIPTION
When the system time is way off, the certificate validation will
fail. For this reason, many swupd commands attempt to fix the
system time if wrong. check-update was not doing this so the
command would fail in this situation.

This commit adds a verification for this so check-update attempts
to fix the system time and continue instead of failing.

Closes #678 

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>