### PR TITLE
swupd.bash" Remove extra " when setting COMPREPL

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -374,7 +374,6 @@ compliant:
 	fi; \
 	exit 1
 
-# Ignore SC2207 because that's the standard way to fill COMPREPLY
 # Ignore SC1008 because scripts are using an unsupported shebang
 shellcheck:
 	for i in $$(git diff --name-only origin/master HEAD | \grep -E "\.bats|\.bash"); do \
@@ -385,7 +384,7 @@ shellcheck:
 	done
 
 shellcheck-all:
-	shellcheck -e SC2207 swupd.bash
+	shellcheck swupd.bash
 	find -name "*.bats" -exec sh -c "\
 		echo checking {}; \
 		sed 's/^@.*/func() {/' {} | \

--- a/swupd.bash
+++ b/swupd.bash
@@ -99,7 +99,9 @@ _swupd()
 	esac
     fi
 
-    COMPREPLY=("$(compgen -W "${opts}" -- "${2}")");
+    # Ignore SC2207 because that's the standard way to fill COMPREPLY
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -W "${opts}" -- "${2}"));
     return 0
 }
 if [ "${BASH_VERSINFO[0]}" -gt 4 ] || { [ "${BASH_VERSINFO[0]}" -eq 4 ] && [ "${BASH_VERSINFO[1]}" -ge 4 ]; }


### PR DESCRIPTION
Bash completion was adding line breaks because of that extra " on COMPREPLY

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>