### PR TITLE
Add swupd-inspector command into swupd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,6 +28,7 @@ swupd_SOURCES = \
 	src/alias.h \
 	src/archives.c \
 	src/autoupdate.c \
+	src/binary_loader.c \
 	src/bundle.c \
 	src/check_update.c \
 	src/clean.c \
@@ -50,6 +51,8 @@ swupd_SOURCES = \
 	src/lib/hashmap.h \
 	src/lib/list.c \
 	src/lib/list.h \
+	src/lib/log.c \
+	src/lib/log.h \
 	src/lib/macros.h \
 	src/lib/strings.c \
 	src/lib/strings.h \
@@ -58,8 +61,6 @@ swupd_SOURCES = \
 	src/lib/thread_pool.c \
 	src/lib/thread_pool.h \
 	src/lock.c \
-	src/lib/log.c \
-	src/lib/log.h \
 	src/main.c \
 	src/manifest.c \
 	src/mirror.c \
@@ -71,13 +72,13 @@ swupd_SOURCES = \
 	src/staging.c \
 	src/stats.c \
 	src/subscriptions.c \
+	src/swupd.h \
 	src/swupd_build_opts.h \
 	src/swupd_build_variant.h \
-	src/swupd_curl_internal.h \
 	src/swupd_curl.h \
+	src/swupd_curl_internal.h \
 	src/swupd_exit_codes.h \
 	src/swupd_internal.h \
-	src/swupd.h \
 	src/telemetry.c \
 	src/timelist.c \
 	src/timelist.h \
@@ -229,6 +230,7 @@ BATS = \
 	test/functional/update/update-with-slightly-old-mirror.bats \
 	test/functional/usability/usa-completion-basic.bats \
 	test/functional/usability/usa-download-retries.bats \
+	test/functional/usability/usa-external-modules.bats \
 	test/functional/verify/verify-add-missing-include.bats \
 	test/functional/verify/verify-add-missing-include-old.bats \
 	test/functional/verify/verify-boot-file.bats \

--- a/configure.ac
+++ b/configure.ac
@@ -174,6 +174,17 @@ AS_IF(
   [AC_DEFINE(OS_IS_STATELESS, 1, [OS is stateless])]
 )
 
+external_modules="yes"
+AC_ARG_ENABLE(
+  [external-modules],
+  [AS_HELP_STRING([--disable-external-modules], [Disable external modules (enabled by default)])],
+  external_modules="$enableval"
+)
+AS_IF(
+  [test -n "$external_modules" -a x"$external_modules" = "xyes"],
+  [AC_DEFINE(EXTERNAL_MODULES_SUPPORT, 1, [external modules are supported])]
+)
+
 
 # With/without options
 AC_ARG_WITH(
@@ -360,4 +371,5 @@ Configuration to build swupd-client:
   Run Tests:				${TESTS}
   Use extended file attributes		${XATTR}
   Use --selinux option for tar		${TARSELINUX}
+  External modules support		${external_modules}
 ])

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -437,6 +437,7 @@ The non-zero return codes for other operations are listed here:
   - **33**: Collisions found between a mix and upstream
   - **34**: swupd ran out of memory
   - **35**: Unable to fix/replace/delete one or more files
+  - **36**: Unable to execute binary, is either missing or invalid
 
 
 SEE ALSO

--- a/src/binary_loader.c
+++ b/src/binary_loader.c
@@ -1,0 +1,85 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2019 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define _GNU_SOURCE
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "swupd.h"
+
+/*
+ * Create a list of parameters compatible with execv().
+ *
+ * By definition:
+ *  - The first parameter is the name of the binary that is being run.
+ *  - Followed by each parameter in argv as a string in the params array.
+ *  - Terminated with a NULL pointer.
+ */
+static char **create_params_list(char *binary_name, int argc, char **argv)
+{
+	char **params = malloc(sizeof(char *) * (argc + 2));
+	int i;
+
+	params[0] = binary_name;
+	for (i = 0; i < argc; i++) {
+		params[i + 1] = argv[i];
+	}
+	params[argc + 1] = NULL;
+
+	return params;
+}
+
+enum swupd_code binary_loader_main(int argc, char **argv)
+{
+	char *binary_name;
+	char *full_binary_path;
+	char *command;
+	char **params = NULL;
+	int ret = SWUPD_OK;
+
+	if (argc == 0) {
+		return SWUPD_INVALID_OPTION;
+	}
+
+	command = argv[0];
+	string_or_die(&binary_name, "swupd-%s", command);
+	string_or_die(&full_binary_path, "/usr/bin/%s", binary_name);
+
+	if (!file_is_executable(full_binary_path)) {
+		error("Binary %s doesn't exist in your system\n", full_binary_path);
+		ret = SWUPD_INVALID_BINARY;
+		goto end;
+	}
+
+	params = create_params_list(binary_name, argc - 1, argv + 1);
+	ret = execv(full_binary_path, params);
+	if (ret < 0) {
+		fprintf(stderr, "Running %s failed\n", binary_name);
+		ret = SWUPD_SUBPROCESS_ERROR;
+	}
+
+end:
+	free(params);
+	free_string(&binary_name);
+	free_string(&full_binary_path);
+
+	return ret;
+}

--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -217,3 +217,14 @@ bool file_exits(const char *filename)
 
 	return false;
 }
+
+bool file_is_executable(const char *filename)
+{
+	struct stat sb;
+
+	if (stat(filename, &sb) == 0 && (sb.st_mode & S_IXUSR)) {
+		return true;
+	}
+
+	return false;
+}

--- a/src/lib/sys.h
+++ b/src/lib/sys.h
@@ -55,6 +55,11 @@ struct list *get_dir_files_sorted(char *path);
  */
 bool file_exits(const char *filename);
 
+/*
+ * Checks if a file exists in the filesystem and is executable.
+ */
+bool file_is_executable(const char *filename);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -47,6 +47,9 @@ static struct subcmd commands[] = {
 	{ "info", "Show the version and the update URLs", info_main },
 	{ "clean", "Clean cached files", clean_main },
 	{ "mirror", "Configure mirror url for swupd content", mirror_main },
+#ifdef EXTERNAL_MODULES_SUPPORT
+	{ "inspector", "Inspect swupd manifests for debugging purposes", binary_loader_main },
+#endif
 	{ 0 }
 };
 

--- a/src/swupd_exit_codes.h
+++ b/src/swupd_exit_codes.h
@@ -45,7 +45,8 @@ enum swupd_code {
 	SWUPD_COULDNT_WRITE_FILE,	    /* 32 couldn't write to a file */
 	SWUPD_MIX_COLLISIONS,		     /* 33 collisions were found between mix and upstream */
 	SWUPD_OUT_OF_MEMORY_ERROR,	   /* 34 swupd ran out of memory */
-	SWUPD_VERIFY_FAILED		     /* 35 verify could not fix/replace/delete one or more files */
+	SWUPD_VERIFY_FAILED,		     /* 35 verify could not fix/replace/delete one or more files */
+	SWUPD_INVALID_BINARY,		     /* 36 binary to be executed is missing or invalid */
 
 };
 

--- a/src/swupd_internal.h
+++ b/src/swupd_internal.h
@@ -13,5 +13,6 @@ extern enum swupd_code search_main(int argc, char **argv);
 extern enum swupd_code info_main(int argc, char **argv);
 extern enum swupd_code clean_main(int argc, char **argv);
 extern enum swupd_code mirror_main(int argc, char **argv);
+extern enum swupd_code binary_loader_main(int argc, char **argv);
 
 #endif

--- a/test/functional/usability/usa-external-modules.bats
+++ b/test/functional/usability/usa-external-modules.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+file_created=false
+
+test_setup() {
+
+	if [ -z "$TRAVIS" ]; then
+		skip "This test is intended to run only in Travis (use TRAVIS=true to run it anyway)..."
+	fi
+
+	if [ ! -e /usr/bin/swupd-inspector ]; then
+		print "swupd-inspector not found in the system, creating a mock one..."
+		{
+			printf '#!/bin/bash\n'
+			printf 'echo "Inspect and download swupd content"\n'
+			# shellcheck disable=SC2016
+			printf 'echo "Fake inspector invoked successfully with these arguments: $1 $2 $3"\n'
+		} | sudo tee /usr/bin/swupd-inspector > /dev/null
+		sudo chmod +x /usr/bin/swupd-inspector
+		file_created=true
+	else
+		print "swupd-inspector was found installed in the system"
+	fi
+
+}
+
+test_teardown() {
+
+	if [ -z "$TRAVIS" ]; then
+		return
+	fi
+
+	if [ "$file_created" = true ]; then
+		print "removing the mock swupd-inspector from the system..."
+		sudo rm /usr/bin/swupd-inspector
+	fi
+
+}
+
+@test "USA008: The external module swupd-inspector can be called from swupd" {
+
+	# swupd should be able to run enabled external programs
+	run sudo sh -c "$SWUPD inspector"
+
+	assert_status_is 0
+	assert_in_output "Inspect and download swupd content"
+
+}
+
+@test "USA009: Arguments are parsed correctly when calling external modules" {
+
+	if [ "$file_created" = false ]; then
+		skip "this test only makes sense using the mock swupd-inspector, skipping it..."
+	fi
+
+	run sudo sh -c "$SWUPD inspector arg1 arg2 arg3"
+
+	assert_status_is 0
+	assert_in_output "Fake inspector invoked successfully with these arguments: arg1 arg2 arg3"
+
+}


### PR DESCRIPTION
Use a binary launcher to load swupd-inspector and execute that
when swupd inspector is run.

Closes #826

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>
Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>