### PR TITLE
sys: Adding a missing --no-block flag on call that shouldn't block

### DIFF
--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -247,7 +247,7 @@ int systemctl_restart(const char *service)
 
 int systemctl_restart_noblock(const char *service)
 {
-	return systemctl_cmd("restart", service, NULL);
+	return systemctl_cmd("restart", "--no-block", service, NULL);
 }
 
 bool systemctl_active(void)


### PR DESCRIPTION
Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>