### PR TITLE
Modify and add compile-time flags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,27 @@ SUFFIXES= .rst
 
 EXTRA_DIST = COPYING scripts/findstatic.pl swupd.bash
 
-AM_CFLAGS = -fPIC -O2 -g -Wall -W -Wformat-security -D_FORTIFY_SOURCE=2 -fno-common -std=gnu99
+AM_CFLAGS = -fPIC -O2 -g -D_FORTIFY_SOURCE=2 -fno-common \
+	-fstack-protector-strong -fstack-clash-protection -fcf-protection -fpie -std=gnu99 \
+	-Wall \
+	-Wextra \
+	-Wfatal-errors \
+	-Werror \
+	-Wformat-security \
+	-Werror=implicit-function-declaration \
+	-Wpointer-arith \
+	-Wlogical-op \
+	-Wunreachable-code \
+	-Wswitch-default \
+	-Wcast-align \
+	-Wbad-function-cast \
+	-Winline \
+	-Wundef \
+	-Wnested-externs \
+	-Wno-missing-field-initializers \
+	-Wredundant-decls
+
+AM_LDFLAGS = -pie
 ACLOCAL_AMFLAGS = -I m4
 
 bin_PROGRAMS = swupd


### PR DESCRIPTION
Added the following non-warning CFLAGS:
-fstack-protector-strong: Improvement on -fstack-protector
-fpie: Position Independent Code/ASLR
-fstack-clash-protection: Increased reliability of stack overflow detection
-fcf-protection: Control flow integrity protection

Added -pie to LDFLAGS.

All warning-related flags are on their own lines, because they look very
messy if they're all shoved together. Enabled many more warnings and
made warnings fatal.

Signed-off-by: Brian J Lovin <brian.j.lovin@intel.com>