### PR TITLE
Don't save the latests Manifest as a hidden file

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -598,7 +598,7 @@ verify_mom:
 		char *momfile;
 
 		string_or_die(&momdir, "%s/var/tmp/swupd", path_prefix);
-		string_or_die(&momfile, "%s/.MoM", momdir);
+		string_or_die(&momfile, "%s/Manifest.MoM", momdir);
 		swupd_rm(momfile);
 		mkdir_p(momdir);
 		string_or_die(&momcopy, "/bin/cp \"%s\" \"%s\" 2>/dev/null",

--- a/swupd.bash
+++ b/swupd.bash
@@ -73,8 +73,8 @@ _swupd()
 	case "${COMP_WORDS[$i]}" in
 	    ("bundle-add")
 		MoM=""
-		if [ -r /var/tmp/swupd/.MoM ]
-		then MoM=/var/tmp/swupd/.MoM
+		if [ -r /var/tmp/swupd/Manifest.MoM ]
+		then MoM=/var/tmp/swupd/Manifest.MoM
 		elif [ -r /var/lib/swupd/version ] &&
 		       installed=$(</var/lib/swupd/version) &&
 		       [ -r "/var/lib/swupd/$installed/Manifest.MoM" ]


### PR DESCRIPTION
As we aren't saving the MoM in a directory we were reading to look for
bundles, we don't need to save it as a hidden file.

Suggestion of @phmccarty 