### PR TITLE
Testlib improvements

### DIFF
--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -339,23 +339,30 @@ create_dir() { # swupd_function
 
 # Generates a file with a hashed name in the specified path
 # Parameters:
-# - PATH: the path where the file will be created    
+# - PATH: the path where the file will be created
+# - SIZE: the size of the file (in bytes), if nothing is specified the size
+#         will be random but fairly small
 create_file() { # swupd_function
  
 	local path=$1
+	local size=$2
 	local hashed_name
 
 	# If no parameters are received show usage
 	if [ $# -eq 0 ]; then
 		cat <<-EOM
 			Usage:
-			    create_file <path>
+			    create_file <path> [size in bytes]
 			EOM
 		return
 	fi
 	validate_path "$path"
 
-	generate_random_content | sudo tee "$path/testfile" > /dev/null
+	if [ -n "$size" ]; then
+		head -c "$size" /dev/urandom | sudo tee "$path/testfile" > /dev/null
+	else
+		generate_random_content | sudo tee "$path/testfile" > /dev/null
+	fi
 	hashed_name=$(sudo "$SWUPD" hashdump "$path"/testfile 2> /dev/null)
 	sudo mv "$path"/testfile "$path"/"$hashed_name"
 	# since tar is all we use, create a tar for the new file

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -175,7 +175,13 @@ print() { # swupd_function
 	fi
 
 	local msg=$1
-	echo -e "$msg" >&3
+	# if file descriptor 3 is not available (for example when sourcing the library
+	# from the command line) use std output instead
+	if { >&3; } 2> /dev/null; then
+		echo -e "$msg" >&3
+	else
+		echo -e "$msg"
+	fi
 
 }
 

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1638,9 +1638,9 @@ start_web_server() { # swupd_function
 				# to avoid hanging the server while testing for the connection to be ready
 				# when the -H (hang server) option is set, we need to use the special url
 				# "/test-connection"
-				curl https://localhost:"$port"/test-connection || status=$?
+				curl https://localhost:"$port"/test-connection > /dev/null --silent || status=$?
 			else
-				curl http://localhost:"$port"/test-connection || status=$?
+				curl http://localhost:"$port"/test-connection > /dev/null --silent || status=$?
 			fi
 
 			# the web server is ready for connections when 0 or 60 is returned. When using


### PR DESCRIPTION
This PR includes the following improvements for testlib:

- Ability to create files with specific size, useful for creating bundles
with files of a known size, or really big files.
- Silencing output when starting a test web server.
- Use std out if there is no file descriptor 3 when using _print_. 