### PR TITLE
Fixing a race condition in testlib

### DIFF
--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -2380,7 +2380,7 @@ update_bundle() { # swupd_function
 			if [ ! -e "$version_path"/files/"$bundle_file".tar ]; then
 				# find the existing tar in previous versions and copy
 				# it to the current directory
-				file_tar=$(sudo find -name "$bundle_file".tar | head -n 1)
+				file_tar=$(sudo find "$WEBDIR" -name "$bundle_file".tar | head -n 1)
 				sudo cp "$file_tar" "$version_path"/files/"$bundle_file".tar
 			fi
 		done


### PR DESCRIPTION
When in a test we create a new version and a bundle update in that new
version, we copy the latest tar for each fullfile from the previous
versions into the new version. The code currently was searching for
those tars starting with the current directory, this was working fine
when running the tests locally because tests are run serially, but this
was causing an unexpected result when running in Travis since tests are
run in parallel, so this was causing the search to sometimes find the
tar in a different test environment (from another test), which was
causing unexpected results and a race condition.

This commit fixes the issue by narrowing the search of the tars to the
web-dir of the specific test environment.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>