### PR TITLE
test: Disabling json tests for now

### DIFF
--- a/test/functional/bundleadd/add-json.bats
+++ b/test/functional/bundleadd/add-json.bats
@@ -7,6 +7,7 @@ load "../testlib"
 
 test_setup() {
 
+	skip "This test is unstable and should be improved. Skipping that for now"
 	create_test_environment "$TEST_NAME"
 	test_files="/file1,/file2,/file3,/file4,/file5,/file6,/file7,/file8,/file9,/file10,/file11"
 	create_bundle -n test-bundle -f "$test_files" "$TEST_NAME"

--- a/test/functional/mirror/mirror-json.bats
+++ b/test/functional/mirror/mirror-json.bats
@@ -7,6 +7,7 @@ load "../testlib"
 
 test_setup() {
 
+	skip "This test is unstable and should be improved. Skipping that for now"
 	create_test_environment "$TEST_NAME"
 
 }

--- a/test/functional/search/search-json.bats
+++ b/test/functional/search/search-json.bats
@@ -7,6 +7,7 @@ load "../testlib"
 
 test_setup() {
 
+	skip "This test is unstable and should be improved. Skipping that for now"
 	create_test_environment "$TEST_NAME"
 	create_bundle -n test-bundle -f /file_1,/file_2 "$TEST_NAME"
 

--- a/test/functional/update/update-json.bats
+++ b/test/functional/update/update-json.bats
@@ -7,6 +7,7 @@ load "../testlib"
 
 test_setup() {
 
+	skip "This test is unstable and should be improved. Skipping that for now"
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle -f /file1,/file2,/file3 "$TEST_NAME"
 	create_version "$TEST_NAME" 20 10

--- a/test/functional/verify/verify-json.bats
+++ b/test/functional/verify/verify-json.bats
@@ -7,6 +7,7 @@ load "../testlib"
 
 test_setup() {
 
+	skip "This test is unstable and should be improved. Skipping that for now"
 	create_test_environment -r "$TEST_NAME"
 	create_bundle -L -n test-bundle1 -f /foo/test-file1,/bar/test-file2,/baz "$TEST_NAME"
 	create_bundle -n test-bundle2 -f /test-file3,/test-file4 "$TEST_NAME"


### PR DESCRIPTION
Disabling json tests that checks for progress because tests are unstable.
If we have any minor changes in the code that could affect how curl is called
we could have different progress reports and because of that we would have false
negatives.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>