### PR TITLE
thread_pool: Run tasks in same thread if threads are not supported

### DIFF
--- a/src/lib/thread_pool.h
+++ b/src/lib/thread_pool.h
@@ -37,6 +37,11 @@ int tp_task_schedule(struct tp *tp, tp_task_run_t run, void *data);
  */
 void tp_complete(struct tp *tp);
 
+/*
+ * Get the number of threads created by this thread pool.
+ */
+int tp_get_num_threads(struct tp *tp);
+
 //TODO: Implement a tp_wait() function
 
 #endif


### PR DESCRIPTION
If we have any errors on pipe2 syscall or in pthread creation run tasks
in main thread. Also set the max downloads in parallel to 1 to avoid timeouts

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>