### PR TITLE
Adding ID to install tests

### DIFF
--- a/test/functional/verify/verify-install-bad.bats
+++ b/test/functional/verify/verify-install-bad.bats
@@ -11,11 +11,11 @@ test_setup() {
 
 }
 
-@test "install bundle with invalid name" {
+@test "VER038: Install bundle with invalid name" {
 
 	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --install -m 10"
 
-	assert_status_is $EMANIFEST_LOAD
+	assert_status_is "$EMANIFEST_LOAD"
 	expected_output=$(cat <<-EOM
 		Warning: Bundle "test-bundl" is invalid, skipping it...
 	EOM

--- a/test/functional/verify/verify-install-multiple.bats
+++ b/test/functional/verify/verify-install-multiple.bats
@@ -4,13 +4,17 @@ load "../testlib"
 
 test_setup() {
 
-	create_test_environment "$TEST_NAME" 10
+	create_test_environment -e "$TEST_NAME" 10
+	create_bundle -n os-core -f /core "$TEST_NAME"
 	create_bundle -n test-bundle -f /file_1,/file_2 "$TEST_NAME"
+	# we will make swupd believe these bundles are already installed
+	# by creating their tracking file in the system
+	sudo touch "$TARGETDIR"/usr/share/clear/bundles/os-core
 	sudo touch "$TARGETDIR"/usr/share/clear/bundles/test-bundle
 
 }
 
-@test "install multiple bundles" {
+@test "VER039: Install multiple bundles" {
 
 	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --install -m 10"
 

--- a/test/functional/verify/verify-install-no-fullfile-fallbacks.bats
+++ b/test/functional/verify/verify-install-no-fullfile-fallbacks.bats
@@ -6,14 +6,17 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME" 10
 	create_bundle -n test-bundle -f /file_1,/file_2 "$TEST_NAME"
+	# we will make swupd believe these bundles are already installed
+	# by creating their tracking file in the system
 	sudo touch "$TARGETDIR"/usr/share/clear/bundles/test-bundle
+	# remove the zero packs
 	sudo rm "$WEBDIR"/10/pack-test-bundle-from-0.tar
 	sudo rm "$WEBDIR"/10/pack-os-core-from-0.tar
 	sudo rm -rf "$WEBDIR"/10/files/*
 
 }
 
-@test "install bundle with no zero packs and no fullfile fallbacks" {
+@test "VER040: Install bundle with no zero packs and no fullfile fallbacks" {
 
 	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --install -m 10"
 

--- a/test/functional/verify/verify-install-no-zero-packs.bats
+++ b/test/functional/verify/verify-install-no-zero-packs.bats
@@ -4,15 +4,19 @@ load "../testlib"
 
 test_setup() {
 
-	create_test_environment "$TEST_NAME" 10
+	create_test_environment -e "$TEST_NAME" 10
+	create_bundle -n os-core -f /core "$TEST_NAME"
 	create_bundle -n test-bundle -f /file_1,/file_2 "$TEST_NAME"
+	# we will make swupd believe these bundles are already installed
+	# by creating their tracking file in the system
+	sudo touch "$TARGETDIR"/usr/share/clear/bundles/os-core
 	sudo touch "$TARGETDIR"/usr/share/clear/bundles/test-bundle
 	sudo rm "$WEBDIR"/10/pack-test-bundle-from-0.tar
 	sudo rm "$WEBDIR"/10/pack-os-core-from-0.tar
 
 }
 
-@test "install bundle with no zero packs" {
+@test "VER041: Install bundle with no zero packs should fall back to fullfiles" {
 
 	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --install -m 10"
 

--- a/test/functional/verify/verify-install.bats
+++ b/test/functional/verify/verify-install.bats
@@ -4,11 +4,12 @@ load "../testlib"
 
 test_setup() {
 
-	create_test_environment "$TEST_NAME" 10
+	create_test_environment -e "$TEST_NAME" 10
+	create_bundle -n os-core -f /core "$TEST_NAME"
 
 }
 
-@test "install only os-core" {
+@test "VER037: Install only os-core" {
 
 	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --install -m 10"
 


### PR DESCRIPTION
Some verify --install tests were submitted some time ago before we
started using IDs for tests, so these tests are missing the ID.

This commit add those missing IDs and make a couple of improvements
in the tests.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>