### PR TITLE
sys: Add run_command() function to replace some usages of system()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,6 @@ swupd_SOURCES = \
 	src/download.c \
 	src/extra_files.c \
 	src/filedesc.c \
-	src/fs.c \
 	src/fullfile.c \
 	src/globals.c \
 	src/hash.c \
@@ -55,6 +54,7 @@ swupd_SOURCES = \
 	src/swupd-error.h \
 	src/swupd-internal.h \
 	src/swupd.h \
+	src/sys.c \
 	src/telemetry.c \
 	src/timelist.c \
 	src/timelist.h \

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -178,15 +178,6 @@ int is_populated_dir(char *dirname)
 	return 0;
 }
 
-int mkdir_p(const char *dir)
-{
-	char *cmd;
-	string_or_die(&cmd, "mkdir -p %s", dir);
-	int ret = system(cmd);
-	free_string(&cmd);
-	return ret;
-}
-
 static int create_required_dirs(void)
 {
 	int ret = 0;

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -178,15 +178,6 @@ int is_populated_dir(char *dirname)
 	return 0;
 }
 
-int copy_all(const char *src, const char *dst)
-{
-	char *cmd;
-	string_or_die(&cmd, "cp -a %s %s 2> /dev/null", src, dst);
-	int ret = system(cmd);
-	free_string(&cmd);
-	return ret;
-}
-
 int mkdir_p(const char *dir)
 {
 	char *cmd;

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -1300,3 +1300,18 @@ int enforce_compliant_manifest(struct file **a, struct file **b, int searchsize,
 	}
 	return ret; // If collisions were found, so manifest is purely additive
 }
+
+long get_manifest_list_contentsize(struct list *manifests)
+{
+	long total_size = 0;
+
+	struct list *ptr = NULL;
+	for (ptr = list_head(manifests); ptr; ptr = ptr->next) {
+		struct manifest *subman;
+		subman = ptr->data;
+
+		total_size += subman->contentsize;
+	}
+
+	return total_size;
+}

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -593,7 +593,6 @@ verify_mom:
 	}
 	/* Make a copy of the Manifest for the completion code */
 	if (latest) {
-		char *momcopy;
 		char *momdir;
 		char *momfile;
 
@@ -601,15 +600,10 @@ verify_mom:
 		string_or_die(&momfile, "%s/Manifest.MoM", momdir);
 		swupd_rm(momfile);
 		mkdir_p(momdir);
-		string_or_die(&momcopy, "/bin/cp \"%s\" \"%s\" 2>/dev/null",
-			      filename, momfile);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-result"
-		(void)system(momcopy); /* If it fails it fails */
-#pragma GCC diagnostic pop
+
+		copy(filename, momfile);
 		free_string(&momdir);
 		free_string(&momfile);
-		free(momcopy);
 	}
 	free_string(&filename);
 	free_string(&url);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -584,7 +584,7 @@ verify_mom:
 		fprintf(stderr, "FAILED TO VERIFY SIGNATURE OF Manifest.MoM. Operation proceeding due to\n"
 				"  --nosigcheck, but system security may be compromised\n");
 		string_or_die(&log_cmd, "echo \"swupd security notice:"
-					" --nosigcheck used to bypass MoM signature verification failure\" | systemd-cat --priority=\"err\" --identifier=\"swupd\"");
+					" --nosigcheck used to bypass MoM signature verification failure\" | /usr/bin/systemd-cat --priority=\"err\" --identifier=\"swupd\"");
 		if (system(log_cmd)) {
 			/* useless noise to suppress gcc & glibc conspiring
 			 * to make us check the result of system */

--- a/src/scripts.c
+++ b/src/scripts.c
@@ -35,15 +35,9 @@
 
 static bool in_container(void)
 {
-	char *detect_container_cmd = NULL;
-	bool ret = false;
 	/* systemd-detect-virt -c does container detection only *
          * The return code is zero if the system is in a container */
-	string_or_die(&detect_container_cmd, "/usr/bin/systemd-detect-virt -c");
-	ret = !system(detect_container_cmd);
-	free_string(&detect_container_cmd);
-
-	return ret;
+	return !run_command("/usr/bin/systemd-detect-virt", "-c");
 }
 
 static void update_boot(void)

--- a/src/staging.c
+++ b/src/staging.c
@@ -40,16 +40,13 @@
 static int create_staging_renamedir(char *rename_tmpdir)
 {
 	int ret;
-	char *rmcommand = NULL;
 
-	string_or_die(&rmcommand, "rm -fr %s", rename_tmpdir);
-	if (!system(rmcommand)) {
+	if (rm_rf(rename_tmpdir) != 0) {
 		/* Not fatal but pretty scary, likely to really fail at the
 		 * next command too. Pass for now as printing may just cause
 		 * confusion */
 		;
 	}
-	free_string(&rmcommand);
 
 	ret = mkdir(rename_tmpdir, S_IRWXU);
 	if (ret == -1 && errno != EEXIST) {

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -13,6 +13,7 @@
 #include "list.h"
 #include "macros.h"
 #include "swupd-error.h"
+#include "sys.h"
 #include "timelist.h"
 
 #ifdef __cplusplus
@@ -324,6 +325,8 @@ extern int compute_hash_lazy(struct file *file, char *filename);
 extern int compute_hash(struct file *file, char *filename) __attribute__((warn_unused_result));
 
 /* manifest.c */
+/* Calculate the total contentsize of a manifest list */
+extern long get_manifest_list_contentsize(struct list *manifests);
 extern struct list *recurse_manifest(struct manifest *manifest, struct list *subs, const char *component, bool server);
 extern struct list *consolidate_files(struct list *files);
 extern struct list *filter_out_existing_files(struct list *files);
@@ -406,11 +409,6 @@ typedef enum telem_prio_t {
 	TELEMETRY_CRIT
 } telem_prio_t;
 extern void telemetry(telem_prio_t level, const char *class, const char *fmt, ...);
-
-/* fs.c */
-extern long get_available_space(const char *path);
-/* Calculate the total contentsize of a manifest list */
-extern long get_manifest_list_contentsize(struct list *manifests);
 
 extern struct file **manifest_files_to_array(struct manifest *manifest);
 extern int enforce_compliant_manifest(struct file **a, struct file **b, int searchsize, int size);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -348,7 +348,6 @@ extern char *mk_full_filename(const char *prefix, const char *path);
 extern bool is_directory_mounted(const char *filename);
 extern bool is_under_mounted_directory(const char *filename);
 extern int is_populated_dir(char *dirname);
-extern int copy_all(const char *src, const char *dst);
 extern int mkdir_p(const char *dir);
 
 extern void run_scripts(bool block);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -348,7 +348,6 @@ extern char *mk_full_filename(const char *prefix, const char *path);
 extern bool is_directory_mounted(const char *filename);
 extern bool is_under_mounted_directory(const char *filename);
 extern int is_populated_dir(char *dirname);
-extern int mkdir_p(const char *dir);
 
 extern void run_scripts(bool block);
 extern void run_preupdate_scripts(struct manifest *manifest);

--- a/src/sys.c
+++ b/src/sys.c
@@ -137,3 +137,13 @@ long get_available_space(const char *path)
 
 	return stat.f_bsize * stat.f_bavail;
 }
+
+int copy_all(const char *src, const char *dst)
+{
+	return run_command_quiet("/bin/cp", "-a", src, dst, NULL);
+}
+
+int copy(const char *src, const char *dst)
+{
+	return run_command_quiet("/bin/cp", src, dst, NULL);
+}

--- a/src/sys.c
+++ b/src/sys.c
@@ -18,7 +18,114 @@
  */
 
 #include "sys.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/statvfs.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int replace_fd(int fd, const char *fd_file)
+{
+	int new_fd;
+
+	if (!fd_file) {
+		return 0;
+	}
+	new_fd = open(fd_file, O_WRONLY | O_CREAT, S_IRWXU);
+	if (new_fd < 0) {
+		return new_fd;
+	}
+
+	return dup2(new_fd, fd);
+}
+
+int run_command_full(const char *stdout_file, const char *stderr_file, const char *cmd, ...)
+{
+	int pid, ret, child_ret;
+
+	pid = fork();
+	if (pid < 0) {
+		fprintf(stderr, "run_command %s failed: %i (%s)\n", cmd, errno, strerror(errno));
+		return -errno;
+	}
+
+	// Main
+	if (pid > 0) {
+		while ((ret = waitpid(pid, &child_ret, 0)) < 0) {
+			if (errno != EINTR) {
+				fprintf(stderr, "run_command %s failed: %i (%s)\n",
+					cmd, errno, strerror(errno));
+				return -errno;
+			}
+		}
+
+		return WEXITSTATUS(child_ret);
+	}
+
+	// Child
+	va_list ap;
+	char *short_cmd;
+	char **params;
+	int args_count = 0, i = 0;
+	char *arg;
+
+	va_start(ap, cmd);
+	while ((arg = va_arg(ap, char *)) != NULL) {
+		args_count++;
+	}
+	va_end(ap);
+
+	// Create params array with space for all parameters,
+	// command basename and NULL terminator
+	params = malloc(sizeof(char *) * (args_count + 2));
+	if (!params) {
+		goto error_child;
+	}
+
+	// We need a copy because of basename
+	short_cmd = strdup(cmd);
+	if (!short_cmd) {
+		abort();
+	}
+
+	params[i++] = basename(short_cmd);
+
+	va_start(ap, cmd);
+	while ((arg = va_arg(ap, char *)) != NULL) {
+		params[i++] = arg;
+	}
+	va_end(ap);
+
+	params[i] = NULL;
+
+	if (replace_fd(STDOUT_FILENO, stdout_file) < 0) {
+		goto error_child;
+	}
+
+	if (replace_fd(STDERR_FILENO, stderr_file) < 0) {
+		goto error_child;
+	}
+
+	ret = execve(cmd, params, NULL);
+	if (ret < 0) {
+		fprintf(stderr, "run_command %s failed: %i (%s)\n", cmd, errno, strerror(errno));
+	}
+	free(params);
+	free(short_cmd);
+
+	exit(EXIT_FAILURE); // execve nevers return on success
+	return 0;
+
+error_child:
+	exit(255);
+	return 0;
+}
 
 long get_available_space(const char *path)
 {

--- a/src/sys.c
+++ b/src/sys.c
@@ -17,7 +17,7 @@
  *
  */
 
-#include "swupd.h"
+#include "sys.h"
 #include <sys/statvfs.h>
 
 long get_available_space(const char *path)
@@ -29,19 +29,4 @@ long get_available_space(const char *path)
 	}
 
 	return stat.f_bsize * stat.f_bavail;
-}
-
-long get_manifest_list_contentsize(struct list *manifests)
-{
-	long total_size = 0;
-
-	struct list *ptr = NULL;
-	for (ptr = list_head(manifests); ptr; ptr = ptr->next) {
-		struct manifest *subman;
-		subman = ptr->data;
-
-		total_size += subman->contentsize;
-	}
-
-	return total_size;
 }

--- a/src/sys.c
+++ b/src/sys.c
@@ -152,3 +152,8 @@ int mkdir_p(const char *dir)
 {
 	return run_command_quiet("/bin/mkdir", "-p", dir, NULL);
 }
+
+int rm_rf(const char *file)
+{
+	return run_command_quiet("/bin/rm", "-rf", file, NULL);
+}

--- a/src/sys.c
+++ b/src/sys.c
@@ -147,3 +147,8 @@ int copy(const char *src, const char *dst)
 {
 	return run_command_quiet("/bin/cp", src, dst, NULL);
 }
+
+int mkdir_p(const char *dir)
+{
+	return run_command_quiet("/bin/mkdir", "-p", dir, NULL);
+}

--- a/src/sys.h
+++ b/src/sys.h
@@ -7,6 +7,31 @@ extern "C" {
 
 extern long get_available_space(const char *path);
 
+/* run_command_quiet: runs a command redirecting the standard and error outputs
+ * redirected to /dev/null. */
+#define run_command_quiet(...) run_command_full("/dev/null", "/dev/null", __VA_ARGS__)
+
+/* run_command: runs a command with standard and error output (stdout and stderr) set */
+#define run_command(...) run_command_full(NULL, NULL, __VA_ARGS__)
+
+/* run_command_full: Run command cmd with parameters informed in a NULL
+ * terminated list of strings.
+ *
+ * Return a negative number (-errno) if we are unable to create a new thread to
+ * run the command and a positive exit code (0-255) if the command was executed.
+ * If there's an error in the execution of the program 255 may also be returned
+ *
+ * Notes:
+ * - This function doesn't execute on a shell like system() so we won't have any
+ *   issue with parameters globbing.
+ * - The full path to cmd is required.
+ *
+ * Example:
+ * run_command(NULL, NULL, "/usr/bin/ls", "/tmp", NULL);
+ * This will run "ls /tmp" and redirect output to stdout and stderr.
+ */
+int run_command_full(const char *stdout_file, const char *stderr_file, const char *cmd, ...);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/sys.h
+++ b/src/sys.h
@@ -38,6 +38,8 @@ int copy_all(const char *src, const char *dst);
 /* copy: Runs cp [src] [dst] using run_command_quiet */
 int copy(const char *src, const char *dst);
 
+int mkdir_p(const char *dir);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/sys.h
+++ b/src/sys.h
@@ -32,6 +32,12 @@ extern long get_available_space(const char *path);
  */
 int run_command_full(const char *stdout_file, const char *stderr_file, const char *cmd, ...);
 
+/* copy_all: Runs cp -a [src] [dst] using run_command_quiet */
+int copy_all(const char *src, const char *dst);
+
+/* copy: Runs cp [src] [dst] using run_command_quiet */
+int copy(const char *src, const char *dst);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/sys.h
+++ b/src/sys.h
@@ -1,0 +1,14 @@
+#ifndef __SWUPD_SYS__
+#define __SWUPD_SYS__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern long get_available_space(const char *path);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/sys.h
+++ b/src/sys.h
@@ -40,6 +40,8 @@ int copy(const char *src, const char *dst);
 
 int mkdir_p(const char *dir);
 
+int rm_rf(const char *file);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/update.c
+++ b/src/update.c
@@ -270,7 +270,9 @@ version_check:
 				fclose(verfile);
 			}
 
-			if (system("/usr/bin/mixin build") != 0) {
+			if (run_command("/usr/bin/mixin"
+					"build",
+					NULL) != 0) {
 				fprintf(stderr, "ERROR: Could not execute mixin\n");
 				ret = EXIT_FAILURE;
 				goto clean_curl;


### PR DESCRIPTION
System API is a very convenient way on executing external commands, but it has
some problems for some usages. System always launches a shell to execute the
desired command, so we can be affected by environment variables (like PATH) and
shell globbing.

We can avoid most of the environment variables affecting the swupd result by
using the full path of the program being executed, but making sure the shell
won't expand all wildcards is tricky and specially dangerous for some commands
that we need to run, like cp, mkdir, etc.

So to make sure no globbing will be performed we can use fork+execve to run
commands instead of system.
