### PR TITLE
Consolidating minversion implementations in testlib

### DIFF
--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1026,17 +1026,49 @@ bump_format() { # swupd_function
 	new_version="$((version+20))"
 	new_version_path="$env_name"/web-dir/"$new_version"
 	format="$(< "$env_name"/web-dir/"$version"/format)"
-	mom="$new_version_path"/Manifest.MoM
 
 	# create two new versions for the format bump, each version separated by 10
 	# from each other and from the current latest version
 	create_version "$env_name" "$middle_version" "$version" "$format"
 	create_version -r "$env_name" "$new_version" "$middle_version" "$((format+1))"
+
+	# Update the +10 version
+	mom="$middle_version_path"/Manifest.MoM
+
+	# +10 and +20 versions should have matching content
+	sudo rm -rf "$middle_version_path"
+	sudo cp -r "$new_version_path" "$middle_version_path"
+
+	# Update +10 format and versions
+	update_manifest -p "$mom" format "$format"
+	update_manifest -p "$mom" version "$middle_version"
+	update_manifest -p "$mom" previous "$version"
+
+	# The +20 version updates the os-release and format files. Change
+	# the versions of these files in the +10 to the +10's version.
+	update_manifest -p "$mom" file-version os-core "$middle_version"
+	update_manifest -p "$middle_version_path"/Manifest.os-core file-version /usr/lib/os-release "$middle_version"
+	update_manifest -p "$middle_version_path"/Manifest.os-core file-version /usr/share/defaults/swupd/format "$middle_version"
+
+	mapfile -t bundles < <(awk '/^M\.\.\./ { print $4 }' "$mom")
+	IFS=$'\n'
+	for bundle in ${bundles[*]}; do
+		manifest="$middle_version_path"/Manifest."$bundle"
+		update_manifest -p "$manifest" format "$format"
+		update_manifest -p "$manifest" version "$middle_version"
+		update_manifest "$manifest" previous "$version"
+	done
+	unset IFS
+	update_hashes_in_mom "$mom"
+
+	# update the new version
+	mom="$new_version_path"/Manifest.MoM
+	update_manifest -p "$mom" previous "$middle_version"
+
 	# regardless of where we found the previous version of os-core, update
 	# the previous version to $middle_version
 	update_manifest -p "$new_version_path"/Manifest.os-core previous "$middle_version"
 
-	# update the new version
 	# copy all manifests in MoM to new version
 	mapfile -t bundles < <(awk '/^M\.\.\./ { print $4 }' "$mom")
 	IFS=$'\n'
@@ -1074,32 +1106,7 @@ bump_format() { # swupd_function
 		create_tar "$manifest"
 	done
 	unset IFS
-	update_hashes_in_mom "$mom"
-
-	# update the middle version
-	sudo rm -rf "$middle_version_path"/files/*
-	sudo rm -f "$middle_version_path"/Manifest*
-	sudo rm -f "$middle_version_path"/pack*
-	sudo cp -r "$new_version_path"/files/* "$middle_version_path"/files/
-	sudo cp "$new_version_path"/Manifest.* "$middle_version_path"/
-	sudo cp "$new_version_path"/pack* "$middle_version_path"/
-	mom="$middle_version_path"/Manifest.MoM
-	update_manifest -p "$mom" format "$((format))"
-	update_manifest -p "$mom" version "$middle_version"
-	update_manifest -p "$mom" previous "$version"
-	sudo sed -i "/....\\t.*\\t.*\\t.*$/s/\\(....\\t.*\\t\\).*\\(\\t\\)/\\1$middle_version\\2/g" "$mom"
-	mapfile -t bundles < <(awk '/^M\.\.\./ { print $4 }' "$mom")
-	IFS=$'\n'
-	for bundle in ${bundles[*]}; do
-		manifest="$middle_version_path"/Manifest."$bundle"
-		update_manifest -p "$manifest" format "$((format))"
-		update_manifest -p "$manifest" version "$middle_version"
-		update_manifest -p "$manifest" previous "$version"
-		sudo sed -i "/....\\t.*\\t.*\\t.*$/s/\\(....\\t.*\\t\\).*\\(\\t\\)/\\1$middle_version\\2/g" "$manifest"
-		sudo rm -rf "$manifest".tar
-		create_tar "$manifest"
-	done
-	unset IFS
+	update_manifest "$mom" minversion "$new_version"
 	update_hashes_in_mom "$mom"
 
 }

--- a/test/functional/update/update-minversion.bats
+++ b/test/functional/update/update-minversion.bats
@@ -8,9 +8,9 @@ test_setup() {
 	create_bundle -L -n bundle1 -v 10 -f /file1 "$TEST_NAME"
 
 	create_version "$TEST_NAME" 20 10 staging
-	update_minversion 20
+	set_as_minversion "$WEBDIR"/20
 
-	sudo rm -f "$WEBDIR"/20/files/*
+	sudo rm -rf "$WEBDIR"/20/files/*
 }
 
 @test "UPD015: Skip fullfile download for unchanged file in minversion update" {

--- a/test/functional/update/update-re-update-bad-os-release.bats
+++ b/test/functional/update/update-re-update-bad-os-release.bats
@@ -29,7 +29,7 @@ test_setup() {
 		    changed bundles   : 1
 		    new bundles       : 0
 		    deleted bundles   : 0
-		    changed files     : 10
+		    changed files     : 1
 		    new files         : 0
 		    deleted files     : 0
 		Starting download of remaining update content. This may take a while...

--- a/test/functional/update/update-re-update-required.bats
+++ b/test/functional/update/update-re-update-required.bats
@@ -24,7 +24,7 @@ test_setup() {
 		    changed bundles   : 1
 		    new bundles       : 0
 		    deleted bundles   : 0
-		    changed files     : 11
+		    changed files     : 2
 		    new files         : 0
 		    deleted files     : 0
 		Starting download of remaining update content. This may take a while...


### PR DESCRIPTION
The update_minversion and bump_format testlib functions both perform a minversion update, but with separate implementations. These implementations should be consolidated.

Closes #618 