### PR TITLE
docs: Fix documentation on --force option

### DIFF
--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -92,13 +92,6 @@ used to modify the core behavior and resources that swupd uses.
    not supported by your version of ``swupd``, you should subtract ``1``
    from the number and try again until it succeeds.
 
--  ``-f, --force``
-
-   Forces completion of swupd beyond critical failures. This may ignore
-   filesystem errors, configuration errors and other errors which are
-   considered fatal, and could damage an installation if not addressed
-   properly.
-
 -  ``-S, --statedir={path}``
 
    Specify an alternate swupd state directory. Normally ``swupd`` uses

--- a/src/globals.c
+++ b/src/globals.c
@@ -34,7 +34,6 @@
 #include "lib/log.h"
 #include "swupd.h"
 bool allow_mix_collisions = false;
-bool force = false;
 bool migrate = false;
 bool sigcheck = true;
 bool timecheck = true;
@@ -705,7 +704,6 @@ void global_print_help(void)
 	fprintf(stderr, "   -c, --contenturl=[URL]  RFC-3986 encoded url for content file downloads\n");
 	fprintf(stderr, "   -v, --versionurl=[URL]  RFC-3986 encoded url for version file downloads\n");
 	fprintf(stderr, "   -F, --format=[staging,1,2,etc.]  the format suffix for version file downloads\n");
-	fprintf(stderr, "   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	fprintf(stderr, "   -n, --nosigcheck        Do not attempt to enforce certificate or signature checking\n");
 	fprintf(stderr, "   -I, --ignore-time       Ignore system/certificate time when validating signature\n");
 	fprintf(stderr, "   -S, --statedir          Specify alternate swupd state directory\n");

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -93,7 +93,6 @@ struct header;
 
 extern bool allow_mix_collisions;
 extern bool verbose_time;
-extern bool force;
 extern bool migrate;
 extern bool sigcheck;
 extern bool timecheck;


### PR DESCRIPTION
--force/-x is specific for verify command, but documentation was stating
that it was global. Removing all references from a global --force and
adding that information to the help page of verify command.

Also moves the force variable from global to verify.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>