### PR TITLE
Correct test group code for checkupdate

### DIFF
--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -2362,11 +2362,12 @@ get_next_available_id() { # swupd_function
 		bundlelist) group=LST;;
 		verify) group=VER;;
 		update) group=UPD;;
-		checkupdate) group=AUT;;
+		checkupdate) group=CHK;;
 		search) group=SRH;;
 		hashdump) group=HSD;;
 		mirror) group=MIR;;
 		completion) group=USA;;
+		usability) group=USA;;
 		autoupdate) group=AUT;;
 		info) group=INF;;
 		clean) group=CLN;;


### PR DESCRIPTION
The check-update tests should use a group code of CHK, but the
test library was using AUT incorrectly which belongs to the autoupdate
tests.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>