### PR TITLE
Makeifile: Check all files under src/ for code style

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -284,7 +284,7 @@ compliant:
 	elif [ $$ret -gt 1 ]; then \
 		exit $$ret; \
 	fi; \
-	clang-format -i -style=file src/**/*.h src/**/*.c; ret=$$?; \
+	clang-format -i -style=file src/*.[ch] src/lib/*.[ch] ; ret=$$?; \
 	if [ $$ret -ne 0 ]; then \
 		exit $$ret; \
 	fi; \


### PR DESCRIPTION
Glob ** will only recurse directories if globstar is set. To avoid skipping
important files run clang-format on src/ and src/lib

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>