### PR TITLE
modules: Take swupd-inspector out of swupd

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -43,13 +43,12 @@ static struct subcmd commands[] = {
 	{ "update", "Update to latest OS version", update_main },
 	{ "verify", "Verify content for OS version", verify_main },
 	{ "check-update", "Check if a new OS version is available", check_update_main },
-	{ "search", "Searches for the best bundle to install a binary or library.", binary_loader_main },
 	{ "search-legacy", "Legacy command to search Clear Linux for a binary or library", search_main },
 	{ "info", "Show the version and the update URLs", info_main },
 	{ "clean", "Clean cached files", clean_main },
 	{ "mirror", "Configure mirror url for swupd content", mirror_main },
 #ifdef EXTERNAL_MODULES_SUPPORT
-	{ "inspector", "Inspect swupd manifests for debugging purposes", binary_loader_main },
+	{ "search", "Searches for the best bundle to install a binary or library.", binary_loader_main },
 #endif
 	{ 0 }
 };

--- a/src/main.c
+++ b/src/main.c
@@ -43,7 +43,7 @@ static struct subcmd commands[] = {
 	{ "update", "Update to latest OS version", update_main },
 	{ "verify", "Verify content for OS version", verify_main },
 	{ "check-update", "Check if a new OS version is available", check_update_main },
-	{ "search-legacy", "Legacy command to search Clear Linux for a binary or library", search_main },
+	{ "search-file", "Command to search files in Clear Linux bundles", search_main },
 	{ "info", "Show the version and the update URLs", info_main },
 	{ "clean", "Clean cached files", clean_main },
 	{ "mirror", "Configure mirror url for swupd content", mirror_main },

--- a/test/functional/search/search-client-certificate.bats
+++ b/test/functional/search/search-client-certificate.bats
@@ -69,7 +69,7 @@ global_teardown() {
 
 @test "SRH012: Search for bundles over HTTPS with a valid client certificate" {
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS test-file"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS test-file"
 
 	assert_status_is 0
 }
@@ -79,7 +79,7 @@ global_teardown() {
 	# remove client certificate
 	sudo rm "$CLIENT_CERT"
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS test-file --debug"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS test-file --debug"
 	assert_status_is "$SWUPD_CURL_INIT_FAILED"
 
 	expected_output=$(cat <<-EOM
@@ -94,7 +94,7 @@ global_teardown() {
 	# make client certificate invalid
 	sudo sh -c "echo foo > $CLIENT_CERT"
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS test-file --debug"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS test-file --debug"
 	assert_status_is "$SWUPD_CURL_INIT_FAILED"
 
 	expected_output=$(cat <<-EOM

--- a/test/functional/search/search-content-check-negative.bats
+++ b/test/functional/search/search-content-check-negative.bats
@@ -35,7 +35,7 @@ global_teardown() {
 	# manifests, so we need to account for those messages in
 	# this first test
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS fake-file"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS fake-file"
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
@@ -52,7 +52,7 @@ global_teardown() {
 
 @test "SRH010: Try searching for a file that does not exist using the full path" {
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS /usr/lib64/test-lib100"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS /usr/lib64/test-lib100"
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
@@ -66,7 +66,7 @@ global_teardown() {
 
 @test "SRH011: Try searching for a library that does not exist" {
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS -l libtest-nohit"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS -l libtest-nohit"
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM

--- a/test/functional/search/search-content-check-positive.bats
+++ b/test/functional/search/search-content-check-positive.bats
@@ -36,7 +36,7 @@ global_teardown() {
 	# really search for anything but the MoM and all manifests
 	# in it should be downloaded to the local system
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS --init"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS --init"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -55,7 +55,7 @@ global_teardown() {
 	# it should find the bundle since the tracking file has the
 	# same name as the bundle
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS test-bundle1"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS test-bundle1"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
@@ -70,7 +70,7 @@ global_teardown() {
 
 @test "SRH002: Search for a file" {
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS test-file2"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS test-file2"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
@@ -85,7 +85,7 @@ global_teardown() {
 
 @test "SRH003: Search for a file that is in multiple bundles" {
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS common"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS common"
 
 	assert_status_is 0
 	# search finds the files in different order, sometimes, test-bundle1
@@ -108,7 +108,7 @@ global_teardown() {
 
 @test "SRH004: Search for a file that is in multiple bundles in different locations" {
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS test-file3"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS test-file3"
 
 	assert_status_is 0
 	# search finds the files in different order, sometimes, test-bundle1
@@ -134,7 +134,7 @@ global_teardown() {
 	# test-file3 is in two bundles but in different path, since we
 	# are specifying a path, search should only find one
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS /bar/test-file3"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS /bar/test-file3"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
@@ -149,7 +149,7 @@ global_teardown() {
 
 @test "SRH006: Search for a binary" {
 
-	run sudo sh -c "$SWUPD search-legacy --binary $SWUPD_OPTS test-bin"
+	run sudo sh -c "$SWUPD search-file --binary $SWUPD_OPTS test-bin"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
@@ -164,7 +164,7 @@ global_teardown() {
 
 @test "SRH007: Search for a library (lib32)" {
 
-	run sudo sh -c "$SWUPD search-legacy --library $SWUPD_OPTS test-lib32"
+	run sudo sh -c "$SWUPD search-file --library $SWUPD_OPTS test-lib32"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
@@ -179,7 +179,7 @@ global_teardown() {
 
 @test "SRH008: Search for a library (lib 64)" {
 
-	run sudo sh -c "$SWUPD search-legacy --library $SWUPD_OPTS test-lib64"
+	run sudo sh -c "$SWUPD search-file --library $SWUPD_OPTS test-lib64"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM

--- a/test/functional/search/search-experimental.bats
+++ b/test/functional/search/search-experimental.bats
@@ -41,7 +41,7 @@ global_teardown() {
 	# for those messages. If the bundle is experimental it should
 	# swhow that
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS test-bundle1"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS test-bundle1"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
@@ -63,7 +63,7 @@ global_teardown() {
 	# same name as the bundle. If the bundle is experimental it
 	# should swhow that
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS test-bundle2"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS test-bundle2"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
@@ -80,7 +80,7 @@ global_teardown() {
 
 	# If the bundle is experimental it should swhow that
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS test-file1"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS test-file1"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
@@ -97,7 +97,7 @@ global_teardown() {
 
 	# If the bundle is experimental it should swhow that
 
-	run sudo sh -c "$SWUPD search-legacy --binary $SWUPD_OPTS test-bin"
+	run sudo sh -c "$SWUPD search-file --binary $SWUPD_OPTS test-bin"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
@@ -114,7 +114,7 @@ global_teardown() {
 
 	# If the bundle is experimental it should swhow that
 
-	run sudo sh -c "$SWUPD search-legacy --library $SWUPD_OPTS test-lib32"
+	run sudo sh -c "$SWUPD search-file --library $SWUPD_OPTS test-lib32"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM

--- a/test/functional/search/search-no-disk-space.bats
+++ b/test/functional/search/search-no-disk-space.bats
@@ -28,7 +28,7 @@ test_setup() {
 	# fill up all the space in the disk
 	sudo dd if=/dev/zero of="$TEST_NAME"/testfs/dummy >& /dev/null || print "Using all space left in disk"
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS test-bundle2"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS test-bundle2"
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
@@ -57,7 +57,7 @@ test_setup() {
 	sudo mv "$big_manifest" "$WEBDIR"/10/Manifest.test-bundle1
 	sudo mv "$big_manifest".tar "$WEBDIR"/10/Manifest.test-bundle1.tar
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS test-bundle2"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS test-bundle2"
 
 	assert_status_is "$SWUPD_RECURSE_MANIFEST"
 	expected_output=$(cat <<-EOM

--- a/test/functional/usability/usa-external-modules.bats
+++ b/test/functional/usability/usa-external-modules.bats
@@ -13,18 +13,18 @@ test_setup() {
 		skip "This test is intended to run only in Travis (use TRAVIS=true to run it anyway)..."
 	fi
 
-	if [ ! -e /usr/bin/swupd-inspector ]; then
-		print "swupd-inspector not found in the system, creating a mock one..."
+	if [ ! -e /usr/bin/swupd-search ]; then
+		print "swupd-search not found in the system, creating a mock one..."
 		{
 			printf '#!/bin/bash\n'
-			printf 'echo "Inspect and download swupd content"\n'
+			printf 'echo "Searches for the best bundle to install a binary or library."\n'
 			# shellcheck disable=SC2016
-			printf 'echo "Fake inspector invoked successfully with these arguments: $1 $2 $3"\n'
-		} | sudo tee /usr/bin/swupd-inspector > /dev/null
-		sudo chmod +x /usr/bin/swupd-inspector
+			printf 'echo "Fake search invoked successfully with these arguments: $1 $2 $3"\n'
+		} | sudo tee /usr/bin/swupd-search > /dev/null
+		sudo chmod +x /usr/bin/swupd-search
 		file_created=true
 	else
-		print "swupd-inspector was found installed in the system"
+		print "swupd-search was found installed in the system"
 	fi
 
 }
@@ -36,31 +36,31 @@ test_teardown() {
 	fi
 
 	if [ "$file_created" = true ]; then
-		print "removing the mock swupd-inspector from the system..."
-		sudo rm /usr/bin/swupd-inspector
+		print "removing the mock swupd-search from the system..."
+		sudo rm /usr/bin/swupd-search
 	fi
 
 }
 
-@test "USA008: The external module swupd-inspector can be called from swupd" {
+@test "USA008: The external module swupd-search can be called from swupd" {
 
 	# swupd should be able to run enabled external programs
-	run sudo sh -c "$SWUPD inspector"
+	run sudo sh -c "$SWUPD search"
 
 	assert_status_is 0
-	assert_in_output "Inspect and download swupd content"
+	assert_in_output "Searches for the best bundle to install a binary or library."
 
 }
 
 @test "USA009: Arguments are parsed correctly when calling external modules" {
 
 	if [ "$file_created" = false ]; then
-		skip "this test only makes sense using the mock swupd-inspector, skipping it..."
+		skip "this test only makes sense using the mock swupd-search, skipping it..."
 	fi
 
-	run sudo sh -c "$SWUPD inspector arg1 arg2 arg3"
+	run sudo sh -c "$SWUPD search arg1 arg2 arg3"
 
 	assert_status_is 0
-	assert_in_output "Fake inspector invoked successfully with these arguments: arg1 arg2 arg3"
+	assert_in_output "Fake search invoked successfully with these arguments: arg1 arg2 arg3"
 
 }


### PR DESCRIPTION
We needed on sample for external binaries, but as now we have swupd-search we
can take swupd inspector out.

Also move local search to list of external modules and fix all related tests

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>