### PR TITLE
Move the MoM from bundles dir to /var/tmp/swupd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,5 @@ test/functional/*/*/test.log
 test/functional/*/*/debug.log
 test/functional/*/*/state
 test/functional/*/*/lines-output
-test/functional/*/*/target-dir/usr/share/clear/bundles/.MoM
 test/functional/*/*.log
 verifytime

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -594,13 +594,21 @@ verify_mom:
 	/* Make a copy of the Manifest for the completion code */
 	if (latest) {
 		char *momcopy;
-		rm_bundle_file(".MoM");
-		string_or_die(&momcopy, "/bin/cp \"%s\" \"%s/%s/.MoM\" 2>/dev/null",
-			      filename, path_prefix, BUNDLES_DIR);
+		char *momdir;
+		char *momfile;
+
+		string_or_die(&momdir, "%s/var/tmp/swupd", path_prefix);
+		string_or_die(&momfile, "%s/.MoM", momdir);
+		swupd_rm(momfile);
+		mkdir_p(momdir);
+		string_or_die(&momcopy, "/bin/cp \"%s\" \"%s\" 2>/dev/null",
+			      filename, momfile);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-result"
 		(void)system(momcopy); /* If it fails it fails */
 #pragma GCC diagnostic pop
+		free_string(&momdir);
+		free_string(&momfile);
 		free(momcopy);
 	}
 	free_string(&filename);

--- a/swupd.bash
+++ b/swupd.bash
@@ -73,8 +73,8 @@ _swupd()
 	case "${COMP_WORDS[$i]}" in
 	    ("bundle-add")
 		MoM=""
-		if [ -r /usr/share/clear/bundles/.MoM ]
-		then MoM=/usr/share/clear/bundles/.MoM
+		if [ -r /var/tmp/swupd/.MoM ]
+		then MoM=/var/tmp/swupd/.MoM
 		elif [ -r /var/lib/swupd/version ] &&
 		       installed=$(</var/lib/swupd/version) &&
 		       [ -r "/var/lib/swupd/$installed/Manifest.MoM" ]

--- a/test/real_content/swupd_update.bats
+++ b/test/real_content/swupd_update.bats
@@ -107,8 +107,6 @@ test_teardown() {
 }
 
 verify_system() {
-	# TODO: This is a bug in verify --picky #632
-	sudo rm -f "${ROOT_DIR}/usr/share/clear/bundles/.MoM"
 
 	run sudo sh -c "$SWUPD verify --picky $SWUPD_OPTS 2>/dev/null"
 	if [ -n "$output" ]; then


### PR DESCRIPTION
swupd copies the latest MoM to /usr/share/clear/bundles/.MoM so we
can use it for bash completion. The problem is that this directory
is tracked by clearlinux and because of that "swupd verify --picky"
will list this file as an extra file. And "swupd verify --fix --picky"
will remove that file.

This commit fixes the issue by changing the location where the .MoM
is copied to being this an untracked location, so the file won't be
removed.

Closes #632

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>