### PR TITLE
Signature - Some organization, certificate revogation and tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -294,6 +294,7 @@ BATS = \
 	test/functional/verify/verify-skip-scripts.bats
 
 UNIT_TESTS = \
+	test/unit/test_signature.test \
 	test/unit/test_strings.test \
 	test/unit/test_manifest.test
 

--- a/src/globals.c
+++ b/src/globals.c
@@ -406,7 +406,6 @@ bool set_path_prefix(char *path)
  * value is used (CERT_PATH). Note that only the first call to this function
  * sets the variable.
  */
-#ifdef SIGNATURES
 static void set_cert_path(char *path)
 {
 	// Early exit if the function was called previously.
@@ -427,12 +426,6 @@ static void set_cert_path(char *path)
 		}
 	}
 }
-#else
-static void set_cert_path(char UNUSED_PARAM *path)
-{
-	return;
-}
-#endif
 
 bool init_globals(void)
 {
@@ -496,9 +489,7 @@ bool init_globals(void)
 		}
 	}
 
-#ifdef SIGNATURES
 	set_cert_path(NULL);
-#endif
 
 	if (verbose_time) {
 		global_times = timelist_new();

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -511,7 +511,7 @@ void free_file_data(void *data)
 
 void swupd_deinit(void)
 {
-	terminate_signature();
+	signature_deinit();
 	swupd_curl_deinit();
 	free_globals();
 	v_lockfile();
@@ -572,9 +572,9 @@ enum swupd_code swupd_init(void)
 	}
 
 	/* If --nosigcheck, we do not attempt any signature checking */
-	if (sigcheck && !initialize_signature()) {
+	if (sigcheck && !signature_init()) {
 		ret = SWUPD_SIGNATURE_VERIFICATION_FAILED;
-		terminate_signature();
+		signature_deinit();
 		goto out_close_lock;
 	}
 

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -572,7 +572,7 @@ enum swupd_code swupd_init(void)
 	}
 
 	/* If --nosigcheck, we do not attempt any signature checking */
-	if (sigcheck && !signature_init()) {
+	if (sigcheck && !signature_init(cert_path, NULL)) {
 		ret = SWUPD_SIGNATURE_VERIFICATION_FAILED;
 		signature_deinit();
 		goto out_close_lock;

--- a/src/lib/macros.h
+++ b/src/lib/macros.h
@@ -7,4 +7,6 @@
 		abort();   \
 	}
 
+#define UNUSED_PARAM __attribute__((__unused__))
+
 #endif

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -348,7 +348,7 @@ retry_load:
 	string_or_die(&url, "%s/%i/Manifest.MoM", content_url, version);
 
 	if (perform_sig_verify) {
-		invalid_sig = !download_and_verify_signature(url, filename, version, mix_exists);
+		invalid_sig = !signature_verify(url, filename, version, mix_exists);
 	}
 
 	/* Only when migrating , ignore the locally made signature check which is guaranteed to have been signed

--- a/src/signature.c
+++ b/src/signature.c
@@ -51,7 +51,6 @@ static int verify_callback(int, X509_STORE_CTX *);
 static bool get_pubkey();
 
 FILE *fp_pubkey = NULL;
-EVP_PKEY *pkey = NULL;
 X509 *cert = NULL;
 X509_STORE *store = NULL;
 STACK_OF(X509) *x509_stack = NULL;
@@ -145,10 +144,6 @@ void signature_deinit(void)
 		x509_stack = NULL;
 	}
 	ERR_free_strings();
-	if (pkey) {
-		EVP_PKEY_free(pkey);
-		pkey = NULL;
-	}
 	EVP_cleanup();
 	if (fp_pubkey) {
 		fclose(fp_pubkey);
@@ -303,12 +298,6 @@ static bool get_pubkey(void)
 		goto error;
 	}
 
-	pkey = X509_get_pubkey(cert);
-	if (!pkey) {
-		error("Failed X509_get_pubkey() for %s\n", CERTNAME);
-		X509_free(cert);
-		goto error;
-	}
 	return true;
 error:
 	ERR_print_errors_fp(stderr);

--- a/src/signature.c
+++ b/src/signature.c
@@ -64,7 +64,7 @@ static char *crl = NULL;
  * be validated.
  *
  * returns: true if can initialize and validate certificates, otherwise false */
-bool initialize_signature(void)
+bool signature_init(void)
 {
 	int ret = -1;
 
@@ -132,7 +132,7 @@ fail:
 
 /* Delete the memory used for string errors as well as memory allocated for
  * certificates and private keys. */
-void terminate_signature(void)
+void signature_deinit(void)
 {
 	//TODO: once implemented, must free chain
 	//TODO: once implemented, must free crl
@@ -425,7 +425,7 @@ int verify_callback(int ok, X509_STORE_CTX *stor)
  * returns: true if signature verification succeeded, false if verification
  * failed, or the signature download failed
  */
-bool download_and_verify_signature(const char *data_url, const char *data_filename, int version, bool mix_exists)
+bool signature_verify(const char *data_url, const char *data_filename, int version, bool mix_exists)
 {
 	char *local = NULL;
 	char *sig_url = NULL;
@@ -468,17 +468,17 @@ out:
 }
 
 #else
-bool initialize_signature(void)
+bool signature_init(void)
 {
 	return true;
 }
 
-void terminate_signature(void)
+void signature_deinit(void)
 {
 	return;
 }
 
-bool download_and_verify_signature(const char UNUSED_PARAM *data_url, const char UNUSED_PARAM *data_filename, int UNUSED_PARAM version, bool UNUSED_PARAM mix_exists)
+bool signature_verify(const char UNUSED_PARAM *data_url, const char UNUSED_PARAM *data_filename, int UNUSED_PARAM version, bool UNUSED_PARAM mix_exists)
 {
 	return true;
 }

--- a/src/signature.c
+++ b/src/signature.c
@@ -433,10 +433,6 @@ bool signature_verify(const char *data_url, const char *data_filename, int versi
 	int ret;
 	bool result;
 
-	if (!sigcheck) {
-		return false;
-	}
-
 	string_or_die(&sig_url, "%s.sig", data_url);
 	string_or_die(&sig_filename, "%s.sig", data_filename);
 	string_or_die(&local, "%s/%i/Manifest.MoM.sig", MIX_STATE_DIR, version);

--- a/src/signature.h
+++ b/src/signature.h
@@ -25,16 +25,16 @@ bool signature_init(const char *certificate_path, const char *crl);
 void signature_deinit(void);
 
 /*
- * The given data file has already been downloaded from the given URL.
- * Download the corresponding signature file, and verify the data against the signature.
- * Delete the signature file if and only if the verification fails.
+ * Verify if file is signed.
  *
- * @param data_url      the URL from which the data came
- * @param data_filename the file containing the data
+ * @param file         path to file to be verified.
+ * @param sig_file     path to signature file.
+ * @param print_errors if false, errors aren't printed.
  *
- * @return true if no error
+ * @return true if the file is signed with certificate used signature_init()
+
  */
-bool signature_verify(const char *data_url, const char *data_filename, int version, bool mix_exists);
+bool signature_verify(const char *file, const char *sig_file, bool print_errors);
 
 #ifdef __cplusplus
 }

--- a/src/signature.h
+++ b/src/signature.h
@@ -1,26 +1,38 @@
-#ifndef SIGNATURE_H_
-#define SIGNATURE_H_
+#ifndef __SIGNATURE_H__
+#define __SIGNATURE_H__
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Initialize this module.
- * @return true <=> no error
+ *
+ * @return true if no error
  */
-bool initialize_signature(void);
+bool signature_init(void);
 
 /*
  * Terminate usage of this module, free resources.
  */
-void terminate_signature(void);
+void signature_deinit(void);
 
 /*
  * The given data file has already been downloaded from the given URL.
  * Download the corresponding signature file, and verify the data against the signature.
  * Delete the signature file if and only if the verification fails.
- * @param data_url - the URL from which the data came
- * @param data_filename - the file containing the data
+ *
+ * @param data_url the URL from which the data came
+ * @param data_filename the file containing the data
+ *
+ * @return true if no error
  */
-bool download_and_verify_signature(const char *data_url, const char *data_filename, int version, bool mix_exists);
+bool signature_verify(const char *data_url, const char *data_filename, int version, bool mix_exists);
 
-#endif /* SIGNATURE_H_ */
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/signature.h
+++ b/src/signature.h
@@ -10,9 +10,14 @@ extern "C" {
 /*
  * Initialize this module.
  *
- * @return true if no error
+ * @param cert_path the path to the certificate to be used to check signatures.
+ * @param crl       a certificate revocation list to be used to check if the
+ *                  certificate is revoked. If null, the certificate is
+ *                  considered valid.
+ *
+ * @return true if no error.
  */
-bool signature_init(void);
+bool signature_init(const char *certificate_path, const char *crl);
 
 /*
  * Terminate usage of this module, free resources.
@@ -24,7 +29,7 @@ void signature_deinit(void);
  * Download the corresponding signature file, and verify the data against the signature.
  * Delete the signature file if and only if the verification fails.
  *
- * @param data_url the URL from which the data came
+ * @param data_url      the URL from which the data came
  * @param data_filename the file containing the data
  *
  * @return true if no error

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -36,8 +36,6 @@ extern "C" {
 #define CURRENT_OS_VERSION -1
 #define BUNDLE_NAME_MAXLEN 256
 
-#define UNUSED_PARAM __attribute__((__unused__))
-
 /* value used for configuring downloads */
 #define DELAY_MULTIPLIER 2
 #define MAX_DELAY 60

--- a/test/unit/test_helper.h
+++ b/test/unit/test_helper.h
@@ -1,14 +1,29 @@
 #include <stdlib.h>
 
+#define print_error(_msg) printf("Test error(%s:%d): %s\n", __FILE__, __LINE__, _msg);
+
 /*
  * Assert and print error message if _exp is false.
  */
-#define check_msg(_exp, _msg) \
-	do {\
-		if (!(_exp)) { \
-			printf("Test error(%s:%d): %s\n", __FILE__, __LINE__, _msg); \
-			exit(EXIT_FAILURE); \
-		} 		\
-	} while(0) \
+#define check_msg(_exp, _msg)			\
+	do {					\
+		if (!(_exp)) {			\
+			print_error(_msg);	\
+			exit(EXIT_FAILURE);	\
+		}				\
+	} while(0)
+
+/*
+ * Assert and print error message if _exp is false.
+ * Goto to label instead of exiting.
+ */
+#define check_msg_goto(_exp, _msg, _label)	\
+	do {					\
+		if (!(_exp)) {			\
+			print_error(_msg);	\
+			goto _label;		\
+		}				\
+	} while(0)
 
 #define check(_exp) check_msg(_exp, "failed")
+#define check_goto(_exp, _label) check_msg_goto(_exp, "failed", _label)

--- a/test/unit/test_signature.c
+++ b/test/unit/test_signature.c
@@ -1,0 +1,122 @@
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "../../src/lib/sys.h"
+#include "../../src/signature.h"
+#include "../../src/lib/strings.h"
+#include "test_helper.h"
+
+static char test_dir[] = "./test_signature-XXXXXX";
+
+static int set_up()
+{
+	if (mkdtemp(test_dir) == NULL) {
+		return -1;
+	}
+
+	return 0;
+}
+
+static int tear_down()
+{
+	rm_rf(test_dir);
+
+	return 0;
+}
+
+static int sign(const char *private_key, const char *public_key, const char *file, const char *file_sig)
+{
+	int ret;
+
+	ret = run_command("/usr/bin/openssl", "smime", "-sign",
+			   "-binary", "-in", file, "-signer", public_key,
+			   "-inkey", private_key, "-outform", "DER", "-out",
+			   file_sig);
+
+	if (ret != 0) {
+		print_error("Sign failed");
+		return -1;
+	}
+
+	return 0;
+}
+
+static int test_sign(const char *private_key, const char *public_key, bool success)
+{
+	char *sig = NULL;
+	char *file = NULL;
+	int ret = -1;
+
+	sig = str_or_die("%s/sig", test_dir);
+	file = __FILE__;
+
+	if (sign(private_key, public_key, file, sig) < 0) {
+		goto error;
+	}
+
+	if (!signature_init(public_key, NULL)) {
+		goto error;
+	}
+
+	// Check if signature match
+	check_goto(signature_verify(file, sig, false) == success, error);
+
+	// Check signature against wrong file
+	check_goto(signature_verify(sig, sig, false) == false, error);
+
+	ret = 0;
+
+error:
+	signature_deinit();
+	free(sig);
+	return ret;
+}
+
+static int test_signature()
+{
+	char *private_key, *public_key;
+	int ret;
+
+	private_key = str_or_die("%s/private.pem", test_dir);
+	public_key = str_or_die("%s/public.pem", test_dir);
+
+	// Create a good key
+	ret = run_command("/usr/bin/openssl", "req", "-x509", "-sha256",
+			  "-nodes", "-days", "365", "-newkey", "rsa:4096",
+			  "-keyout", private_key, "-out", public_key,
+			  "-subj", "/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost", NULL);
+	if (ret != 0) {
+		return -1;
+	}
+
+	ret = test_sign(private_key, public_key, true);
+
+	//TODO: Add tests with invalid signatures - expired, OCSP
+
+	free(private_key);
+	free(public_key);
+
+	return ret;
+}
+
+int main()
+{
+
+	if (set_up() < 0) {
+		print_error("Test set_up() error");
+		goto error;
+	}
+
+	if (test_signature() < 0) {
+		goto error;
+	}
+
+	tear_down();
+
+	return 0;
+
+error:
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
 - Reorganize code to take swupd specific code from signature.c
 - Add unit tests for signature verification
 - Check if OCSP is set as critical and reject the certificate if so, because OCSP isn't supported on swupd yet.