### PR TITLE
Global

### DIFF
--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -37,163 +37,65 @@
 
 static char **bundles;
 
-static void print_help(const char *name)
+static void print_help(void)
 {
 	fprintf(stderr, "Usage:\n");
-	fprintf(stderr, "   swupd %s [options] [bundle1 bundle2 (...)]\n\n", basename((char *)name));
-	fprintf(stderr, "Help Options:\n");
-	fprintf(stderr, "   -h, --help              Show help options\n");
-	fprintf(stderr, "   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
-	fprintf(stderr, "   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
-	fprintf(stderr, "   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
-	fprintf(stderr, "   -P, --port=[port #]        Port number to connect to at the url for version string and content file downloads\n");
-	fprintf(stderr, "   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
-	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
-	fprintf(stderr, "   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
-	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
-	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");
-	fprintf(stderr, "   -C, --certpath          Specify alternate path to swupd certificates\n");
-	fprintf(stderr, "   -t, --time              Show verbose time output for swupd operations\n");
-	fprintf(stderr, "   -N, --no-scripts        Do not run the post-update scripts and boot update tool\n");
-	fprintf(stderr, "   -b, --no-boot-update    Do not update the boot files using clr-boot-manager\n");
-	fprintf(stderr, "   -D, --max-parallel-downloads=[n] Set the maximum number of parallel downloads\n");
+	fprintf(stderr, "   swupd bundle-add [OPTION...] [bundle1 bundle2 (...)]\n\n");
+
+	//TODO: Add documentation explaining this command
+
+	global_print_help();
+
+	fprintf(stderr, "Options:\n");
 	fprintf(stderr, "   --skip-diskspace-check  Do not check free disk space before adding bundle\n");
 	fprintf(stderr, "\n");
 }
 
 static const struct option prog_opts[] = {
-	{ "help", no_argument, 0, 'h' },
-	{ "url", required_argument, 0, 'u' },
-	{ "contenturl", required_argument, 0, 'c' },
-	{ "versionurl", required_argument, 0, 'v' },
-	{ "port", required_argument, 0, 'P' },
 	{ "list", no_argument, 0, 'l' },
-	{ "path", required_argument, 0, 'p' },
-	{ "format", required_argument, 0, 'F' },
-	{ "nosigcheck", no_argument, 0, 'n' },
-	{ "ignore-time", no_argument, 0, 'I' },
-	{ "statedir", required_argument, 0, 'S' },
-	{ "certpath", required_argument, 0, 'C' },
-	{ "time", no_argument, 0, 't' },
-	{ "no-scripts", no_argument, 0, 'N' },
-	{ "no-boot-update", no_argument, 0, 'b' },
-	{ "max-parallel-downloads", required_argument, 0, 'D' },
 	{ "skip-diskspace-check", no_argument, &skip_diskspace_check, 1 },
-	{ 0, 0, 0, 0 }
+};
+
+static bool parse_opt(int opt, UNUSED_PARAM char *optarg)
+{
+	switch (opt) {
+	case 'l':
+		fprintf(stderr, "Error: [-l, --list] option is deprecated, use\n"
+				"bundle-list [-a|--all] sub-command instead.\n\n");
+		exit(EXIT_FAILURE);
+	}
+	return false;
+}
+
+static const struct global_options opts = {
+	prog_opts,
+	sizeof(prog_opts) / sizeof(struct option),
+	parse_opt,
+	print_help,
 };
 
 static bool parse_options(int argc, char **argv)
 {
-	int opt;
+	int optind = global_parse_options(argc, argv, &opts);
 
-	while ((opt = getopt_long(argc, argv, "hnIu:c:v:P:p:F:lS:tNbC:D:", prog_opts, NULL)) != -1) {
-		switch (opt) {
-		case '?':
-		case 'h':
-			print_help(argv[0]);
-			exit(EXIT_SUCCESS);
-		case 'u':
-			if (!optarg) {
-				fprintf(stderr, "error: invalid --url argument\n\n");
-				goto err;
-			}
-			set_version_url(optarg);
-			set_content_url(optarg);
-			break;
-		case 'c':
-			if (!optarg) {
-				fprintf(stderr, "Invalid --contenturl argument\n\n");
-				goto err;
-			}
-			set_content_url(optarg);
-			break;
-		case 'v':
-			if (!optarg) {
-				fprintf(stderr, "Invalid --versionurl argument\n\n");
-				goto err;
-			}
-			set_version_url(optarg);
-			break;
-		case 'p': /* default empty path_prefix verifies the running OS */
-			if (!optarg || !set_path_prefix(optarg)) {
-				fprintf(stderr, "Invalid --path argument\n\n");
-				goto err;
-			}
-			break;
-		case 'P':
-			if (sscanf(optarg, "%ld", &update_server_port) != 1) {
-				fprintf(stderr, "Invalid --port argument\n\n");
-				goto err;
-			}
-			break;
-		case 'F':
-			if (!optarg || !set_format_string(optarg)) {
-				fprintf(stderr, "Invalid --format argument\n\n");
-				goto err;
-			}
-			break;
-		case 'S':
-			if (!optarg || !set_state_dir(optarg)) {
-				fprintf(stderr, "Invalid --statedir argument\n\n");
-				goto err;
-			}
-			break;
-		case 'l':
-			fprintf(stderr, "error: [-l, --list] option is deprecated, use\n"
-					"bundle-list [-a|--all] sub-command instead.\n\n");
-			exit(EXIT_FAILURE);
-		case 'n':
-			sigcheck = false;
-			break;
-		case 'I':
-			timecheck = false;
-			break;
-		case 't':
-			verbose_time = true;
-			break;
-		case 'N':
-			no_scripts = true;
-			break;
-		case 'b':
-			no_boot_update = true;
-			break;
-		case 'C':
-			if (!optarg) {
-				fprintf(stderr, "Invalid --certpath argument\n\n");
-				goto err;
-			}
-			set_cert_path(optarg);
-			break;
-		case 'D':
-			if (sscanf(optarg, "%d", &max_parallel_downloads) != 1) {
-				fprintf(stderr, "Invalid --max-parallel-downloads argument\n\n");
-				goto err;
-			}
-			break;
-		case 0:
-			break;
-		default:
-			fprintf(stderr, "error: unrecognized option\n\n");
-			goto err;
-		}
+	if (optind < 0) {
+		return false;
 	}
 
 	if (argc <= optind) {
-		fprintf(stderr, "error: missing bundle(s) to be installed\n\n");
-		goto err;
+		fprintf(stderr, "Error: missing bundle(s) to be installed\n\n");
+		return false;
 	}
 
 	bundles = argv + optind;
 
 	return true;
-err:
-	print_help(argv[0]);
-	return false;
 }
 
 int bundle_add_main(int argc, char **argv)
 {
 	if (!parse_options(argc, argv)) {
+		print_help();
 		return EINVALID_OPTION;
 	}
 

--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -43,141 +43,78 @@ static void free_deps(void)
 	free_string(&cmdline_option_deps);
 }
 
-static void print_help(const char *name)
+static void print_help(void)
 {
 	fprintf(stderr, "Usage:\n");
-	fprintf(stderr, "   swupd %s [options]\n\n", basename((char *)name));
-	fprintf(stderr, "Help Options:\n");
-	fprintf(stderr, "   -h, --help              Show help options\n");
+	fprintf(stderr, "   swupd bundle-list [OPTIONS...]\n\n");
+
+	//TODO: Add documentation explaining this command
+
+	global_print_help();
+
+	fprintf(stderr, "Options:\n");
 	fprintf(stderr, "   -a, --all               List all available bundles for the current version of Clear Linux\n");
-	fprintf(stderr, "   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
-	fprintf(stderr, "   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
-	fprintf(stderr, "   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
-	fprintf(stderr, "   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol\n");
-	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
-	fprintf(stderr, "   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
-	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
-	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");
-	fprintf(stderr, "   -C, --certpath          Specify alternate path to swupd certificates\n");
 	fprintf(stderr, "   -d, --deps=[BUNDLE]     List bundles included by BUNDLE\n");
 	fprintf(stderr, "   -D, --has-dep=[BUNDLE]  List dependency tree of all bundles which have BUNDLE as a dependency\n");
-
 	fprintf(stderr, "\n");
 }
 
 static const struct option prog_opts[] = {
-	{ "help", no_argument, 0, 'h' },
 	{ "all", no_argument, 0, 'a' },
-	{ "url", required_argument, 0, 'u' },
-	{ "contenturl", required_argument, 0, 'c' },
-	{ "versionurl", required_argument, 0, 'v' },
-	{ "path", required_argument, 0, 'p' },
-	{ "format", required_argument, 0, 'F' },
-	{ "nosigcheck", no_argument, 0, 'n' },
-	{ "statedir", required_argument, 0, 'S' },
-	{ "ignore-time", no_argument, 0, 'I' },
-	{ "certpath", required_argument, 0, 'C' },
-	{ "has-dep", required_argument, 0, 'D' },
 	{ "deps", required_argument, 0, 'd' },
+	{ "has-dep", required_argument, 0, 'D' },
+};
 
-	{ 0, 0, 0, 0 }
+static bool parse_opt(int opt, char *optarg)
+{
+	switch (opt) {
+	case 'a':
+		cmdline_option_all = true;
+		cmdline_local = false;
+		return true;
+	case 'D':
+		if (!optarg) {
+			fprintf(stderr, "Invalid --has-dep argument\n\n");
+			return false;
+		}
+		string_or_die(&cmdline_option_has_dep, "%s", optarg);
+		atexit(free_has_dep);
+		cmdline_local = false;
+		return true;
+	case 'd':
+		if (!optarg) {
+			fprintf(stderr, "Invalid --deps argument\n\n");
+			return false;
+		}
+		string_or_die(&cmdline_option_deps, "%s", optarg);
+		atexit(free_deps);
+		cmdline_local = false;
+		return true;
+	}
+	return false;
+}
+
+static const struct global_options opts = {
+	prog_opts,
+	sizeof(prog_opts) / sizeof(struct option),
+	parse_opt,
+	print_help,
 };
 
 static bool parse_options(int argc, char **argv)
 {
-	int opt;
+	int ind = global_parse_options(argc, argv, &opts);
 
-	while ((opt = getopt_long(argc, argv, "hanIu:c:v:p:F:S:C:d:D:", prog_opts, NULL)) != -1) {
-		switch (opt) {
-		case '?':
-		case 'h':
-			print_help(argv[0]);
-			exit(EXIT_SUCCESS);
-		case 'a':
-			cmdline_option_all = true;
-			cmdline_local = false;
-			break;
-		case 'u':
-			if (!optarg) {
-				fprintf(stderr, "error: invalid --url argument\n\n");
-				goto err;
-			}
-			set_version_url(optarg);
-			set_content_url(optarg);
-			break;
-		case 'c':
-			if (!optarg) {
-				fprintf(stderr, "Invalid --contenturl argument\n\n");
-				goto err;
-			}
-			set_content_url(optarg);
-			break;
-		case 'v':
-			if (!optarg) {
-				fprintf(stderr, "Invalid --versionurl argument\n\n");
-				goto err;
-			}
-			set_version_url(optarg);
-			break;
-		case 'p': /* default empty path_prefix verifies the running OS */
-			if (!optarg || !set_path_prefix(optarg)) {
-				fprintf(stderr, "Invalid --path argument\n\n");
-				goto err;
-			}
-			break;
-		case 'F':
-			if (!optarg || !set_format_string(optarg)) {
-				fprintf(stderr, "Invalid --format argument\n\n");
-				goto err;
-			}
-			break;
-		case 'n':
-			sigcheck = false;
-			break;
-		case 'I':
-			timecheck = false;
-			break;
-		case 'S':
-			if (!optarg || !set_state_dir(optarg)) {
-				fprintf(stderr, "Invalid --statedir argument\n\n");
-				goto err;
-			}
-			break;
-		case 'C':
-			if (!optarg) {
-				fprintf(stderr, "Invalid --certpath argument\n\n");
-				goto err;
-			}
-			set_cert_path(optarg);
-			break;
-		case 'D':
-			if (!optarg) {
-				fprintf(stderr, "Invalid --has-dep argument\n\n");
-				goto err;
-			}
-			string_or_die(&cmdline_option_has_dep, "%s", optarg);
-			atexit(free_has_dep);
-			cmdline_local = false;
-			break;
-		case 'd':
-			if (!optarg) {
-				fprintf(stderr, "Invalid --deps argument\n\n");
-				goto err;
-			}
-			string_or_die(&cmdline_option_deps, "%s", optarg);
-			atexit(free_deps);
-			cmdline_local = false;
-			break;
-		default:
-			fprintf(stderr, "error: unrecognized option\n\n");
-			goto err;
-		}
+	if (ind < 0) {
+		return false;
+	}
+
+	if (argc > ind) {
+		fprintf(stderr, "Error: unexpected arguments\n\n");
+		return false;
 	}
 
 	return true;
-err:
-	print_help(argv[0]);
-	return false;
 }
 
 int bundle_list_main(int argc, char **argv)
@@ -185,6 +122,7 @@ int bundle_list_main(int argc, char **argv)
 	int ret;
 
 	if (!parse_options(argc, argv)) {
+		print_help();
 		return EXIT_FAILURE;
 	}
 

--- a/src/clr_bundle_rm.c
+++ b/src/clr_bundle_rm.c
@@ -38,131 +38,48 @@
 
 static char **bundles;
 
-static void print_help(const char *name)
+static void print_help(void)
 {
 	fprintf(stderr, "Usage:\n");
-	fprintf(stderr, "   swupd %s [options] [bundle1, bundle2, ...]\n\n", basename((char *)name));
-	fprintf(stderr, "Help Options:\n");
-	fprintf(stderr, "   -h, --help              Show help options\n");
-	fprintf(stderr, "   -p, --path=[PATH...]    Use [PATH...] as the path to verify (eg: a chroot or btrfs subvol)\n");
-	fprintf(stderr, "   -u, --url=[URL]         RFC-3986 encoded url for version string and content file downloads\n");
-	fprintf(stderr, "   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
-	fprintf(stderr, "   -v, --versionurl=[URL]  RFC-3986 encoded url for version string download\n");
-	fprintf(stderr, "   -P, --port=[port #]     Port number to connect to at the url for version string and content file downloads\n");
-	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
-	fprintf(stderr, "   -n, --nosigcheck        Do not attempt to enforce certificate or signature checks\n");
-	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
-	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");
-	fprintf(stderr, "   -C, --certpath          Specify alternate path to swupd certificates\n");
+	fprintf(stderr, "   swupd bundle-remove [OPTION...] [bundle1 bundle2 (...)]\n\n");
+
+	//TODO: Add documentation explaining this command
+
+	global_print_help();
+
+	fprintf(stderr, "Options:\n");
 	fprintf(stderr, "\n");
 }
 
-static const struct option prog_opts[] = {
-	{ "help", no_argument, 0, 'h' },
-	{ "path", required_argument, 0, 'p' },
-	{ "url", required_argument, 0, 'u' },
-	{ "contenturl", required_argument, 0, 'c' },
-	{ "versionurl", required_argument, 0, 'v' },
-	{ "port", required_argument, 0, 'P' },
-	{ "format", required_argument, 0, 'F' },
-	{ "nosigcheck", no_argument, 0, 'n' },
-	{ "ignore-time", no_argument, 0, 'I' },
-	{ "statedir", required_argument, 0, 'S' },
-	{ "certpath", required_argument, 0, 'C' },
-	{ 0, 0, 0, 0 }
+static const struct global_options opts = {
+	NULL,
+	0,
+	NULL,
+	print_help,
 };
 
 static bool parse_options(int argc, char **argv)
 {
-	int opt;
+	int ind = global_parse_options(argc, argv, &opts);
 
-	while ((opt = getopt_long(argc, argv, "hnIp:u:c:v:P:F:S:C:", prog_opts, NULL)) != -1) {
-		switch (opt) {
-		case '?':
-		case 'h':
-			print_help(argv[0]);
-			exit(EXIT_SUCCESS);
-		case 'p': /* default empty path_prefix removes on the running OS */
-			if (!optarg || !set_path_prefix(optarg)) {
-				fprintf(stderr, "Invalid --path argument\n\n");
-				goto err;
-			}
-			break;
-		case 'u':
-			if (!optarg) {
-				fprintf(stderr, "error: invalid --url argument\n\n");
-				goto err;
-			}
-			set_version_url(optarg);
-			set_content_url(optarg);
-			break;
-		case 'c':
-			if (!optarg) {
-				fprintf(stderr, "Invalid --contenturl argument\n\n");
-				goto err;
-			}
-			set_content_url(optarg);
-			break;
-		case 'v':
-			if (!optarg) {
-				fprintf(stderr, "Invalid --versionurl argument\n\n");
-				goto err;
-			}
-			set_version_url(optarg);
-			break;
-		case 'P':
-			if (sscanf(optarg, "%ld", &update_server_port) != 1) {
-				fprintf(stderr, "Invalid --port argument\n\n");
-				goto err;
-			}
-			break;
-		case 'F':
-			if (!optarg || !set_format_string(optarg)) {
-				fprintf(stderr, "Invalid --format argument\n\n");
-				goto err;
-			}
-			break;
-		case 'S':
-			if (!optarg || !set_state_dir(optarg)) {
-				fprintf(stderr, "Invalid --statedir argument\n\n");
-				goto err;
-			}
-			break;
-		case 'n':
-			sigcheck = false;
-			break;
-		case 'I':
-			timecheck = false;
-			break;
-		case 'C':
-			if (!optarg) {
-				fprintf(stderr, "Invalid --certpath argument\n\n");
-				goto err;
-			}
-			set_cert_path(optarg);
-			break;
-		default:
-			fprintf(stderr, "error: unrecognized option\n\n");
-			goto err;
-		}
+	if (ind < 0) {
+		return false;
 	}
 
-	if (argc <= optind) {
-		fprintf(stderr, "error: missing bundle(s) to be removed\n\n");
-		goto err;
+	if (argc <= ind) {
+		fprintf(stderr, "Error: missing bundle(s) to be removed\n\n");
+		return false;
 	}
 
-	bundles = argv + optind;
+	bundles = argv + ind;
 
 	return true;
-err:
-	print_help(argv[0]);
-	return false;
 }
 
 int bundle_remove_main(int argc, char **argv)
 {
 	if (!parse_options(argc, argv)) {
+		print_help();
 		return EINVALID_OPTION;
 	}
 

--- a/src/globals.c
+++ b/src/globals.c
@@ -70,7 +70,7 @@ char *version_url = NULL;
 char *content_url = NULL;
 bool content_url_is_local = false;
 char *cert_path = NULL;
-long update_server_port = -1;
+int update_server_port = -1;
 static int max_parallel_downloads = -1;
 char *swupd_cmd = NULL;
 
@@ -566,6 +566,8 @@ static const struct option global_opts[] = {
 
 static bool global_parse_opt(int opt, char *optarg)
 {
+	int err;
+
 	switch (opt) {
 	case 0:
 		/* Handle options that don't have shortcut. */
@@ -585,8 +587,9 @@ static bool global_parse_opt(int opt, char *optarg)
 		set_content_url(optarg);
 		return true;
 	case 'P':
-		if (sscanf(optarg, "%ld", &update_server_port) != 1) {
-			fprintf(stderr, "Invalid --port argument\n\n");
+		err = strtoi_err(optarg, &update_server_port);
+		if (err < 0 || update_server_port < 0) {
+			fprintf(stderr, "Invalid --port argument: %s\n\n", optarg);
 			return false;
 		}
 		return true;
@@ -639,8 +642,9 @@ static bool global_parse_opt(int opt, char *optarg)
 		set_cert_path(optarg);
 		return true;
 	case 'W':
-		if (sscanf(optarg, "%d", &max_parallel_downloads) != 1) {
-			fprintf(stderr, "Invalid --max-parallel-downloads argument\n\n");
+		err = strtoi_err(optarg, &max_parallel_downloads);
+		if (err < 0 || max_parallel_downloads <= 0) {
+			fprintf(stderr, "Invalid --max-parallel-downloads argument: %s\n\n", optarg);
 			return false;
 		}
 		return true;

--- a/src/globals.c
+++ b/src/globals.c
@@ -549,7 +549,7 @@ static const struct option global_opts[] = {
 	{ "format", required_argument, 0, 'F' },
 	{ "help", no_argument, 0, 'h' },
 	{ "ignore-time", no_argument, 0, 'I' },
-	{ "max-parallel-downloads", required_argument, 0, 'D' },
+	{ "max-parallel-downloads", required_argument, 0, 'W' },
 	{ "no-boot-update", no_argument, 0, 'b' },
 	{ "no-scripts", no_argument, 0, 'N' },
 	{ "nosigcheck", no_argument, 0, 'n' },
@@ -559,6 +559,8 @@ static const struct option global_opts[] = {
 	{ "time", no_argument, 0, 't' },
 	{ "url", required_argument, 0, 'u' },
 	{ "versionurl", required_argument, 0, 'v' },
+	//TODO: -D option is deprecated. Remove that on a Major release
+	{ "", required_argument, 0, 'D' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -636,12 +638,23 @@ static bool global_parse_opt(int opt, char *optarg)
 		}
 		set_cert_path(optarg);
 		return true;
-	case 'D':
+	case 'W':
 		if (sscanf(optarg, "%d", &max_parallel_downloads) != 1) {
 			fprintf(stderr, "Invalid --max-parallel-downloads argument\n\n");
 			return false;
 		}
 		return true;
+	}
+
+	return false;
+}
+
+static bool global_parse_deprecated(int opt, char *optarg)
+{
+	switch (opt) {
+	case 'D':
+		fprintf(stderr, "Deprecated option -D was renamed. Prefer using -W or --max-parallel-downloads.\n\n");
+		return global_parse_opt('W', optarg);
 	}
 
 	return false;
@@ -686,7 +699,7 @@ void global_print_help(void)
 	fprintf(stderr, "   -t, --time              Show verbose time output for swupd operations\n");
 	fprintf(stderr, "   -N, --no-scripts        Do not run the post-update scripts and boot update tool\n");
 	fprintf(stderr, "   -b, --no-boot-update    Do not install boot files to the boot partition (containers)\n");
-	fprintf(stderr, "   -D, --max-parallel-downloads=[n] Set the maximum number of parallel downloads\n");
+	fprintf(stderr, "   -W, --max-parallel-downloads=[n] Set the maximum number of parallel downloads\n");
 	fprintf(stderr, "\n");
 }
 
@@ -729,6 +742,11 @@ int global_parse_options(int argc, char **argv, const struct global_options *opt
 
 		// Try to parse global options
 		if (global_parse_opt(opt, optarg)) {
+			continue;
+		}
+
+		// Try to parse deprecated global options
+		if (global_parse_deprecated(opt, optarg)) {
 			continue;
 		}
 

--- a/src/main.c
+++ b/src/main.c
@@ -128,7 +128,7 @@ static int parse_options(int argc, char **argv, int *index)
 			/* found a subcommand, or a random non-option argument */
 			ret = subcmd_index(optarg);
 			if (ret < 0) {
-				fprintf(stderr, "error: unrecognized subcommand `%s'\n\n",
+				fprintf(stderr, "Error: unrecognized subcommand `%s'\n\n",
 					optarg);
 				goto error;
 			} else {

--- a/src/search.c
+++ b/src/search.c
@@ -341,7 +341,7 @@ static void print_help(void)
 	fprintf(stderr, "   -l, --library           Search paths where libraries are located for a match\n");
 	fprintf(stderr, "   -b, --binary            Search paths where binaries are located for a match\n");
 	fprintf(stderr, "   -s, --scope=[query type] 'b' or 'o' for first hit per (b)undle, or one hit total across the (o)s\n");
-	fprintf(stderr, "   -t, --top=[NUM]         Only display the top NUM results for each bundle\n");
+	fprintf(stderr, "   -T, --top=[NUM]         Only display the top NUM results for each bundle\n");
 	fprintf(stderr, "   -m, --csv               Output all results in CSV format (machine-readable)\n");
 	fprintf(stderr, "   -d, --display-files	   Output full file list, no search done\n");
 	fprintf(stderr, "   -i, --init              Download all manifests then return, no search done\n");
@@ -354,7 +354,9 @@ static const struct option prog_opts[] = {
 	{ "init", no_argument, 0, 'i' },
 	{ "library", no_argument, 0, 'l' },
 	{ "scope", required_argument, 0, 's' },
-	{ "top", required_argument, 0, 't' },
+	{ "top", required_argument, 0, 'T' },
+	//TODO: -t option is deprecated. Remove that on a Major release
+	{ "", required_argument, 0, 't' },
 };
 
 static bool parse_opt(int opt, char *optarg)
@@ -376,6 +378,9 @@ static bool parse_opt(int opt, char *optarg)
 
 		return true;
 	case 't':
+		fprintf(stderr, "Deprecated option -t was renamed. Prefer using -T or --top.\n\n");
+		/* fallthrough */
+	case 'T':
 		err = strtoi_err(optarg, &num_results);
 		if (err != 0) {
 			fprintf(stderr, "Invalid --top argument\n\n");

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -3,6 +3,7 @@
 
 #include <curl/curl.h>
 #include <dirent.h>
+#include <getopt.h>
 #include <limits.h>
 #include <regex.h>
 #include <stdbool.h>
@@ -178,7 +179,6 @@ extern bool no_scripts;
 extern bool no_boot_update;
 extern char *format_string;
 extern char *path_prefix;
-extern bool set_format_string(char *userinput);
 extern bool init_globals(void);
 extern void free_globals(void);
 extern void save_cmd(char **argv);
@@ -193,13 +193,8 @@ extern char *content_url;
 extern bool content_url_is_local;
 extern char *cert_path;
 extern long update_server_port;
-extern int max_parallel_downloads;
 extern char *default_format_path;
 extern bool set_path_prefix(char *path);
-extern int set_content_url(char *url);
-extern int set_version_url(char *url);
-extern void set_cert_path(char *path);
-extern bool set_state_dir(char *path);
 
 extern void check_root(void);
 extern void increment_retries(int *retries, int *timeout);
@@ -426,6 +421,18 @@ extern void print_update_conf_info(void);
 extern void handle_mirror_if_stale(void);
 
 extern int clean_statedir(bool all, bool dry_run);
+
+/* Parameter parsing in global.c */
+extern struct global_const global;
+struct global_options {
+	const struct option *longopts;
+	const int longopts_len;
+	bool (*parse_opt)(int opt, char *optarg);
+	void (*print_help)(void);
+};
+
+void global_print_help(void);
+int global_parse_options(int argc, char **argv, const struct global_options *opts);
 
 /* some disk sizes constants for the various features:
  *   ...consider adding build automation to catch at build time

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -192,7 +192,7 @@ extern char *version_url;
 extern char *content_url;
 extern bool content_url_is_local;
 extern char *cert_path;
-extern long update_server_port;
+extern int update_server_port;
 extern char *default_format_path;
 extern bool set_path_prefix(char *path);
 

--- a/src/update.c
+++ b/src/update.c
@@ -599,12 +599,18 @@ static void print_help(void)
 
 static bool parse_opt(int opt, char *optarg)
 {
+	int err;
+
 	switch (opt) {
 	case 'm':
 		if (strcmp("latest", optarg) == 0) {
 			requested_version = -1;
-		} else if (sscanf(optarg, "%i", &requested_version) != 1) {
-			fprintf(stderr, "Invalid --manifest argument\n\n");
+			return true;
+		}
+
+		err = strtoi_err(optarg, &requested_version);
+		if (err < 0 || requested_version < 0) {
+			fprintf(stderr, "Invalid --manifest argument: %s\n\n", optarg);
 			return false;
 		}
 		return true;

--- a/src/verify.c
+++ b/src/verify.c
@@ -506,12 +506,18 @@ static void remove_orphaned_files(struct manifest *official_manifest, bool repai
 
 static bool parse_opt(int opt, char *optarg)
 {
+	int err;
+
 	switch (opt) {
 	case 'm':
 		if (strcmp("latest", optarg) == 0) {
 			version = -1;
-		} else if (sscanf(optarg, "%i", &version) != 1) {
-			fprintf(stderr, "Invalid --manifest argument\n\n");
+			return true;
+		}
+
+		err = strtoi_err(optarg, &version);
+		if (err < 0 || version < 0) {
+			fprintf(stderr, "Invalid --manifest argument: %s\n\n", optarg);
 			return false;
 		}
 		return true;

--- a/test/functional/bundleremove/remove-parse-args.bats
+++ b/test/functional/bundleremove/remove-parse-args.bats
@@ -7,6 +7,6 @@ load "../testlib"
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS"
 
 	assert_status_is "$EINVALID_OPTION"
-	assert_in_output "error: missing bundle(s) to be removed"
+	assert_in_output "Error: missing bundle(s) to be removed"
 
 }


### PR DESCRIPTION
There is a list of parameters in swupd that are really configuration changes that applies to almost every command (and they should apply to any command that uses any feature that this setting is configuring).

But those parameters were being set specifically for each swupd command, making it a hard task to keep documentation updated and make sure that all parameters are really added to all commands that may benefit from using them.

When I was reviewing parameters sanitization I decided to take some time to close #571 to make our lives easier.

So this pull request consolidate parameters in global.c and fixes some sanitization problems I found.

Note that we have a problem related to weird path names (#640) but this isn't a sanitization problem because that path is valid. 

Fixes: #571
