### PR TITLE
Removing option --force where is not needed

### DIFF
--- a/src/check_update.c
+++ b/src/check_update.c
@@ -41,7 +41,6 @@ static void print_help(const char *name)
 	fprintf(stderr, "   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
 	fprintf(stderr, "   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
 	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
-	fprintf(stderr, "   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	fprintf(stderr, "   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
 	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
 	fprintf(stderr, "   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
@@ -56,7 +55,6 @@ static const struct option prog_opts[] = {
 	{ "versionurl", required_argument, 0, 'v' },
 	{ "port", required_argument, 0, 'P' },
 	{ "format", required_argument, 0, 'F' },
-	{ "force", no_argument, 0, 'x' },
 	{ "nosigcheck", no_argument, 0, 'n' },
 	{ "path", required_argument, 0, 'p' },
 	{ "statedir", required_argument, 0, 'S' },
@@ -69,7 +67,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hIxnu:v:P:F:p:S:C:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hInu:v:P:F:p:S:C:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -114,9 +112,6 @@ static bool parse_options(int argc, char **argv)
 				fprintf(stderr, "Invalid --path argument\n\n");
 				goto err;
 			}
-			break;
-		case 'x':
-			force = true;
 			break;
 		case 'n':
 			sigcheck = false;

--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -49,7 +49,6 @@ static void print_help(const char *name)
 	fprintf(stderr, "   -P, --port=[port #]        Port number to connect to at the url for version string and content file downloads\n");
 	fprintf(stderr, "   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
 	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
-	fprintf(stderr, "   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	fprintf(stderr, "   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
 	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
 	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");
@@ -71,7 +70,6 @@ static const struct option prog_opts[] = {
 	{ "list", no_argument, 0, 'l' },
 	{ "path", required_argument, 0, 'p' },
 	{ "format", required_argument, 0, 'F' },
-	{ "force", no_argument, 0, 'x' },
 	{ "nosigcheck", no_argument, 0, 'n' },
 	{ "ignore-time", no_argument, 0, 'I' },
 	{ "statedir", required_argument, 0, 'S' },
@@ -88,7 +86,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxnIu:c:v:P:p:F:lS:tNbC:D:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hnIu:c:v:P:p:F:lS:tNbC:D:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -144,9 +142,6 @@ static bool parse_options(int argc, char **argv)
 			fprintf(stderr, "error: [-l, --list] option is deprecated, use\n"
 					"bundle-list [-a|--all] sub-command instead.\n\n");
 			exit(EXIT_FAILURE);
-		case 'x':
-			force = true;
-			break;
 		case 'n':
 			sigcheck = false;
 			break;

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -50,7 +50,6 @@ static void print_help(const char *name)
 	fprintf(stderr, "   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
 	fprintf(stderr, "   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
 	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
-	fprintf(stderr, "   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	fprintf(stderr, "   -n, --nosigcheck        Do not attempt to enforce certificate or signature checks\n");
 	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
 	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");
@@ -66,7 +65,6 @@ static const struct option prog_opts[] = {
 	{ "versionurl", required_argument, 0, 'v' },
 	{ "port", required_argument, 0, 'P' },
 	{ "format", required_argument, 0, 'F' },
-	{ "force", no_argument, 0, 'x' },
 	{ "nosigcheck", no_argument, 0, 'n' },
 	{ "ignore-time", no_argument, 0, 'I' },
 	{ "statedir", required_argument, 0, 'S' },
@@ -78,7 +76,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hxnIp:u:c:v:P:F:S:C:", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hnIp:u:c:v:P:F:S:C:", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -129,9 +127,6 @@ static bool parse_options(int argc, char **argv)
 				fprintf(stderr, "Invalid --statedir argument\n\n");
 				goto err;
 			}
-			break;
-		case 'x':
-			force = true;
 			break;
 		case 'n':
 			sigcheck = false;

--- a/src/update.c
+++ b/src/update.c
@@ -580,7 +580,6 @@ static const struct option prog_opts[] = {
 	{ "status", no_argument, 0, 's' },
 	{ "format", required_argument, 0, 'F' },
 	{ "path", required_argument, 0, 'p' },
-	{ "force", no_argument, 0, 'x' },
 	{ "nosigcheck", no_argument, 0, 'n' },
 	{ "ignore-time", no_argument, 0, 'I' },
 	{ "statedir", required_argument, 0, 'S' },
@@ -614,7 +613,6 @@ static void print_help(const char *name)
 	fprintf(stderr, "   -s, --status            Show current OS version and latest version available on server\n");
 	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
 	fprintf(stderr, "   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
-	fprintf(stderr, "   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	fprintf(stderr, "   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
 	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
 	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");
@@ -633,7 +631,7 @@ static bool parse_options(int argc, char **argv)
 {
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "hm:xnIdtNbTau:P:c:v:sF:p:S:C:D:k", prog_opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hm:nIdtNbTau:P:c:v:sF:p:S:C:D:k", prog_opts, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 		case 'h':
@@ -710,9 +708,6 @@ static bool parse_options(int argc, char **argv)
 				fprintf(stderr, "Invalid --path argument\n\n");
 				goto err;
 			}
-			break;
-		case 'x':
-			force = true;
 			break;
 		case 'T':
 			migrate = true;


### PR DESCRIPTION
The --force option is included in bundle-add, bundle-remove,
check-update, update and verify, but it is really only used in
verify.

This commit removes the option from the commands that are not using
it so it is not misleading to users. If at some point we need to
implement somthing with --force it can be added back at that point.

Closes #636

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>