### PR TITLE
Add space to separate 'mixin build' command

### DIFF
--- a/src/update.c
+++ b/src/update.c
@@ -270,9 +270,7 @@ version_check:
 				fclose(verfile);
 			}
 
-			if (run_command("/usr/bin/mixin"
-					"build",
-					NULL) != 0) {
+			if (run_command("/usr/bin/mixin", "build", NULL) != 0) {
 				fprintf(stderr, "ERROR: Could not execute mixin\n");
 				ret = EXIT_FAILURE;
 				goto clean_curl;


### PR DESCRIPTION
The run_command calls /usr/bin/mixinbuild, but it should call
/usr/bin/mixin build.

Signed-off-by: John Akre <john.w.akre@intel.com>