### PR TITLE
Removing search heuristics

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -193,6 +193,7 @@ BATS = \
 	test/functional/search/search-client-certificate.bats \
 	test/functional/search/search-experimental.bats \
 	test/functional/search/search-no-disk-space.bats \
+	test/functional/search/search-sort.bats \
 	test/functional/update/update-boot-file.bats \
 	test/functional/update/update-boot-skip.bats \
 	test/functional/update/update-bundle-removed.bats \

--- a/test/functional/search/search-sort.bats
+++ b/test/functional/search/search-sort.bats
@@ -41,7 +41,7 @@ global_teardown() {
 
 @test "SRH023: search shows the results in alphabetical order" {
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS -T 10 alfa"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS --order=alpha alfa"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
@@ -64,7 +64,7 @@ global_teardown() {
 
 @test "SRH024: search shows the results ordered by bundle size (smallest first)" {
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS alfa"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS --order=size alfa"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
@@ -87,7 +87,7 @@ global_teardown() {
 
 @test "SRH025: search can show all files in all bundles" {
 
-	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS -d"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS -d"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
@@ -120,5 +120,27 @@ global_teardown() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
+
+}
+
+@test "SRH026: search limits the results" {
+
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS --top=3 alfa"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Bundle alfa-charly	\\(2 MB to install\\)
+		./usr/share/clear/bundles/alfa-charly
+		Bundle alfa-zulu	\\(1 MB to install\\)
+		./alfaromeo/echo
+		./bar/alfa
+		./foo/alfa
+		.file results truncated...
+		Bundle victor	\\(3 MB to install\\)
+		./alfa/zulu
+		./bar/alfa
+	EOM
+	)
+	assert_regex_in_output "$expected_output"
 
 }

--- a/test/functional/search/search-sort.bats
+++ b/test/functional/search/search-sort.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+
+	small=/small-file:"$(create_file "$WEBDIR"/10/files 1MB)"
+	medium=/medium-file:"$(create_file "$WEBDIR"/10/files 2MB)"
+	large=/large-file:"$(create_file "$WEBDIR"/10/files 3MB)"
+
+	create_bundle -n alfa-zulu -f /yankee/alfalfa,/alfaromeo/echo,/foo/quebec,/foo/alfa,/foo/delta,/bar/alfa,"$small" "$TEST_NAME"
+	create_bundle -n victor -f /yankee,/bar/alfa,/alfa/zulu,/papa,"$large" "$TEST_NAME"
+	create_bundle -n alfa-charly -f /foxtrot,/tango/sierra,/kilo,"$medium" "$TEST_NAME"
+
+}
+
+test_setup() {
+
+	# do nothing
+	return
+
+}
+
+test_teardown() {
+
+	# do nothing
+	return
+
+}
+
+global_teardown() {
+
+	destroy_test_environment "$TEST_NAME"
+
+}
+
+@test "SRH023: search shows the results in alphabetical order" {
+
+	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS -T 10 alfa"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Bundle alfa-charly	\\(2 MB to install\\)
+		./usr/share/clear/bundles/alfa-charly
+		Bundle alfa-zulu	\\(1 MB to install\\)
+		./alfaromeo/echo
+		./bar/alfa
+		./foo/alfa
+		./usr/share/clear/bundles/alfa-zulu
+		./yankee/alfalfa
+		Bundle victor	\\(3 MB to install\\)
+		./alfa/zulu
+		./bar/alfa
+	EOM
+	)
+	assert_regex_in_output "$expected_output"
+
+}
+
+@test "SRH024: search shows the results ordered by bundle size (smallest first)" {
+
+	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS alfa"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Bundle alfa-zulu	\\(1 MB to install\\)
+		./usr/share/clear/bundles/alfa-zulu
+		./bar/alfa
+		./foo/alfa
+		./alfaromeo/echo
+		./yankee/alfalfa
+		Bundle alfa-charly	\\(2 MB to install\\)
+		./usr/share/clear/bundles/alfa-charly
+		Bundle victor	\\(3 MB to install\\)
+		./alfa/zulu
+		./bar/alfa
+	EOM
+	)
+	assert_regex_in_output "$expected_output"
+
+}
+
+@test "SRH025: search can show all files in all bundles" {
+
+	run sudo sh -c "$SWUPD search-legacy $SWUPD_OPTS -d"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Displaying all bundles and their files:
+		--Bundle: alfa-charly--
+		    /usr/share/clear/bundles/alfa-charly
+		    /medium-file
+		    /kilo
+		    /tango/sierra
+		    /foxtrot
+		--Bundle: victor--
+		    /usr/share/clear/bundles/victor
+		    /large-file
+		    /papa
+		    /alfa/zulu
+		    /bar/alfa
+		    /yankee
+		--Bundle: alfa-zulu--
+		    /usr/share/clear/bundles/alfa-zulu
+		    /small-file
+		    /bar/alfa
+		    /foo/delta
+		    /foo/alfa
+		    /foo/quebec
+		    /alfaromeo/echo
+		    /yankee/alfalfa
+		--Bundle: os-core--
+		    /usr/share/clear/bundles/os-core
+		    /core
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}


### PR DESCRIPTION
The search command uses a score system to weight the results it finds,
the purpose of this is to try and show the most relevant results to the
user on top, however since the focus of the search command is changing,
we don't need to guess what the user is looking for and just show all we
find.

This commit removes the score ordering from the search command.