### PR TITLE
Setting upstream server in client cert tests

### DIFF
--- a/test/functional/bundleadd/add-client-certificate.bats
+++ b/test/functional/bundleadd/add-client-certificate.bats
@@ -29,6 +29,11 @@ global_setup() {
 	create_trusted_cacert "$server_pub"
 
 	start_web_server -c "$client_pub" -p "$server_pub" -k "$server_key"
+
+	# Set the web server as our upstream server
+	port=$(get_web_server_port "$TEST_NAME")
+	set_upstream_server "$TEST_NAME" "https://localhost:$port/$TEST_NAME/web-dir"
+
 }
 
 test_setup() {
@@ -65,7 +70,7 @@ global_teardown() {
 
 @test "ADD023: Adding a bundle over HTTPS with a valid client certificate" {
 
-	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS_HTTPS test-bundle"
+	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
 	assert_status_is 0
 	assert_file_exists "$TEST_NAME"/target-dir/usr/bin/test-file
@@ -76,7 +81,7 @@ global_teardown() {
 	# remove client certificate
 	sudo rm "$CLIENT_CERT"
 
-	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS_HTTPS test-bundle"
+	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
@@ -91,7 +96,7 @@ global_teardown() {
 	# make client certificate invalid
 	sudo sh -c "echo foo > $CLIENT_CERT"
 
-	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS_HTTPS test-bundle"
+	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM

--- a/test/functional/bundlelist/list-client-certificate.bats
+++ b/test/functional/bundlelist/list-client-certificate.bats
@@ -28,6 +28,11 @@ global_setup() {
 	create_trusted_cacert "$server_pub"
 
 	start_web_server -c "$client_pub" -p "$server_pub" -k "$server_key"
+
+	# Set the web server as our upstream server
+	port=$(get_web_server_port "$TEST_NAME")
+	set_upstream_server "$TEST_NAME" "https://localhost:$port/$TEST_NAME/web-dir"
+
 }
 
 test_setup() {
@@ -63,7 +68,7 @@ global_teardown() {
 
 @test "LST003: List all available bundles over HTTPS with a valid client certificate" {
 
-	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS_HTTPS --all"
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --all"
 
 	assert_status_is 0
 }
@@ -73,7 +78,7 @@ global_teardown() {
 	# remove client certificate
 	sudo rm "$CLIENT_CERT"
 
-	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS_HTTPS --all"
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --all"
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
@@ -88,7 +93,7 @@ global_teardown() {
 	# make client certificate invalid
 	sudo sh -c "echo foo > $CLIENT_CERT"
 
-	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS_HTTPS --all"
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --all"
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM

--- a/test/functional/bundleremove/remove-client-certificate.bats
+++ b/test/functional/bundleremove/remove-client-certificate.bats
@@ -29,6 +29,11 @@ global_setup() {
 	create_trusted_cacert "$server_pub"
 
 	start_web_server -c "$client_pub" -p "$server_pub" -k "$server_key"
+
+	# Set the web server as our upstream server
+	port=$(get_web_server_port "$TEST_NAME")
+	set_upstream_server "$TEST_NAME" "https://localhost:$port/$TEST_NAME/web-dir"
+
 }
 
 test_setup() {
@@ -66,7 +71,7 @@ global_teardown() {
 
 @test "REM014: Removing bundle over HTTPS with a valid client certificate" {
 
-	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS_HTTPS test-bundle"
+	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle"
 
 	assert_status_is 0
 	assert_file_not_exists "$TEST_NAME"/target-dir/foo/test-file
@@ -77,7 +82,7 @@ global_teardown() {
 	# remove client certificate
 	sudo rm "$CLIENT_CERT"
 
-	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS_HTTPS test-bundle"
+	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle"
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
@@ -92,7 +97,7 @@ global_teardown() {
 	# make client certificate invalid
 	sudo sh -c "echo foo > $CLIENT_CERT"
 
-	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS_HTTPS test-bundle"
+	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle"
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM

--- a/test/functional/search/search-client-certificate.bats
+++ b/test/functional/search/search-client-certificate.bats
@@ -29,6 +29,11 @@ global_setup() {
 	create_trusted_cacert "$server_pub"
 
 	start_web_server -c "$client_pub" -p "$server_pub" -k "$server_key"
+
+	# Set the web server as our upstream server
+	port=$(get_web_server_port "$TEST_NAME")
+	set_upstream_server "$TEST_NAME" "https://localhost:$port/$TEST_NAME/web-dir"
+
 }
 
 test_setup() {
@@ -64,7 +69,7 @@ global_teardown() {
 
 @test "SRH012: Search for bundles over HTTPS with a valid client certificate" {
 
-	run sudo sh -c "$SWUPD search $SWUPD_OPTS_HTTPS test-file"
+	run sudo sh -c "$SWUPD search $SWUPD_OPTS test-file"
 
 	assert_status_is 0
 }
@@ -74,7 +79,7 @@ global_teardown() {
 	# remove client certificate
 	sudo rm "$CLIENT_CERT"
 
-	run sudo sh -c "$SWUPD search $SWUPD_OPTS_HTTPS test-file"
+	run sudo sh -c "$SWUPD search $SWUPD_OPTS test-file"
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
@@ -89,7 +94,7 @@ global_teardown() {
 	# make client certificate invalid
 	sudo sh -c "echo foo > $CLIENT_CERT"
 
-	run sudo sh -c "$SWUPD search $SWUPD_OPTS_HTTPS test-file"
+	run sudo sh -c "$SWUPD search $SWUPD_OPTS test-file"
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -286,9 +286,6 @@ set_env_variables() { # swupd_function
 	if [ -f "$PORT_FILE" ]; then
 		PORT=$(cat "$PORT_FILE")
 		export PORT
-		export SWUPD_OPTS_HTTPS="$SWUPD_OPTS -u https://localhost:$PORT/$env_name/web-dir"
-		export SWUPD_OPTS_HTTP="$SWUPD_OPTS -u http://localhost:$PORT/$env_name/web-dir"
-		export SWUPD_OPTS_HTTP_NO_CERT="-S $path/$env_name/state -p $path/$env_name/target-dir -F staging -u http://localhost:$PORT/$env_name/web-dir/"
 	fi
 
 	if [ -f "$SERVER_PID_FILE" ]; then
@@ -1598,7 +1595,7 @@ start_web_server() { # swupd_function
 	# wait for server to be available
 	for i in $(seq 1 100); do
 		if [ -f "$PORT_FILE" ]; then
-			port=$(get_web_server_port)
+			port=$(get_web_server_port "$TEST_NAME")
 			status=0
 
 			# use https when the server is using certificates

--- a/test/functional/verify/verify-client-certificate.bats
+++ b/test/functional/verify/verify-client-certificate.bats
@@ -28,6 +28,11 @@ global_setup() {
 	create_trusted_cacert "$server_pub"
 
 	start_web_server -c "$client_pub" -p "$server_pub" -k "$server_key"
+
+	# Set the web server as our upstream server
+	port=$(get_web_server_port "$TEST_NAME")
+	set_upstream_server "$TEST_NAME" "https://localhost:$port/$TEST_NAME/web-dir"
+
 }
 
 test_setup() {
@@ -63,7 +68,7 @@ global_teardown() {
 
 @test "VER013: Verify installed content on a system over HTTPS with a valid client certificate" {
 
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS_HTTPS"
+	run sudo sh -c "$SWUPD verify $SWUPD_OPTS"
 
 	assert_status_is 0
 }
@@ -73,7 +78,7 @@ global_teardown() {
 	# remove client certificate
 	sudo rm "$CLIENT_CERT"
 
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS_HTTPS"
+	run sudo sh -c "$SWUPD verify $SWUPD_OPTS"
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
@@ -88,7 +93,7 @@ global_teardown() {
 	# make client certificate invalid
 	sudo sh -c "echo foo > $CLIENT_CERT"
 
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS_HTTPS"
+	run sudo sh -c "$SWUPD verify $SWUPD_OPTS"
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM


### PR DESCRIPTION
The tests that attempt to verify the client certificate were using the
swupd -u option to set the url of the "upstream server". Recently a
function was added to the test library to set the default upstream
server.

This commit modifies these tests so they used the new function to set
the upstream server instead of using the -u option. This will provide
the benefit of the test environment being more similar to a prod
environment, also makes the test setup less convoluted and the tests
easier to read.

This PR is built on top of PR #739, once that PR merges this will have to be rebased.