### PR TITLE
Remove unecessary srand() calls

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -688,8 +688,6 @@ int add_subscriptions(struct list *bundles, struct list **subs, struct manifest 
 	struct list *iter;
 	struct manifest *manifest;
 
-	srand(time(NULL));
-
 	iter = list_head(bundles);
 	while (iter) {
 		bundle = iter->data;

--- a/src/update.c
+++ b/src/update.c
@@ -239,8 +239,6 @@ static enum swupd_code main_update()
 	bool re_update = false;
 	bool versions_match = false;
 
-	srand(time(NULL));
-
 	ret = swupd_init();
 	if (ret != 0) {
 		/* being here means we already close log by a previously caught error */


### PR DESCRIPTION
We don't use rand() in swupd so don't need to initialize the random generator.
This was a leftover from previous code that used rand() for tests purposes.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>