### PR TITLE
Show when a bundle is experimental in swupd search

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -170,6 +170,7 @@ BATS = \
 	test/functional/search/search-content-check-negative.bats \
 	test/functional/search/search-content-check-positive.bats \
 	test/functional/search/search-client-certificate.bats \
+	test/functional/search/search-experimental.bats \
 	test/functional/update/update-boot-file.bats \
 	test/functional/update/update-boot-skip.bats \
 	test/functional/update/update-bundle-removed.bats \

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -68,7 +68,7 @@ int list_installable_bundles()
 	while (list) {
 		file = list->data;
 		list = list->next;
-		get_bundle_name(&name, file);
+		name = get_printable_bundle_name(file->filename, file->is_experimental);
 		printf("%s\n", name);
 		free_string(&name);
 	}
@@ -1168,7 +1168,7 @@ skip_mom:
 			bundle_manifest = search_bundle_in_manifest(MoM, basename((char *)item->data));
 		}
 		if (bundle_manifest) {
-			get_bundle_name(&name, bundle_manifest);
+			name = get_printable_bundle_name(bundle_manifest->filename, bundle_manifest->is_experimental);
 		} else {
 			string_or_die(&name, basename((char *)item->data));
 		}

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -1200,7 +1200,10 @@ struct list *get_dir_files_sorted(char *path)
 }
 
 /* Appends the (experimental) label if applicable to the bundle name */
-void get_bundle_name(char **name, struct file *bundle_manifest)
+char *get_printable_bundle_name(const char *bundle_name, bool is_experimental)
 {
-	string_or_die(name, "%s%s", bundle_manifest->filename, bundle_manifest->is_experimental ? " (experimental)" : "");
+	char *printable_name = NULL;
+
+	string_or_die(&printable_name, "%s%s", bundle_name, is_experimental ? " (experimental)" : "");
+	return printable_name;
 }

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -382,7 +382,7 @@ extern void print_progress(unsigned int count, unsigned int max);
 extern bool is_compatible_format(int format_num);
 extern bool is_current_version(int version);
 extern bool on_new_format(void);
-extern void get_bundle_name(char **name, struct file *bundle_manifest);
+extern char *get_printable_bundle_name(const char *bundle_name, bool is_experimental);
 
 /* subscription.c */
 struct list *free_list_file(struct list *item);

--- a/test/functional/search/search-experimental.bats
+++ b/test/functional/search/search-experimental.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -e -n test-bundle1 -f /common,/foo/test-file1,/foo/test-file3,/usr/bin/test-bin,/usr/lib/test-lib32 "$TEST_NAME"
+	create_bundle -L -e -n test-bundle2 -f /common,/bar/test-file2,/bar/test-file3,/usr/lib64/test-lib64 "$TEST_NAME"
+
+}
+
+test_setup() {
+
+	# do nothing
+	return
+
+}
+
+test_teardown() {
+
+	# do nothing
+	return
+
+}
+
+global_teardown() {
+
+	destroy_test_environment "$TEST_NAME"
+
+}
+
+@test "SRH015: Search for an experimental bundle" {
+
+	# it should find the bundle since the tracking file has the
+	# same name as the bundle, also the first time we run search
+	# it needs to download the manifests, so we need to account
+	# for those messages. If the bundle is experimental it should
+	# swhow that
+
+	run sudo sh -c "$SWUPD search $SWUPD_OPTS test-bundle1"
+
+	assert_status_is 0
+	assert_in_output "Searching for 'test-bundle1'"
+	# there is going to be a whole lot of content within the line
+	# above and the lines below so we are excluding those from the
+	# check
+	expected_output=$(cat <<-EOM
+		Downloading Clear Linux manifests
+		.* MB total...
+		Completed manifests download.
+		Bundle test-bundle1 \\(experimental\\)	\\(0 MB to install\\)
+		./usr/share/clear/bundles/test-bundle1
+	EOM
+	)
+	assert_regex_in_output "$expected_output"
+
+}
+
+@test "SRH016: Search for an experimental bundle that is already installed" {
+
+	# it should find the bundle since the tracking file has the
+	# same name as the bundle. If the bundle is experimental it
+	# should swhow that
+
+	run sudo sh -c "$SWUPD search $SWUPD_OPTS test-bundle2"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Searching for 'test-bundle2'
+		Bundle test-bundle2 \\(experimental\\)	\\[installed\\]	\\(0 MB on system\\)
+		./usr/share/clear/bundles/test-bundle2
+	EOM
+	)
+	assert_regex_in_output "$expected_output"
+
+}
+
+@test "SRH017: Search for a file that is part of an experimental bundle" {
+
+	# If the bundle is experimental it should swhow that
+
+	run sudo sh -c "$SWUPD search $SWUPD_OPTS test-file1"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Searching for 'test-file1'
+		Bundle test-bundle1 \\(experimental\\)	\\(0 MB to install\\)
+		./foo/test-file1
+	EOM
+	)
+	assert_regex_in_output "$expected_output"
+
+}
+
+@test "SRH018: Search for a binary file that is part of an experimental bundle" {
+
+	# If the bundle is experimental it should swhow that
+
+	run sudo sh -c "$SWUPD search --binary $SWUPD_OPTS test-bin"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Searching for 'test-bin'
+		Bundle test-bundle1 \\(experimental\\)	\\(0 MB to install\\)
+		./usr/bin/test-bin
+	EOM
+	)
+	assert_regex_in_output "$expected_output"
+
+}
+
+@test "SRH019: Search for a library that is part of an experimental bundle" {
+
+	# If the bundle is experimental it should swhow that
+
+	run sudo sh -c "$SWUPD search --library $SWUPD_OPTS test-lib32"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Searching for 'test-lib32'
+		Bundle test-bundle1 \\(experimental\\)	\\(0 MB to install\\)
+		./usr/lib/test-lib32
+	EOM
+	)
+	assert_regex_in_output "$expected_output"
+
+}


### PR DESCRIPTION
This commit adds ability to show when a bundle is experimental in the
results of a swupd search.

Closes #676