### PR TITLE
Distinguish experimental bundles in a bundle list

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -45,6 +45,7 @@
 */
 int list_installable_bundles()
 {
+	char *name;
 	struct list *list;
 	struct file *file;
 	struct manifest *MoM = NULL;
@@ -67,7 +68,9 @@ int list_installable_bundles()
 	while (list) {
 		file = list->data;
 		list = list->next;
-		printf("%s\n", file->filename);
+		get_bundle_name(&name, file);
+		printf("%s\n", name);
+		free_string(&name);
 	}
 
 	free_manifest(MoM);

--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -126,22 +126,18 @@ int bundle_list_main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-	if (cmdline_local) {
-		set_path_prefix(NULL);
-		ret = list_local_bundles();
-		if (ret) {
-			check_root();
-		}
-		return ret;
-	}
-
 	ret = swupd_init();
-	if (ret != 0) {
+	/* if swupd fails to initialize, the only list command we can still attempt is
+	 * listing locally installed bundles (with the limitation of not showing what
+	 * bundles are experimental) */
+	if (ret != 0 && !cmdline_local) {
 		fprintf(stderr, "Error: Failed updater initialization. Exiting now\n");
 		return ret;
 	}
 
-	if (cmdline_option_deps != NULL) {
+	if (cmdline_local) {
+		ret = list_local_bundles();
+	} else if (cmdline_option_deps != NULL) {
 		ret = show_included_bundles(cmdline_option_deps);
 	} else if (cmdline_option_has_dep != NULL) {
 		ret = show_bundle_reqd_by(cmdline_option_has_dep, cmdline_option_all);

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -1198,3 +1198,9 @@ struct list *get_dir_files_sorted(char *path)
 
 	return list_sort(files, lex_sort);
 }
+
+/* Appends the (experimental) label if applicable to the bundle name */
+void get_bundle_name(char **name, struct file *bundle_manifest)
+{
+	string_or_die(name, "%s%s", bundle_manifest->filename, bundle_manifest->is_experimental ? " (experimental)" : "");
+}

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -382,6 +382,7 @@ extern void print_progress(unsigned int count, unsigned int max);
 extern bool is_compatible_format(int format_num);
 extern bool is_current_version(int version);
 extern bool on_new_format(void);
+extern void get_bundle_name(char **name, struct file *bundle_manifest);
 
 /* subscription.c */
 struct list *free_list_file(struct list *item);

--- a/test/functional/bundlelist/list-experimental.bats
+++ b/test/functional/bundlelist/list-experimental.bats
@@ -5,12 +5,29 @@
 
 load "../testlib"
 
-test_setup() {
+global_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -e -n test-bundle1 -f /file_1 "$TEST_NAME"
 	create_bundle -e -n test-bundle2 -f /file_2 "$TEST_NAME"
 	create_bundle -n test-bundle3 -f /file_3 "$TEST_NAME"
+
+}
+
+test_setup() {
+
+	return
+
+}
+
+test_teardown() {
+
+	return
+}
+
+global_teardown() {
+
+	destroy_test_environment "$TEST_NAME"
 
 }
 
@@ -29,9 +46,45 @@ test_setup() {
 		test-bundle3
 	EOM
 	)
-	assert_is_output --identical "$expected_output"
-	# TODO(castulo): at the moment all that is expected is that swupd doesn't break
-	# with the e modifier in the MoM, this test should be extended to identify what
-	# bundles are experimental once it is implemented in swupd
+	assert_is_output "$expected_output"
+
+}
+
+@test "LST015: List all installed bundles including experimental" {
+
+	# bundle-list with no options should list only installed bundles, there should
+	# be a way to distinguish those that are experimental
+
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		os-core
+		test-bundle1 (experimental)
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "LST016: List all installed bundles including experimental when the MoM fails to be retrieved" {
+
+	# bundle-list with no options should list only installed bundles, there should
+	# be a way to distinguish those that are experimental
+
+	sudo rm "$STATEDIR"/10/Manifest.MoM
+	sudo rm "$WEBDIR"/10/Manifest.MoM.tar
+
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Failed to retrieve 10 MoM manifest
+		Warning: Could not determine which installed bundles are experimental
+		os-core
+		test-bundle1
+	EOM
+	)
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundlelist/list-experimental.bats
+++ b/test/functional/bundlelist/list-experimental.bats
@@ -8,7 +8,7 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment "$TEST_NAME"
-	create_bundle -L -n test-bundle1 -f /file_1 "$TEST_NAME"
+	create_bundle -L -e -n test-bundle1 -f /file_1 "$TEST_NAME"
 	create_bundle -e -n test-bundle2 -f /file_2 "$TEST_NAME"
 	create_bundle -n test-bundle3 -f /file_3 "$TEST_NAME"
 
@@ -24,12 +24,12 @@ test_setup() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		os-core
-		test-bundle1
-		test-bundle2
+		test-bundle1 (experimental)
+		test-bundle2 (experimental)
 		test-bundle3
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 	# TODO(castulo): at the moment all that is expected is that swupd doesn't break
 	# with the e modifier in the MoM, this test should be extended to identify what
 	# bundles are experimental once it is implemented in swupd


### PR DESCRIPTION
This PR adds the ability to show an identifier in bundles that are
marked as experimental when listing available bundles or installed
bundles:
```
swupd bundle-list --all
swupd bundle-list
```
