### PR TITLE
Add compile-time warning flags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,23 @@ SUFFIXES= .rst
 
 EXTRA_DIST = COPYING scripts/findstatic.pl swupd.bash
 
-AM_CFLAGS = -fPIC -O2 -g -Wall -W -Wformat-security -D_FORTIFY_SOURCE=2 -fno-common -std=gnu99
+AM_CFLAGS = -fPIC -O2 -g -D_FORTIFY_SOURCE=2 -fno-common -std=gnu99 \
+	-Wall \
+	-Wextra \
+	-Wpedantic \
+	-Wformat-security \
+	-Wpointer-arith \
+	-Wlogical-op \
+	-Wunreachable-code \
+	-Wswitch-default \
+	-Wcast-align \
+	-Wbad-function-cast \
+	-Winline \
+	-Wundef \
+	-Wnested-externs \
+	-Wno-missing-field-initializers \
+	-Wredundant-decls
+
 ACLOCAL_AMFLAGS = -I m4
 
 bin_PROGRAMS = swupd

--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -63,6 +63,8 @@ static bool parse_opt(int opt, UNUSED_PARAM char *optarg)
 		fprintf(stderr, "Error: [-l, --list] option is deprecated, use\n"
 				"bundle-list [-a|--all] sub-command instead.\n\n");
 		exit(EXIT_FAILURE);
+	default:
+		return false;
 	}
 	return false;
 }

--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -90,6 +90,8 @@ static bool parse_opt(int opt, char *optarg)
 		atexit(free_deps);
 		cmdline_local = false;
 		return true;
+	default:
+		return false;
 	}
 	return false;
 }

--- a/src/delta.c
+++ b/src/delta.c
@@ -41,7 +41,7 @@
 static bool compute_hash_from_file(char *filename, char *hash)
 {
 	/* TODO: implement this without the indirection of creating a file... */
-	struct file f = {};
+	struct file f = { 0 };
 
 	f.filename = filename;
 	f.use_xattrs = true;
@@ -135,8 +135,8 @@ void apply_deltas(struct manifest *current_manifest)
 		char *delta_file;
 		string_or_die(&delta_file, "%s/%s", delta_dir, delta_name);
 
-		char from[SWUPD_HASH_LEN] = {};
-		char to[SWUPD_HASH_LEN] = {};
+		char from[SWUPD_HASH_LEN] = { 0 };
+		char to[SWUPD_HASH_LEN] = { 0 };
 		if (!check_delta_filename(delta_name, &from[0], &to[0])) {
 			fprintf(stderr, "Invalid name for delta file: %s\n", delta_file);
 			goto next;

--- a/src/globals.c
+++ b/src/globals.c
@@ -648,6 +648,8 @@ static bool global_parse_opt(int opt, char *optarg)
 			return false;
 		}
 		return true;
+	default:
+		return false;
 	}
 
 	return false;
@@ -659,6 +661,8 @@ static bool global_parse_deprecated(int opt, char *optarg)
 	case 'D':
 		fprintf(stderr, "Deprecated option -D was renamed. Prefer using -W or --max-parallel-downloads.\n\n");
 		return global_parse_opt('W', optarg);
+	default:
+		return false;
 	}
 
 	return false;

--- a/src/hash.c
+++ b/src/hash.c
@@ -222,7 +222,7 @@ int compute_hash(struct file *file, char *filename)
 
 bool verify_file(struct file *file, char *filename)
 {
-	struct file local = {};
+	struct file local = { 0 };
 
 	local.filename = file->filename;
 	/*
@@ -245,7 +245,7 @@ bool verify_file(struct file *file, char *filename)
 
 bool verify_file_lazy(char *filename)
 {
-	struct file local = {};
+	struct file local = { 0 };
 
 	if (compute_hash_lazy(&local, filename) != 0) {
 		return false;

--- a/src/mirror.c
+++ b/src/mirror.c
@@ -70,6 +70,8 @@ static bool parse_opt(int opt, char *optarg)
 		}
 		unset = true;
 		return true;
+	default:
+		return false;
 	}
 	return false;
 }

--- a/src/search.c
+++ b/src/search.c
@@ -419,6 +419,8 @@ static bool parse_opt(int opt, char *optarg)
 	case 'd':
 		display_files = true;
 		return true;
+	default:
+		return false;
 	}
 	return false;
 }

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -251,32 +251,32 @@ static inline void account_deleted_file(void)
 static inline void account_changed_file(void)
 {
 	swupd_stats[2]++;
-};
+}
 
 static inline void account_new_bundle(void)
 {
 	swupd_stats[3]++;
-};
+}
 
 static inline void account_deleted_bundle(void)
 {
 	swupd_stats[4]++;
-};
+}
 
 static inline void account_changed_bundle(void)
 {
 	swupd_stats[5]++;
-};
+}
 
 static inline void account_delta_hit(void)
 {
 	swupd_stats[6]++;
-};
+}
 
 static inline void account_delta_miss(void)
 {
 	swupd_stats[7]++;
-};
+}
 
 extern void print_statistics(int version1, int version2);
 

--- a/src/update.c
+++ b/src/update.c
@@ -632,6 +632,8 @@ static bool parse_opt(int opt, char *optarg)
 	case 'k':
 		keepcache = true;
 		return true;
+	default:
+		return false;
 	}
 
 	return false;

--- a/src/verify.c
+++ b/src/verify.c
@@ -555,6 +555,8 @@ static bool parse_opt(int opt, char *optarg)
 		}
 		cmdline_option_picky_whitelist = optarg;
 		return true;
+	default:
+		return false;
 	}
 	return false;
 }


### PR DESCRIPTION
Note: Wpedantic adds a bunch of warnings right now.

All warning-related flags are on their own lines, because they look very
messy if they're all shoved together. Enabled many more warnings and
made warnings fatal.

Signed-off-by: Brian J Lovin <brian.j.lovin@intel.com>