### PR TITLE
update: Be consistent in exit codes when trying to update to the same version

### DIFF
--- a/src/swupd.h
+++ b/src/swupd.h
@@ -209,7 +209,6 @@ extern enum swupd_code walk_tree(struct manifest *, const char *, bool, const re
 
 extern int get_latest_version(char *v_url);
 extern enum swupd_code read_versions(int *current_version, int *server_version, char *path_prefix);
-extern enum swupd_code check_versions(int *current_version, int *server_version, int requested_version, char *path_prefix);
 extern int get_current_version(char *path_prefix);
 
 extern bool ignore(struct file *file);

--- a/src/update.c
+++ b/src/update.c
@@ -198,6 +198,32 @@ static bool need_new_upstream(int server)
 	return false;
 }
 
+static enum swupd_code check_versions(int *current_version, int *server_version, int requested_version, char *path_prefix)
+{
+	int ret;
+
+	ret = read_versions(current_version, server_version, path_prefix);
+	if (ret != SWUPD_OK) {
+		return ret;
+	}
+	if (*current_version == 0) {
+		fprintf(stderr, "Update from version 0 not supported yet.\n");
+		return SWUPD_INVALID_OPTION;
+	}
+	if (requested_version != -1) {
+		if (requested_version <= *current_version) {
+			fprintf(stderr, "Requested version for update (%d) must be greater than current version (%d)\n",
+				requested_version, *current_version);
+			return SWUPD_INVALID_OPTION;
+		}
+		if (requested_version < *server_version) {
+			*server_version = requested_version;
+		}
+	}
+
+	return SWUPD_OK;
+}
+
 static enum swupd_code main_update()
 {
 	int current_version = -1, server_version = -1;

--- a/src/update.c
+++ b/src/update.c
@@ -211,7 +211,7 @@ static enum swupd_code check_versions(int *current_version, int *server_version,
 		return SWUPD_INVALID_OPTION;
 	}
 	if (requested_version != -1) {
-		if (requested_version <= *current_version) {
+		if (requested_version < *current_version) {
 			fprintf(stderr, "Requested version for update (%d) must be greater than current version (%d)\n",
 				requested_version, *current_version);
 			return SWUPD_INVALID_OPTION;
@@ -313,7 +313,12 @@ version_check:
 	}
 
 	if (server_version <= current_version) {
-		fprintf(stderr, "Version on server (%i) is not newer than system version (%i)\n", server_version, current_version);
+		if (requested_version == server_version) {
+			fprintf(stderr, "Requested version (%i)", requested_version);
+		} else {
+			fprintf(stderr, "Version on server (%i)", server_version);
+		}
+		fprintf(stderr, " is not newer than system version (%i)\n", current_version);
 		ret = SWUPD_OK;
 		goto clean_curl;
 	}

--- a/src/version.c
+++ b/src/version.c
@@ -153,32 +153,6 @@ enum swupd_code read_versions(int *current_version, int *server_version, char *p
 	return SWUPD_OK;
 }
 
-enum swupd_code check_versions(int *current_version, int *server_version, int requested_version, char *path_prefix)
-{
-	int ret;
-
-	ret = read_versions(current_version, server_version, path_prefix);
-	if (ret != SWUPD_OK) {
-		return ret;
-	}
-	if (*current_version == 0) {
-		fprintf(stderr, "Update from version 0 not supported yet.\n");
-		return SWUPD_INVALID_OPTION;
-	}
-	if (requested_version != -1) {
-		if (requested_version <= *current_version) {
-			fprintf(stderr, "Requested version for update (%d) must be greater than current version (%d)\n",
-				requested_version, *current_version);
-			return SWUPD_INVALID_OPTION;
-		}
-		if (requested_version < *server_version) {
-			*server_version = requested_version;
-		}
-	}
-
-	return SWUPD_OK;
-}
-
 int read_mix_version_file(char *filename, char *path_prefix)
 {
 	char line[LINE_MAX];

--- a/test/functional/update/update-to-same-version.bats
+++ b/test/functional/update/update-to-same-version.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+
+# Author: Otavio Pontes
+# Email: otavio.pontes@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_version -p "$TEST_NAME" 20 10
+
+}
+
+@test "UPD050: Update to the same version using -m" {
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS -m 10"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Update started.
+		Requested version (10) is not newer than system version (10)
+		Update complete. System already up-to-date at version 10
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "UPD051: Update to same version using -m, when already in last version" {
+
+	set_current_version "$TEST_NAME" 20
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS -m 20"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Update started.
+		Requested version (20) is not newer than system version (20)
+		Update complete. System already up-to-date at version 20
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "UPD052: Update when already in last version" {
+
+	set_current_version "$TEST_NAME" 20
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Update started.
+		Version on server (20) is not newer than system version (20)
+		Update complete. System already up-to-date at version 20
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}


### PR DESCRIPTION

    
    Use similar output and same exit code used when you are already in the
    last version in the case where you are updating to the same version you
    already are.
    
    i.e. if you are in version 100, both commands are going to have the same
    exit code:
    
     - swupd update
     - swupd update -m 100
