### PR TITLE
bundle-add overwrites old content

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -170,6 +170,7 @@ BATS = \
 	test/functional/bundleadd/add-multiple.bats \
 	test/functional/bundleadd/add-no-disk-space.bats \
 	test/functional/bundleadd/add-no-signature.bats \
+	test/functional/bundleadd/add-overwrite-files.bats \
 	test/functional/bundleadd/add-skip-scripts.bats \
 	test/functional/bundleadd/add-uses-fullfile.bats \
 	test/functional/bundleadd/add-uses-zeropack.bats \

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -848,7 +848,7 @@ struct list *filter_out_existing_files(struct list *files)
 		file = list->data;
 
 		filename = mk_full_filename(path_prefix, file->filename);
-		if (verify_file_lazy(filename)) {
+		if (verify_file(file, filename)) {
 			ret = list_free_item(list, NULL);
 		}
 		free_string(&filename);

--- a/test/functional/bundleadd/add-overwrite-files.bats
+++ b/test/functional/bundleadd/add-overwrite-files.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+
+	# pre-create two files in /usr/bin
+	sudo mkdir -p "$TARGETDIR"/usr/bin
+	write_to_protected_file "$TARGETDIR"/usr/bin/foo "old file"
+	write_to_protected_file "$TARGETDIR"/usr/bin/bar "file that should remain"
+	hash=$(sudo "$SWUPD" hashdump --quiet "$TARGETDIR"/usr/bin/bar)
+	sudo cp "$TARGETDIR"/usr/bin/bar "$WEBDIR"/10/files/"$hash"
+
+	# create a bundle that includes those two files, one file should match
+	# the hash and the other one shouldn't
+	create_bundle -n test-bundle -f /usr/bin/foo,/usr/bin/bar:"$WEBDIR"/10/files/"$hash" "$TEST_NAME"
+
+}
+
+@test "ADD050: Adding a bundle that overwrites an existing file" {
+
+	# When swupd is installing a bundle and a file included in the bundle
+	# already exists in the target system, it should replace the file if the
+	# file is different
+
+	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
+
+	assert_status_is "$SWUPD_OK"
+	assert_file_exists "$TARGETDIR"/usr/bin/foo
+	assert_not_equal "old file" "$(cat "$TARGETDIR"/usr/bin/foo)"
+	assert_file_exists "$TARGETDIR"/usr/bin/bar
+	assert_equal "file that should remain" "$(cat "$TARGETDIR"/usr/bin/bar)"
+
+}


### PR DESCRIPTION
When swupd is installing a bundle, it goes through the list of files to
install and removes those files that already exist in the target system
from the list without checking if the file needs to be updated or not.

This commit changes this process so the file is removed from the
list of files to install only if the file already exist in the target
system and the hash matches the hash in the manifest.

Closes #863

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>