### PR TITLE
Link swupd with verifytime

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -60,6 +60,7 @@ swupd_SOURCES = \
 	src/timelist.h \
 	src/update.c \
 	src/verify.c \
+	src/verifytime.c \
 	src/version.c \
 	src/xattrs.c \
 	src/xattrs.h
@@ -73,7 +74,10 @@ swupd_LDADD = \
 	$(bsdiff_LIBS) \
 	$(libarchive_LIBS)
 
-verifytime_SOURCES = src/verifytime.c
+verifytime_SOURCES = src/verifytime.h \
+	src/verifytime.c \
+	src/verifytime_main.c
+
 bin_PROGRAMS += verifytime
 
 EXTRA_DIST += \

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -40,6 +40,7 @@
 #include "signature.h"
 #include "swupd-build-variant.h"
 #include "swupd.h"
+#include "verifytime.h"
 
 void check_root(void)
 {
@@ -550,7 +551,7 @@ int swupd_init(void)
 	/* Check that our system time is reasonably valid before continuing,
 	 * or the certificate verification will fail with invalid time */
 	if (timecheck) {
-		if (system("verifytime") != 0) {
+		if (!verify_time()) {
 			ret = EBADTIME;
 			goto out_fds;
 		}

--- a/src/verifytime.c
+++ b/src/verifytime.c
@@ -19,8 +19,9 @@
  *         Tudor Marcu <tudor.marcu@intel.com>
  *
  */
+#include "verifytime.h"
+
 #include <errno.h>
-#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -75,7 +76,7 @@ static bool set_time(time_t mtime)
 	return true;
 }
 
-int main()
+bool verify_time()
 {
 	time_t currtime;
 	struct tm *timeinfo;
@@ -86,7 +87,7 @@ int main()
 
 	versionstamp = get_versionstamp();
 	if (versionstamp == 0) {
-		return 1;
+		return true;
 	}
 	time_t versiontime = (time_t)versionstamp;
 
@@ -97,9 +98,9 @@ int main()
 		 * The system time wasn't sane, so set it here and try again */
 		fprintf(stderr, "Warning: Current time is %s\nAttempting to fix...", asctime(timeinfo));
 		if (set_time(versiontime) == false) {
-			return 1;
+			return true;
 		}
 	}
 
-	return 0;
+	return false;
 }

--- a/src/verifytime.h
+++ b/src/verifytime.h
@@ -1,0 +1,17 @@
+#ifndef __VERIFYTIME__
+#define __VERIFYTIME__
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* verifytime.c */
+bool verify_time();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/verifytime_main.c
+++ b/src/verifytime_main.c
@@ -1,0 +1,24 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2017 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "verifytime.h"
+
+int main()
+{
+	return verify_time() ? 1 : 0;
+}


### PR DESCRIPTION
Instead on counting with the verify time in the system, link swupd
with verifytime lib.

This reduces one point of failure of swupd on recovering a corrupt system.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>