### PR TITLE
Provide the ability to set the upstream server in a test environment.

### DIFF
--- a/test/functional/checkupdate/chk-update-slow-server.bats
+++ b/test/functional/checkupdate/chk-update-slow-server.bats
@@ -2,33 +2,28 @@
 
 load "../testlib"
 
-global_setup() {
+test_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_version "$TEST_NAME" 99990 10 staging
 
 	# start slow response web server
 	start_web_server -s
-}
 
-test_setup() {
+	# Set the web server as our upstream server
+	port=$(get_web_server_port "$TEST_NAME")
+	set_upstream_server "$TEST_NAME" "http://localhost:$port/$TEST_NAME/web-dir"
 
-	return
 }
 
 test_teardown() {
-
-	return
-}
-
-global_teardown() {
 
 	destroy_test_environment "$TEST_NAME"
 }
 
 @test "CHK003: Check for available updates with a slow server" {
 
-	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS_HTTP"
+	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Current OS version: 10

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -2599,6 +2599,9 @@ global_env=false
 
 setup() {
 
+	print "\n$sep"
+	print "$alt_sep"
+	print "$sep"
 	# a global environment will always use number 1, so check for that
 	# environment first
 	if [ -d "$TEST_NAME"_1 ]; then
@@ -2639,6 +2642,7 @@ setup() {
 		set_env_variables "$TEST_NAME"
 	fi
 	test_setup
+	print "Test setup complete. Starting test execution..."
 
 }
 
@@ -2653,6 +2657,7 @@ teardown() {
 	if [ "$BATS_TEST_NUMBER" -eq "${#BATS_TEST_NAMES[@]}" ]; then
 		global_teardown
 	fi
+	print "Test teardown complete."
 
 }
 
@@ -2689,6 +2694,7 @@ test_teardown() {
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 sep="------------------------------------------------------------------"
+alt_sep="++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 
 print_assert_failure() {
 

--- a/test/functional/update/update-slow-server.bats
+++ b/test/functional/update/update-slow-server.bats
@@ -2,8 +2,7 @@
 
 load "../testlib"
 
-global_setup() {
-
+test_setup() {
 	# Skip this test if not running in Travis CI, because test takes too long for
 	# local development. To run this locally do: TRAVIS=true make check
 	if [ -z "${TRAVIS}" ]; then
@@ -15,18 +14,14 @@ global_setup() {
 	update_bundle "$TEST_NAME" test-bundle --update /foo/bar
 
 	start_web_server -d pack-test-bundle-from-10.tar -s
-}
 
-test_setup() {
-	return
+	# Set the web server as our upstream server
+	port=$(get_web_server_port "$TEST_NAME")
+	set_upstream_server "$TEST_NAME" "http://localhost:$port/$TEST_NAME/web-dir"
+
 }
 
 test_teardown() {
-	return
-}
-
-global_teardown() {
-
 	# teardown only if in travis CI
 	if [ -n "${TRAVIS}" ]; then
 		destroy_test_environment "$TEST_NAME"
@@ -36,7 +31,7 @@ global_teardown() {
 
 @test "UPD025: Updating a system using a slow server" {
 
-	run sudo sh -c "$SWUPD update $SWUPD_OPTS_HTTP"
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM


### PR DESCRIPTION
Every test environment gets created with a default value for versionurl
and contenturl that points to the appropriate place using the "file://"
protocol. In some occassions the user may want to change this value to
something different, for example if he/she is planning on using an http
server to host the version/content.

This PR provides a way of setting up the upstream server in the test environment.