### PR TITLE
curl: swupd_curl_query_content_size is leaking file content

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -220,9 +220,9 @@ void swupd_curl_deinit(void)
 	curl_global_cleanup();
 }
 
-static size_t filesize_from_header_cb(void UNUSED_PARAM *func, size_t size, size_t nmemb, void UNUSED_PARAM *data)
+static size_t dummy_write_cb(void UNUSED_PARAM *func, size_t size, size_t nmemb, void UNUSED_PARAM *data)
 {
-	/* Drop the header, we just want file size */
+	/* Drop the content */
 	return (size_t)(size * nmemb);
 }
 
@@ -243,12 +243,17 @@ double swupd_curl_query_content_size(char *url)
 		return -1;
 	}
 
-	curl_ret = curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, filesize_from_header_cb);
+	curl_ret = curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, dummy_write_cb);
 	if (curl_ret != CURLE_OK) {
 		return -1;
 	}
 
 	curl_ret = curl_easy_setopt(curl, CURLOPT_HEADER, 0L);
+	if (curl_ret != CURLE_OK) {
+		return -1;
+	}
+
+	curl_ret = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, dummy_write_cb);
 	if (curl_ret != CURLE_OK) {
 		return -1;
 	}

--- a/test/functional/search/search-content-check-negative.bats
+++ b/test/functional/search/search-content-check-negative.bats
@@ -38,11 +38,8 @@ global_teardown() {
 	run sudo sh -c "$SWUPD search $SWUPD_OPTS fake-file"
 
 	assert_status_is 0
-	assert_in_output "Searching for 'fake-file'"
-	# there is going to be a whole lot of content within the line
-	# above and the lines below so we are excluding those from the
-	# check
 	expected_output=$(cat <<-EOM
+		Searching for 'fake-file'
 		Downloading Clear Linux manifests
 		.* MB total...
 		Completed manifests download.

--- a/test/functional/search/search-content-check-positive.bats
+++ b/test/functional/search/search-content-check-positive.bats
@@ -40,11 +40,8 @@ global_teardown() {
 	run sudo sh -c "$SWUPD search $SWUPD_OPTS test-bundle1"
 
 	assert_status_is 0
-	assert_in_output "Searching for 'test-bundle1'"
-	# there is going to be a whole lot of content within the line
-	# above and the lines below so we are excluding those from the
-	# check
 	expected_output=$(cat <<-EOM
+		Searching for 'test-bundle1'
 		Downloading Clear Linux manifests
 		.* MB total...
 		Completed manifests download.

--- a/test/functional/search/search-experimental.bats
+++ b/test/functional/search/search-experimental.bats
@@ -44,11 +44,8 @@ global_teardown() {
 	run sudo sh -c "$SWUPD search $SWUPD_OPTS test-bundle1"
 
 	assert_status_is 0
-	assert_in_output "Searching for 'test-bundle1'"
-	# there is going to be a whole lot of content within the line
-	# above and the lines below so we are excluding those from the
-	# check
 	expected_output=$(cat <<-EOM
+		Searching for 'test-bundle1'
 		Downloading Clear Linux manifests
 		.* MB total...
 		Completed manifests download.


### PR DESCRIPTION
When CURLOPT_NOBODY is set to true, curl shouldn't get the body of a file,
we should get only headers. This works fine for all tested scenarios using
http and https. It's also working in most scenarios that uses file://, but
it fails on travis environment. So, add a dummy function to ignore body data
if present.

There was a hack in search tests to ignore leaked file content. Removing that
hack.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>