### PR TITLE
Clean up unused variables from test

### DIFF
--- a/test/functional/update/update-slow-server.bats
+++ b/test/functional/update/update-slow-server.bats
@@ -2,10 +2,6 @@
 
 load "../testlib"
 
-server_pid=""
-port=""
-THEME_DIRNAME="$FUNC_DIR/update"
-
 global_setup() {
 
 	# Skip this test if not running in Travis CI, because test takes too long for


### PR DESCRIPTION
There are some variables left over from commit
897f5d44c896bcd7f5a8048e262ff1c131db88fa

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>