### PR TITLE
Set user-agent header

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -725,6 +725,9 @@ CURLcode swupd_curl_set_basic_options(CURL *curl, const char *url, bool fail_on_
 		goto exit;
 	}
 
+	curl_easy_setopt(curl, CURLOPT_USERAGENT, PACKAGE "/" VERSION);
+	// No error checking needed, this is not critical information
+
 	if (update_server_port > 0) {
 		curl_ret = curl_easy_setopt(curl, CURLOPT_PORT, update_server_port);
 		if (curl_ret != CURLE_OK) {


### PR DESCRIPTION
This change sets swupd client User-Agent header to PACKAGE/VERSION. This is
 a standard HTTP header to identify the client that originates a request.

Signed-off-by: Alex Jaramillo <alex.v.jaramillo@intel.com>