### PR TITLE
Search-file rework

### DIFF
--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -249,11 +249,6 @@ SUBCOMMANDS
         Perform collection and download of all required manifest
         resources needed to perform the search, then exit.
 
-    - `-d, --display-files`
-
-        Do not search for any particular string, instead, print out all
-        files, paths, etc. listed in any manifest, and exit.
-
     - `-s, --scope={b|o}`
 
         Restrict search to only list the first match found in **bundle**

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -249,11 +249,6 @@ SUBCOMMANDS
         Perform collection and download of all required manifest
         resources needed to perform the search, then exit.
 
-    - `-s, --scope={b|o}`
-
-        Restrict search to only list the first match found in **bundle**
-        or **os**.
-
 ``update``
 
     Performs a system software update.

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -1052,3 +1052,19 @@ char *get_printable_bundle_name(const char *bundle_name, bool is_experimental)
 	string_or_die(&printable_name, "%s%s", bundle_name, is_experimental ? " (experimental)" : "");
 	return printable_name;
 }
+
+/* Helper to print regexp errors */
+void print_regexp_error(int errcode, regex_t *regexp)
+{
+	size_t len;
+	char *error_buffer = NULL;
+
+	len = regerror(errcode, regexp, NULL, 0);
+	error_buffer = malloc(len);
+	ON_NULL_ABORT(error_buffer);
+
+	regerror(errcode, regexp, error_buffer, len);
+	error("Invalid regular expression: %s\n", error_buffer)
+
+	    free(error_buffer);
+}

--- a/src/lib/list.c
+++ b/src/lib/list.c
@@ -302,3 +302,19 @@ bool list_longer_than(struct list *list, int count)
 	}
 	return false;
 }
+
+void *list_search(struct list *list, const void *item, comparison_fn_t comparison_fn)
+{
+	for (; list; list = list->next) {
+		if (comparison_fn(list->data, item) == 0) {
+			return list->data;
+		}
+	}
+
+	return NULL;
+}
+
+int list_strcmp(const void *a, const void *b)
+{
+	return strcmp((const char *)a, (const char *)b);
+}

--- a/src/lib/list.h
+++ b/src/lib/list.h
@@ -56,4 +56,20 @@ struct list *list_deep_clone_strs(struct list *source);
 /* check list length */
 extern bool list_longer_than(struct list *list, int count);
 
+/*
+ * Search 'item' on 'list' using 'comparisson_fn' function to compare elements.
+ * 'comparison_fn' is always called with one item from the 'list' as first
+ * argument and 'item' as the second.
+ * If one element is found it is returned. NULL is returned otherwise.
+ *
+ * Note: you can use list_strcmp to search a string in a string list:
+ *       list_search(list, "my_string", list_strcmp);
+ */
+void *list_search(struct list *list, const void *item, comparison_fn_t comparison_fn);
+
+/*
+ * strcmp to be used with list_search() or list_sort() on a list of strings.
+ */
+int list_strcmp(const void *a, const void *b);
+
 #endif

--- a/src/search.c
+++ b/src/search.c
@@ -39,13 +39,13 @@ bool csv_format = false;
 bool init = false;
 
 enum sort_type {
-	alpha,
-	size
+	SORT_TYPE_ALPHA,
+	SORT_TYPE_SIZE
 };
 
 static char search_type = '0';
 static int num_results = INT_MAX;
-static int sort = alpha;
+static int sort = SORT_TYPE_ALPHA;
 
 /* bundle_result contains the information to print */
 struct bundle_result {
@@ -341,9 +341,9 @@ static bool parse_opt(int opt, char *optarg)
 	switch (opt) {
 	case 'o':
 		if (!strcmp(optarg, "alpha")) {
-			sort = alpha;
+			sort = SORT_TYPE_ALPHA;
 		} else if (!strcmp(optarg, "size")) {
-			sort = size;
+			sort = SORT_TYPE_SIZE;
 		} else {
 			error("Invalid --order argument\n\n");
 			return false;
@@ -553,10 +553,10 @@ static enum swupd_code do_search(struct manifest *MoM, char search_type, char *s
 	}
 	list_free_list_and_data(bundle_info, free_bundle_result_data);
 
-	if (sort == alpha) {
+	if (sort == SORT_TYPE_ALPHA) {
 		/* sort alphabetically */
 		sort_results();
-	} else if (sort == size) {
+	} else if (sort == SORT_TYPE_SIZE) {
 		/* sort by bundle size */
 		results = list_sort(results, bundle_size_cmp);
 	}

--- a/src/search.c
+++ b/src/search.c
@@ -340,9 +340,7 @@ static const struct option prog_opts[] = {
 	{ "library", no_argument, 0, 'l' },
 	{ "scope", required_argument, 0, 's' },
 	{ "top", required_argument, 0, 'T' },
-	//TODO: -t option is deprecated. Remove that on a Major release
 	{ "order", required_argument, 0, 'o' },
-	{ "", required_argument, 0, 't' },
 };
 
 static bool parse_opt(int opt, char *optarg)
@@ -373,9 +371,6 @@ static bool parse_opt(int opt, char *optarg)
 		}
 
 		return true;
-	case 't':
-		warn("Deprecated option -t was renamed. Prefer using -T or --top.\n\n");
-		/* fallthrough */
 	case 'T':
 		err = strtoi_err(optarg, &num_results);
 		if (err != 0) {

--- a/src/search.c
+++ b/src/search.c
@@ -454,7 +454,7 @@ static enum swupd_code download_all_manifests(struct manifest *mom, struct list 
 		progress_report(complete, total);
 		complete++;
 		if (!manifest) {
-			printf("\n"); //Progress bar
+			info("\n"); //Progress bar
 			error("Cannot load %s manifest for version %i\n",
 			      file->filename, file->last_change);
 			failed_count++;
@@ -481,22 +481,22 @@ static enum swupd_code download_all_manifests(struct manifest *mom, struct list 
 
 static void print_help(void)
 {
-	fprintf(stderr, "Usage:\n");
-	fprintf(stderr, "   swupd search [OPTION...] 'search_term'\n\n");
-	fprintf(stderr, "		'search_term': A substring of a binary, library or filename (default)\n");
-	fprintf(stderr, "		Return: Bundle name : filename matching search term\n\n");
+	print("Usage:\n");
+	print("   swupd search [OPTION...] 'search_term'\n\n");
+	print("		'search_term': A substring of a binary, library or filename (default)\n");
+	print("		Return: Bundle name : filename matching search term\n\n");
 
 	global_print_help();
 
-	fprintf(stderr, "Options:\n");
-	fprintf(stderr, "   -l, --library           Search paths where libraries are located for a match\n");
-	fprintf(stderr, "   -b, --binary            Search paths where binaries are located for a match\n");
-	fprintf(stderr, "   -T, --top=[NUM]         Only display the top NUM results for each bundle\n");
-	fprintf(stderr, "   -m, --csv               Output all results in CSV format (machine-readable)\n");
-	fprintf(stderr, "   -i, --init              Download all manifests then return, no search done\n");
-	fprintf(stderr, "   -o, --order=[ORDER]     Sort the output. ORDER is one of the following values:\n");
-	fprintf(stderr, "                           'alpha' to order alphabetically (default)\n");
-	fprintf(stderr, "                           'size' to order by bundle size (smaller to larger)\n");
+	print("Options:\n");
+	print("   -l, --library           Search paths where libraries are located for a match\n");
+	print("   -b, --binary            Search paths where binaries are located for a match\n");
+	print("   -T, --top=[NUM]         Only display the top NUM results for each bundle\n");
+	print("   -m, --csv               Output all results in CSV format (machine-readable)\n");
+	print("   -i, --init              Download all manifests then return, no search done\n");
+	print("   -o, --order=[ORDER]     Sort the output. ORDER is one of the following values:\n");
+	print("                           'alpha' to order alphabetically (default)\n");
+	print("                           'size' to order by bundle size (smaller to larger)\n");
 }
 
 static const struct option prog_opts[] = {

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -342,6 +342,7 @@ extern bool is_compatible_format(int format_num);
 extern bool is_current_version(int version);
 extern bool on_new_format(void);
 extern char *get_printable_bundle_name(const char *bundle_name, bool is_experimental);
+extern void print_regexp_error(int errcode, regex_t *regexp);
 
 /* subscription.c */
 struct list *free_list_file(struct list *item);

--- a/src/verify.c
+++ b/src/verify.c
@@ -94,7 +94,6 @@ static void print_help(void)
 static bool compile_whitelist()
 {
 	int errcode;
-	char *error_buffer = NULL;
 	char *full_regex = NULL;
 	bool success = false;
 
@@ -105,22 +104,14 @@ static bool compile_whitelist()
 	errcode = regcomp(&picky_whitelist_buffer, full_regex, REG_NOSUB | REG_EXTENDED);
 	picky_whitelist = &picky_whitelist_buffer;
 	if (errcode) {
-		size_t len;
-		len = regerror(errcode, picky_whitelist, NULL, 0);
-		error_buffer = malloc(len);
-		ON_NULL_ABORT(error_buffer);
-
-		regerror(errcode, picky_whitelist, error_buffer, len);
-		error("Invalid --picky-whitelist=%s: %s\n", cmdline_option_picky_whitelist, error_buffer);
+		error("Problem processing --picky-whitelist=%s\n", cmdline_option_picky_whitelist);
+		print_regexp_error(errcode, picky_whitelist);
 		goto done;
 	}
 	success = true;
 
 done:
 	free_string(&full_regex);
-	if (error_buffer) {
-		free_string(&error_buffer);
-	}
 	return success;
 }
 

--- a/swupd.bash
+++ b/swupd.bash
@@ -57,7 +57,7 @@ _swupd()
 		opts="--help"
 		break;;
 	    ("search-file")
-		opts="--help --library --binary --top --csv --init --ignore-time --url --contenturl --versionurl --port --path --format --statedir --certpath -debug --quiet "
+		opts="--help --library --binary --top --csv --init --ignore-time --url --contenturl --versionurl --port --path --format --statedir --certpath --regexp --debug --quiet "
 		break;;
 	    ("info")
 		opts="--debug --quiet "

--- a/swupd.bash
+++ b/swupd.bash
@@ -57,7 +57,7 @@ _swupd()
 		opts="--help"
 		break;;
 	    ("search-file")
-		opts="--help --library --binary --scope --top --csv --init --ignore-time --url --contenturl --versionurl --port --path --format --statedir --certpath -debug --quiet "
+		opts="--help --library --binary --top --csv --init --ignore-time --url --contenturl --versionurl --port --path --format --statedir --certpath -debug --quiet "
 		break;;
 	    ("info")
 		opts="--debug --quiet "

--- a/swupd.bash
+++ b/swupd.bash
@@ -57,7 +57,7 @@ _swupd()
 		opts="--help"
 		break;;
 	    ("search-file")
-		opts="--help --library --binary --scope --top --csv --display-files --init --ignore-time --url --contenturl --versionurl --port --path --format --statedir --certpath --debug --quiet "
+		opts="--help --library --binary --scope --top --csv --init --ignore-time --url --contenturl --versionurl --port --path --format --statedir --certpath -debug --quiet "
 		break;;
 	    ("info")
 		opts="--debug --quiet "

--- a/test/functional/search/search-content-check-negative.bats
+++ b/test/functional/search/search-content-check-negative.bats
@@ -39,11 +39,9 @@ global_teardown() {
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
+		Downloading Clear Linux manifests \\(.* MB\\)
 		Searching for 'fake-file'
-		Downloading Clear Linux manifests
-		.* MB total...
-		Completed manifests download.
-		Search term not found.
+		Search term not found
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
@@ -57,7 +55,7 @@ global_teardown() {
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
 		Searching for '/usr/lib64/test-lib100'
-		Search term not found.
+		Search term not found
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
@@ -71,7 +69,7 @@ global_teardown() {
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
 		Searching for 'libtest-nohit'
-		Search term not found.
+		Search term not found
 	EOM
 	)
 	assert_is_output "$expected_output"

--- a/test/functional/search/search-content-check-positive.bats
+++ b/test/functional/search/search-content-check-positive.bats
@@ -40,9 +40,7 @@ global_teardown() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Downloading Clear Linux manifests
-		.* MB total...
-		Completed manifests download.
+		Downloading Clear Linux manifests \\(.* MB\\)
 		Successfully retrieved manifests. Exiting
 	EOM
 	)
@@ -60,7 +58,7 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Searching for 'test-bundle1'
-		Bundle test-bundle1	\\(0 MB to install\\)
+		Bundle test-bundle1 \\(0 MB to install\\)
 		./usr/share/clear/bundles/test-bundle1
 	EOM
 	)
@@ -75,7 +73,7 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Searching for 'test-file2'
-		Bundle test-bundle2	\\(0 MB to install\\)
+		Bundle test-bundle2 \\(0 MB to install\\)
 		./bar/test-file2
 	EOM
 	)
@@ -92,13 +90,13 @@ global_teardown() {
 	# will be listed first and sometimes test-bundle2 will be listed first
 	# so we need to check them separatelly
 	expected_output=$(cat <<-EOM
-		Bundle test-bundle1	\\(0 MB to install\\)
+		Bundle test-bundle1 \\(0 MB to install\\)
 		./common
 	EOM
 	)
 	assert_regex_in_output "$expected_output"
 	expected_output=$(cat <<-EOM
-		Bundle test-bundle2	\\(0 MB to install\\)
+		Bundle test-bundle2 \\(0 MB to install\\)
 		./common
 	EOM
 	)
@@ -115,13 +113,13 @@ global_teardown() {
 	# will be listed first and sometimes test-bundle2 will be listed first
 	# so we need to check them separatelly
 	expected_output=$(cat <<-EOM
-		Bundle test-bundle1	\\(0 MB to install\\)
+		Bundle test-bundle1 \\(0 MB to install\\)
 		./foo/test-file3
 	EOM
 	)
 	assert_regex_in_output "$expected_output"
 	expected_output=$(cat <<-EOM
-		Bundle test-bundle2	\\(0 MB to install\\)
+		Bundle test-bundle2 \\(0 MB to install\\)
 		./bar/test-file3
 	EOM
 	)
@@ -139,7 +137,7 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Searching for '/bar/test-file3'
-		Bundle test-bundle2	\\(0 MB to install\\)
+		Bundle test-bundle2 \\(0 MB to install\\)
 		./bar/test-file3
 	EOM
 	)
@@ -154,7 +152,7 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Searching for 'test-bin'
-		Bundle test-bundle1	\\(0 MB to install\\)
+		Bundle test-bundle1 \\(0 MB to install\\)
 		./usr/bin/test-bin
 	EOM
 	)
@@ -169,7 +167,7 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Searching for 'test-lib32'
-		Bundle test-bundle1	\\(0 MB to install\\)
+		Bundle test-bundle1 \\(0 MB to install\\)
 		./usr/lib/test-lib32
 	EOM
 	)
@@ -184,10 +182,28 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Searching for 'test-lib64'
-		Bundle test-bundle2	\\(0 MB to install\\)
+		Bundle test-bundle2 \\(0 MB to install\\)
 		./usr/lib64/test-lib64
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
+
+}
+
+@test "SRH010: Search for a library and binary" {
+
+	run sudo sh -c "$SWUPD search-file --library --binary $SWUPD_OPTS test-"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Searching for 'test-'
+		Bundle test-bundle1 \\(0 MB to install\\)
+		./usr/lib/test-lib32
+		./usr/bin/test-bin
+		Bundle test-bundle2 \\(0 MB to install\\)
+		./usr/lib64/test-lib64
+	EOM
+	)
+	assert_regex_in_output "$expected_output"
 
 }

--- a/test/functional/search/search-content-check-positive.bats
+++ b/test/functional/search/search-content-check-positive.bats
@@ -207,3 +207,20 @@ global_teardown() {
 	assert_regex_in_output "$expected_output"
 
 }
+
+@test "SRH012: Search using regular expressions" {
+
+	run sudo sh -c "$SWUPD search-file --regexp $SWUPD_OPTS ^/usr/lib.*lib.*$"
+
+	#Searching for '^/usr/lib.*lib.*$'
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Bundle test-bundle1 \\(0 MB to install\\)
+		./usr/lib/test-lib32
+		Bundle test-bundle2 \\(0 MB to install\\)
+		./usr/lib64/test-lib64
+	EOM
+	)
+	assert_regex_in_output "$expected_output"
+
+}

--- a/test/functional/search/search-experimental.bats
+++ b/test/functional/search/search-experimental.bats
@@ -45,12 +45,8 @@ global_teardown() {
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Downloading Clear Linux manifests \\(.* MB\\)
 		Searching for 'test-bundle1'
-		Downloading Clear Linux manifests
-		.* MB total...
-		Completed manifests download.
-		Bundle test-bundle1 \\(experimental\\)	\\(0 MB to install\\)
-		./usr/share/clear/bundles/test-bundle1
 	EOM
 	)
 	assert_regex_in_output "$expected_output"
@@ -68,7 +64,7 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Searching for 'test-bundle2'
-		Bundle test-bundle2 \\(experimental\\)	\\[installed\\]	\\(0 MB on system\\)
+		Bundle test-bundle2 \\(experimental\\) \\[installed\\] \\(0 MB on system\\)
 		./usr/share/clear/bundles/test-bundle2
 	EOM
 	)
@@ -85,7 +81,7 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Searching for 'test-file1'
-		Bundle test-bundle1 \\(experimental\\)	\\(0 MB to install\\)
+		Bundle test-bundle1 \\(experimental\\) \\(0 MB to install\\)
 		./foo/test-file1
 	EOM
 	)
@@ -102,7 +98,7 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Searching for 'test-bin'
-		Bundle test-bundle1 \\(experimental\\)	\\(0 MB to install\\)
+		Bundle test-bundle1 \\(experimental\\) \\(0 MB to install\\)
 		./usr/bin/test-bin
 	EOM
 	)
@@ -119,7 +115,7 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Searching for 'test-lib32'
-		Bundle test-bundle1 \\(experimental\\)	\\(0 MB to install\\)
+		Bundle test-bundle1 \\(experimental\\) \\(0 MB to install\\)
 		./usr/lib/test-lib32
 	EOM
 	)

--- a/test/functional/search/search-no-disk-space.bats
+++ b/test/functional/search/search-no-disk-space.bats
@@ -34,7 +34,7 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/10/Manifest.MoM.tar'
 		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
-		Failed to retrieve 10 MoM manifest
+		Error: Failed to retrieve 10 MoM manifest
 		Error: Cannot load official manifest MoM for version 10
 	EOM
 	)
@@ -62,7 +62,7 @@ test_setup() {
 		Downloading Clear Linux manifests \\(.* MB\\)
 		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/10/Manifest.test-bundle1.tar'
 		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?
-		Failed to retrieve 10 test-bundle1 manifest
+		Error: Failed to retrieve 10 test-bundle1 manifest
 		Error: Cannot load test-bundle1 manifest for version 10
 		Warning: Failed to download 1 manifest - search results will be partial
 		Searching for 'test-bundle2'

--- a/test/functional/search/search-no-disk-space.bats
+++ b/test/functional/search/search-no-disk-space.bats
@@ -32,12 +32,10 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
-		Searching for 'test-bundle2'
 		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/10/Manifest.MoM.tar'
 		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
-		Error: Failed to retrieve 10 MoM manifest
+		Failed to retrieve 10 MoM manifest
 		Error: Cannot load official manifest MoM for version 10
-		Error: Failed to download manifests
 	EOM
 	)
 	assert_is_output "$expected_output"
@@ -61,16 +59,14 @@ test_setup() {
 
 	assert_status_is "$SWUPD_RECURSE_MANIFEST"
 	expected_output=$(cat <<-EOM
-		Searching for 'test-bundle2'
-		Downloading Clear Linux manifests
-		.* MB total...
+		Downloading Clear Linux manifests \\(.* MB\\)
 		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/10/Manifest.test-bundle1.tar'
 		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?
-		Error: Failed to retrieve 10 test-bundle1 manifest
-		Error: Cannot load test-bundle1 sub-manifest for version 10
-		Error: 1 manifest failed to download.
-		Warning: One or more manifests failed to download, search results will be partial.
-		Bundle test-bundle2	\\(0 MB to install\\)
+		Failed to retrieve 10 test-bundle1 manifest
+		Error: Cannot load test-bundle1 manifest for version 10
+		Warning: Failed to download 1 manifest - search results will be partial
+		Searching for 'test-bundle2'
+		Bundle test-bundle2 \\(0 MB to install\\)
 		./usr/share/clear/bundles/test-bundle2
 	EOM
 	)

--- a/test/functional/search/search-sort.bats
+++ b/test/functional/search/search-sort.bats
@@ -45,15 +45,15 @@ global_teardown() {
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
-		Bundle alfa-charly	\\(2 MB to install\\)
+		Bundle alfa-charly \\(2 MB to install\\)
 		./usr/share/clear/bundles/alfa-charly
-		Bundle alfa-zulu	\\(1 MB to install\\)
+		Bundle alfa-zulu \\(1 MB to install\\)
 		./alfaromeo/echo
 		./bar/alfa
 		./foo/alfa
 		./usr/share/clear/bundles/alfa-zulu
 		./yankee/alfalfa
-		Bundle victor	\\(3 MB to install\\)
+		Bundle victor \\(3 MB to install\\)
 		./alfa/zulu
 		./bar/alfa
 	EOM
@@ -68,15 +68,15 @@ global_teardown() {
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
-		Bundle alfa-zulu	\\(1 MB to install\\)
+		Bundle alfa-zulu \\(1 MB to install\\)
 		./usr/share/clear/bundles/alfa-zulu
 		./bar/alfa
 		./foo/alfa
 		./alfaromeo/echo
 		./yankee/alfalfa
-		Bundle alfa-charly	\\(2 MB to install\\)
+		Bundle alfa-charly \\(2 MB to install\\)
 		./usr/share/clear/bundles/alfa-charly
-		Bundle victor	\\(3 MB to install\\)
+		Bundle victor \\(3 MB to install\\)
 		./alfa/zulu
 		./bar/alfa
 	EOM
@@ -87,39 +87,39 @@ global_teardown() {
 
 @test "SRH025: search can show all files in all bundles" {
 
-	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS -d"
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
-		Displaying all bundles and their files:
-		--Bundle: alfa-charly--
-		    /usr/share/clear/bundles/alfa-charly
-		    /medium-file
-		    /kilo
-		    /tango/sierra
-		    /foxtrot
-		--Bundle: victor--
-		    /usr/share/clear/bundles/victor
-		    /large-file
-		    /papa
-		    /alfa/zulu
-		    /bar/alfa
-		    /yankee
-		--Bundle: alfa-zulu--
-		    /usr/share/clear/bundles/alfa-zulu
-		    /small-file
-		    /bar/alfa
-		    /foo/delta
-		    /foo/alfa
-		    /foo/quebec
-		    /alfaromeo/echo
-		    /yankee/alfalfa
-		--Bundle: os-core--
-		    /usr/share/clear/bundles/os-core
-		    /core
+		Searching for ''
+		Bundle alfa-charly .*
+		./usr/share/clear/bundles/alfa-charly
+		./medium-file
+		./kilo
+		./tango/sierra
+		./foxtrot
+		Bundle alfa-zulu .*
+		./usr/share/clear/bundles/alfa-zulu
+		./small-file
+		./bar/alfa
+		./foo/delta
+		./foo/alfa
+		./foo/quebec
+		./alfaromeo/echo
+		./yankee/alfalfa
+		Bundle os-core .*
+		./usr/share/clear/bundles/os-core
+		./core
+		Bundle victor .*
+		./usr/share/clear/bundles/victor
+		./large-file
+		./papa
+		./alfa/zulu
+		./bar/alfa
+		./yankee
 	EOM
 	)
-	assert_regex_is_output "$expected_output"
+	assert_regex_in_output "$expected_output"
 
 }
 
@@ -129,14 +129,16 @@ global_teardown() {
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
-		Bundle alfa-charly	\\(2 MB to install\\)
+		Searching for 'alfa'
+		Displaying only top 3 file results per bundle
+		File results may be truncated
+		Bundle alfa-charly \\(2 MB to install\\)
 		./usr/share/clear/bundles/alfa-charly
-		Bundle alfa-zulu	\\(1 MB to install\\)
-		./alfaromeo/echo
+		Bundle alfa-zulu \\(1 MB to install\\)
+		./usr/share/clear/bundles/alfa-zulu
 		./bar/alfa
 		./foo/alfa
-		.file results truncated...
-		Bundle victor	\\(3 MB to install\\)
+		Bundle victor \\(3 MB to install\\)
 		./alfa/zulu
 		./bar/alfa
 	EOM


### PR DESCRIPTION
Rewriting some functions on swupd search so we don't need to store everything in memory to be printed later. Print things as we find them. This makes search-file a lot faster and with a smaller memory footprint

Fixex #388 