### PR TITLE
time: Use strftotime instead of asctime

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -84,11 +84,14 @@ bool initialize_signature(void)
 			BIO *b;
 			time_t currtime = 0;
 			struct tm *timeinfo;
+			char time_str[50];
 
 			/* The system time wasn't sane, print out what it is and the cert validity range */
 			time(&currtime);
 			timeinfo = localtime(&currtime);
-			fprintf(stderr, "Warning: Current time is %s\n", asctime(timeinfo));
+
+			strftime(time_str, sizeof(time_str), "%a %b %d %H:%M:%S %Y", timeinfo);
+			fprintf(stderr, "Warning: Current time is %s\n", time_str);
 			fprintf(stderr, "Certificate validity is:\n");
 			b = BIO_new_fp(stdout, BIO_NOCLOSE);
 			if (b == NULL) {

--- a/src/verifytime.c
+++ b/src/verifytime.c
@@ -96,7 +96,10 @@ bool verify_time()
 		/* TODO: Get even better time than the versionstamp using a collection of servers,
 		 * and fallback to using versionstamp time if it does not work or seem reasonable.
 		 * The system time wasn't sane, so set it here and try again */
-		fprintf(stderr, "Warning: Current time is %s\nAttempting to fix...", asctime(timeinfo));
+		char time_str[50];
+
+		strftime(time_str, sizeof(time_str), "%a %b %d %H:%M:%S %Y", timeinfo);
+		fprintf(stderr, "Warning: Current time is %s\nAttempting to fix...", time_str);
 		if (set_time(versiontime) == false) {
 			return false;
 		}


### PR DESCRIPTION
Strtotime is safer than asctime, so prefer that. It's known that there are
implementations of asctime that doesn't handle errors very well.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>