### PR TITLE
archives: Don't assume tarball includes '/' for directories

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -906,18 +906,6 @@ int link_or_rename(const char *orig, const char *dest)
 	return 0;
 }
 
-static int check_single_file_tarball(const char *tarfilename, struct file *file)
-{
-	int err;
-	char *filename;
-
-	string_or_die(&filename, "%s%s", file->hash, file->is_dir ? "/" : "");
-	err = archives_check_single_file_tarball(tarfilename, filename);
-	free(filename);
-
-	return err;
-}
-
 /* This function will break if the same HASH.tar full file is downloaded
  * multiple times in parallel. */
 int untar_full_download(void *data)
@@ -960,7 +948,7 @@ int untar_full_download(void *data)
 	}
 	free_string(&tar_dotfile);
 
-	err = check_single_file_tarball(tarfile, file);
+	err = archives_check_single_file_tarball(tarfile, file->hash);
 	if (err) {
 		goto exit;
 	}

--- a/src/lib/archives.h
+++ b/src/lib/archives.h
@@ -13,7 +13,8 @@ int archives_extract_to(const char *tarfile, const char *outputdir);
 
 /*
  * Check if this tarball is valid and if it contains only one file with the
- * specified name.
+ * specified name. Trailing '/' is ignored for directories on the tarball, so
+ * don't include that on file.
  */
 int archives_check_single_file_tarball(const char *tarfilename, const char *file);
 


### PR DESCRIPTION
At first I assumed that all tarballs would have a trailing '/' for directories
and this isn't true. But we can't assume that we won't have a trailing '/'. So
archives_check_single_file_tarball() is now ignoring trailing '/' when comparing
files. That is the same behavior of the function that
archives_check_single_file_tarball() replaced.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>