### PR TITLE
Travis improvements to speed up the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,18 @@ language: c
 
 env:
     global:
-        - MAKEFLAGS="-j 32"
+        - MAKEFLAGS="-j 2"
+    matrix:
+        - FUNCTIONAL_TESTS=test/functional/update
+        - FUNCTIONAL_TESTS=test/functional/verify
+        - FUNCTIONAL_TESTS=test/functional/bundleadd
+        - FUNCTIONAL_TESTS=test/functional/bundleremove
+        - FUNCTIONAL_TESTS=test/functional/bundlelist
+        - FUNCTIONAL_TESTS=test/functional/search
+        - FUNCTIONAL_TESTS=test/functional/checkupdate
+        - FUNCTIONAL_TESTS=test/functional/hashdump
+        - FUNCTIONAL_TESTS=test/functional/mirror
+        - FUNCTIONAL_TESTS=test/functional/usability
 
 # Pre-install missing build dependencies:
 # - libcheck 0.9.10 is slightly too old, since 0.9.12 adds TAP support
@@ -39,13 +50,13 @@ before_script:
         - ./configure CFLAGS="$CFLAGS -fsanitize=address -Werror" --prefix=/usr --with-fallback-capaths=$TRAVIS_BUILD_DIR/swupd_test_certificates --with-systemdsystemunitdir=/usr/lib/systemd/system
         - make compliant
         - make shellcheck
+        - bats test/functional/generate-cert.prereq
 
 # Ubuntu's default umask is 0002, but this break's swupd hash calculations.
 script:
         - sudo find test/functional -exec chmod g-w {} \;
         - make &&
-          make check &&
           sudo sh -c 'umask 0022 && make install' &&
-          sudo sh -c 'umask 0022 && make install-check'
-
-after_failure: cat test-suite.log
+          sudo sh -c 'umask 0022 && make install-check' &&
+          sudo sh -c 'umask 0022 && make unit-check' &&
+          bats "$FUNCTIONAL_TESTS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,15 +30,18 @@ install:
         - sudo ln -s /usr/share/docutils/scripts/python3/rst2man /usr/bin/rst2man.py
         - git fetch origin master:refs/remotes/origin/master #Download origin/master for shelcheck
 
+before_script:
+        - autoreconf --verbose --warnings=none --install --force
+        - ./configure CFLAGS="$CFLAGS -fsanitize=address -Werror" --prefix=/usr --with-fallback-capaths=$TRAVIS_BUILD_DIR/swupd_test_certificates --with-systemdsystemunitdir=/usr/lib/systemd/system
+        - make compliant
+        - make shellcheck
+
 # Ubuntu's default umask is 0002, but this break's swupd hash calculations.
 script:
         - sudo find test/functional -exec chmod g-w {} \;
-        - autoreconf --verbose --warnings=none --install --force &&
-          ./configure CFLAGS="$CFLAGS -fsanitize=address -Werror" --prefix=/usr --with-fallback-capaths=$TRAVIS_BUILD_DIR/swupd_test_certificates --with-systemdsystemunitdir=/usr/lib/systemd/system &&
-          make -j48 &&
+        - make -j48 &&
           sudo sh -c 'umask 0022 && make -j48 check' &&
           sudo sh -c 'umask 0022 && make install' &&
-          sudo sh -c 'umask 0022 && make install-check' &&
-          make compliant &&
-          make shellcheck
+          sudo sh -c 'umask 0022 && make install-check'
+
 after_failure: cat test-suite.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: required
 dist: xenial
 language: c
 
+env:
+    global:
+        - MAKEFLAGS="-j 32"
+
 # Pre-install missing build dependencies:
 # - libcheck 0.9.10 is slightly too old, since 0.9.12 adds TAP support
 # - bsdiff 1.* is the Clear Linux OS fork
@@ -39,8 +43,8 @@ before_script:
 # Ubuntu's default umask is 0002, but this break's swupd hash calculations.
 script:
         - sudo find test/functional -exec chmod g-w {} \;
-        - make -j48 &&
-          sudo sh -c 'umask 0022 && make -j48 check' &&
+        - make &&
+          make check &&
           sudo sh -c 'umask 0022 && make install' &&
           sudo sh -c 'umask 0022 && make install-check'
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -385,4 +385,7 @@ if ENABLE_TESTS
 install-check:
 	test/installation/test.bats
 
+unit-check:
+	env TEST_SUITE_LOG=unit_tests.log TESTS=$(UNIT_TESTS) make -e check
+
 endif


### PR DESCRIPTION
### This is the proposed solution:
- [x] Run `make compliant` and `shellcheck` before running `make` and running the functional tests  so if there is code style issues with the code the build fails right away instead of failing after all tests have finished. This will allow use to fail faster if the build is going to fail anyway.
- [x]	Use the correct number of parallel jobs in make. From the documentation: "See [Virtualization environments](https://docs.travis-ci.com/user/reference/overview/#virtualization-environments) to determine how many CPUs an environment normally has and set the make job parameter to a similar number (or slightly higher if your build frequently waits on disk I/O)". Ubuntu environments have only 2 cores.
- [x] Running functional tests is the most time consuming task in the build process, so if we split them in different jobs instead of running them in a single job we can avoid reaching the timeout.

Closes #852 