### PR TITLE
Making set_version_url and set_content_url public

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -201,7 +201,7 @@ static int set_url(char **global, char *url, const char *path)
  * NULL, content_url will be set to its value. Otherwise, the value is read
  * from the 'contenturl' configuration file.
  */
-static int set_content_url(char *url)
+int set_content_url(char *url)
 {
 	if (content_url) {
 		/* Only set once; we assume the first successful set is the best choice */
@@ -226,7 +226,7 @@ static int set_content_url(char *url)
  * NULL, version_url will be set to its value. Otherwise, the value is read
  * from the 'versionurl' configuration file.
  */
-static int set_version_url(char *url)
+int set_version_url(char *url)
 {
 	if (version_url) {
 		/* Only set once; we assume the first successful set is the best choice */

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -197,6 +197,8 @@ extern char *cert_path;
 extern int update_server_port;
 extern char *default_format_path;
 extern bool set_path_prefix(char *path);
+extern int set_content_url(char *url);
+extern int set_version_url(char *url);
 
 extern void check_root(void);
 extern void increment_retries(int *retries, int *timeout);


### PR DESCRIPTION
Functions set_version_url and set_content_url were recently made static
since they were not being used outside of the globals file. Another
commit was merged that was using those functions from another file.

This commit makes those functions back to public.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>