### PR TITLE
Makefile: Only run shellcheck on scripts that have changed in current…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
         - sudo apt-get install clang-format-6.0
         - sudo apt-get install shellcheck
         - sudo ln -s /usr/share/docutils/scripts/python3/rst2man /usr/bin/rst2man.py
+        - git fetch origin master:refs/remotes/origin/master #Download origin/master for shelcheck
 
 # Ubuntu's default umask is 0002, but this break's swupd hash calculations.
 script:

--- a/Makefile.am
+++ b/Makefile.am
@@ -302,6 +302,14 @@ compliant:
 # Ignore SC1008 because scripts are using an unsupported shebang
 # TODO: Run shellcheck in testlib after issue #662 is fixed
 shellcheck:
+	for i in $$(git diff --name-only origin/master HEAD | \grep -E "\.bats|\.bash" | \grep -v testlib.bash); do \
+		echo checking "$$i"; \
+		sed 's/^@.*/func() {/' "$$i" | \
+		sed 's/^load.*/source test\/functional\/testlib.bash/' | \
+		shellcheck -s bash -x -e SC1008 /dev/stdin; \
+	done
+
+shellcheck-all:
 	shellcheck -e SC2207 swupd.bash
 	find -name "*.bats" -exec sh -c "\
 		echo checking {}; \


### PR DESCRIPTION
… branch

Use origin/master branch to check which bash and bats scripts have changed and
run shellcheck only on them. This intends to make travis check faster.