### PR TITLE
curl: Don't warn users on non critical SSL errors

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -122,10 +122,10 @@ static int check_connection(const char *test_capath)
 	case CURLE_OK:
 		return 0;
 	case CURLE_SSL_CACERT:
-		fprintf(stderr, "Error: unable to verify server SSL certificate\n");
+		fprintf(stderr, "Warning: Unable to verify server SSL certificate\n");
 		return -EBADCERT;
 	case CURLE_SSL_CERTPROBLEM:
-		fprintf(stderr, "Curl: Problem with the local client SSL certificate\n");
+		fprintf(stderr, "Warning: Problem with the local client SSL certificate\n");
 		return -EBADCERT;
 	default:
 		swupd_curl_strerror(curl_ret);
@@ -171,6 +171,7 @@ int swupd_curl_init(void)
 				continue;
 			}
 
+			fprintf(stderr, "Trying fallback CA path %s\n", tok);
 			ret = check_connection(tok);
 			if (ret == 0) {
 				capath = strdup_or_die(tok);

--- a/test/functional/bundleadd/add-client-certificate.bats
+++ b/test/functional/bundleadd/add-client-certificate.bats
@@ -80,7 +80,7 @@ global_teardown() {
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
-			Error: unable to verify server SSL certificate
+			Warning: Unable to verify server SSL certificate
 	EOM
 	)
 	assert_in_output "$expected_output"
@@ -95,7 +95,7 @@ global_teardown() {
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
-			Curl: Problem with the local client SSL certificate
+			Warning: Problem with the local client SSL certificate
 	EOM
 	)
 	assert_in_output "$expected_output"

--- a/test/functional/bundlelist/list-client-certificate.bats
+++ b/test/functional/bundlelist/list-client-certificate.bats
@@ -77,7 +77,7 @@ global_teardown() {
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
-			Error: unable to verify server SSL certificate
+			Warning: Unable to verify server SSL certificate
 	EOM
 	)
 	assert_in_output "$expected_output"
@@ -92,7 +92,7 @@ global_teardown() {
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
-			Curl: Problem with the local client SSL certificate
+			Warning: Problem with the local client SSL certificate
 	EOM
 	)
 	assert_in_output "$expected_output"

--- a/test/functional/bundleremove/remove-client-certificate.bats
+++ b/test/functional/bundleremove/remove-client-certificate.bats
@@ -81,7 +81,7 @@ global_teardown() {
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
-			Error: unable to verify server SSL certificate
+			Warning: Unable to verify server SSL certificate
 	EOM
 	)
 	assert_in_output "$expected_output"
@@ -96,7 +96,7 @@ global_teardown() {
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
-			Curl: Problem with the local client SSL certificate
+			Warning: Problem with the local client SSL certificate
 	EOM
 	)
 	assert_in_output "$expected_output"

--- a/test/functional/checkupdate/chk-update-client-certificate.bats
+++ b/test/functional/checkupdate/chk-update-client-certificate.bats
@@ -84,7 +84,7 @@ global_teardown() {
 	assert_status_is "$ENOSWUPDSERVER"
 
 	expected_output=$(cat <<-EOM
-			Error: unable to verify server SSL certificate
+			Warning: Unable to verify server SSL certificate
 	EOM
 	)
 	assert_in_output "$expected_output"
@@ -101,7 +101,7 @@ global_teardown() {
 	assert_status_is "$ENOSWUPDSERVER"
 
 	expected_output=$(cat <<-EOM
-			Curl: Problem with the local client SSL certificate
+			Warning: Problem with the local client SSL certificate
 	EOM
 	)
 	assert_in_output "$expected_output"

--- a/test/functional/search/search-client-certificate.bats
+++ b/test/functional/search/search-client-certificate.bats
@@ -78,7 +78,7 @@ global_teardown() {
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
-			Error: unable to verify server SSL certificate
+			Warning: Unable to verify server SSL certificate
 	EOM
 	)
 	assert_in_output "$expected_output"
@@ -93,7 +93,7 @@ global_teardown() {
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
-			Curl: Problem with the local client SSL certificate
+			Warning: Problem with the local client SSL certificate
 	EOM
 	)
 	assert_in_output "$expected_output"

--- a/test/functional/update/update-client-certificate.bats
+++ b/test/functional/update/update-client-certificate.bats
@@ -82,7 +82,7 @@ global_teardown() {
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
-			Error: unable to verify server SSL certificate
+			Warning: Unable to verify server SSL certificate
 	EOM
 	)
 	assert_in_output "$expected_output"
@@ -97,7 +97,7 @@ global_teardown() {
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
-			Curl: Problem with the local client SSL certificate
+			Warning: Problem with the local client SSL certificate
 	EOM
 	)
 	assert_in_output "$expected_output"

--- a/test/functional/verify/verify-client-certificate.bats
+++ b/test/functional/verify/verify-client-certificate.bats
@@ -77,7 +77,7 @@ global_teardown() {
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
-			Error: unable to verify server SSL certificate
+			Warning: Unable to verify server SSL certificate
 	EOM
 	)
 	assert_in_output "$expected_output"
@@ -92,7 +92,7 @@ global_teardown() {
 	assert_status_is "$ECURL_INIT"
 
 	expected_output=$(cat <<-EOM
-			Curl: Problem with the local client SSL certificate
+			Warning: Problem with the local client SSL certificate
 	EOM
 	)
 	assert_in_output "$expected_output"


### PR DESCRIPTION
If we have an ssl error we try to use a fallback capath directory. Don't warn
users for errors unless we have failed on connecting using all available
fallback paths.

Fixes: #746

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>