### PR TITLE
Support "optional" bundles in manifests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -170,6 +170,7 @@ BATS = \
 	test/functional/bundleadd/add-experimental.bats \
 	test/functional/bundleadd/add-fall-back-to-fullfile.bats \
 	test/functional/bundleadd/add-include.bats \
+	test/functional/bundleadd/add-include-optional.bats \
 	test/functional/bundleadd/add-install-time.bats \
 	test/functional/bundleadd/add-json.bats \
 	test/functional/bundleadd/add-multiple.bats \

--- a/Makefile.am
+++ b/Makefile.am
@@ -202,6 +202,7 @@ BATS = \
 	test/functional/bundleremove/remove-include-nested.bats \
 	test/functional/bundleremove/remove-json.bats \
 	test/functional/bundleremove/remove-no-disk-space.bats \
+	test/functional/bundleremove/remove-optional-bundles.bats \
 	test/functional/bundleremove/remove-os-core.bats \
 	test/functional/bundleremove/remove-parse-args.bats \
 	test/functional/bundleremove/remove-with-dependency.bats \

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -728,6 +728,16 @@ int add_subscriptions(struct list *bundles, struct list **subs, struct manifest 
 			}
 			ret |= r; /* merge in recursive call results */
 		}
+
+		if (manifest->optional) {
+			int r = add_subscriptions(manifest->optional, subs, mom, find_all, recursion + 1);
+			if (r & add_sub_ERR) {
+				free_manifest(manifest);
+				goto out;
+			}
+			ret |= r; /* merge in recursive call results */
+		}
+
 		free_manifest(manifest);
 
 		if (!find_all && is_installed_bundle(bundle)) {

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -729,7 +729,7 @@ int add_subscriptions(struct list *bundles, struct list **subs, struct manifest 
 			ret |= r; /* merge in recursive call results */
 		}
 
-		if (manifest->optional) {
+		if (!skip_optional_bundles && manifest->optional) {
 			int r = add_subscriptions(manifest->optional, subs, mom, find_all, recursion + 1);
 			if (r & add_sub_ERR) {
 				free_manifest(manifest);

--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -47,12 +47,14 @@ static void print_help(void)
 	global_print_help();
 
 	print("Options:\n");
+	print("   -o, --skip-optional     Do not install optional bundles\n");
 	print("   --skip-diskspace-check  Do not check free disk space before adding bundle\n");
 	print("\n");
 }
 
 static const struct option prog_opts[] = {
 	{ "list", no_argument, 0, 'l' },
+	{ "skip-optional", no_argument, 0, 'o' },
 	{ "skip-diskspace-check", no_argument, &skip_diskspace_check, 1 },
 };
 
@@ -63,6 +65,9 @@ static bool parse_opt(int opt, UNUSED_PARAM char *optarg)
 		error("[-l, --list] option is deprecated, use\n"
 		      "bundle-list [-a|--all] sub-command instead.\n\n");
 		exit(EXIT_FAILURE);
+	case 'o':
+		skip_optional_bundles = true;
+		return true;
 	default:
 		return false;
 	}

--- a/src/globals.c
+++ b/src/globals.c
@@ -54,6 +54,7 @@ char *mounted_dirs = NULL;
 char *bundle_to_add = NULL;
 char *state_dir = NULL;
 int skip_diskspace_check = 0;
+bool skip_optional_bundles = false;
 bool keepcache = false;
 timelist *global_times = NULL;
 int max_retries = 3;

--- a/src/manifest.h
+++ b/src/manifest.h
@@ -22,6 +22,7 @@ struct manifest {
 	uint64_t filecount;
 	uint64_t contentsize;
 	struct list *includes; /* list of strings with manifest names */
+	struct list *optional;
 	char *component;
 
 	// File list

--- a/src/manifest_parser.c
+++ b/src/manifest_parser.c
@@ -42,6 +42,7 @@ struct manifest *manifest_parse(const char *component, const char *filename, boo
 	int err;
 	struct manifest *manifest;
 	struct list *includes = NULL;
+	struct list *optional = NULL;
 	unsigned long long filecount = 0;
 	unsigned long long contentsize = 0;
 
@@ -138,6 +139,8 @@ struct manifest *manifest_parse(const char *component, const char *filename, boo
 			}
 		} else if (strncmp_const(line, "includes:\t") == 0) {
 			includes = list_prepend_data(includes, strdup_or_die(c));
+		} else if (strncmp_const(line, "optional:\t") == 0) {
+			optional = list_prepend_data(optional, strdup_or_die(c));
 		}
 	}
 
@@ -145,6 +148,7 @@ struct manifest *manifest_parse(const char *component, const char *filename, boo
 	manifest->filecount = filecount;
 	manifest->contentsize = contentsize;
 	manifest->includes = includes;
+	manifest->optional = optional;
 
 	if (header_only) {
 		fclose(infile);
@@ -291,6 +295,9 @@ void free_manifest(struct manifest *manifest)
 	}
 	if (manifest->includes) {
 		list_free_list_and_data(manifest->includes, free);
+	}
+	if (manifest->optional) {
+		list_free_list_and_data(manifest->optional, free);
 	}
 	free_string(&manifest->component);
 	free(manifest);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -182,6 +182,7 @@ extern char **swupd_argv;
 extern char *bundle_to_add;
 extern char *state_dir;
 extern int skip_diskspace_check;
+extern bool skip_optional_bundles;
 extern timelist *global_times;
 extern int max_retries;
 extern int retry_delay;

--- a/test/functional/bundleadd/add-include-optional.bats
+++ b/test/functional/bundleadd/add-include-optional.bats
@@ -27,8 +27,9 @@ test_setup() {
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Loading required manifests...
+		No packs need to be downloaded
 		Starting download of remaining update content. This may take a while...
-		Finishing download of update content...
 		Installing bundle(s) files...
 		Calling post-update helper scripts.
 		Successfully installed 1 bundle
@@ -38,5 +39,36 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/foo/test-file1
 	assert_file_exists "$TARGETDIR"/bar/test-file2
 	assert_file_exists "$TARGETDIR"/baz/test-file3
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
+
+}
+
+@test "ADD052: Adding a bundle skipping its optional bundle" {
+
+	# An optional bundle is not required to be installed in the system while includes
+	# are. Swupd will install optional bundles on bundle-add unless specified otherwise
+	# by using the --skip--optional flag.
+
+	run sudo sh -c "$SWUPD bundle-add --skip-optional $SWUPD_OPTS test-bundle1"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Loading required manifests...
+		No packs need to be downloaded
+		Starting download of remaining update content. This may take a while...
+		Installing bundle(s) files...
+		Calling post-update helper scripts.
+		Successfully installed 1 bundle
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/foo/test-file1
+	assert_file_exists "$TARGETDIR"/bar/test-file2
+	assert_file_not_exists "$TARGETDIR"/baz/test-file3
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
 
 }

--- a/test/functional/bundleadd/add-include-optional.bats
+++ b/test/functional/bundleadd/add-include-optional.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n test-bundle1 -f /foo/test-file1 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /bar/test-file2 "$TEST_NAME"
+	create_bundle -n test-bundle3 -f /baz/test-file3 "$TEST_NAME"
+	# add test-bundle2 as a dependency of test-bundle1 and test-bundle3 as optional
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle1 test-bundle3
+
+}
+
+@test "ADD051: Adding a bundle that includes an optional bundle" {
+
+	# An optional bundle is not required to be installed in the system while includes
+	# are. Swupd will install optional bundles on bundle-add unless specified otherwise
+	# by using the --skip--optional flag.
+
+	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Starting download of remaining update content. This may take a while...
+		Finishing download of update content...
+		Installing bundle(s) files...
+		Calling post-update helper scripts.
+		Successfully installed 1 bundle
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/foo/test-file1
+	assert_file_exists "$TARGETDIR"/bar/test-file2
+	assert_file_exists "$TARGETDIR"/baz/test-file3
+
+}

--- a/test/functional/bundleremove/remove-optional-bundles.bats
+++ b/test/functional/bundleremove/remove-optional-bundles.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle1 -f /foo/test-file1 "$TEST_NAME"
+	create_bundle -L -n test-bundle2 -f /bar/test-file2 "$TEST_NAME"
+	create_bundle -L -n test-bundle3 -f /baz/test-file3 "$TEST_NAME"
+
+	# add test-bundle2 as a dependency of test-bundle1 and
+	# test-bundle3 as optional
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle1 test-bundle3
+
+}
+
+@test "REM021: Removing an optional bundle" {
+
+	# An optional bundle is not required to be installed in the system while includes
+	# are, but they are installed by default. Users shuld be able to remove them.
+
+	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle3"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Deleting bundle files...
+		Total deleted files: 3
+		Successfully removed 1 bundle
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/foo/test-file1
+	assert_file_exists "$TARGETDIR"/bar/test-file2
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TARGETDIR"/baz/test-file3
+	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
+
+}

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -853,7 +853,9 @@ add_to_manifest() { # swupd_function
 add_dependency_to_manifest() { # swupd_function
 
 	local partial=false
+	local flag=includes
 	[ "$1" = "-p" ] && { partial=true ; shift ; }
+	[ "$1" = "-o" ] && { flag=optional ; shift ; }
 	local manifest=$1
 	local dependency=$2
 	local path
@@ -864,13 +866,18 @@ add_dependency_to_manifest() { # swupd_function
 	if [ $# -eq 0 ]; then
 		cat <<-EOM
 			Usage:
-			    add_dependency_to_manifest <manifest> <dependency>
+			    add_dependency_to_manifest [-p] [-o] <manifest> <dependency>
 
 			Options:
 			    -p    If set (partial), the dependency will be added to the manifest,
 			          but the manifest's tar won't be re-created, nor the hash in the
 			          MoM will be updated either. This is useful if more updates are
 			          to be done in the manifest to avoid extra processing
+			    -o    If set (optional), the dependency will be added to the manifest
+			          as an optional dependency.
+
+			    Note: if both options -p and -o are to be used, they must be specified in that order or
+			      one option will be ignored.
 			EOM
 		return
 	fi
@@ -895,7 +902,7 @@ add_dependency_to_manifest() { # swupd_function
 		update_manifest -p "$manifest" previous "$pre_version"
 	fi
 	update_manifest -p "$manifest" timestamp "$(date +"%s")"
-	sudo sed -i "/^contentsize:.*/a includes:\\t$dependency" "$manifest"
+	sudo sed -i "/^contentsize:.*/a $flag:\\t$dependency" "$manifest"
 	# If a manifest tar already exists for that manifest, renew the manifest tar
 	# unless specified otherwise
 	if [ "$partial" = false ]; then

--- a/test/unit/data/mom2
+++ b/test/unit/data/mom2
@@ -5,6 +5,7 @@ minversion:	10
 filecount:	1
 timestamp:	123
 contentsize:	456
+optional:	bundleC
 XXXXXXXX:	XXXXXX
 
 M...	0000000000000000000000000000000000000000000000000000000000000001	10	m1


### PR DESCRIPTION
This PR adds support in swupd for optional bundles in manifests. An optional bundle is similar to the required bundles (included bundles) but have a couple of differences.

- Optional bundles are installed by default when the main bundle that includes them is installed.
- Users have the option to skip the installation of `Optional` bundles by using the flag `--skip-optional` or `-o` with `bundle-add`.
- Optional bundles can be removed from the system even if the main bundle that installed them is still in the system.

Closes #875 