### PR TITLE
verifytime: Fix return value of verify_time function

### DIFF
--- a/src/verifytime.c
+++ b/src/verifytime.c
@@ -87,7 +87,7 @@ bool verify_time()
 
 	versionstamp = get_versionstamp();
 	if (versionstamp == 0) {
-		return true;
+		return false;
 	}
 	time_t versiontime = (time_t)versionstamp;
 
@@ -98,9 +98,9 @@ bool verify_time()
 		 * The system time wasn't sane, so set it here and try again */
 		fprintf(stderr, "Warning: Current time is %s\nAttempting to fix...", asctime(timeinfo));
 		if (set_time(versiontime) == false) {
-			return true;
+			return false;
 		}
 	}
 
-	return false;
+	return true;
 }

--- a/src/verifytime_main.c
+++ b/src/verifytime_main.c
@@ -20,5 +20,9 @@
 
 int main()
 {
-	return verify_time() ? 1 : 0;
+	if (verify_time()) {
+		return 0; // Success
+	}
+
+	return 1; // Error
 }


### PR DESCRIPTION
There was some confusion about shell return code and bools.
Shell returns 0 for true and bools are 0 for false.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>