### PR TITLE
Fixing the time shown using update -t

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -214,6 +214,7 @@ BATS = \
 	test/functional/update/update-rename-ghosted.bats \
 	test/functional/update/update-re-update-bad-os-release.bats \
 	test/functional/update/update-re-update-required.bats \
+	test/functional/update/update-show-time.bats \
 	test/functional/update/update-skip-scripts.bats \
 	test/functional/update/update-slow-server.bats \
 	test/functional/update/update-statedir-bad-hash.bats \

--- a/test/functional/update/update-show-time.bats
+++ b/test/functional/update/update-show-time.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle -f /foo "$TEST_NAME"
+	create_version "$TEST_NAME" 20 10
+	update_bundle "$TEST_NAME" test-bundle --update /foo
+
+}
+
+@test "UPD055: Update a system showing detailed operation time" {
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS --time"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Raw elapsed time stats:
+		.* ms: Total execution time
+		.* ms: |-- Prepare for update
+		.* ms: |-- Get versions
+		.* ms: |-- Clean up download directory
+		.* ms: |-- Load manifests
+		.* ms:     |-- Load MoM manifests
+		.* ms:     |-- Recurse and consolidate bundle manifests
+		.* ms:         |-- Add included bundle manifests
+		.* ms: |-- Run pre-update scripts
+		.* ms: |-- Download packs
+		.* ms: |-- Apply deltas
+		.* ms: |-- Create update list
+		.* ms: |-- Update loop
+		.* ms: |-- Run post-update scripts
+
+	CPU process time stats:
+	.* ms: Total execution time
+	.* ms: |-- Prepare for update
+	.* ms: |-- Get versions
+	.* ms: |-- Clean up download directory
+	.* ms: |-- Load manifests
+	.* ms:     |-- Load MoM manifests
+	.* ms:     |-- Recurse and consolidate bundle manifests
+	.* ms:         |-- Add included bundle manifests
+	.* ms: |-- Run pre-update scripts
+	.* ms: |-- Download packs
+	.* ms: |-- Apply deltas
+	.* ms: |-- Create update list
+	.* ms: |-- Update loop
+	.* ms: |-- Run post-update scripts
+	Update successful. System updated from version 10 to version 20
+	EOM
+	)
+	assert_regex_in_output "$expected_output"
+
+}


### PR DESCRIPTION
When running an update using the flag --time/-t the user is presented
with a verbose time output of the update operations. The time collected
for those operations was wrong.

This commit fixes the issue and presents a verbose output that is
consistent with other commands like bundle-add --time.

Closes #584

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>