### PR TITLE
Log - curl downloads

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,9 @@ swupd_SOURCES = \
 	src/lib/sys.c \
 	src/lib/sys.h \
 	src/lock.c \
+	src/lib/log.c \
+	src/lib/log.h \
+	src/macros.h \
 	src/main.c \
 	src/manifest.c \
 	src/mirror.c \

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -29,6 +29,7 @@
 #include <unistd.h>
 
 #include "swupd.h"
+#include "lib/log.h"
 #include "verifytime.h"
 
 static void print_help(void)

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -64,13 +64,13 @@ static int check_update()
 	if (ret != 0) {
 		return ret;
 	} else {
-		fprintf(stderr, "Current OS version: %d\n", current_version);
+		info("Current OS version: %d\n", current_version);
 		if (current_version < server_version) {
-			fprintf(stderr, "There is a new OS version available: %d\n", server_version);
+			info("There is a new OS version available: %d\n", server_version);
 			update_motd(server_version);
 			return 0; /* update available */
 		} else if (current_version >= server_version) {
-			fprintf(stderr, "There are no updates available\n");
+			info("There are no updates available\n");
 		}
 		return 1; /* No update available */
 	}
@@ -92,7 +92,7 @@ static bool parse_options(int argc, char **argv)
 	}
 
 	if (argc > optind) {
-		fprintf(stderr, "Error: unexpected arguments\n\n");
+		error("unexpected arguments\n\n");
 		return false;
 	}
 

--- a/src/curl.c
+++ b/src/curl.c
@@ -385,11 +385,13 @@ restart_download:
 		goto exit;
 	}
 
+	debug("CURL - start sync download: %s -> %s\n", url, in_memory_file ? "<memory>" : filename);
 	curl_ret = curl_easy_perform(curl);
 	if (curl_ret == CURLE_OK || curl_ret == CURLE_HTTP_RETURNED_ERROR) {
 		curl_ret = curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &ret);
 	}
 
+	debug("CURL - completed sync download: curl ret %d, http response  %d\n", curl_ret, ret);
 exit:
 	if (!in_memory_file) {
 		curl_ret = swupd_download_file_complete(curl_ret, &local);

--- a/src/download.c
+++ b/src/download.c
@@ -258,6 +258,7 @@ static int perform_curl_io_and_complete(struct swupd_curl_parallel_handle *h, in
 		}
 		local_download = strncmp(url, "file://", 7) == 0;
 
+		debug("CURL - complete ASYNC download: %s -> %s\n", file->url, file->file.path);
 		/* Get error code from easy handle and augment it if
 		 * completing the download encounters further problems. */
 		curl_ret = swupd_download_file_complete(msg->data.result, &file->file);
@@ -458,6 +459,7 @@ static int process_download(struct swupd_curl_parallel_handle *h, struct multi_c
 		goto out_bad;
 	}
 
+	debug("CURL - start ASYNC download: %s -> %s\n", file->url, file->file.path);
 	curlm_ret = curl_multi_add_handle(h->mcurl, curl);
 	if (curlm_ret != CURLM_OK) {
 		goto out_bad;

--- a/src/globals.c
+++ b/src/globals.c
@@ -31,6 +31,7 @@
 #include <unistd.h>
 
 #include "config.h"
+#include "lib/log.h"
 #include "swupd.h"
 bool allow_mix_collisions = false;
 bool force = false;
@@ -72,6 +73,7 @@ bool content_url_is_local = false;
 char *cert_path = NULL;
 int update_server_port = -1;
 static int max_parallel_downloads = -1;
+static int log_level = LOG_INFO;
 char *swupd_cmd = NULL;
 
 /* If the MIX_BUNDLES_DIR has the valid-mix flag file we can run through
@@ -559,6 +561,8 @@ static const struct option global_opts[] = {
 	{ "time", no_argument, 0, 't' },
 	{ "url", required_argument, 0, 'u' },
 	{ "versionurl", required_argument, 0, 'v' },
+	{ "quiet", no_argument, &log_level, LOG_ERROR },
+	{ "debug", no_argument, &log_level, LOG_DEBUG },
 	//TODO: -D option is deprecated. Remove that on a Major release
 	{ "", required_argument, 0, 'D' },
 	{ 0, 0, 0, 0 }
@@ -756,6 +760,14 @@ int global_parse_options(int argc, char **argv, const struct global_options *opt
 
 		ret = -1;
 		goto end;
+	}
+
+	set_log_level(log_level);
+	//TODO: Remove this on a major release
+	if (log_level == LOG_ERROR) {
+		print("Experimental option --quiet. Not fully supported yet.\n");
+	} else if (log_level == LOG_DEBUG) {
+		print("Experimental option --debug. Not fully supported yet.\n");
 	}
 
 end:

--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -1,0 +1,66 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2012-2016 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define _GNU_SOURCE
+
+#include <stdarg.h>
+#include <time.h>
+
+#include "log.h"
+#define DEBUG_HEADER_SIZE 50
+
+static int cur_log_level = LOG_INFO;
+
+void set_log_level(int log_level)
+{
+	cur_log_level = log_level;
+}
+
+void log_full(int log_level, FILE *out, const char *file, int line, const char *label, const char *format, ...)
+{
+	if (cur_log_level < log_level) {
+		return;
+	}
+
+	char time_str[50];
+	va_list ap;
+	struct tm *timeinfo;
+	int printed;
+
+	// In debug mode, print more information
+	if (cur_log_level == LOG_DEBUG) {
+		time_t currtime;
+		time(&currtime);
+		timeinfo = localtime(&currtime);
+		strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", timeinfo);
+
+		printed = fprintf(out, "%s (%s:%d)", time_str, file, line);
+		if (printed < DEBUG_HEADER_SIZE) {
+			fprintf(out, "%*c", 50 - printed, ' ');
+		}
+	}
+
+	if (label) {
+		fprintf(out, "%s: ", label);
+	}
+
+	va_start(ap, format);
+	vfprintf(out, format, ap);
+	va_end(ap);
+}

--- a/src/lib/log.h
+++ b/src/lib/log.h
@@ -1,0 +1,40 @@
+#ifndef __SWUPD_LOG__
+#define __SWUPD_LOG__
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LOG_ALWAYS 0
+#define LOG_ERROR 2
+#define LOG_WARN 4
+#define LOG_INFO 6
+#define LOG_DEBUG 8
+
+/*
+ * Set the minimum priority log to be printed by log functions.
+ */
+void set_log_level(int log_level);
+
+/*
+ * Print a message to 'out' if 'log_level' is greater or equal the log level
+ * set by set_log_level().
+ */
+void log_full(int log_level, FILE *out, const char *file, int line, const char *label, const char *format, ...);
+
+/*
+ * Helpers for logging: print(), error(), warn(), info(), debug()
+ */
+#define print(_fmt, ...) log_full(LOG_ALWAYS, stdout, __FILE__, __LINE__, NULL, _fmt, ##__VA_ARGS__);
+#define error(_fmt, ...) log_full(LOG_ERROR, stderr, __FILE__, __LINE__, "Error", _fmt, ##__VA_ARGS__);
+#define warn(_fmt, ...) log_full(LOG_WARN, stderr, __FILE__, __LINE__, "Warning", _fmt, ##__VA_ARGS__);
+#define info(_fmt, ...) log_full(LOG_INFO, stdout, __FILE__, __LINE__, NULL, _fmt, ##__VA_ARGS__);
+#define debug(_fmt, ...) log_full(LOG_DEBUG, stdout, __FILE__, __LINE__, "Debug", _fmt, ##__VA_ARGS__);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -15,6 +15,7 @@
 #include "lib/macros.h"
 #include "lib/strings.h"
 #include "lib/sys.h"
+#include "lib/log.h"
 #include "swupd-error.h"
 #include "timelist.h"
 


### PR DESCRIPTION
I have a local code with prints I use to debug some download bugs. I didn't commit that before because it's too verbose to print it always.

This series introduce a new log API and 2 new flags (--debug and --quiet) and a commit using that to print download debug information. As those flags are experimental and are not completely finished (--quiet is far from quiet in current master) I didn't added that to the documentation or help messages.