### PR TITLE
Do not retry files download if there is no more space on disk

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -166,11 +166,6 @@ BATS = \
 	test/functional/checkupdate/chk-update-version-match.bats \
 	test/functional/completion/completion-basic.bats \
 	test/functional/hashdump/hashdump-file-hash.bats \
-	test/functional/verify/verify-install.bats \
-	test/functional/verify/verify-install-bad.bats \
-	test/functional/verify/verify-install-multiple.bats \
-	test/functional/verify/verify-install-no-fullfile-fallbacks.bats \
-	test/functional/verify/verify-install-no-zero-packs.bats \
 	test/functional/mirror/mirror-createdir.bats \
 	test/functional/mirror/mirror-createdir-negative.bats \
 	test/functional/search/search-content-check-negative.bats \
@@ -227,10 +222,16 @@ BATS = \
 	test/functional/verify/verify-format-mismatch-override.bats \
 	test/functional/verify/verify-ghosted.bats \
 	test/functional/verify/verify-good.bats \
+	test/functional/verify/verify-install-bad.bats \
+	test/functional/verify/verify-install.bats \
 	test/functional/verify/verify-install-directory.bats \
 	test/functional/verify/verify-install-latest-directory.bats \
+	test/functional/verify/verify-install-multiple.bats \
+	test/functional/verify/verify-install-no-fullfile-fallbacks.bats \
+	test/functional/verify/verify-install-no-zero-packs.bats \
 	test/functional/verify/verify-latest-missing.bats \
 	test/functional/verify/verify-missing-file.bats \
+	test/functional/verify/verify-no-disk-space.bats \
 	test/functional/verify/verify-picky.bats \
 	test/functional/verify/verify-picky-downgrade.bats \
 	test/functional/verify/verify-picky-ghosted.bats \

--- a/Makefile.am
+++ b/Makefile.am
@@ -149,6 +149,7 @@ BATS = \
 	test/functional/bundlelist/list-has-dep-nested-server.bats \
 	test/functional/bundlelist/list-installed.bats \
 	test/functional/bundlelist/list-no-deps.bats \
+	test/functional/bundlelist/list-no-disk-space.bats \
 	test/functional/bundlelist/list-none-has-deps.bats \
 	test/functional/bundleremove/remove-basics.bats \
 	test/functional/bundleremove/remove-boot-file.bats \

--- a/Makefile.am
+++ b/Makefile.am
@@ -191,6 +191,7 @@ BATS = \
 	test/functional/update/update-newest-deleted.bats \
 	test/functional/update/update-newest-ghosted.bats \
 	test/functional/update/update-non-responsive.bats \
+	test/functional/update/update-no-disk-space.bats \
 	test/functional/update/update-older-server-version.bats \
 	test/functional/update/update-rename.bats \
 	test/functional/update/update-rename-ghosted.bats \

--- a/Makefile.am
+++ b/Makefile.am
@@ -174,6 +174,7 @@ BATS = \
 	test/functional/search/search-content-check-positive.bats \
 	test/functional/search/search-client-certificate.bats \
 	test/functional/search/search-experimental.bats \
+	test/functional/search/search-no-disk-space.bats \
 	test/functional/update/update-boot-file.bats \
 	test/functional/update/update-boot-skip.bats \
 	test/functional/update/update-bundle-removed.bats \

--- a/Makefile.am
+++ b/Makefile.am
@@ -132,6 +132,7 @@ BATS = \
 	test/functional/bundleadd/add-include.bats \
 	test/functional/bundleadd/add-install-time.bats \
 	test/functional/bundleadd/add-multiple.bats \
+	test/functional/bundleadd/add-no-disk-space.bats \
 	test/functional/bundleadd/add-no-signature.bats \
 	test/functional/bundleadd/add-skip-scripts.bats \
 	test/functional/bundleadd/add-uses-fullfile.bats \

--- a/Makefile.am
+++ b/Makefile.am
@@ -155,6 +155,7 @@ BATS = \
 	test/functional/bundleremove/remove-client-certificate.bats \
 	test/functional/bundleremove/remove-include.bats \
 	test/functional/bundleremove/remove-include-nested.bats \
+	test/functional/bundleremove/remove-no-disk-space.bats \
 	test/functional/bundleremove/remove-os-core.bats \
 	test/functional/bundleremove/remove-parse-args.bats \
 	test/functional/bundleremove/remove-with-dependency.bats \

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -734,8 +734,6 @@ out:
 static int install_bundles(struct list *bundles, struct list **subs, struct manifest *mom)
 {
 	int ret;
-	int retries = 0;
-	int timeout = 10;
 	int bundles_failed = 0;
 	int already_installed = 0;
 	int bundles_installed = 0;
@@ -830,13 +828,8 @@ static int install_bundles(struct list *bundles, struct list **subs, struct mani
 	timelist_timer_start(global_times, "Download packs");
 	(void)rm_staging_dir_contents("download");
 
-download_subscribed_packs:
-	if (list_longer_than(to_install_files, 10) && download_subscribed_packs(*subs, mom, true)) {
-		if (retries < MAX_TRIES && !content_url_is_local) {
-			increment_retries(&retries, &timeout);
-			printf("\nRetry #%d downloading subscribed packs\n", retries);
-			goto download_subscribed_packs;
-		}
+	if (list_longer_than(to_install_files, 10)) {
+		download_subscribed_packs(*subs, mom, true);
 	}
 	timelist_timer_stop(global_times); // closing: Download packs
 

--- a/src/search.c
+++ b/src/search.c
@@ -570,7 +570,7 @@ static void do_search(struct manifest *MoM, char search_type, char *search_term)
 		done_with_bundle = false;
 
 		/* Load sub-manifest */
-		subman = load_manifest(file->last_change, file, MoM, false);
+		subman = load_manifest(file->last_change, file, MoM, false, NULL);
 		if (!subman) {
 			fprintf(stderr, "Failed to load manifest %s\n", file->filename);
 			man_load_failures = true;
@@ -762,7 +762,7 @@ static int download_manifests(struct manifest **MoM, struct list **subs)
 
 		if (access(untard_file, F_OK) == -1) {
 			/* Do download */
-			subMan = load_manifest(file->last_change, file, *MoM, false);
+			subMan = load_manifest(file->last_change, file, *MoM, false, NULL);
 			if (!subMan) {
 				fprintf(stderr, "Cannot load official manifest MoM for version %i\n", current_version);
 			} else {

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -220,7 +220,7 @@ extern void apply_heuristics(struct file *file);
 extern int file_sort_filename(const void *a, const void *b);
 extern int file_sort_filename_reverse(const void *a, const void *b);
 extern struct manifest *load_mom(int version, bool latest, bool mix_exists, int *err);
-extern struct manifest *load_manifest(int version, struct file *file, struct manifest *mom, bool header_only);
+extern struct manifest *load_manifest(int version, struct file *file, struct manifest *mom, bool header_only, int *err);
 extern struct manifest *load_manifest_full(int version, bool mix);
 extern struct list *create_update_list(struct manifest *server);
 extern void link_manifests(struct manifest *m1, struct manifest *m2);
@@ -327,7 +327,7 @@ extern int compute_hash(struct file *file, char *filename) __attribute__((warn_u
 /* manifest.c */
 /* Calculate the total contentsize of a manifest list */
 extern long get_manifest_list_contentsize(struct list *manifests);
-extern struct list *recurse_manifest(struct manifest *manifest, struct list *subs, const char *component, bool server);
+extern struct list *recurse_manifest(struct manifest *manifest, struct list *subs, const char *component, bool server, int *err);
 extern struct list *consolidate_files(struct list *files);
 extern struct list *filter_out_existing_files(struct list *files);
 

--- a/src/verify.c
+++ b/src/verify.c
@@ -756,7 +756,7 @@ int verify_main(int argc, char **argv)
 
 	set_subscription_versions(official_manifest, NULL, &subs);
 load_submanifests:
-	official_manifest->submanifests = recurse_manifest(official_manifest, subs, NULL, false);
+	official_manifest->submanifests = recurse_manifest(official_manifest, subs, NULL, false, NULL);
 	if (!official_manifest->submanifests) {
 		if (retries < MAX_TRIES) {
 			increment_retries(&retries, &timeout);

--- a/test/functional/bundleadd/add-bad-hash-state.bats
+++ b/test/functional/bundleadd/add-bad-hash-state.bats
@@ -8,8 +8,8 @@ test_setup() {
 	create_bundle -n test-bundle -f /usr/bin/test-file "$TEST_NAME"
 	# set up state directory with bad hash file and pack hint
 	file_hash=$(get_hash_from_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle /usr/bin/test-file)
-	sudo sh -c "echo \"test file MODIFIED\" > $TEST_NAME/state/staged/$file_hash"
-	sudo touch "$TEST_NAME"/state/pack-test-bundle-from-0-to-10.tar
+	sudo sh -c "echo \"test file MODIFIED\" > $STATEDIR/staged/$file_hash"
+	sudo touch "$STATEDIR"/pack-test-bundle-from-0-to-10.tar
 
 }
 
@@ -18,13 +18,13 @@ test_setup() {
 	# since one of the files needed to install the bundle is already in the state/staged
 	# directory, in theory this one should be used instead of downloading it again...
 	# however since the hash of this file is wrong it should be deleted and re-downloaded
- 	hash_before=$(sudo "$SWUPD" hashdump "$TEST_NAME"/state/staged/"$file_hash")
+	hash_before=$(sudo "$SWUPD" hashdump "$STATEDIR"/staged/"$file_hash")
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
 	assert_status_is 0
-	hash_after=$(sudo "$SWUPD" hashdump "$TEST_NAME"/state/staged/"$file_hash")
-	assert_file_exists "$TEST_NAME"/target-dir/usr/bin/test-file
+	hash_after=$(sudo "$SWUPD" hashdump "$STATEDIR"/staged/"$file_hash")
+	assert_file_exists "$TARGETDIR"/usr/bin/test-file
 	assert_not_equal "$hash_before" "$hash_after"
 	expected_output=$(cat <<-EOM
 		Starting download of remaining update content. This may take a while...

--- a/test/functional/bundleadd/add-bad-hash.bats
+++ b/test/functional/bundleadd/add-bad-hash.bats
@@ -25,14 +25,13 @@ test_setup() {
 	# downloaded fullfile had a bad hash - immediately fatal with a 1 return code
 	assert_status_is 1
 	# the bad hash file should not exist on the system
-	assert_file_not_exists "$TEST_NAME"/target-dir/usr/bin/file1
+	assert_file_not_exists "$TARGETDIR"/usr/bin/file1
 	expected_output=$(cat <<-EOM
 		Starting download of remaining update content. This may take a while...
 		Finishing download of update content...
-		Error: File content hash mismatch for $TEST_DIRNAME/state/staged/e6d85023c5e619eb43d5cfbfdbdec784afef5a82ffa54e8c93bda3e0883360a3 (bad server data?)
+		Error: File content hash mismatch for $TEST_DIRNAME/testfs/state/staged/e6d85023c5e619eb43d5cfbfdbdec784afef5a82ffa54e8c93bda3e0883360a3 (bad server data?)
 	EOM
 	)
 	assert_is_output "$expected_output"
 
 }
-

--- a/test/functional/bundleadd/add-boot-file.bats
+++ b/test/functional/bundleadd/add-boot-file.bats
@@ -15,7 +15,7 @@ test_setup() {
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
 	assert_status_is 0
-	assert_file_exists "$TEST_NAME/target-dir/usr/lib/kernel/test-file"
+	assert_file_exists "$TARGETDIR/usr/lib/kernel/test-file"
 	expected_output=$(cat <<-EOM
 		Starting download of remaining update content. This may take a while...
 		Finishing download of update content...

--- a/test/functional/bundleadd/add-boot-skip.bats
+++ b/test/functional/bundleadd/add-boot-skip.bats
@@ -15,7 +15,7 @@ test_setup() {
 	run sudo sh -c "$SWUPD bundle-add -b $SWUPD_OPTS test-bundle"
 
 	assert_status_is 0
-	assert_file_exists "$TEST_NAME/target-dir/usr/lib/kernel/test-file"
+	assert_file_exists "$TARGETDIR/usr/lib/kernel/test-file"
 	expected_output=$(cat <<-EOM
 		Starting download of remaining update content. This may take a while...
 		Finishing download of update content...

--- a/test/functional/bundleadd/add-client-certificate.bats
+++ b/test/functional/bundleadd/add-client-certificate.bats
@@ -73,7 +73,7 @@ global_teardown() {
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
 	assert_status_is 0
-	assert_file_exists "$TEST_NAME"/target-dir/usr/bin/test-file
+	assert_file_exists "$TARGETDIR"/usr/bin/test-file
 }
 
 @test "ADD024: Try adding bundle over HTTPS with no client certificate" {

--- a/test/functional/bundleadd/add-include.bats
+++ b/test/functional/bundleadd/add-include.bats
@@ -8,7 +8,7 @@ test_setup() {
 	create_bundle -n test-bundle1 -f /foo/test-file1 "$TEST_NAME"
 	create_bundle -n test-bundle2 -f /bar/test-file2 "$TEST_NAME"
 	# add test-bundle2 as a dependency of test-bundle1
-	add_dependency_to_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
 
 }
 
@@ -17,8 +17,8 @@ test_setup() {
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1"
 
 	assert_status_is 0
-	assert_file_exists "$TEST_NAME"/target-dir/foo/test-file1
-	assert_file_exists "$TEST_NAME"/target-dir/bar/test-file2
+	assert_file_exists "$TARGETDIR"/foo/test-file1
+	assert_file_exists "$TARGETDIR"/bar/test-file2
 	expected_output=$(cat <<-EOM
 		Starting download of remaining update content. This may take a while...
 		Finishing download of update content...

--- a/test/functional/bundleadd/add-multiple.bats
+++ b/test/functional/bundleadd/add-multiple.bats
@@ -16,10 +16,10 @@ test_setup() {
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1 test-bundle2"
 
 	assert_status_is 0
-	assert_dir_exists "$TEST_NAME/target-dir/usr/bin"
-	assert_dir_exists "$TEST_NAME/target-dir/media/lib"
-	assert_file_exists "$TEST_NAME/target-dir/usr/bin/10"
-	assert_file_exists "$TEST_NAME/target-dir/media/lib/file2"
+	assert_dir_exists "$TARGETDIR/usr/bin"
+	assert_dir_exists "$TARGETDIR/media/lib"
+	assert_file_exists "$TARGETDIR/usr/bin/10"
+	assert_file_exists "$TARGETDIR/media/lib/file2"
 	expected_output=$(cat <<-EOM
 		Downloading packs...
 		Extracting test-bundle1 pack for version 10

--- a/test/functional/bundleadd/add-no-disk-space.bats
+++ b/test/functional/bundleadd/add-no-disk-space.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	# create a test environment with 10 MB of space
+	create_test_environment -s 10 "$TEST_NAME"
+
+	# create a file with a size of 20 MB and create a bundle
+	# that uses that file and 10 other files (to force pack download)
+	file1=/test-file:"$(create_file "$WEBDIR"/10/files 20MB)"
+	bfiles="/file1,/file2,/file3,/file4,/file5,/file6,/file7,/file8,/file9,/file10"
+	create_bundle -n test-bundle -f "$bfiles","$file1" "$TEST_NAME"
+
+	# create the state version dirs ahead of time
+	sudo mkdir "$TEST_NAME"/testfs/state/10
+
+}
+
+@test "ADD044: Adding a bundle with no disk space left (downloading the MoM)" {
+
+	# When adding a bundle and we run out of disk space while downloading the
+	# MoMs we should not retry the download since it will fail for sure
+
+	# fill up all the space in the disk
+	sudo dd if=/dev/zero of="$TEST_NAME"/testfs/dummy >& /dev/null || print "Using all space left in disk"
+
+	run sudo sh -c "timeout 30 $SWUPD bundle-add $SWUPD_OPTS test-bundle"
+
+	assert_status_is "$EMOM_LOAD"
+	expected_output=$(cat <<-EOM
+		Curl: Error downloading to local file - $TEST_DIRNAME/testfs/state/10/Manifest.MoM.tar
+		Check free space for $TEST_DIRNAME/testfs/state?
+		Failed to retrieve 10 MoM manifest
+		Cannot load official manifest MoM for version 10
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "ADD045: Adding a bundle with no disk space left (downloading the bundle manifest)" {
+
+	# When adding a bundle and we run out of disk space while downloading the
+	# bundle manifest we should not retry the download since it will fail for sure
+
+	# let's replace the bundle Manifest tar with a much larger file that will exceed
+	# the available space on disk
+	sudo rm "$WEBDIR"/10/Manifest.test-bundle
+	sudo rm "$WEBDIR"/10/Manifest.test-bundle.tar
+	fake_manifest=$(create_file "$WEBDIR"/10 15MB)
+	manifest_name=$(basename "$fake_manifest")
+	sudo mv "$WEBDIR"/10/"$manifest_name" "$WEBDIR"/10/Manifest.test-bundle
+	sudo mv "$WEBDIR"/10/"$manifest_name".tar "$WEBDIR"/10/Manifest.test-bundle.tar
+
+	run sudo sh -c "timeout 30 $SWUPD bundle-add $SWUPD_OPTS test-bundle"
+
+	assert_status_is "$EBUNDLE_INSTALL"
+	expected_output=$(cat <<-EOM
+		Curl: Error downloading to local file - $TEST_DIRNAME/testfs/state/10/Manifest.test-bundle.tar
+		Check free space for $TEST_DIRNAME/testfs/state?
+		Failed to retrieve 10 test-bundle manifest
+		Unable to download manifest test-bundle version 10, exiting now
+		Failed to install 1 of 1 bundles
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "ADD046: Adding a bundle with no disk space left (downloading the bundle files)" {
+
+	# When adding a bundle, the default is to check the disk space available
+	# and skip the installation if it is determined there is no enough space
+
+	run sudo sh -c "timeout 30 $SWUPD bundle-add $SWUPD_OPTS test-bundle"
+
+	assert_status_is "$EBUNDLE_INSTALL"
+	expected_output=$(cat <<-EOM
+		Error: Bundle too large by 11M.
+		NOTE: currently, swupd only checks /usr/ (or the passed-in path with /usr/ appended) for available space.
+		To skip this error and install anyways, add the --skip-diskspace-check flag to your command.
+		Failed to install 1 of 1 bundles
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "ADD047: Adding a bundle with no disk space left and skipping diskspace check (downloading the bundle files)" {
+
+	# When adding a bundle, the default is to check the disk space available
+	# and skip the installation if it is determined there is no enough space, however
+	# this check can be skipped with a flag, and in that case if we run out of disk
+	# space while downloading the bundle files we should not retry the download since
+	# it will fail for sure
+
+	# use a web server for serving the content, this is necessary
+	# since the code behaves differently if the content is local (e.g. file://)
+	start_web_server -r
+	set_upstream_server "$TEST_NAME" http://localhost:"$(get_web_server_port "$TEST_NAME")"/"$TEST_NAME"/web-dir
+
+	run sudo sh -c "timeout 30 $SWUPD bundle-add --skip-diskspace-check $SWUPD_OPTS test-bundle"
+
+	assert_status_is "$EBUNDLE_INSTALL"
+	expected_output=$(cat <<-EOM
+		Downloading packs...
+		Error for $TEST_DIRNAME/testfs/state/pack-test-bundle-from-0-to-10.tar download: Response 200 - Failed writing received data to disk/application
+		Check free space for $TEST_DIRNAME/testfs/state\\?
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Error for $TEST_DIRNAME/testfs/state/download/.*.tar download: Response 200 - Failed writing received data to disk/application
+		Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error for $TEST_DIRNAME/testfs/state/download/.*.tar download: Response 200 - Failed writing received data to disk/application
+		Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error for $TEST_DIRNAME/testfs/state/download/.*.tar download: Response 200 - Failed writing received data to disk/application
+		Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error for $TEST_DIRNAME/testfs/state/download/.*.tar download: Response 200 - Failed writing received data to disk/application
+		Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error for $TEST_DIRNAME/testfs/state/download/.*.tar download: Response 200 - Failed writing received data to disk/application
+		Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error for $TEST_DIRNAME/testfs/state/download/.*.tar download: Response 200 - Failed writing received data to disk/application
+		Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error for $TEST_DIRNAME/testfs/state/download/.*.tar download: Response 200 - Failed writing received data to disk/application
+		Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error for $TEST_DIRNAME/testfs/state/download/.*.tar download: Response 200 - Failed writing received data to disk/application
+		Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error for $TEST_DIRNAME/testfs/state/download/.*.tar download: Response 200 - Failed writing received data to disk/application
+		Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error for $TEST_DIRNAME/testfs/state/download/.*.tar download: Response 200 - Failed writing received data to disk/application
+		Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error for $TEST_DIRNAME/testfs/state/download/.*.tar download: Response 200 - Failed writing received data to disk/application
+		Check free space for $TEST_DIRNAME/testfs/state\\?
+		ERROR: Could not download some files from bundles, aborting bundle installation.
+		Failed to install 1 of 1 bundles
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}

--- a/test/functional/bundleadd/add-skip-scripts.bats
+++ b/test/functional/bundleadd/add-skip-scripts.bats
@@ -14,7 +14,7 @@ test_setup() {
 
 	run sudo sh -c "$SWUPD bundle-add --no-scripts $SWUPD_OPTS test-bundle"
 	assert_status_is 0
-	assert_file_exists "$TEST_NAME/target-dir/usr/lib/kernel/test-file"
+	assert_file_exists "$TARGETDIR/usr/lib/kernel/test-file"
 	expected_output=$(cat <<-EOM
 		Starting download of remaining update content. This may take a while...
 		Finishing download of update content...

--- a/test/functional/bundleadd/add-verify-fix-path.bats
+++ b/test/functional/bundleadd/add-verify-fix-path.bats
@@ -10,12 +10,12 @@ test_setup() {
 	# bundles created with the testlib add all needed directories to the
 	# manifest by default, so we need to remove the directory from test-bundle1
 	# so its missing the path to the file.
-	remove_from_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle1 /foo
-	remove_from_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle1 /foo/bar
+	remove_from_manifest "$WEBDIR"/10/Manifest.test-bundle1 /foo
+	remove_from_manifest "$WEBDIR"/10/Manifest.test-bundle1 /foo/bar
 	# since test-bundle2 is already installed, both directories defined
 	# there already exist, so we need to delete one of the /foo/bar so it
 	# can be fixed using verify_fix_path
-	sudo rm -rf "$TEST_NAME"/target-dir/foo/bar
+	sudo rm -rf "$TARGETDIR"/foo/bar
 
 }
 
@@ -27,7 +27,7 @@ test_setup() {
 		Starting download of remaining update content. This may take a while...
 		Finishing download of update content...
 		Installing bundle(s) files...
-		Update target directory does not exist: $TEST_DIRNAME/target-dir/foo/bar. Auto-fix disabled
+		Update target directory does not exist: $TEST_DIRNAME/testfs/target-dir/foo/bar. Auto-fix disabled
 		Path /foo/bar is missing on the file system ... fixing
 		Path /foo/bar/test-file1 is missing on the file system ... fixing
 		Calling post-update helper scripts.

--- a/test/functional/bundlelist/list-no-disk-space.bats
+++ b/test/functional/bundlelist/list-no-disk-space.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	# create a test environment with 10 MB of space
+	create_test_environment -s 10 "$TEST_NAME"
+
+	# create two bundles, one installed one not installed (no matter its size)
+	create_bundle -L -n test-bundle1 -f /file_1 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /file_2 "$TEST_NAME"
+
+	# create the state version dirs ahead of time
+	sudo mkdir "$TEST_NAME"/testfs/state/10
+
+}
+
+@test "LST017: List local bundles when there is no disk space left (downloading the MoM)" {
+
+	# When listing installed bundles, if we run out of disk space while downloading the
+	# MoM we should not retry the download since it will fail for sure
+
+	# fill up all the space in the disk
+	sudo dd if=/dev/zero of="$TEST_NAME"/testfs/dummy >& /dev/null || print "Using all space left in disk"
+
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Curl: Error downloading to local file - $TEST_DIRNAME/testfs/state/10/Manifest.MoM.tar
+		Check free space for $TEST_DIRNAME/testfs/state?
+		Failed to retrieve 10 MoM manifest
+		Warning: Could not determine which installed bundles are experimental
+		os-core
+		test-bundle1
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "LST018: List all bundles when there is no disk space left (downloading the MoM)" {
+
+	# When listing bundles, if we run out of disk space while downloading the
+	# MoM we should not retry the download since it will fail for sure
+
+	# fill up all the space in the disk
+	sudo dd if=/dev/zero of="$TEST_NAME"/testfs/dummy >& /dev/null || print "Using all space left in disk"
+
+	run sudo sh -c "$SWUPD bundle-list --all $SWUPD_OPTS"
+
+	assert_status_is "$EMOM_LOAD"
+	expected_output=$(cat <<-EOM
+		Curl: Error downloading to local file - $TEST_DIRNAME/testfs/state/10/Manifest.MoM.tar
+		Check free space for $TEST_DIRNAME/testfs/state?
+		Failed to retrieve 10 MoM manifest
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/bundleremove/remove-include-nested.bats
+++ b/test/functional/bundleremove/remove-include-nested.bats
@@ -22,9 +22,9 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
 	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
 	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
-	assert_file_exists "$TEST_NAME"/target-dir/test-file1
-	assert_file_exists "$TEST_NAME"/target-dir/test-file2
-	assert_file_exists "$TEST_NAME"/target-dir/test-file3
+	assert_file_exists "$TARGETDIR"/test-file1
+	assert_file_exists "$TARGETDIR"/test-file2
+	assert_file_exists "$TARGETDIR"/test-file3
 	expected_output=$(cat <<-EOM
 		Error: bundle requested to be removed is required by the following bundles:
 		format:

--- a/test/functional/bundleremove/remove-no-disk-space.bats
+++ b/test/functional/bundleremove/remove-no-disk-space.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	# create a test environment with 10 MB of space
+	create_test_environment -s 10 "$TEST_NAME"
+
+	# create a bundle (no matter its size since we'll be removing it)
+	create_bundle -L -n test-bundle -f /file_1 "$TEST_NAME"
+
+	# create the state version dirs ahead of time
+	sudo mkdir "$TEST_NAME"/testfs/state/10
+
+}
+
+@test "REM017: Removing a bundle with no disk space left (downloading the MoM)" {
+
+	# When removing a bundle, if we run out of disk space while downloading the
+	# MoM we should not retry the download since it will fail for sure
+
+	# fill up all the space in the disk
+	sudo dd if=/dev/zero of="$TEST_NAME"/testfs/dummy >& /dev/null || print "Using all space left in disk"
+
+	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle"
+
+	assert_status_is "$EMOM_LOAD"
+	expected_output=$(cat <<-EOM
+		Curl: Error downloading to local file - $TEST_DIRNAME/testfs/state/10/Manifest.MoM.tar
+		Check free space for $TEST_DIRNAME/testfs/state?
+		Failed to retrieve 10 MoM manifest
+		Unable to download/verify 10 Manifest.MoM
+		Failed to remove 1 of 1 bundles
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "REM018: Removing a bundle with no disk space left (downloading other bundle manifests)" {
+
+	# When removing a bundle, if we run out of disk space while downloading the
+	# bundle manifests we should not retry the download since it will fail for sure
+	# bundle remove needs the manifest from all other bundles in the system to check
+	# for dependencies with the bundle to be removed
+
+	# let's replace the Manifest tar from os-core with a much larger file that will exceed
+	# the available space on disk
+	sudo rm "$WEBDIR"/10/Manifest.os-core
+	sudo rm "$WEBDIR"/10/Manifest.os-core.tar
+	big_manifest=$(create_file "$WEBDIR"/10 15MB)
+	sudo mv "$big_manifest" "$WEBDIR"/10/Manifest.os-core
+	sudo mv "$big_manifest".tar "$WEBDIR"/10/Manifest.os-core.tar
+
+	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle"
+
+	assert_status_is "$ERECURSE_MANIFEST"
+	expected_output=$(cat <<-EOM
+		Curl: Error downloading to local file - $TEST_DIRNAME/testfs/state/10/Manifest.os-core.tar
+		Check free space for $TEST_DIRNAME/testfs/state?
+		Failed to retrieve 10 os-core manifest
+		Error: Cannot load MoM sub-manifests
+		Failed to remove 1 of 1 bundles
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "REM019: Removing a bundle with no disk space left (downloading the bundle manifest)" {
+
+	# When removing a bundle, if we run out of disk space while downloading the
+	# bundle manifest we should not retry the download since it will fail for sure
+
+	# let's replace the Manifest tar from the bundle with a much larger file that will exceed
+	# the available space on disk
+	sudo rm "$WEBDIR"/10/Manifest.test-bundle
+	sudo rm "$WEBDIR"/10/Manifest.test-bundle.tar
+	big_manifest=$(create_file "$WEBDIR"/10 15MB)
+	sudo mv "$big_manifest" "$WEBDIR"/10/Manifest.test-bundle
+	sudo mv "$big_manifest".tar "$WEBDIR"/10/Manifest.test-bundle.tar
+
+	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle"
+
+	assert_status_is "$ERECURSE_MANIFEST"
+	expected_output=$(cat <<-EOM
+		Curl: Error downloading to local file - $TEST_DIRNAME/testfs/state/10/Manifest.test-bundle.tar
+		Check free space for $TEST_DIRNAME/testfs/state?
+		Failed to retrieve 10 test-bundle manifest
+		Error: Cannot load test-bundle sub-manifest (ret = 8)
+		Failed to remove 1 of 1 bundles
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/checkupdate/chk-update-no-target-content.bats
+++ b/test/functional/checkupdate/chk-update-no-target-content.bats
@@ -6,7 +6,7 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME"
 	# remove os-release file from target-dir so no current version can be determined
-	sudo rm "$TEST_NAME"/target-dir/usr/lib/os-release
+	sudo rm "$TARGETDIR"/usr/lib/os-release
 
 }
 

--- a/test/functional/search/search-content-check-negative.bats
+++ b/test/functional/search/search-content-check-negative.bats
@@ -46,7 +46,7 @@ global_teardown() {
 		Search term not found.
 	EOM
 	)
-	assert_regex_in_output "$expected_output"
+	assert_regex_is_output "$expected_output"
 
 }
 

--- a/test/functional/search/search-content-check-positive.bats
+++ b/test/functional/search/search-content-check-positive.bats
@@ -49,7 +49,7 @@ global_teardown() {
 		./usr/share/clear/bundles/test-bundle1
 	EOM
 	)
-	assert_regex_in_output "$expected_output"
+	assert_regex_is_output "$expected_output"
 
 }
 

--- a/test/functional/search/search-experimental.bats
+++ b/test/functional/search/search-experimental.bats
@@ -72,7 +72,7 @@ global_teardown() {
 		./usr/share/clear/bundles/test-bundle2
 	EOM
 	)
-	assert_regex_in_output "$expected_output"
+	assert_regex_is_output "$expected_output"
 
 }
 

--- a/test/functional/search/search-no-disk-space.bats
+++ b/test/functional/search/search-no-disk-space.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	# create a test environment with 10 MB of space
+	create_test_environment -s 3 "$TEST_NAME"
+
+	# create two bundles
+	create_bundle -n test-bundle1 -f /file_1 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /file_2 "$TEST_NAME"
+
+	# create the state version dirs ahead of time
+	sudo mkdir "$TEST_NAME"/testfs/state/10
+	sudo chmod -R 0700 "$TEST_NAME"/testfs/state/10
+
+}
+
+@test "SRH020: Search for a bundle when there is no disk space left (downloading the MoM)" {
+
+	# When searching for bundles, if we run out of disk space while downloading the
+	# MoM we should not retry the download since it will fail for sure
+
+	# fill up all the space in the disk
+	sudo dd if=/dev/zero of="$TEST_NAME"/testfs/dummy >& /dev/null || print "Using all space left in disk"
+
+	run sudo sh -c "$SWUPD search $SWUPD_OPTS test-bundle2"
+
+	assert_status_is "$EMOM_LOAD"
+	expected_output=$(cat <<-EOM
+		Searching for 'test-bundle2'
+		Curl: Error downloading to local file - $TEST_DIRNAME/testfs/state/10/Manifest.MoM.tar
+		Check free space for $TEST_DIRNAME/testfs/state?
+		Failed to retrieve 10 MoM manifest
+		Cannot load official manifest MoM for version 10
+		Error: Failed to download manifests
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "SRH021: Search for a bundle when there is no disk space left (downloading bundle manifests)" {
+
+	# When searching for bundles, if we run out of disk space while downloading the
+	# manifests we should not retry the download since it will fail for sure
+
+	# let's replace the Manifest tar from the bundle with a much larger file that will exceed
+	# the available space on disk
+	sudo rm "$WEBDIR"/10/Manifest.test-bundle1
+	sudo rm "$WEBDIR"/10/Manifest.test-bundle1.tar
+	big_manifest=$(create_file "$WEBDIR"/10 3MB)
+	sudo mv "$big_manifest" "$WEBDIR"/10/Manifest.test-bundle1
+	sudo mv "$big_manifest".tar "$WEBDIR"/10/Manifest.test-bundle1.tar
+
+	run sudo sh -c "$SWUPD search $SWUPD_OPTS test-bundle2"
+
+	assert_status_is "$ERECURSE_MANIFEST"
+	assert_in_output "Searching for 'test-bundle2'"
+	# there is going to be a whole lot of content within the line
+	# above and the lines below so we are excluding those from the
+	# check
+	# TODO(castulo): there is a strange behavior with the way search
+	# works on travis, it adds all the content of the downloaded manifests
+	# into the command output. Once we figure out why this happens we
+	# need to check for the whole output using only one assertion
+	expected_output=$(cat <<-EOM
+		Downloading Clear Linux manifests
+		.* MB total...
+		Curl: Error downloading to local file - $TEST_DIRNAME/testfs/state/10/Manifest.test-bundle1.tar
+		Check free space for $TEST_DIRNAME/testfs/state\\?
+		Failed to retrieve 10 test-bundle1 manifest
+		Cannot load test-bundle1 sub-manifest for version 10
+		1 manifest failed to download.
+		Warning: One or more manifests failed to download, search results will be partial.
+		Bundle test-bundle2	\\(0 MB to install\\)
+		./usr/share/clear/bundles/test-bundle2
+	EOM
+	)
+	assert_regex_in_output "$expected_output"
+
+}

--- a/test/functional/search/search-no-disk-space.bats
+++ b/test/functional/search/search-no-disk-space.bats
@@ -60,15 +60,8 @@ test_setup() {
 	run sudo sh -c "$SWUPD search $SWUPD_OPTS test-bundle2"
 
 	assert_status_is "$ERECURSE_MANIFEST"
-	assert_in_output "Searching for 'test-bundle2'"
-	# there is going to be a whole lot of content within the line
-	# above and the lines below so we are excluding those from the
-	# check
-	# TODO(castulo): there is a strange behavior with the way search
-	# works on travis, it adds all the content of the downloaded manifests
-	# into the command output. Once we figure out why this happens we
-	# need to check for the whole output using only one assertion
 	expected_output=$(cat <<-EOM
+		Searching for 'test-bundle2'
 		Downloading Clear Linux manifests
 		.* MB total...
 		Curl: Error downloading to local file - $TEST_DIRNAME/testfs/state/10/Manifest.test-bundle1.tar
@@ -81,6 +74,6 @@ test_setup() {
 		./usr/share/clear/bundles/test-bundle2
 	EOM
 	)
-	assert_regex_in_output "$expected_output"
+	assert_regex_is_output "$expected_output"
 
 }

--- a/test/functional/update/update-no-disk-space.bats
+++ b/test/functional/update/update-no-disk-space.bats
@@ -1,0 +1,178 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	# create a test environment with 10 MB of space and a
+	# bundle "test-bundle" installed on it
+	create_test_environment -s 10 "$TEST_NAME"
+	create_bundle -L -n test-bundle -f /foo "$TEST_NAME"
+
+	# create a new version 20
+	create_version "$TEST_NAME" 20 10
+
+	# create a file with a size of 20 MB and create an update
+	# for test-bundle that adds that file
+	file1=/test-file:"$(create_file "$WEBDIR"/20/files 20MB)"
+	update_bundle "$TEST_NAME" test-bundle --add "$file1"
+
+	# create the state version dirs ahead of time
+	sudo mkdir "$TEST_NAME"/testfs/state/10
+	sudo mkdir "$TEST_NAME"/testfs/state/20
+
+}
+
+@test "UPD042: Updating a system with no disk space left (downloading the current MoM)" {
+
+	# When updating a system and we run out of disk space while downloading the
+	# MoMs we should not retry the download since it will fail for sure
+
+	# fill up all the space in the disk
+	sudo dd if=/dev/zero of="$TEST_NAME"/testfs/dummy >& /dev/null || print "Using all space left in disk"
+
+	run sudo sh -c "timeout 30 $SWUPD update $SWUPD_OPTS"
+
+	assert_status_is "$EMOM_LOAD"
+	expected_output=$(cat <<-EOM
+		Update started.
+		Preparing to update from 10 to 20
+		Curl: Error downloading to local file - $TEST_DIRNAME/testfs/state/10/Manifest.MoM.tar
+		Check free space for $TEST_DIRNAME/testfs/state?
+		Failed to retrieve 10 MoM manifest
+		Update failed.
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "UPD043: Updating a system with no disk space left (downloading the server MoM)" {
+
+	# When updating a system and we run out of disk space while downloading the
+	# MoMs we should not retry the download since it will fail for sure
+
+	# let's replace the bundle Manifest tar with a much larger file that will exceed
+	# the available space on disk
+	sudo rm "$WEBDIR"/20/Manifest.MoM
+	sudo rm "$WEBDIR"/20/Manifest.MoM.tar
+	fake_manifest=$(create_file "$WEBDIR"/20 15MB)
+	manifest_name=$(basename "$fake_manifest")
+	sudo mv "$WEBDIR"/20/"$manifest_name" "$WEBDIR"/20/Manifest.MoM
+	sudo mv "$WEBDIR"/20/"$manifest_name".tar "$WEBDIR"/20/Manifest.MoM.tar
+
+	run sudo sh -c "timeout 30 $SWUPD update $SWUPD_OPTS"
+
+	assert_status_is "$EMOM_LOAD"
+	expected_output=$(cat <<-EOM
+		Update started.
+		Preparing to update from 10 to 20
+		Curl: Error downloading to local file - $TEST_DIRNAME/testfs/state/20/Manifest.MoM.tar
+		Check free space for $TEST_DIRNAME/testfs/state?
+		Failed to retrieve 20 MoM manifest
+		Update failed.
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "UPD044: Updating a system with no disk space left (downloading the current bundle manifests)" {
+
+	# When updating a system and we run out of disk space while downloading the
+	# bundle manifest we should not retry the download since it will fail for sure
+
+	# let's replace the bundle Manifest tar with a much larger file that will exceed
+	# the available space on disk
+	sudo rm "$WEBDIR"/10/Manifest.test-bundle
+	sudo rm "$WEBDIR"/10/Manifest.test-bundle.tar
+	fake_manifest=$(create_file "$WEBDIR"/10 15MB)
+	manifest_name=$(basename "$fake_manifest")
+	sudo mv "$WEBDIR"/10/"$manifest_name" "$WEBDIR"/10/Manifest.test-bundle
+	sudo mv "$WEBDIR"/10/"$manifest_name".tar "$WEBDIR"/10/Manifest.test-bundle.tar
+
+	run sudo sh -c "timeout 30 $SWUPD update $SWUPD_OPTS"
+
+	assert_status_is "$ERECURSE_MANIFEST"
+	expected_output=$(cat <<-EOM
+		Update started.
+		Preparing to update from 10 to 20
+		Curl: Error downloading to local file - $TEST_DIRNAME/testfs/state/10/Manifest.test-bundle.tar
+		Check free space for $TEST_DIRNAME/testfs/state?
+		Failed to retrieve 10 test-bundle manifest
+		Cannot load current MoM sub-manifests, exiting
+		Update failed.
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "UPD045: Updating a system with no disk space left (downloading the server bundle manifests)" {
+
+	# When updating a system and we run out of disk space while downloading the
+	# bundle manifest we should not retry the download since it will fail for sure
+
+	# let's replace the bundle Manifest tar with a much larger file that will exceed
+	# the available space on disk
+	sudo rm "$WEBDIR"/20/Manifest.test-bundle
+	sudo rm "$WEBDIR"/20/Manifest.test-bundle.tar
+	fake_manifest=$(create_file "$WEBDIR"/20 15MB)
+	manifest_name=$(basename "$fake_manifest")
+	sudo mv "$WEBDIR"/20/"$manifest_name" "$WEBDIR"/20/Manifest.test-bundle
+	sudo mv "$WEBDIR"/20/"$manifest_name".tar "$WEBDIR"/20/Manifest.test-bundle.tar
+
+	run sudo sh -c "timeout 30 $SWUPD update $SWUPD_OPTS"
+
+	assert_status_is "$ERECURSE_MANIFEST"
+	expected_output=$(cat <<-EOM
+		Update started.
+		Preparing to update from 10 to 20
+		Curl: Error downloading to local file - $TEST_DIRNAME/testfs/state/20/Manifest.test-bundle.tar
+		Check free space for $TEST_DIRNAME/testfs/state?
+		Failed to retrieve 20 test-bundle manifest
+		Unable to download manifest test-bundle version 20, exiting now
+		Update failed.
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "UPD046: Updating a system with no disk space left (downloading the bundle files)" {
+
+	# When updating a system and we run out of disk space while downloading the
+	# bundle files we should not retry the download since it will fail for sure
+
+	file_hash=$(get_hash_from_manifest "$WEBDIR"/20/Manifest.test-bundle /test-file)
+
+	run sudo sh -c "timeout 30 $SWUPD update $SWUPD_OPTS"
+
+	assert_status_is "$EFILEDOWNLOAD"
+	expected_output=$(cat <<-EOM
+		Update started.
+		Preparing to update from 10 to 20
+		Downloading packs...
+		Error for $TEST_DIRNAME/testfs/state/pack-test-bundle-from-10-to-20.tar download: Response 0 - Failed writing received data to disk/application
+		Check free space for $TEST_DIRNAME/testfs/state?
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 1
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 0
+		    new files         : 1
+		    deleted files     : 0
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Error for $TEST_DIRNAME/testfs/state/download/.$file_hash.tar download: Response 0 - Failed writing received data to disk/application
+		Check free space for $TEST_DIRNAME/testfs/state?
+		ERROR: Could not download all files, aborting update
+		Update failed.
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/verify/verify-missing-file.bats
+++ b/test/functional/verify/verify-missing-file.bats
@@ -25,8 +25,8 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_not_exists "$TEST_NAME"/target-dir/foo/test-file1
-	assert_file_exists "$TEST_NAME"/target-dir/bar/test-file2
+	assert_file_not_exists "$TARGETDIR"/foo/test-file1
+	assert_file_exists "$TARGETDIR"/bar/test-file2
 
 }
 
@@ -52,7 +52,7 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_exists "$TEST_NAME"/target-dir/foo/test-file1
-	assert_file_exists "$TEST_NAME"/target-dir/bar/test-file2
+	assert_file_exists "$TARGETDIR"/foo/test-file1
+	assert_file_exists "$TARGETDIR"/bar/test-file2
 
 }

--- a/test/functional/verify/verify-no-disk-space.bats
+++ b/test/functional/verify/verify-no-disk-space.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	# create a test environment with 10 MB of space
+	create_test_environment -s 10 "$TEST_NAME"
+
+	# create a bundle with 10+ files
+	bfiles="/file1,/file2,/file3,/file4,/file5,/file6,/file7,/file8,/file9,/file10"
+	create_bundle -L -n test-bundle -f "$bfiles" "$TEST_NAME"
+
+	# create a new version
+	create_version "$TEST_NAME" 20 10
+
+	# create a file with a size of 20 MB and create an
+	# update for the bundle that uses that file
+	file1=/test-file:"$(create_file "$WEBDIR"/10/files 20MB)"
+	update_bundle "$TEST_NAME" test-bundle --add "$file1"
+
+	# create the state version dirs ahead of time
+	sudo mkdir "$TEST_NAME"/testfs/state/10
+	sudo mkdir "$TEST_NAME"/testfs/state/20
+
+}
+
+@test "VER042: Verify a system with no disk space left (downloading the MoM)" {
+
+	# When verifying a system and we run out of disk space while downloading the
+	# MoMs we should not retry the download since it will fail for sure
+
+	# fill up all the space in the disk
+	sudo dd if=/dev/zero of="$TEST_NAME"/testfs/dummy >& /dev/null || print "Using all space left in disk"
+
+	run sudo sh -c "timeout 30 $SWUPD verify --fix --force --manifest=20 $SWUPD_OPTS"
+
+	assert_status_is "$EMOM_LOAD"
+	expected_output=$(cat <<-EOM
+		Verifying version 20
+		Curl: Error downloading to local file - $TEST_DIRNAME/testfs/state/20/Manifest.MoM.tar
+		Check free space for $TEST_DIRNAME/testfs/state?
+		Failed to retrieve 20 MoM manifest
+		Unable to download/verify 20 Manifest.MoM
+		Error: Fix did not fully succeed
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "VER043: Verify a system with no disk space left (downloading the bundle manifest)" {
+
+	# When verifying a system and we run out of disk space while downloading the
+	# bundle manifest we should not retry the download since it will fail for sure
+
+	# let's replace the bundle Manifest tar with a much larger file that will exceed
+	# the available space on disk
+	sudo rm "$WEBDIR"/20/Manifest.test-bundle
+	sudo rm "$WEBDIR"/20/Manifest.test-bundle.tar
+	big_manifest=$(create_file "$WEBDIR"/20 15MB)
+	sudo mv "$big_manifest" "$WEBDIR"/20/Manifest.test-bundle
+	sudo mv "$big_manifest".tar "$WEBDIR"/20/Manifest.test-bundle.tar
+
+	run sudo sh -c "timeout 30 $SWUPD verify --fix --force --manifest=20 $SWUPD_OPTS"
+
+	assert_status_is "$EMANIFEST_LOAD"
+	expected_output=$(cat <<-EOM
+		Verifying version 20
+		WARNING: the force or picky option is specified; ignoring version mismatch for verify --fix
+		Curl: Error downloading to local file - $TEST_DIRNAME/testfs/state/20/Manifest.test-bundle.tar
+		Check free space for $TEST_DIRNAME/testfs/state?
+		Failed to retrieve 20 test-bundle manifest
+		Unable to download manifest test-bundle version 20, exiting now
+		Error: Fix did not fully succeed
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "VER044: Verify a system with no disk space left (downloading the bundle files)" {
+
+	# When verifying a system and we run out of disk space while downloading the
+	# bundle manifest we should not retry the download since it will fail for sure
+
+	fhash=$(get_hash_from_manifest "$WEBDIR"/20/Manifest.test-bundle /test-file)
+
+	run sudo sh -c "timeout 30 $SWUPD verify --fix --force --manifest=20 $SWUPD_OPTS"
+
+	assert_status_is "$EFILEDOWNLOAD"
+	expected_output=$(cat <<-EOM
+		Verifying version 20
+		WARNING: the force or picky option is specified; ignoring version mismatch for verify --fix
+		Verifying files
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Error for $TEST_DIRNAME/testfs/state/download/.$fhash.tar download: Response 0 - Failed writing received data to disk/application
+		Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Unable to download necessary files for this OS release
+		Error: Fix did not fully succeed
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}


### PR DESCRIPTION
When a disk gets full on a file download during an update, we are currently scheduling up to five retries for that download, which are going to fail for sure since there is no more space on disk.
This PR changes this behavior so it only tries to download the file once if we receive an error about the disk being full so we don't waste time.

The PR includes these commits:

- A commit with the necessary updates in the test library so we can create test environments that are limited in space.
- A commit that includes tests to validate the different scenarios where the disk can get filled up during an update.
- The changes to the swupd code to abort download retries when the disk is full.

Closes #752 

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>