### PR TITLE
update: use execv() instead of system() to re-execute update

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -73,7 +73,7 @@ char *cert_path = NULL;
 int update_server_port = -1;
 static int max_parallel_downloads = -1;
 static int log_level = LOG_INFO;
-char *swupd_cmd = NULL;
+char **swupd_argv = NULL;
 
 /* If the MIX_BUNDLES_DIR has the valid-mix flag file we can run through
  * adding the mix data to the OS */
@@ -525,23 +525,7 @@ void free_globals(void)
 
 void save_cmd(char **argv)
 {
-	int size = 0;
-
-	/* Find size of total argv strings */
-	for (int i = 0; argv[i]; i++) {
-		/* +1 for space (" ") after flag that will be added later */
-		size += strlen(argv[i]) + 1;
-	}
-
-	/* +1 for null terminator */
-	swupd_cmd = malloc(size + 1);
-	ON_NULL_ABORT(swupd_cmd);
-
-	strcpy(swupd_cmd, "");
-	for (int i = 0; argv[i]; i++) {
-		strcat(swupd_cmd, argv[i]);
-		strcat(swupd_cmd, " ");
-	}
+	swupd_argv = argv;
 }
 
 size_t get_max_xfer(size_t default_max_xfer)

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -170,7 +170,7 @@ extern char *path_prefix;
 extern bool init_globals(void);
 extern void free_globals(void);
 extern void save_cmd(char **argv);
-extern char *swupd_cmd;
+extern char **swupd_argv;
 extern char *bundle_to_add;
 extern char *state_dir;
 extern int skip_diskspace_check;

--- a/test/functional/update/update-re-update-bad-os-release.bats
+++ b/test/functional/update/update-re-update-bad-os-release.bats
@@ -19,7 +19,7 @@ test_setup() {
 
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS_NO_FMT"
 
-	assert_status_is 1
+	assert_status_is "$SWUPD_CURRENT_VERSION_UNKNOWN"
 	expected_output=$(cat <<-EOM
 		Update started.
 		Preparing to update from 10 to 20


### PR DESCRIPTION
Note that we don't need to use run_command() (fork + exec) because
we don't need to handle any output on swupd. We can just replace current
process with the new swupd execution.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>