### PR TITLE
locale: Set locale to system locale

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,7 @@
 
 #define _GNU_SOURCE // for basename()
 #include <getopt.h>
+#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -157,6 +158,12 @@ int main(int argc, char **argv)
 	int index;
 	int ret;
 
+	/* Set locale to system locale
+	 * Change from the standard (C) to system locale, so libarchive can
+	 * handle filename conversions.
+	 * More information on the libarchive problem:
+	 * https://github.com/libarchive/libarchive/wiki/Filenames */
+	setlocale(LC_ALL, "");
 	if (parse_options(argc, argv, &index) < 0) {
 		return EINVALID_OPTION;
 	}


### PR DESCRIPTION
Standard locale on C applications is C and we use in clearlinux UTF-8
for file names. Libarchive checks the program locale to convert
filenames so we need to set this.

According to setlocale documentation, setlocale(LC_ALL, "") sets the locale
to system default (in the case of ClearLinux, UTF-8).

More information on the libarchive problem:
https://github.com/libarchive/libarchive/wiki/Filenames and
https://github.com/libarchive/libarchive/issues/587

Fixes #445

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>