### PR TITLE
Removing check for optarg for parameters with required arguments

### DIFF
--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -73,19 +73,11 @@ static bool parse_opt(int opt, char *optarg)
 		cmdline_local = false;
 		return true;
 	case 'D':
-		if (!optarg) {
-			fprintf(stderr, "Invalid --has-dep argument\n\n");
-			return false;
-		}
 		string_or_die(&cmdline_option_has_dep, "%s", optarg);
 		atexit(free_has_dep);
 		cmdline_local = false;
 		return true;
 	case 'd':
-		if (!optarg) {
-			fprintf(stderr, "Invalid --deps argument\n\n");
-			return false;
-		}
 		string_or_die(&cmdline_option_deps, "%s", optarg);
 		atexit(free_deps);
 		cmdline_local = false;

--- a/src/globals.c
+++ b/src/globals.c
@@ -577,16 +577,12 @@ static bool global_parse_opt(int opt, char *optarg)
 		/* Handle options that don't have shortcut. */
 		return true;
 	case 'p': /* default empty path_prefix verifies the running OS */
-		if (!optarg || !set_path_prefix(optarg)) {
+		if (!set_path_prefix(optarg)) {
 			fprintf(stderr, "Invalid --path argument\n\n");
 			return false;
 		}
 		return true;
 	case 'u':
-		if (!optarg) {
-			fprintf(stderr, "Invalid --url argument\n\n");
-			return false;
-		}
 		set_version_url(optarg);
 		set_content_url(optarg);
 		return true;
@@ -598,27 +594,19 @@ static bool global_parse_opt(int opt, char *optarg)
 		}
 		return true;
 	case 'c':
-		if (!optarg) {
-			fprintf(stderr, "Invalid --contenturl argument\n\n");
-			return false;
-		}
 		set_content_url(optarg);
 		return true;
 	case 'v':
-		if (!optarg) {
-			fprintf(stderr, "Invalid --versionurl argument\n\n");
-			return false;
-		}
 		set_version_url(optarg);
 		return true;
 	case 'F':
-		if (!optarg || !set_format_string(optarg)) {
+		if (!set_format_string(optarg)) {
 			fprintf(stderr, "Invalid --format argument\n\n");
 			return false;
 		}
 		return true;
 	case 'S':
-		if (!optarg || !set_state_dir(optarg)) {
+		if (!set_state_dir(optarg)) {
 			fprintf(stderr, "Invalid --statedir argument\n\n");
 			return false;
 		}
@@ -639,10 +627,6 @@ static bool global_parse_opt(int opt, char *optarg)
 		no_boot_update = true;
 		return true;
 	case 'C':
-		if (!optarg) {
-			fprintf(stderr, "Invalid --certpath argument\n\n");
-			return false;
-		}
 		set_cert_path(optarg);
 		return true;
 	case 'W':

--- a/src/hashdump.c
+++ b/src/hashdump.c
@@ -76,7 +76,7 @@ int hashdump_main(int argc, char **argv)
 			file.use_xattrs = false;
 			break;
 		case 'p':
-			if (!optarg || !set_path_prefix(optarg)) {
+			if (!set_path_prefix(optarg)) {
 				fprintf(stderr, "Invalid --path/-p argument\n\n");
 				return EINVALID_OPTION;
 			}

--- a/src/search.c
+++ b/src/search.c
@@ -370,7 +370,7 @@ static bool parse_opt(int opt, char *optarg)
 
 	switch (opt) {
 	case 's':
-		if (!optarg || (strcmp(optarg, "b") && (strcmp(optarg, "o")))) {
+		if (strcmp(optarg, "b") && (strcmp(optarg, "o"))) {
 			fprintf(stderr, "Invalid --scope argument. Must be 'b' or 'o'\n\n");
 			return false;
 		}

--- a/src/verify.c
+++ b/src/verify.c
@@ -540,10 +540,6 @@ static bool parse_opt(int opt, char *optarg)
 		cmdline_option_picky = true;
 		return true;
 	case 'X':
-		if (!optarg) {
-			fprintf(stderr, "Missing --picky-tree argument\n\n");
-			return false;
-		}
 		if (optarg[0] != '/') {
 			fprintf(stderr, "--picky-tree must be an absolute path, for example /usr\n\n");
 			return false;
@@ -551,10 +547,6 @@ static bool parse_opt(int opt, char *optarg)
 		cmdline_option_picky_tree = optarg;
 		return true;
 	case 'w':
-		if (!optarg) {
-			fprintf(stderr, "Missing --picky-whitelist argument\n\n");
-			return false;
-		}
 		cmdline_option_picky_whitelist = optarg;
 		return true;
 	default:


### PR DESCRIPTION
According to getopt_long documentation optarg is always set when argument is
required. It can be empty when argument is optional, but we don't have that
case in swupd.

So we can remove the extra check for empty optarg on opt parse functions.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>