### PR TITLE
Telemetry: include `bytes transferred` wherever applicable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ install:
         - wget https://github.com/clearlinux/bsdiff/releases/download/v1.0.2/bsdiff-1.0.2.tar.xz
         - tar -xvf bsdiff-1.0.2.tar.xz
         - pushd bsdiff-1.0.2 && ./configure --prefix=/usr --disable-tests && make -j48 && sudo make install && popd
-        - wget https://curl.haxx.se/download/curl-7.51.0.tar.gz
-        - tar -xvf curl-7.51.0.tar.gz
-        - pushd curl-7.51.0 && ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu && make -j48 && sudo make install && popd
+        - wget https://curl.haxx.se/download/curl-7.64.0.tar.gz
+        - tar -xvf curl-7.64.0.tar.gz
+        - pushd curl-7.64.0 && ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu && make -j48 && sudo make install && popd
         - wget https://download.clearlinux.org/releases/13010/clear/Swupd_Root.pem
         - sudo install -D -m0644 Swupd_Root.pem /usr/share/clear/update-ca/Swupd_Root.pem
         - wget https://github.com/libarchive/libarchive/archive/v3.3.1.tar.gz

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -507,10 +507,12 @@ enum swupd_code remove_bundles(char **bundles)
 			  "bundleremove",
 			  "bundle=%s\n"
 			  "current_version=%d\n"
-			  "result=%d\n",
+			  "result=%d\n"
+			  "bytes=%ld\n",
 			  *bundles,
 			  current_version,
-			  ret);
+			  ret,
+			  total_curl_sz);
 
 		free_subscriptions(&subs);
 		swupd_deinit();
@@ -634,10 +636,12 @@ enum swupd_code remove_bundles(char **bundles)
 			  "bundleremove",
 			  "bundle=%s\n"
 			  "current_version=%d\n"
-			  "result=%d\n",
+			  "result=%d\n"
+			  "bytes=%ld\n",
 			  bundle,
 			  current_version,
-			  ret);
+			  ret,
+			  total_curl_sz);
 		/* if at least one of the bundles fails to be removed, exit with a failure */
 		if (ret) {
 			ret_code = ret;
@@ -1106,10 +1110,12 @@ clean_and_exit:
 		  "bundleadd",
 		  "bundles=%s\n"
 		  "current_version=%d\n"
-		  "result=%d\n",
+		  "result=%d\n"
+		  "bytes=%ld\n",
 		  bundles_list_str,
 		  current_version,
-		  ret);
+		  ret,
+		  total_curl_sz);
 
 	list_free_list_and_data(bundles_list, free);
 	free_string(&bundles_list_str);

--- a/src/curl.c
+++ b/src/curl.c
@@ -53,6 +53,8 @@
 
 static CURL *curl = NULL;
 
+curl_off_t total_curl_sz = 0;
+
 /* alternative CA Path */
 static char *capath = NULL;
 
@@ -359,6 +361,13 @@ enum download_status process_curl_error_codes(int curl_ret, CURL *curl_handle)
 	if (curl_easy_getinfo(curl_handle, CURLINFO_EFFECTIVE_URL, &url) != CURLE_OK) {
 		url = "<not available>";
 	}
+
+	/*
+	 * retrieve bytes transferred, errors or not
+	 */
+	curl_off_t curl_sz;
+	curl_easy_getinfo(curl_handle, CURLINFO_SIZE_DOWNLOAD_T, &curl_sz);
+	total_curl_sz += curl_sz;
 
 	if (curl_ret == CURLE_OK || curl_ret == CURLE_HTTP_RETURNED_ERROR ||
 	    curl_ret == CURLE_RECV_ERROR) {

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -107,6 +107,8 @@ extern bool need_systemd_reexec;
 extern struct list *post_update_actions;
 extern bool keepcache;
 
+extern curl_off_t total_curl_sz;
+
 struct update_stat {
 	uint64_t st_mode;
 	uint64_t st_uid;

--- a/src/update.c
+++ b/src/update.c
@@ -465,14 +465,17 @@ clean_curl:
 		  "current_version=%d\n"
 		  "server_version=%d\n"
 		  "result=%d\n"
-		  "time=%5.1f\n",
+		  "time=%5.1f\n"
+		  "bytes=%ld\n",
 		  current_version,
 		  server_version,
 		  ret,
-		  delta);
+		  delta,
+		  total_curl_sz);
 
 	if (server_version > current_version) {
-		printf("Update took %0.1f seconds\n", delta);
+		printf("Update took %0.1f seconds, %ld bytes transferred\n", delta,
+		       total_curl_sz);
 	}
 	timelist_print_stats(global_times);
 
@@ -641,10 +644,12 @@ static enum swupd_code print_versions()
 		  "check",
 		  "result=%d\n"
 		  "version_current=%d\n"
-		  "version_server=%d\n",
+		  "version_server=%d\n"
+		  "bytes=%ld\n",
 		  ret,
 		  current_version,
-		  server_version);
+		  server_version,
+		  total_curl_sz);
 
 	return ret;
 }

--- a/src/verify.c
+++ b/src/verify.c
@@ -938,7 +938,8 @@ clean_and_exit:
 		  "file_deleted_count=%d\n"
 		  "file_not_deleted_count=%d\n"
 		  "file_mismatch_count=%d\n"
-		  "file_extraneous_count=%d\n",
+		  "file_extraneous_count=%d\n"
+		  "bytes=%ld\n",
 		  cmdline_option_fix || cmdline_option_install,
 		  ret,
 		  version,
@@ -950,7 +951,8 @@ clean_and_exit:
 		  counts.deleted,
 		  counts.not_deleted,
 		  counts.mismatch,
-		  counts.extraneous);
+		  counts.extraneous,
+		  total_curl_sz);
 	if (ret == SWUPD_OK) {
 		if (cmdline_option_fix || cmdline_option_install) {
 			fprintf(stderr, "Fix successful\n");

--- a/test/functional/ignore-list
+++ b/test/functional/ignore-list
@@ -1,5 +1,5 @@
 WARNING: post-update helper script .* not found, it will be skipped
-Update took .* seconds
+Update took .*
 Compile-time options:.*
 Compile-time configuration:
 mount point.*

--- a/test/functional/update/update-boot-file_1.ignore-list
+++ b/test/functional/update/update-boot-file_1.ignore-list
@@ -1,4 +1,4 @@
-Update took .* seconds
+Update took .*
 Compile-time options:.*
 Compile-time configuration:
 mount point.*

--- a/test/functional/verify/verify-boot-file_2.ignore-list
+++ b/test/functional/verify/verify-boot-file_2.ignore-list
@@ -1,4 +1,4 @@
-Update took .* seconds
+Update took .*
 Compile-time options:.*
 Compile-time configuration:
 mount point.*


### PR DESCRIPTION
Display the bytes transferred after each update in the message
that shows "took N seconds" by appending the info.

This includes total transfer bytes for verify, update, check,
bundle-add and bundle-remove.

The curl error handling function is the perfect location to
capture the bytes for each transfer, and add them to a global
counter. The global counter is then included in each telemetry
event.