### PR TITLE
Checking if the boot script exist before running

### DIFF
--- a/test/functional/bundleadd/add-boot-file.bats
+++ b/test/functional/bundleadd/add-boot-file.bats
@@ -18,12 +18,15 @@ test_setup() {
 	assert_file_exists "$TARGETDIR/usr/lib/kernel/test-file"
 	expected_output=$(cat <<-EOM
 		Starting download of remaining update content. This may take a while...
+		.
 		Finishing download of update content...
 		Installing bundle(s) files...
+		.
 		Calling post-update helper scripts.
+		WARNING: post-update helper script ($TEST_DIRNAME/testfs/target-dir//usr/bin/clr-boot-manager) not found, it will be skipped
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }

--- a/test/functional/update/update-boot-file.bats
+++ b/test/functional/update/update-boot-file.bats
@@ -32,6 +32,7 @@ test_setup() {
 		Applying update
 		Update was applied.
 		Calling post-update helper scripts.
+		WARNING: post-update helper script ($TEST_DIRNAME/testfs/target-dir//usr/bin/clr-boot-manager) not found, it will be skipped
 		Update successful. System updated from version 10 to version 100
 	EOM
 	)

--- a/test/functional/update/update-boot-file_1.ignore-list
+++ b/test/functional/update/update-boot-file_1.ignore-list
@@ -1,4 +1,3 @@
-WARNING: post-update helper script .* not found, it will be skipped
 Update took .* seconds
 Compile-time options:.*
 Compile-time configuration:

--- a/test/functional/verify/verify-boot-file.bats
+++ b/test/functional/verify/verify-boot-file.bats
@@ -47,6 +47,7 @@ test_setup() {
 		    1 of 1 files were fixed
 		    0 of 1 files were not fixed
 		Calling post-update helper scripts.
+		WARNING: post-update helper script \\($TEST_DIRNAME/testfs/target-dir//usr/bin/clr-boot-manager\\) not found, it will be skipped
 		Fix successful
 	EOM
 	)

--- a/test/functional/verify/verify-boot-file_2.ignore-list
+++ b/test/functional/verify/verify-boot-file_2.ignore-list
@@ -1,4 +1,3 @@
-WARNING: post-update helper script .* not found, it will be skipped
 Update took .* seconds
 Compile-time options:.*
 Compile-time configuration:


### PR DESCRIPTION
When swupd needs to run a boot script it does so without checking if the
file exists in the system or not. This will cause an error to be raised
by the shell if the script does not exist.

This commit adds a check for the existance of the script before
attempting to run it.

Closes #795

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>