### PR TITLE
WIP: New progress bar

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,6 +44,7 @@ swupd_SOURCES = \
 	src/hashdump.c \
 	src/helpers.c \
 	src/heuristics.c \
+	src/lib/progress.c \
 	src/info.c \
 	src/lib/hashmap.c \
 	src/lib/hashmap.h \

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -847,7 +847,7 @@ static enum swupd_code install_bundles(struct list *bundles, struct list **subs,
 	(void)rm_staging_dir_contents("download");
 
 	if (list_longer_than(to_install_files, 10)) {
-		download_subscribed_packs(*subs, mom, true);
+		download_subscribed_packs(*subs, mom);
 	}
 	timelist_timer_stop(global_times); // closing: Download packs
 

--- a/src/lib/progress.c
+++ b/src/lib/progress.c
@@ -1,0 +1,145 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2012-2016 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *   Authors:
+ *         Otavio Pontes <otavio.pontes@intel.com>
+ *
+ */
+
+#define _GNU_SOURCE
+
+#include <stdbool.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+
+#include "progress.h"
+#include "log.h"
+
+#define PREFIX_MINIMUM ((int)sizeof("(100000/100000)") - 1)
+#define BAR_MINIMUM ((int)sizeof(" [] ") - 1)
+#define PERCENTAGE_MINIMUM ((int)sizeof("000%") - 1)
+#define TEMPLATE_MINIMUM (PREFIX_MINIMUM + BAR_MINIMUM + PERCENTAGE_MINIMUM)
+#define FILE_COLS (80)
+
+struct progress {
+	int total;
+	const char *header;
+	bool terminal;
+	int next_percentage;
+} progress;
+
+static void print_bar(int percentage, int progress_bar_size)
+{
+	int i, progress, bar_size;
+
+	bar_size = progress_bar_size - BAR_MINIMUM;
+	progress = ((int)(((float)percentage * bar_size) / 100));
+
+	fprintf(stderr, " [");
+	for (i = 0; i < progress; i++) {
+		fprintf(stderr, "%c", '=');
+	}
+	fprintf(stderr, "%*s", bar_size - progress, "");
+	fprintf(stderr, "] ");
+}
+
+static void print_text(const char *text, int text_size)
+{
+	int printed;
+
+	if (text_size <= 0) {
+		return;
+	}
+
+	printed = fprintf(stderr, "%.*s", text_size, text);
+	fprintf(stderr, "%*s", text_size - printed, "");
+}
+
+static void print_progress_line(int current, int percentage, int cols, const char *text)
+{
+	int progress_bar_size, printed, text_size;
+
+	if (cols < TEMPLATE_MINIMUM) {
+		goto percentage;
+	}
+
+	progress_bar_size = cols / 3 + BAR_MINIMUM; // 1/3 of the total area
+
+	printed = fprintf(stderr, "(%d/%d) ", current, progress.total);
+	text_size = cols - printed - progress_bar_size - PERCENTAGE_MINIMUM;
+	print_text(text, text_size);
+	print_bar(percentage, progress_bar_size);
+
+percentage:
+	fprintf(stderr, "%2d%%", percentage);
+	fflush(stderr);
+}
+
+static void progress_update_file(int current, int percentage, const char *partial_text)
+{
+	if (!partial_text) {
+		if (percentage < progress.next_percentage)
+			return;
+		partial_text = progress.header;
+		progress.next_percentage = (((int)(percentage / 10)) * 10) + 10;
+	}
+
+	print_progress_line(current, percentage, FILE_COLS, partial_text);
+	fprintf(stderr, "\n");
+}
+
+void progress_start(char *header, int total)
+{
+	progress.header = header;
+	progress.total = total;
+	progress.terminal = isatty(fileno(stderr));
+	progress_update(0, NULL);
+}
+
+void progress_update(int current, const char *partial_text)
+{
+	int cols, percentage;
+	struct winsize w;
+
+	percentage = (int)((float)(current * 100)/ progress.total);
+
+	if (!progress.terminal) {
+		progress_update_file(current, percentage, partial_text);
+		return;
+	}
+
+	// Get terminal size
+	ioctl(0, TIOCGWINSZ, &w);
+	cols = w.ws_col;
+
+	if (cols < PERCENTAGE_MINIMUM) {
+		return;
+	}
+
+	fprintf(stderr, "\r");
+	print_progress_line(current, percentage, cols, progress.header);
+}
+
+void progress_end()
+{
+	progress_update(progress.total, NULL);
+	fprintf(stderr, "\n");
+
+	progress.header = "";
+	progress.total = 0;
+}

--- a/src/lib/progress.h
+++ b/src/lib/progress.h
@@ -1,0 +1,17 @@
+#ifndef __INCLUDE_GUARD_PROGRESS_H
+#define __INCLUDE_GUARD_PROGRESS_H
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void progress_start(char *header, int total);
+void progress_update(int current, const char *partial_text);
+void progress_end();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/lib/strings.c
+++ b/src/lib/strings.c
@@ -49,6 +49,20 @@ void string_or_die(char **strp, const char *fmt, ...)
 	va_end(ap);
 }
 
+char *str_or_die(const char *fmt, ...)
+{
+	char *str;
+	va_list ap;
+
+	va_start(ap, fmt);
+	if (vasprintf(&str, fmt, ap) < 0) {
+		abort();
+	}
+	va_end(ap);
+
+	return str;
+}
+
 void free_string(char **s)
 {
 	if (s) {

--- a/src/lib/strings.h
+++ b/src/lib/strings.h
@@ -7,20 +7,33 @@
 extern "C" {
 #endif
 
-/* Save in strp a new allocated string with content printed from fmt and
+/*
+ * Save in strp a new allocated string with content printed from fmt and
  * parameters using vasprintf. Abort on memory allocation errors.
  */
 void string_or_die(char **strp, const char *fmt, ...);
 
-/* Return a duplicated copy of the string using strdup().
+
+/*
+ * Same behavior as string_or_die(), but it returns the string, instead of
+ * setting strp.
+ */
+char *str_or_die(const char *fmt, ...);
+
+/*
+ * Return a duplicated copy of the string using strdup().
  * Abort if there's no memory to allocate the new string.
  */
 char *strdup_or_die(const char *const str);
 
-/* Free string and set it's value to NULL */
+/*
+ * Free string and set it's value to NULL
+ */
 void free_string(char **s);
 
-/* Join strings from string list separated by the separator */
+/*
+ * Join strings from string list separated by the separator
+ */
 char *string_join(const char *separator, struct list *string);
 
 #ifdef __cplusplus

--- a/src/packs.c
+++ b/src/packs.c
@@ -161,11 +161,10 @@ static int download_pack(void *download_handle, int oldversion, int newversion, 
 }
 
 /* pull in packs for base and any subscription */
-int download_subscribed_packs(struct list *subs, struct manifest *mom, bool required)
+int download_subscribed_packs(struct list *subs, struct manifest *mom)
 {
 	struct list *iter;
 	struct sub *sub = NULL;
-	int err;
 	int is_mix = 0;
 	unsigned int list_length = list_len(subs);
 	unsigned int complete = 0;
@@ -189,15 +188,8 @@ int download_subscribed_packs(struct list *subs, struct manifest *mom, bool requ
 		if (bundle) {
 			is_mix = bundle->is_mix;
 		}
-		err = download_pack(download_handle, sub->oldversion, sub->version, sub->component, is_mix);
+		download_pack(download_handle, sub->oldversion, sub->version, sub->component, is_mix);
 		print_progress(complete, list_length);
-		if (err < 0) {
-			if (required) { /* Probably need printf("\n") here */
-				return err;
-			} else {
-				continue;
-			}
-		}
 	}
 
 	print_progress(list_length, list_length); /* Force out 100% */

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -276,7 +276,7 @@ static inline void account_delta_miss(void)
 extern void print_statistics(int version1, int version2);
 
 extern int download_fullfiles(struct list *files, int *num_downloads);
-extern int download_subscribed_packs(struct list *subs, struct manifest *mom, bool required);
+extern int download_subscribed_packs(struct list *subs, struct manifest *mom);
 
 extern void apply_deltas(struct manifest *current_manifest);
 extern int untar_full_download(void *data);

--- a/src/update.c
+++ b/src/update.c
@@ -437,7 +437,7 @@ load_server_submanifests:
 
 	/* Step 5: get the packs and untar */
 	timelist_timer_start(global_times, "Download Packs");
-	download_subscribed_packs(latest_subs, server_manifest, false);
+	download_subscribed_packs(latest_subs, server_manifest);
 	timelist_timer_stop(global_times);
 
 	timelist_timer_start(global_times, "Apply deltas");

--- a/src/verify.c
+++ b/src/verify.c
@@ -136,7 +136,7 @@ static int get_all_files(struct manifest *official_manifest, struct list *subs)
 	int ret;
 
 	/* for install we need everything so synchronously download zero packs */
-	ret = download_subscribed_packs(subs, official_manifest, true);
+	ret = download_subscribed_packs(subs, official_manifest);
 	if (ret < 0) { // require zero pack
 		/* If we hit this point, we know we have a network connection, therefore
 		 * 	the error is server-side. This is also a critical error, so detailed


### PR DESCRIPTION
One thing that people complain a lot about swupd is the progress indicator and the fact that we print millions of dots when outputting to a file. Introducing in this commit a suggestion of a new progress bar. It's not printing the total download size, speed or any other download information, but that's something easier to extend now.

So far the only thing that was replaced to use the new progress bar was the pack downloads, because I am waiting on feedback before porting all print_progress we have in swupd.

Example of output on swupd update:

    Update started.
    Preparing to update from 27460 to 27490
    Packs to download:
            vim
            unbundle
            sysadmin-basic
            storage-utils-dev
            storage-utils
            qt-basic
            python3-basic
            python2-basic
            os-core-update-index
            os-core-update
            os-core
            network-basic
            mkosi
            mixer
            machine-learning-basic
            linux-tools
            libxml2
            kernel-native
            icdiff
            gpgme
            git
            firefox
            docutils
            diffoscope
            devpkg-qtbase
            devpkg-glib
            dev-utils-dev
            desktop-kde-libs
            desktop-assets
            desktop-apps
            desktop
            computer-vision-basic
            cloud-api
            c-basic
            kde-frameworks5

    (24/47) Downloading and extracting packs       [=============             ] 51%

If we are redirecting stderr to a file one progress bar will be printed each time we complete 10% of the progress, so only 11 lines will be printed. The output is human readable and easy to parse. (we can add an option to print on every step if that output is going to be used by the installer to give users feedback)

    (0/47) Downloading and extracting packs        [                          ]  0%
    (5/47) Downloading and extracting packs        [==                        ] 10%
    (10/47) Downloading and extracting packs       [=====                     ] 21%
    (15/47) Downloading and extracting packs       [========                  ] 31%
    (19/47) Downloading and extracting packs       [==========                ] 40%
    (24/47) Downloading and extracting packs       [=============             ] 51%
    (29/47) Downloading and extracting packs       [===============           ] 61%
    (33/47) Downloading and extracting packs       [==================        ] 70%
    (47/47) Downloading and extracting packs       [==========================] 100%
