### PR TITLE
Verify --fix skip files that are unsafe to delete without warning the user

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -219,6 +219,7 @@ BATS = \
 	test/functional/verify/verify-directory-tree-deleted.bats \
 	test/functional/verify/verify-empty-dir-deleted.bats \
 	test/functional/verify/verify-fix.bats \
+	test/functional/verify/verify-fix-unsafe-to-delete.bats \
 	test/functional/verify/verify-fix-version-mismatch.bats \
 	test/functional/verify/verify-fix-version-mismatch-override.bats \
 	test/functional/verify/verify-format-mismatch.bats \

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -690,13 +690,9 @@ int get_dirfd_path(const char *fullname)
 	}
 
 	if (strcmp(real_path, dir) != 0) {
-		/* FIXME: Should instead check to see if real_path is marked
-		 * non-deleted in the consolidated manifest. If it is
-		 * non-deleted, then we must not delete the file (and also not
-		 * flag an error); otherwise, it can be safely deleted. Until
-		 * that check is implemented, always skip the file, because we
-		 * cannot safely determine if it can be deleted. */
-		ret = -1;
+		/* The path to the file contains a symlink, skip the file,
+		 * because we cannot safely determine if it can be deleted. */
+		ret = -2;
 		close(fd);
 	} else {
 		ret = fd;

--- a/src/verify.c
+++ b/src/verify.c
@@ -455,20 +455,22 @@ static void remove_orphaned_files(struct manifest *official_manifest, bool repai
 			goto out;
 		}
 
+		fd = get_dirfd_path(fullname);
+		if (fd < 0) {
+			if (fd == -1) {
+				counts.extraneous++;
+				counts.not_deleted++;
+			}
+			goto out;
+		}
+
 		counts.extraneous++;
 		printf("File that should be deleted: %s\n", fullname);
 
 		/* if not repairing, we're done */
 		if (!repair) {
+			close(fd);
 			goto out;
-		}
-
-		fd = get_dirfd_path(fullname);
-		if (fd < 0) {
-			fprintf(stderr, "Not safe to delete: %s\n", fullname);
-			free_string(&fullname);
-			counts.not_deleted++;
-			continue;
 		}
 
 		base = basename(fullname);

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1755,14 +1755,14 @@ create_bundle() { # swupd_function
 		# this file is added in every bundle by default, it would add too much overhead
 		# for most tests
 		fdir=$(dirname "${val%:*}")
-		if [ ! "$(sudo cat "$manifest" | grep -x "[D|L]\\.\\.\\..*$fdir")" ] && [ "$fdir" != "/usr/share/clear/bundles" ] \
+		if [ ! "$(sudo cat "$manifest" | grep -x "[DL]\\.\\.\\..*$fdir")" ] && [ "$fdir" != "/usr/share/clear/bundles" ] \
 		&& [ "$fdir" != "/" ]; then
 			bundle_dir=$(create_dir "$files_path")
 			add_to_manifest -p "$manifest" "$bundle_dir" "$fdir"
 			# add each one of the directories of the path if they are not in the manifest already
 			while [ "$(dirname "$fdir")" != "/" ]; do
 				fdir=$(dirname "$fdir")
-				if [ ! "$(sudo cat "$manifest" | grep -x "[D|L]\\.\\.\\..*$fdir")" ]; then
+				if [ ! "$(sudo cat "$manifest" | grep -x "[DL]\\.\\.\\..*$fdir")" ]; then
 					add_to_manifest -p "$manifest" "$bundle_dir" "$fdir"
 				fi
 			done
@@ -1867,7 +1867,7 @@ create_bundle() { # swupd_function
 		# add it to the bundle (except if the directory is "/")
 		fdir=$(dirname "$val")
 		if [ "$fdir" != "/" ]; then
-			if [ ! "$(sudo cat "$manifest" | grep -x "[D|L]\\.\\.\\..*$fdir")" ]; then
+			if [ ! "$(sudo cat "$manifest" | grep -x "[DL]\\.\\.\\..*$fdir")" ]; then
 				bundle_dir=$(create_dir "$files_path")
 				add_to_manifest -p "$manifest" "$bundle_dir" "$fdir"
 			fi
@@ -1935,7 +1935,7 @@ create_bundle() { # swupd_function
 		# add it to the bundle (except if the directory is "/")
 		fdir=$(dirname "$val")
 		if [ "$fdir" != "/" ]; then
-			if [ ! "$(sudo cat "$manifest" | grep -x "[D|L]\\.\\.\\..*$fdir")" ]; then
+			if [ ! "$(sudo cat "$manifest" | grep -x "[DL]\\.\\.\\..*$fdir")" ]; then
 				bundle_dir=$(create_dir "$files_path")
 				add_to_manifest -p "$manifest" "$bundle_dir" "$fdir"
 			fi
@@ -1979,7 +1979,7 @@ create_bundle() { # swupd_function
 		# add it to the bundle (except if the directory is "/")
 		fdir=$(dirname "$val")
 		if [ "$fdir" != "/" ]; then
-			if [ ! "$(sudo cat "$manifest" | grep -x "[D|L]\\.\\.\\..*$fdir")" ]; then
+			if [ ! "$(sudo cat "$manifest" | grep -x "[DL]\\.\\.\\..*$fdir")" ]; then
 				bundle_dir=$(create_dir "$files_path")
 				add_to_manifest -p "$manifest" "$bundle_dir" "$fdir"
 			fi

--- a/test/functional/verify/verify-fix-unsafe-to-delete.bats
+++ b/test/functional/verify/verify-fix-unsafe-to-delete.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle -c /foo -f /foo/file1,/foo/file2,/bar/file3 "$TEST_NAME"
+	create_version "$TEST_NAME" 20 10
+	update_bundle "$TEST_NAME" test-bundle --delete /foo/file1
+	set_current_version "$TEST_NAME" 20
+
+}
+
+@test "VER042: Verify fixes a system with extra files that are unsafe to delete" {
+
+	# when running verify --fix and there are extra files, but the extra
+	# files are found not safe to be deleted, they should be skipped and
+	# users should not be notified about these
+
+	run sudo sh -c "$SWUPD verify --fix $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Verifying version 20
+		Verifying files
+		Adding any missing files
+		Fixing modified files
+		Inspected 9 files
+		Calling post-update helper scripts.
+		Fix successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}


### PR DESCRIPTION
When running verify --fix, if there are files in the system that are
marked as deleted in the manifest, then they are removed from the
system. However, if a component of the path of the file is a
symbolic link, the file is determined to be unsafe to be removed and
it is left in the system, the user is warned, and the not-deleted
file count is incremented.

This commit modifies this behavior so verify just skips the file, the
user is not warned with the "Not safe to delete: <FILE>" error message,
and so the not-deleted file count is not incremented since it is really
not useful for the end user.

Closes #765