### PR TITLE
Timeout for testing connection in swupd init

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -185,6 +185,7 @@ BATS = \
 	test/functional/update/update-newest-added.bats \
 	test/functional/update/update-newest-deleted.bats \
 	test/functional/update/update-newest-ghosted.bats \
+	test/functional/update/update-non-responsive.bats \
 	test/functional/update/update-older-server-version.bats \
 	test/functional/update/update-rename.bats \
 	test/functional/update/update-rename-ghosted.bats \

--- a/src/curl.c
+++ b/src/curl.c
@@ -91,11 +91,34 @@ exit:
 	return curl_ret;
 }
 
+static CURLcode swupd_curl_set_timeouts(CURL *curl)
+{
+	CURLcode curl_ret;
+
+	curl_ret = curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, SWUPD_CURL_CONNECT_TIMEOUT);
+	if (curl_ret != CURLE_OK) {
+		goto exit;
+	}
+
+	curl_ret = curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, SWUPD_CURL_LOW_SPEED_LIMIT);
+	if (curl_ret != CURLE_OK) {
+		goto exit;
+	}
+
+	curl_ret = curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, SWUPD_CURL_RCV_TIMEOUT);
+	if (curl_ret != CURLE_OK) {
+		goto exit;
+	}
+
+exit:
+	return curl_ret;
+}
+
 static int check_connection(const char *test_capath)
 {
 	CURLcode curl_ret;
 
-	curl_ret = curl_easy_setopt(curl, CURLOPT_URL, version_url);
+	curl_ret = swupd_curl_set_basic_options(curl, version_url);
 	if (curl_ret != CURLE_OK) {
 		return -1;
 	}
@@ -111,10 +134,6 @@ static int check_connection(const char *test_capath)
 			return -1;
 		}
 	}
-	curl_ret = swupd_curl_set_optional_client_cert(curl);
-	if (curl_ret != CURLE_OK) {
-		return -1;
-	}
 
 	curl_ret = curl_easy_perform(curl);
 
@@ -127,6 +146,8 @@ static int check_connection(const char *test_capath)
 	case CURLE_SSL_CERTPROBLEM:
 		fprintf(stderr, "Curl: Problem with the local client SSL certificate\n");
 		return -EBADCERT;
+	case CURLE_OPERATION_TIMEDOUT:
+		return -CURLE_OPERATION_TIMEDOUT;
 	default:
 		swupd_curl_strerror(curl_ret);
 		/* something bad, stop */
@@ -159,6 +180,9 @@ int swupd_curl_init(void)
 	ret = check_connection(NULL);
 	if (ret == 0) {
 		return 0;
+	} else if (ret == -CURLE_OPERATION_TIMEDOUT) {
+		fprintf(stderr, "Error: Communicating with server timed out.\n");
+		return -1;
 	}
 
 	if (FALLBACK_CAPATHS[0]) {
@@ -588,17 +612,7 @@ CURLcode swupd_curl_set_basic_options(CURL *curl, const char *url)
 		}
 	}
 
-	curl_ret = curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, SWUPD_CURL_CONNECT_TIMEOUT);
-	if (curl_ret != CURLE_OK) {
-		goto exit;
-	}
-
-	curl_ret = curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, SWUPD_CURL_LOW_SPEED_LIMIT);
-	if (curl_ret != CURLE_OK) {
-		goto exit;
-	}
-
-	curl_ret = curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, SWUPD_CURL_RCV_TIMEOUT);
+	curl_ret = swupd_curl_set_timeouts(curl);
 	if (curl_ret != CURLE_OK) {
 		goto exit;
 	}

--- a/test/functional/server.py
+++ b/test/functional/server.py
@@ -230,11 +230,8 @@ if __name__ == "__main__":
         # since this is going to change the working directory for python
         # it needs to be run in the end so it does not affect other variables
         # that were based on the original path
-        directory = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)),
-            args.directory)
         # change the current working dir to that one we want to serve
-        os.chdir(directory)
+        os.chdir(args.directory)
 
     try:
         httpd.serve_forever()

--- a/test/functional/update/update-non-responsive.bats
+++ b/test/functional/update/update-non-responsive.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	# Skip this test if not running in Travis CI, because test takes too long for
+	# local development.
+	# To run this locally along with all other tests do:
+	#    TRAVIS=true make check
+	# or to run only this test locally do:
+	#    TRAVIS=true bats update-non-responsive.bats
+	if [ -z "$TRAVIS" ]; then
+		skip "Skipping slow test for local development, test only runs in CI"
+	fi
+
+	create_test_environment "$TEST_NAME"
+
+	# create an update
+	create_version -p "$TEST_NAME" 20 10
+	update_bundle "$TEST_NAME" os-core --add /test_file1
+
+	# start the web server (the server will hang)
+	start_web_server -r -H -D "$WEBDIR"
+	port=$(get_web_server_port "$TEST_NAME")
+
+	# set the versionurl and contenturl to point to the web server
+	set_upstream_server "$TEST_NAME" http://localhost:"$port"/
+
+}
+
+test_teardown() {
+
+	# teardown only if in travis CI
+	if [ -n "$TRAVIS" ]; then
+		destroy_test_environment "$TEST_NAME"
+	fi
+
+}
+
+@test "UPD042: Updating a system, and the upstream server is not responding" {
+
+	# if the upstream server is unresponsive the update should fail after 2 minute
+	# timeout with a useful message
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+
+	assert_status_is "$ECURL_INIT"
+	expected_output=$(cat <<-EOM
+		Error: Communicating with server timed out.
+		Updater failed to initialize, exiting now.
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_not_exists "$TARGETDIR"/test_file1
+
+}
+
+@test "UPD043: Updating a system with a mirror set, and the mirror is not responding" {
+
+	# if the mirror is unresponsive, then the update should fail after 2 minute
+	# timeout with a useful message
+
+	# Extra setup: set the mirror in the test environment to point to the web server
+	write_to_protected_file "$TARGETDIR"/etc/swupd/mirror_versionurl http://localhost:"$port"/
+	write_to_protected_file "$TARGETDIR"/etc/swupd/mirror_contenturl http://localhost:"$port"/
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+
+	assert_status_is "$ECURL_INIT"
+	expected_output=$(cat <<-EOM
+		Error: Communicating with server timed out.
+		Updater failed to initialize, exiting now.
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_not_exists "$TARGETDIR"/test_file1
+
+}
+
+@test "UPD044: Updating a system, and the upstream server is not responding but a mirror is set" {
+
+	# if the upstream server is unresponsive but the user has a working
+	# mirror set up, then the update should work normally since it should
+	# use the mirror
+
+	# Extra setup: set a mirror in the test environment
+	create_mirror "$TEST_NAME"
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Update started.
+		Curl: Communicating with server timed out.
+		Preparing to update from 10 to 20
+		Downloading packs...
+		Extracting os-core pack for version 20
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 1
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 0
+		    new files         : 1
+		    deleted files     : 0
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Staging file content
+		Applying update
+		Update was applied.
+		Calling post-update helper scripts.
+		Update successful. System updated from version 10 to version 20
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/test_file1
+
+}

--- a/test/functional/update/update-slow-server.bats
+++ b/test/functional/update/update-slow-server.bats
@@ -3,6 +3,7 @@
 load "../testlib"
 
 test_setup() {
+
 	# Skip this test if not running in Travis CI, because test takes too long for
 	# local development. To run this locally do: TRAVIS=true make check
 	if [ -z "${TRAVIS}" ]; then
@@ -13,15 +14,16 @@ test_setup() {
 	create_version -p "$TEST_NAME" 100 10
 	update_bundle "$TEST_NAME" test-bundle --update /foo/bar
 
-	start_web_server -d pack-test-bundle-from-10.tar -s
+	start_web_server -D "$WEBDIR" -d 100/pack-test-bundle-from-10.tar -s
 
 	# Set the web server as our upstream server
 	port=$(get_web_server_port "$TEST_NAME")
-	set_upstream_server "$TEST_NAME" "http://localhost:$port/$TEST_NAME/web-dir"
+	set_upstream_server "$TEST_NAME" "http://localhost:$port"
 
 }
 
 test_teardown() {
+
 	# teardown only if in travis CI
 	if [ -n "${TRAVIS}" ]; then
 		destroy_test_environment "$TEST_NAME"
@@ -38,7 +40,7 @@ test_teardown() {
 		Update started.
 		Preparing to update from 10 to 100
 		Downloading packs...
-		Error for .*/state/pack-test-bundle-from-10-to-100.tar download: Response 206 - No error
+		Error for .*/state/pack-test-bundle-from-10-to-100.tar download: Response 206 - Transferred a partial file
 		Starting download retry #1 for .*100/pack-test-bundle-from-10.tar
 		Error for .*/state/pack-test-bundle-from-10-to-100.tar download: Response 200 - Requested range was not delivered by the server
 		Range command not supported by server, download resume disabled.


### PR DESCRIPTION
As part of the swupd initialization, curl is initialized, which means it
is configured and the connection is tested. When configuring curl for
this test, no timeout was being configured, which was causing curl to
hang waiting for a response from the server if the server was unresponsive.

This commit configures the curl timeouts the same way they are being
configured when downloading files, so in case we get an unresponsive
server (or mirror) it doesn't get stuck forever.

Closes #669

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>