### PR TITLE
Set signature verification enabled as default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 script:
         - sudo find test/functional -exec chmod g-w {} \;
         - autoreconf --verbose --warnings=none --install --force &&
-          ./configure CFLAGS="$CFLAGS -fsanitize=address -Werror" --prefix=/usr --with-fallback-capaths=$TRAVIS_BUILD_DIR/swupd_test_certificates --enable-signature-verification --with-systemdsystemunitdir=/usr/lib/systemd/system &&
+          ./configure CFLAGS="$CFLAGS -fsanitize=address -Werror" --prefix=/usr --with-fallback-capaths=$TRAVIS_BUILD_DIR/swupd_test_certificates --with-systemdsystemunitdir=/usr/lib/systemd/system &&
           make -j48 &&
           sudo sh -c 'umask 0022 && make -j48 check' &&
           sudo sh -c 'umask 0022 && make install' &&

--- a/configure.ac
+++ b/configure.ac
@@ -62,13 +62,14 @@ AS_IF(
 
 AC_ARG_ENABLE(
   [signature-verification],
-  [AS_HELP_STRING([--enable-signature-verification], [Enable signature check (disabled by default)])],
-  [AC_DEFINE([SIGNATURES], 1, [Enable signature check as default])]
+  [AS_HELP_STRING([--disable-signature-verification], [Disable signature check (enabled by default)])]
 )
-SIGVERIFICATION="no"
+SIGVERIFICATION="yes"
 AS_IF(
-  [test -n "$enable_signature_verification" -a "$enable_signature_verification" = "yes"],
-  [SIGVERIFICATION="$enable_signature_verification"]
+  [test "x$enable_signature_verification" != "xno"],
+  [AC_DEFINE(SIGNATURES, 1, [Enable signature check])
+     SIGVERIFICATION="yes"],
+  [SIGVERIFICATION="no"]
 )
 
 AC_ARG_ENABLE(

--- a/docker/dockerrun.sh
+++ b/docker/dockerrun.sh
@@ -46,7 +46,7 @@ find test/functional -exec chmod g-w {} \;
 
 # Configure the build
 autoreconf --verbose --warnings=none --install --force || die_fatal "Configure failure"
-./configure --enable-signature-verification  || die_fatal "Configure failure"
+./configure || die_fatal "Configure failure"
 
 # Build error
 make $jobCount || die_fatal "Build failure"

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -102,7 +102,7 @@ Once this is done, you can actually run the job, this is the script section of t
        S script
           sudo find test/functional -exec chmod g-w {} \;
           autoreconf --verbose --warnings=none --install --force &&
-          ./configure --enable-signature-verification &&
+          ./configure &&
           make -j48 &&
           sudo sh -c 'umask 0022 && make -j48 check' &&
           sudo sh -c 'umask 0022 && make install'


### PR DESCRIPTION
Signature verification was disabled as a default parameters to make it easier
for people to build the project on other distros. But this can be dangerous
as users may start using a built swupd without signature checking to
install a CL distro.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>