### PR TITLE
Removes iter manifests from bundle-add completion

### DIFF
--- a/swupd.bash
+++ b/swupd.bash
@@ -86,7 +86,7 @@ _swupd()
 		fi
 		if [ -n "$MoM" ]
 		then
-		    opts+="$( sed '1,/^$/d; s/^.*\t/ /' "$MoM" | LC_ALL=C sort )"
+		    opts+="$( sed '1,/^$/d; s/^.*\t/ /; /.*\.I\..*/d' "$MoM" | LC_ALL=C sort )"
 		fi ;;
 	    ("bundle-remove")
 		opts+=" $(unset CDPATH; test -d /usr/share/clear/bundles && \


### PR DESCRIPTION
There is a bug in the code that causes swupd bundle-add <TAB><TAB>
to list regular bundle names as well as iterative manifest names.

This commit fixes the issue by removing the iterative manifests from
the list of results.

Closes #906

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>