### PR TITLE
globals: Use path_prefix for cert_path

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -414,7 +414,7 @@ static void set_cert_path(char *path)
 			string_or_die(&cert_path, "%s", MIX_CERT);
 		} else {
 			// CERT_PATH is guaranteed to be valid at this point.
-			string_or_die(&cert_path, "%s", CERT_PATH);
+			string_or_die(&cert_path, "%s%s", path_prefix, CERT_PATH);
 		}
 	}
 }


### PR DESCRIPTION
The certificate path should be looked up based on the path_prefix as
the configuration of the content under the path_prefix may be
different than the base system's.