### PR TITLE
Fixes a bug in update when using mirrors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -196,6 +196,9 @@ BATS = \
 	test/functional/update/update-verify-fix-path-hash-mismatch.bats \
 	test/functional/update/update-verify-fix-path-missing-dir.bats \
 	test/functional/update/update-verify-fullfile-hash.bats \
+	test/functional/update/update-with-mirror.bats \
+	test/functional/update/update-with-old-mirror.bats \
+	test/functional/update/update-with-slightly-old-mirror.bats \
 	test/functional/verify/verify-add-missing-include.bats \
 	test/functional/verify/verify-add-missing-include-old.bats \
 	test/functional/verify/verify-boot-file.bats \

--- a/src/mirror.c
+++ b/src/mirror.c
@@ -65,6 +65,13 @@ static int unset_mirror_url()
 		goto out;
 	}
 
+	/* we need to set the version and content URLs again if not they will
+	 * remain with the value from the mirror */
+	free_string(&version_url);
+	free_string(&content_url);
+	set_version_url(NULL);
+	set_content_url(NULL);
+
 out:
 	free_string(&content_path);
 	free_string(&version_path);
@@ -161,7 +168,7 @@ void handle_mirror_if_stale(void)
 	char *fullpath = NULL;
 
 	fullpath = mk_full_filename(path_prefix, DEFAULT_VERSION_URL_PATH);
-	int ret = get_value_from_path(&ret_str, fullpath, false);
+	int ret = get_value_from_path(&ret_str, fullpath, true);
 	if (ret != 0 || ret_str == NULL) {
 		/* no versionurl file here, might not exist under --path argument */
 		goto out;
@@ -181,6 +188,9 @@ void handle_mirror_if_stale(void)
 			mirror_version,
 			central_version);
 		unset_mirror_url();
+		/* we need to re-set the cached_version to latest using the central version,
+		 * since at the moment the cached_version is the outdated mirror version */
+		get_latest_version(ret_str);
 		goto out;
 	}
 	if (diff > MIRROR_STALE_WARN) {

--- a/test/functional/mirror/mirror-createdir-negative.bats
+++ b/test/functional/mirror/mirror-createdir-negative.bats
@@ -29,6 +29,7 @@ global_teardown() {
 
 @test "MIR004: Try setting up a mirror when /etc/swupd is a file instead of a directory" {
 
+	sudo rm -rf "$TARGETDIR"/etc/swupd
 	sudo touch "$TARGETDIR"/etc/swupd
 
 	run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
@@ -46,6 +47,7 @@ global_teardown() {
 
 @test "MIR005: Try setting up a mirror when /etc/swupd is a symlink to a file instead of a directory" {
 
+	sudo rm -rf "$TARGETDIR"/etc/swupd
 	sudo touch "$TARGETDIR"/foo
 	sudo ln -s "$(realpath "$TARGETDIR"/foo)" "$TARGETDIR"/etc/swupd
 

--- a/test/functional/mirror/mirror-createdir-negative.bats
+++ b/test/functional/mirror/mirror-createdir-negative.bats
@@ -38,7 +38,9 @@ global_teardown() {
 	expected_output=$(cat <<-EOM
 		.*/etc/swupd: not a directory
 		Unable to set mirror url
-		Default version URL not found. Use the -v option instead.
+		Installed version: 10
+		Version URL:       file://.*/web-dir
+		Content URL:       file://.*/web-dir
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
@@ -57,7 +59,9 @@ global_teardown() {
 	expected_output=$(cat <<-EOM
 		.*/etc/swupd: not a directory
 		Unable to set mirror url
-		Default version URL not found. Use the -v option instead.
+		Installed version: 10
+		Version URL:       file://.*/web-dir
+		Content URL:       file://.*/web-dir
 	EOM
 	)
 	assert_regex_is_output "$expected_output"

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1410,6 +1410,36 @@ destroy_test_environment() { # swupd_function
 
 }
 
+# creates a mirror of whatever is in web-dir
+# Parameters:
+# - ENVIRONMENT_NAME: the name of the test environment where the mirror will be created
+create_mirror() { # swupd_function
+
+	local env_name=$1
+	local path
+
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    create_mirror <environment_name>
+			EOM
+		return
+	fi
+	validate_param "$env_name"
+	path=$(dirname "$(realpath "$env_name")")
+
+	# create the mirror
+	sudo mkdir "$env_name"/mirror
+	sudo cp -r "$env_name"/web-dir "$env_name"/mirror
+	export MIRROR="$env_name"/mirror/web-dir
+
+	# set the mirror in the target-dir
+	write_to_protected_file "$env_name"/target-dir/etc/swupd/mirror_versionurl "file://$path/$MIRROR"
+	write_to_protected_file "$env_name"/target-dir/etc/swupd/mirror_contenturl "file://$path/$MIRROR"
+
+}
+
 # creates a web server to host fake swupd content with or without certifiates
 start_web_server() { # swupd_function
 

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -269,6 +269,13 @@ set_env_variables() { # swupd_function
 	validate_path "$env_name"
 	path=$(dirname "$(realpath "$env_name")")
 
+	# different options for swupd
+	export SWUPD_OPTS="-S $path/$env_name/state -p $path/$env_name/target-dir -F staging -C $FUNC_DIR/Swupd_Root.pem -I"
+	export SWUPD_OPTS_KEEPCACHE="$SWUPD_OPTS --keepcache"
+	export SWUPD_OPTS_NO_CERT="-S $path/$env_name/state -p $path/$env_name/target-dir -F staging"
+	export SWUPD_OPTS_MIRROR="-p $path/$env_name/target-dir"
+	export SWUPD_OPTS_NO_FMT="-S $path/$env_name/state -p $path/$env_name/target-dir -C $FUNC_DIR/Swupd_Root.pem -I"
+
 	export CLIENT_CERT_DIR="$TEST_NAME/target-dir/etc/swupd"
 	export CLIENT_CERT="$CLIENT_CERT_DIR/client.pem"
 	export CACERT_DIR="$SWUPD_DIR/swupd_test_certificates" # trusted key store path
@@ -279,8 +286,8 @@ set_env_variables() { # swupd_function
 	if [ -f "$PORT_FILE" ]; then
 		PORT=$(cat "$PORT_FILE")
 		export PORT
-		export SWUPD_OPTS_HTTPS="-S $path/$env_name/state -p $path/$env_name/target-dir -F staging -u https://localhost:$PORT/$env_name/web-dir -C $FUNC_DIR/Swupd_Root.pem -I"
-		export SWUPD_OPTS_HTTP="-S $path/$env_name/state -p $path/$env_name/target-dir -F staging -u http://localhost:$PORT/$env_name/web-dir -C $FUNC_DIR/Swupd_Root.pem -I"
+		export SWUPD_OPTS_HTTPS="$SWUPD_OPTS -u https://localhost:$PORT/$env_name/web-dir"
+		export SWUPD_OPTS_HTTP="$SWUPD_OPTS -u http://localhost:$PORT/$env_name/web-dir"
 		export SWUPD_OPTS_HTTP_NO_CERT="-S $path/$env_name/state -p $path/$env_name/target-dir -F staging -u http://localhost:$PORT/$env_name/web-dir/"
 	fi
 
@@ -288,11 +295,6 @@ set_env_variables() { # swupd_function
 		export SERVER_PID=$(cat "$SERVER_PID_FILE")
 	fi
 
-	export SWUPD_OPTS="-S $path/$env_name/state -p $path/$env_name/target-dir -F staging -u file://$path/$env_name/web-dir -C $FUNC_DIR/Swupd_Root.pem -I"
-	export SWUPD_OPTS_KEEPCACHE="-S $path/$env_name/state -p $path/$env_name/target-dir -F staging -u file://$path/$env_name/web-dir -C $FUNC_DIR/Swupd_Root.pem -I --keepcache"
-	export SWUPD_OPTS_NO_CERT="-S $path/$env_name/state -p $path/$env_name/target-dir -F staging -u file://$path/$env_name/web-dir"
-	export SWUPD_OPTS_MIRROR="-p $path/$env_name/target-dir"
-	export SWUPD_OPTS_NO_FMT="-S $path/$env_name/state -p $path/$env_name/target-dir -u file://$path/$env_name/web-dir -C $FUNC_DIR/Swupd_Root.pem -I"
 	export TEST_DIRNAME="$path"/"$env_name"
 	export WEBDIR="$env_name"/web-dir
 	export TARGETDIR="$env_name"/target-dir
@@ -1294,6 +1296,7 @@ create_test_environment() { # swupd_function
 	local env_name=$1 
 	local version=${2:-10}
 	local format=${3:-staging}
+	local path
 	# If no parameters are received show usage
 	if [ $# -eq 0 ]; then
 		cat <<-EOM
@@ -1326,12 +1329,15 @@ create_test_environment() { # swupd_function
 	fi
 
 	# target-dir files & dirs
+	path=$(dirname "$(realpath "$env_name")")
 	sudo mkdir -p "$env_name"/target-dir/usr/lib
 	sudo cp "$env_name"/web-dir/"$version"/os-release "$env_name"/target-dir/usr/lib/os-release
 	sudo mkdir -p "$env_name"/target-dir/usr/share/clear/bundles
 	sudo mkdir -p "$env_name"/target-dir/usr/share/defaults/swupd
 	sudo cp "$env_name"/web-dir/"$version"/format "$env_name"/target-dir/usr/share/defaults/swupd/format
-	sudo mkdir -p "$env_name"/target-dir/etc
+	write_to_protected_file "$env_name"/target-dir/usr/share/defaults/swupd/versionurl "file://$path/$env_name/web-dir"
+	write_to_protected_file "$env_name"/target-dir/usr/share/defaults/swupd/contenturl "file://$path/$env_name/web-dir"
+	sudo mkdir -p "$env_name"/target-dir/etc/swupd
 
 	# state files & dirs
 	sudo mkdir -p "$env_name"/state/{staged,download,delta,telemetry}

--- a/test/functional/update/update-with-mirror.bats
+++ b/test/functional/update/update-with-mirror.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle1 -f /file_1 "$TEST_NAME"
+
+	create_version "$TEST_NAME" 20 10
+	update_bundle "$TEST_NAME" test-bundle1 --add /file_2
+
+	# create a mirror at this point
+	create_mirror "$TEST_NAME"
+
+	# the following update won't be part of the mirror cause it
+	# was done after the mirror was created
+	create_version "$TEST_NAME" 30 20
+	update_bundle "$TEST_NAME" test-bundle1 --add /file_3
+
+}
+
+@test "UPD039: Updating a system using a mirror" {
+
+	# When doing an update with a mirror set up, swupd will use that mirror,
+	# to get the content from
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Update started.
+		Preparing to update from 10 to 20
+		Downloading packs...
+		Extracting test-bundle1 pack for version 20
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 1
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 0
+		    new files         : 1
+		    deleted files     : 0
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Staging file content
+		Applying update
+		Update was applied.
+		Calling post-update helper scripts.
+		Update successful. System updated from version 10 to version 20
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/file_2
+	assert_file_not_exists "$TARGETDIR"/file_3
+
+}

--- a/test/functional/update/update-with-old-mirror.bats
+++ b/test/functional/update/update-with-old-mirror.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle1 -f /file_1 "$TEST_NAME"
+
+	create_version "$TEST_NAME" 20 10
+	update_bundle "$TEST_NAME" test-bundle1 --add /file_2
+
+	# create a mirror at this point
+	create_mirror "$TEST_NAME"
+
+	# the following update won't be part of the mirror cause it
+	# was done after the mirror was created
+	create_version "$TEST_NAME" 1000 20
+	update_bundle "$TEST_NAME" test-bundle1 --add /file_3
+
+}
+
+@test "UPD041: Updating a system using a stale mirror" {
+
+	# When doing an update with a mirror set up, swupd will make sure
+	# the mirror is not too far behind the upstream content server, if
+	# it is, it unsets the mirror so the update uses the upstream server
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Update started.
+		WARNING: removing stale mirror configuration. Mirror version (20) is too far behind upstream version (1000)
+		Preparing to update from 10 to 1000
+		Downloading packs...
+		Statistics for going from version 10 to version 1000:
+		    changed bundles   : 1
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 0
+		    new files         : 2
+		    deleted files     : 0
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Staging file content
+		Applying update
+		Update was applied.
+		Calling post-update helper scripts.
+		2 files were not in a pack
+		Update successful. System updated from version 10 to version 1000
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/file_2
+	assert_file_exists "$TARGETDIR"/file_3
+
+}

--- a/test/functional/update/update-with-slightly-old-mirror.bats
+++ b/test/functional/update/update-with-slightly-old-mirror.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle1 -f /file_1 "$TEST_NAME"
+
+	create_version "$TEST_NAME" 20 10
+	update_bundle "$TEST_NAME" test-bundle1 --add /file_2
+
+	# create a mirror at this point
+	create_mirror "$TEST_NAME"
+
+	# the following update won't be part of the mirror cause it
+	# was done after the mirror was created
+	create_version "$TEST_NAME" 100 20
+	update_bundle "$TEST_NAME" test-bundle1 --add /file_3
+
+}
+
+@test "UPD040: Updating a system using a slightly outdated mirror" {
+
+	# When doing an update with a mirror set up, swupd will make sure
+	# the mirror is not too far behind the upstream content server, if
+	# it is, it unsets the mirror so the update uses the upstream server,
+	# if it is only slightly old (< 500) it warns the user and continues
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Update started.
+		WARNING: mirror version (20) is behind upstream version (100)
+		Preparing to update from 10 to 20
+		Downloading packs...
+		Extracting test-bundle1 pack for version 20
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 1
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 0
+		    new files         : 1
+		    deleted files     : 0
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Staging file content
+		Applying update
+		Update was applied.
+		Calling post-update helper scripts.
+		Update successful. System updated from version 10 to version 20
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/file_2
+	assert_file_not_exists "$TARGETDIR"/file_3
+
+}

--- a/test/functional/verify/verify-fix.bats
+++ b/test/functional/verify/verify-fix.bats
@@ -143,16 +143,18 @@ test_setup() {
 		.deleted
 		--picky removing extra files under .*/target-dir/usr
 		REMOVING /usr/untracked_file3
-		Inspected 19 files
+		REMOVING /usr/share/defaults/swupd/versionurl
+		REMOVING /usr/share/defaults/swupd/contenturl
+		Inspected 21 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
 		    0 of 2 missing files were not replaced
 		  2 files did not match
 		    2 of 2 files were fixed
 		    0 of 2 files were not fixed
-		  2 files found which should be deleted
-		    2 of 2 files were deleted
-		    0 of 2 files were not deleted
+		  4 files found which should be deleted
+		    4 of 4 files were deleted
+		    0 of 4 files were not deleted
 		Calling post-update helper scripts.
 		Fix successful
 	EOM
@@ -166,6 +168,8 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/bat/untracked_file1
 	assert_file_exists "$TARGETDIR"/bar/untracked_file2
 	assert_file_not_exists "$TARGETDIR"/usr/untracked_file3
+	assert_file_not_exists "$TARGETDIR"/usr/share/defaults/swupd/versionurl
+	assert_file_not_exists "$TARGETDIR"/usr/share/defaults/swupd/contenturl
 
 }
 

--- a/test/functional/verify/verify-picky-downgrade.bats
+++ b/test/functional/verify/verify-picky-downgrade.bats
@@ -52,17 +52,19 @@ test_setup() {
 		Hash mismatch for file: .*/target-dir/usr/lib/os-release
 		.fixed
 		--picky removing extra files under .*/target-dir/usr
+		REMOVING /usr/share/defaults/swupd/versionurl
+		REMOVING /usr/share/defaults/swupd/contenturl
 		REMOVING /usr/share/clear/bundles/test-bundle2
 		REMOVING /usr/foo/file_3
 		REMOVING /usr/foo/file_2
 		REMOVING DIR /usr/foo/
-		Inspected 17 files
+		Inspected 19 files
 		  1 file did not match
 		    1 of 1 files were fixed
 		    0 of 1 files were not fixed
-		  4 files found which should be deleted
-		    4 of 4 files were deleted
-		    0 of 4 files were not deleted
+		  6 files found which should be deleted
+		    6 of 6 files were deleted
+		    0 of 6 files were not deleted
 		Calling post-update helper scripts.
 		Fix successful
 	EOM
@@ -130,12 +132,14 @@ test_setup() {
 		Warning: Bundle "test-bundle2" is invalid, skipping it...
 		WARNING: One or more installed bundles are not available at version 10.
 		Generating list of extra files under .*/target-dir/usr
+		/usr/share/defaults/swupd/versionurl
+		/usr/share/defaults/swupd/contenturl
 		/usr/share/clear/bundles/test-bundle2
 		/usr/foo/file_3
 		/usr/foo/file_2
 		/usr/foo/
-		Inspected 17 files
-		  4 files found which should be deleted
+		Inspected 19 files
+		  6 files found which should be deleted
 		Verify successful
 	EOM
 	)
@@ -145,5 +149,7 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/bar/file_4
 	assert_file_exists "$TARGETDIR"/bar/file_5
 	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGETDIR"/usr/share/defaults/swupd/versionurl
+	assert_file_exists "$TARGETDIR"/usr/share/defaults/swupd/contenturl
 
 }

--- a/test/functional/verify/verify-picky-ghosted-missing.bats
+++ b/test/functional/verify/verify-picky-ghosted-missing.bats
@@ -22,7 +22,12 @@ test_setup() {
 		Adding any missing files
 		Fixing modified files
 		--picky removing extra files under .*/target-dir/usr
-		Inspected 13 files
+		REMOVING /usr/share/defaults/swupd/versionurl
+		REMOVING /usr/share/defaults/swupd/contenturl
+		Inspected 15 files
+		  2 files found which should be deleted
+		    2 of 2 files were deleted
+		    0 of 2 files were not deleted
 		Calling post-update helper scripts.
 		Fix successful
 	EOM

--- a/test/functional/verify/verify-picky-ghosted.bats
+++ b/test/functional/verify/verify-picky-ghosted.bats
@@ -20,7 +20,12 @@ test_setup() {
 		Adding any missing files
 		Fixing modified files
 		--picky removing extra files under .*/target-dir/usr
-		Inspected 13 files
+		REMOVING /usr/share/defaults/swupd/versionurl
+		REMOVING /usr/share/defaults/swupd/contenturl
+		Inspected 15 files
+		  2 files found which should be deleted
+		    2 of 2 files were deleted
+		    0 of 2 files were not deleted
 		Calling post-update helper scripts.
 		Fix successful
 	EOM

--- a/test/functional/verify/verify-picky-whitelist.bats
+++ b/test/functional/verify/verify-picky-whitelist.bats
@@ -30,13 +30,15 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Verifying version 10
 		Generating list of extra files under .*/target-dir/usr
+		/usr/share/defaults/swupd/versionurl
+		/usr/share/defaults/swupd/contenturl
 		/usr/file1
 		/usr/bat/baz/file5
 		/usr/bat/baz/file4
 		/usr/bat/baz/
 		/usr/bat/
-		Inspected 16 files
-		  5 files found which should be deleted
+		Inspected 18 files
+		  7 files found which should be deleted
 		Verify successful
 	EOM
 	)

--- a/test/functional/verify/verify-picky.bats
+++ b/test/functional/verify/verify-picky.bats
@@ -28,12 +28,14 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Verifying version 10
 		Generating list of extra files under .*/target-dir/usr
+		/usr/share/defaults/swupd/versionurl
+		/usr/share/defaults/swupd/contenturl
 		/usr/foo/bar/file2
 		/usr/foo/bar/
 		/usr/foo/
 		/usr/file1
-		Inspected 15 files
-		  4 files found which should be deleted
+		Inspected 17 files
+		  6 files found which should be deleted
 		Verify successful
 	EOM
 	)


### PR DESCRIPTION
There are a couple of problems when the user has a mirror set up,
and tries to update. The first one is that in the case where the
user is using the -p option and a mirror, the version of the mirror
was failing to be retrieved since the path_prefix was being added
to the path twice. The second problem was that when the mirror being
used by the user was stale, the mirror was being unset but some values
had already being cached, causing the update function to fail.

This PR fixes the issues and add a few tests to validate the correct behavior.