### PR TITLE
Moving experimental flag from 4th to 2nd position

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -278,6 +278,8 @@ static struct manifest *manifest_from_file(int version, char *component, bool he
 			file->is_deleted = 1;
 			file->is_ghosted = 1;
 			deleted++;
+		} else if (c[1] == 'e') {
+			file->is_experimental = 1;
 		} else if (c[1] != '.') { /* unknown modifier #1 */
 			free(file);
 			goto err;
@@ -299,8 +301,6 @@ static struct manifest *manifest_from_file(int version, char *component, bool he
 		} else if (c[3] == 'm') {
 			file->is_mix = 1;
 			manifest->is_mix = 1;
-		} else if (c[3] == 'e') {
-			file->is_experimental = 1;
 		} else if (c[3] != '.') { /* unknown modifier #3 */
 			free(file);
 			goto err;

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -688,7 +688,7 @@ add_to_manifest() { # swupd_function
 	fi
 	sudo sed -i "s/^contentsize:.*/contentsize:\\t$contentsize/" "$manifest"
 	# add to manifest content
-	write_to_protected_file -a "$manifest" "$item_type.$boot_type$experimental\\t$name\\t$version\\t$item_path\\n"
+	write_to_protected_file -a "$manifest" "$item_type$experimental$boot_type.\\t$name\\t$version\\t$item_path\\n"
 	# If a manifest tar already exists for that manifest, renew the manifest tar unless specified otherwise
 	if [ "$partial" = false ]; then
 		retar_manifest "$manifest"


### PR DESCRIPTION
There was a change of plans in the mixer side and looks like the flag
that will be used to mark a bundle as an experimental will be the 2nd
one instead of the 4th one.

This commit moves the flag to the 2nd position in the swupd client.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>