### PR TITLE
Warn user when adding an experimental bundle

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -120,6 +120,7 @@ BATS = \
 	test/functional/bundleadd/add-boot-skip.bats \
 	test/functional/bundleadd/add-client-certificate.bats \
 	test/functional/bundleadd/add-directory.bats \
+	test/functional/bundleadd/add-experimental.bats \
 	test/functional/bundleadd/add-fall-back-to-fullfile.bats \
 	test/functional/bundleadd/add-include.bats \
 	test/functional/bundleadd/add-install-time.bats \

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -758,6 +758,11 @@ static int install_bundles(struct list *bundles, struct list **subs, struct mani
 			/* track as installed since they tried to install it */
 			track_installed(bundle);
 		}
+		/* warn the user if the bundle to be installed is experimental */
+		file = search_bundle_in_manifest(mom, bundle);
+		if (file && file->is_experimental) {
+			fprintf(stderr, "Warning: Bundle %s is experimental\n", bundle);
+		}
 	}
 
 	/* Use a bitwise AND with the add_sub_NEW mask to determine if at least

--- a/test/functional/bundleadd/add-experimental.bats
+++ b/test/functional/bundleadd/add-experimental.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -e -n test-bundle1 -f /file_1,/foo/file_2 "$TEST_NAME"
+
+}
+
+test_teardown() {
+
+	destroy_test_environment "$TEST_NAME"
+
+}
+@test "ADD032: Add an experimental bundle" {
+
+	# Experimental bundles are added normally but the user gets warned about it
+
+	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Warning: Bundle test-bundle1 is experimental
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Installing bundle(s) files...
+		Calling post-update helper scripts.
+		Successfully installed 1 bundle
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}


### PR DESCRIPTION
This commit adds the ability of warning the user if he/she tries
to install an experimental bundle.