### PR TITLE
Curl: Don't set curl fail on error when checking the connection

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -129,7 +129,7 @@ static int check_connection(const char *test_capath)
 	long response = 0;
 
 	debug("Curl - check_connection url: %s\n", version_url);
-	curl_ret = swupd_curl_set_basic_options(curl, version_url);
+	curl_ret = swupd_curl_set_basic_options(curl, version_url, false);
 	if (curl_ret != CURLE_OK) {
 		return -1;
 	}
@@ -522,7 +522,7 @@ restart_download:
 		}
 	}
 
-	curl_ret = swupd_curl_set_basic_options(curl, url);
+	curl_ret = swupd_curl_set_basic_options(curl, url, true);
 	if (curl_ret != CURLE_OK) {
 		goto exit;
 	}
@@ -704,7 +704,7 @@ exit:
 	return curl_ret;
 }
 
-CURLcode swupd_curl_set_basic_options(CURL *curl, const char *url)
+CURLcode swupd_curl_set_basic_options(CURL *curl, const char *url, bool fail_on_error)
 {
 	static bool use_ssl = true;
 
@@ -749,10 +749,12 @@ CURLcode swupd_curl_set_basic_options(CURL *curl, const char *url)
 		goto exit;
 	}
 
-	/* Avoid downloading HTML files for error responses if the HTTP code is >= 400 */
-	curl_ret = curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1);
-	if (curl_ret != CURLE_OK) {
-		goto exit;
+	if (fail_on_error) {
+		/* Avoid downloading HTML files for error responses if the HTTP code is >= 400 */
+		curl_ret = curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1);
+		if (curl_ret != CURLE_OK) {
+			goto exit;
+		}
 	}
 
 exit:

--- a/src/curl_async.c
+++ b/src/curl_async.c
@@ -439,7 +439,7 @@ static int process_download(struct swupd_curl_parallel_handle *h, struct multi_c
 		goto out_bad;
 	}
 
-	curl_ret = swupd_curl_set_basic_options(curl, file->url);
+	curl_ret = swupd_curl_set_basic_options(curl, file->url, true);
 	if (curl_ret != CURLE_OK) {
 		goto out_bad;
 	}

--- a/src/swupd_curl_internal.h
+++ b/src/swupd_curl_internal.h
@@ -36,7 +36,7 @@ extern CURLcode swupd_download_file_close(CURLcode curl_ret, struct curl_file *f
 /*
  * Set swupd default basic options to curl handler.
  */
-extern CURLcode swupd_curl_set_basic_options(CURL *curl, const char *url);
+extern CURLcode swupd_curl_set_basic_options(CURL *curl, const char *url, bool fail_on_error);
 
 /* Process download curl return code 'curl_ret' and if needed the response code to
  * fill 'err' with an error code and return the status of this download. */


### PR DESCRIPTION
When we are checking if the SSL is working and the server is up we don't care
about the server return code. We just care if the server is responding. So
we shouldn't set the curl option CURLOPT_FAILONERROR.

The major problem of this change is that some servers don't respond to GET
in '/'. So checking the connection using the version url will fail in that
cases if CURLOPT_FAILONERROR is set.

As we don't really need the other options, reverting that change back to
how it was before.

Fixes #792

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>