### PR TITLE
Adding ID to bundle-list tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -132,6 +132,7 @@ BATS = \
 	test/functional/bundlelist/list-has-dep-nested.bats \
 	test/functional/bundlelist/list-has-dep-nested-not-installed.bats \
 	test/functional/bundlelist/list-has-dep-nested-server.bats \
+	test/functional/bundlelist/list-installed.bats \
 	test/functional/bundlelist/list-no-deps.bats \
 	test/functional/bundlelist/list-none-has-deps.bats \
 	test/functional/bundleremove/remove-basics.bats \

--- a/test/functional/bundlelist/list-all.bats
+++ b/test/functional/bundlelist/list-all.bats
@@ -10,9 +10,10 @@ test_setup() {
 
 }
 
-@test "bundle-list all bundles" {
+@test "LST002: List all available bundles" {
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --all"
+
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		os-core

--- a/test/functional/bundlelist/list-client-certificate.bats
+++ b/test/functional/bundlelist/list-client-certificate.bats
@@ -61,14 +61,14 @@ global_teardown() {
 	destroy_test_environment "$TEST_NAME"
 }
 
-@test "list bundles with valid client cert" {
+@test "LST003: List all available bundles over HTTPS with a valid client certificate" {
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS_HTTPS --all"
 
 	assert_status_is 0
 }
 
-@test "list bundles with no client cert" {
+@test "LST004: Try listing all available bundles over HTTPS with no client certificate" {
 
 	# remove client certificate
 	sudo rm "$CLIENT_CERT"
@@ -83,7 +83,7 @@ global_teardown() {
 	assert_in_output "$expected_output"
 }
 
-@test "list bundles with invalid client cert" {
+@test "LST005: Try listing all available bundles over HTTPS with an invalid client certificate" {
 
 	# make client certificate invalid
 	sudo sh -c "echo foo > $CLIENT_CERT"

--- a/test/functional/bundlelist/list-deps-flat.bats
+++ b/test/functional/bundlelist/list-deps-flat.bats
@@ -14,9 +14,10 @@ test_setup() {
 
 }
 
-@test "bundle-list list bundle deps with flat included bundles" {
+@test "LST006: List bundle's dependencies when bundle has flat dependencies" {
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --deps test-bundle1"
+
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Bundles included by test-bundle1:

--- a/test/functional/bundlelist/list-deps-invalid-bundle.bats
+++ b/test/functional/bundlelist/list-deps-invalid-bundle.bats
@@ -2,9 +2,10 @@
 
 load "../testlib"
 
-@test "bundle-list list bundle deps with invalid bundle name" {
+@test "LST009: Try listing bundle's dependencies when bundle does not exist" {
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --deps not-a-bundle"
+
 	assert_status_is 1
 	expected_output=$(cat <<-EOM
 		Warning: Bundle "not-a-bundle" is invalid, skipping it...

--- a/test/functional/bundlelist/list-deps-nested.bats
+++ b/test/functional/bundlelist/list-deps-nested.bats
@@ -14,7 +14,7 @@ test_setup() {
 
 }
 
-@test "bundle-list list bundle deps with nested included bundles" {
+@test "LST007: List bundle's dependencies when bundle has nested dependencies" {
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --deps test-bundle1"
 	assert_status_is 0

--- a/test/functional/bundlelist/list-has-dep-nested-not-installed.bats
+++ b/test/functional/bundlelist/list-has-dep-nested-not-installed.bats
@@ -14,9 +14,10 @@ test_setup() {
 
 }
 
-@test "bundle-list list bundle has-deps with bundle not installed" {
+@test "LST013: Try listing bundles that have a given bundle as dependency (and the bundle is not installed)" {
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --has-dep test-bundle1"
+
 	assert_status_is "$EBUNDLE_NOT_TRACKED"
 	expected_output=$(cat <<-EOM
 		Error: Bundle "test-bundle1" does not seem to be installed

--- a/test/functional/bundlelist/list-has-dep-nested-server.bats
+++ b/test/functional/bundlelist/list-has-dep-nested-server.bats
@@ -14,9 +14,10 @@ test_setup() {
 
 }
 
-@test "bundle-list list bundle has-deps with --all dependent packages" {
+@test "LST010: List all bundles that have a given bundle as dependency" {
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --has-dep test-bundle1 --all"
+
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		All installable and installed bundles that have test-bundle1 as a dependency:

--- a/test/functional/bundlelist/list-has-dep-nested.bats
+++ b/test/functional/bundlelist/list-has-dep-nested.bats
@@ -14,9 +14,10 @@ test_setup() {
 
 }
 
-@test "bundle-list list bundle has-deps with nested dependent bundles" {
+@test "LST011: List installed bundles that have a given bundle as dependency (with nested deps)" {
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --has-dep test-bundle1"
+
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Installed bundles that have test-bundle1 as a dependency:

--- a/test/functional/bundlelist/list-installed.bats
+++ b/test/functional/bundlelist/list-installed.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle1 -f /file_1 "$TEST_NAME"
+	create_bundle -L -n test-bundle2 -f /file_2 "$TEST_NAME"
+	create_bundle -n test-bundle3 -f /file_3 "$TEST_NAME"
+
+}
+
+@test "LST001: List all installed bundles" {
+
+	# bundle-list with no options should list only installed bundles
+
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		os-core
+		test-bundle1
+		test-bundle2
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/bundlelist/list-no-deps.bats
+++ b/test/functional/bundlelist/list-no-deps.bats
@@ -10,9 +10,10 @@ test_setup() {
 
 }
 
-@test "bundle-list list bundle deps with no included bundles" {
+@test "LST008: List bundle's dependencies when bundle has no dependencies" {
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --deps test-bundle1"
+
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		No included bundles

--- a/test/functional/bundlelist/list-none-has-deps.bats
+++ b/test/functional/bundlelist/list-none-has-deps.bats
@@ -10,9 +10,10 @@ test_setup() {
 
 }
 
-@test "bundle-list list bundle has-deps with no dependent bundles" {
+@test "LST012: List bundles that have a given bundle as dependency (and there are none)" {
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --has-dep test-bundle1"
+
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		No bundles have test-bundle1 as a dependency


### PR DESCRIPTION
Adding an ID to all bundle-list tests and rewording some of the
test descriptions to make it more readable.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>