### PR TITLE
swupd: Don't include libcurl headers

### DIFF
--- a/src/clean.c
+++ b/src/clean.c
@@ -22,6 +22,7 @@
 #include <errno.h>
 #include <getopt.h>
 #include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "swupd.h"

--- a/src/curl.c
+++ b/src/curl.c
@@ -53,7 +53,7 @@
 
 static CURL *curl = NULL;
 
-curl_off_t total_curl_sz = 0;
+uint64_t total_curl_sz = 0;
 
 /* alternative CA Path */
 static char *capath = NULL;

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -1,7 +1,6 @@
 #ifndef __INCLUDE_GUARD_SWUPD_H
 #define __INCLUDE_GUARD_SWUPD_H
 
-#include <curl/curl.h>
 #include <dirent.h>
 #include <getopt.h>
 #include <limits.h>
@@ -97,7 +96,7 @@ extern bool need_update_bootloader;
 extern bool need_systemd_reexec;
 extern bool keepcache;
 
-extern curl_off_t total_curl_sz;
+extern uint64_t total_curl_sz;
 
 struct update_stat {
 	uint64_t st_mode;

--- a/src/update.c
+++ b/src/update.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "config.h"


### PR DESCRIPTION
We have a layer isolating curl API calls, so don't include libcurl
headers on swupd.h.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>