### PR TITLE
Adding path_prefix for versionstamp

### DIFF
--- a/src/check_update.c
+++ b/src/check_update.c
@@ -51,7 +51,7 @@ static enum swupd_code check_update()
 	/* Check that our system time is reasonably valid before continuing,
 	* or the certificate verification will fail with invalid time */
 	if (timecheck) {
-		if (!verify_time()) {
+		if (!verify_time(path_prefix)) {
 			return SWUPD_BAD_TIME;
 		}
 	}

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -538,9 +538,14 @@ enum swupd_code swupd_init(void)
 	/* Check that our system time is reasonably valid before continuing,
 	 * or the certificate verification will fail with invalid time */
 	if (timecheck) {
-		if (!verify_time()) {
-			ret = SWUPD_BAD_TIME;
-			goto out_fds;
+		if (!verify_time(path_prefix)) {
+			/* in the case we are doing an installation to an empty directory
+			 * using swupd verify --install, we won't have a valid versionstamp
+			 * in path_prefix, so try searching without the path_prefix */
+			if (!verify_time(NULL)) {
+				ret = SWUPD_BAD_TIME;
+				goto out_fds;
+			}
 		}
 	}
 

--- a/src/verifytime.h
+++ b/src/verifytime.h
@@ -8,7 +8,7 @@ extern "C" {
 #endif
 
 /* verifytime.c */
-bool verify_time();
+bool verify_time(char *);
 
 #ifdef __cplusplus
 }

--- a/src/verifytime_main.c
+++ b/src/verifytime_main.c
@@ -18,9 +18,11 @@
  */
 #include "verifytime.h"
 
+#include <stdlib.h>
+
 int main()
 {
-	if (verify_time()) {
+	if (verify_time(NULL)) {
 		return 0; // Success
 	}
 


### PR DESCRIPTION
When a user is using the -p/--path option with swupd he can point to a
chroot installation of clear or a custom mount. However when swupd
checks the system time to see if it is sane it compares it with a
versionstamp hardcoded in  /usr/share/clear/versionstamp, which causes
swupd to fail in systems using -p.

This commit prepends the path_prefix to the versionstamp path so it
points to the correct file if using the --path option.

Closes #812

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>