### PR TITLE
Update verify to include purpose for cert check

### DIFF
--- a/scripts/assert-certificate-validity.sh
+++ b/scripts/assert-certificate-validity.sh
@@ -19,7 +19,7 @@ fi
 
 openssl_verify()
 {
-	openssl smime -verify -in "$1" -inform der -content "$2" -CAfile "$3" > /dev/null 2>&1
+	openssl smime -verify -purpose any -in "$1" -inform der -content "$2" -CAfile "$3" > /dev/null 2>&1
 
 }
 


### PR DESCRIPTION
Newer versions of openssl require a valid purpose so
pass this in for the cert check.

Signed-off-by: David Klimesh <david.j.klimesh@intel.com>