### PR TITLE
Providing option to disable compiler optimizations

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,8 @@ SUFFIXES= .rst
 
 EXTRA_DIST = COPYING scripts/findstatic.pl swupd.bash
 
-AM_CFLAGS = -fPIC -O2 -g -D_FORTIFY_SOURCE=2 -fno-common -std=gnu99 \
+AM_CFLAGS = -fPIC -g -D_FORTIFY_SOURCE=2 -fno-common -std=gnu99 \
+	-O$(OPTIMIZE) \
 	-Wall \
 	-Wextra \
 	-Wformat-security \

--- a/autogen.sh
+++ b/autogen.sh
@@ -19,5 +19,5 @@ args="\
 --prefix=/usr \
 --enable-silent-rules"
 
-./configure CFLAGS="-g -O2 $CFLAGS" $args "$@"
+./configure "$args" "$@"
 make clean

--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,18 @@ AC_CHECK_PROGS(TAR, tar)
 
 # Enable/disable options
 AC_ARG_ENABLE(
+  [optimizations],
+  [AS_HELP_STRING([--disable-optimizations], [Disable compiler optimizations (enabled by default)])],
+  compiler_optimizations="$enableval",
+  [AC_SUBST(OPTIMIZE, [2])]
+)
+AS_IF(
+  [test -n "$compiler_optimizations" -a x"$compiler_optimizations" = "xno"],
+  [AC_SUBST(OPTIMIZE, [0])],
+  [AC_SUBST(OPTIMIZE, [2])]
+)
+
+AC_ARG_ENABLE(
   [bzip2],
   [AS_HELP_STRING([--disable-bzip2], [Do not use bzip2 compression (uses bzip2 by default)])]
 )


### PR DESCRIPTION
This commit adds an option to disable compiler optimizations which is
very useful when debugging a problem in swupd.

Note: the user would still need to make sure the optimization option is
not enabled in his/her CFLAGS variable.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>