### PR TITLE
sys: Fix memory leak

### DIFF
--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -36,7 +36,7 @@
 
 static int replace_fd(int fd, const char *fd_file)
 {
-	int new_fd;
+	int new_fd, replaced_fd;
 
 	if (!fd_file) {
 		return 0;
@@ -46,7 +46,9 @@ static int replace_fd(int fd, const char *fd_file)
 		return new_fd;
 	}
 
-	return dup2(new_fd, fd);
+	replaced_fd = dup2(new_fd, fd);
+	close(new_fd);
+	return replaced_fd;
 }
 
 int run_command_full(const char *stdout_file, const char *stderr_file, const char *cmd, ...)


### PR DESCRIPTION
The code was assuming that dup2 was replacing the fd, but this is not the case.
It is duplicating it, so new_fd was leaking.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>