### PR TITLE
curl: Check for errors before using value from curl_easy_getinfo call

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -365,9 +365,10 @@ enum download_status process_curl_error_codes(int curl_ret, CURL *curl_handle)
 	/*
 	 * retrieve bytes transferred, errors or not
 	 */
-	curl_off_t curl_sz;
-	curl_easy_getinfo(curl_handle, CURLINFO_SIZE_DOWNLOAD_T, &curl_sz);
-	total_curl_sz += curl_sz;
+	curl_off_t curl_sz = 0;
+	if (curl_easy_getinfo(curl_handle, CURLINFO_SIZE_DOWNLOAD_T, &curl_sz) == CURLE_OK) {
+		total_curl_sz += curl_sz;
+	}
 
 	if (curl_ret == CURLE_OK || curl_ret == CURLE_HTTP_RETURNED_ERROR ||
 	    curl_ret == CURLE_RECV_ERROR) {


### PR DESCRIPTION
Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>