### PR TITLE
Renaming "swupd verify" to "swupd diagnose"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
                 - UPDATE_SUBGROUP2="$(find test/functional/update -name *.bats | tail -n $UPDATE_SUBGROUP2_TOTAL | tr '\n' ' ')"
                 - GROUP1="$UPDATE_SUBGROUP1"
                 - GROUP2="$UPDATE_SUBGROUP2 $(find test/functional/{checkupdate,hashdump,mirror,usability} -name *.bats -printf '%p ')"
-                - GROUP3="$(find test/functional/{verify,search,os-install,repair} -name *.bats -printf '%p ')"
+                - GROUP3="$(find test/functional/{diagnose,search,os-install,repair} -name *.bats -printf '%p ')"
                 - GROUP4="$(find test/functional/{bundleadd,bundleremove,bundlelist} -name *.bats -printf '%p ')"
 
 jobs:
@@ -31,7 +31,7 @@ jobs:
                   name: "Functional Tests - update (group 2), checkupdate, hashdump, mirror, usability"
                   script: env TESTS="$GROUP2" make -e check
                 - stage: test
-                  name: "Functional Tests - verify, os-install, repair, search"
+                  name: "Functional Tests - diagnose, os-install, repair, search"
                   script: env TESTS="$GROUP3" make -e check
                 - stage: test
                   name: "Functional Tests - bundle-add, bundle-remove, bundle-list"

--- a/Makefile.am
+++ b/Makefile.am
@@ -211,6 +211,16 @@ BATS = \
 	test/functional/checkupdate/chk-update-no-target-content.bats \
 	test/functional/checkupdate/chk-update-slow-server.bats \
 	test/functional/checkupdate/chk-update-version-match.bats \
+	test/functional/diagnose/diagnose-basics.bats \
+	test/functional/diagnose/diagnose-boot-file.bats \
+	test/functional/diagnose/diagnose-client-certificate.bats \
+	test/functional/diagnose/diagnose-directory-tree-deleted.bats \
+	test/functional/diagnose/diagnose-good.bats \
+	test/functional/diagnose/diagnose-json.bats \
+	test/functional/diagnose/diagnose-missing-file.bats \
+	test/functional/diagnose/diagnose-picky.bats \
+	test/functional/diagnose/diagnose-picky-downgrade.bats \
+	test/functional/diagnose/diagnose-picky-whitelist.bats \
 	test/functional/hashdump/hashdump-file-hash.bats \
 	test/functional/mirror/mirror-createdir.bats \
 	test/functional/mirror/mirror-createdir-negative.bats \
@@ -292,17 +302,7 @@ BATS = \
 	test/functional/update/update-with-slightly-old-mirror.bats \
 	test/functional/usability/usa-completion-basic.bats \
 	test/functional/usability/usa-download-retries.bats \
-	test/functional/usability/usa-external-modules.bats \
-	test/functional/verify/verify-boot-file.bats \
-	test/functional/verify/verify-client-certificate.bats \
-	test/functional/verify/verify-directory-tree-deleted.bats \
-	test/functional/verify/verify-fix.bats \
-	test/functional/verify/verify-good.bats \
-	test/functional/verify/verify-json.bats \
-	test/functional/verify/verify-missing-file.bats \
-	test/functional/verify/verify-picky.bats \
-	test/functional/verify/verify-picky-downgrade.bats \
-	test/functional/verify/verify-picky-whitelist.bats
+	test/functional/usability/usa-external-modules.bats
 
 UNIT_TESTS = \
 	test/unit/test_signature.test \

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -26,7 +26,7 @@ The updates are fetched from a central software update server. If a
 valid update is found on the server, it can be downloaded and applied.
 
 The ``swupd`` tool can also install and remove bundles, check for
-updates without applying them, perform system-level verification of
+updates without applying them, perform system-level diagnose of
 the system software, and install an OS.
 
 A *version url* server provides version information. This server
@@ -183,6 +183,75 @@ SUBCOMMANDS
 
     Checks whether an update is available and prints out the information
     if so. Does not download update content.
+
+``diagnose``
+
+    Perform system software installation verification. The program will
+    obtain all the manifests needed from version url and content url to
+    establish whether the system software is correctly installed and not
+    overwritten, modified, missing or otherwise incorrect (permissions, etc.).
+
+    After obtaining the proper resources, all files that are under
+    control of the software update program are verified according to the
+    manifest data
+
+    - `-m, --manifest`
+
+        Diagnose against manifest version M.
+
+    - `-Y, --picky`
+
+        List files which should not exist. Only files listed in the
+        manifests should exist.
+
+    - `-X, --picky-tree=[PATH]`
+
+        Selects the sub-tree where --picky looks for extra files. To be
+        specified as absolute path. The default is `/usr`.
+
+    - `-w, --picky-whitelist=[RE]`
+
+        Any path matching the POSIX extended regular expression is
+        ignored by --picky. The given expression is always wrapped
+        in ``^(`` and ``)$`` and thus has to match the entire path.
+        Matched directories get skipped completely.
+
+        The default is to ignore ``/usr/lib/kernel``,
+        ``/usr/lib/modules``, ``/usr/src`` and ``/usr/local``.
+
+        Examples:
+
+        - ``/var|/etc/machine-id``
+
+            Ignores ``/var`` or ``/etc/machine-id``, regardless of
+            whether they are directories or something else. In the
+            usual case that ``/var`` is a directory, also everything
+            inside it is ignored because the directory gets skipped
+            while scanning the directory tree.
+
+        - empty string or ``^$``
+
+            Matches nothing, because paths are never empty.
+
+    - `-q, --quick`
+
+        Omit checking hash values. Instead only looks for missing files
+        and directories and/or symlinks.
+
+    - `-x, --force`
+
+        Attempt to proceed even if non-critical errors found.
+
+    - `-B, --bundles=[BUNDLES]`
+
+        Only verify the (comma separated) list of bundles are installed
+        correctly.
+
+        Examples:
+
+        - ``--bundles os-core,vi``
+
+            Only runs the verify operation on the os-core and vi bundles.
 
 ``hashdump {path}``
 
@@ -384,7 +453,7 @@ SUBCOMMANDS
         Do not delete the swupd state directory content after updating the
         system.
 
-``verify``
+``verify (deprecated)``
 
     Perform system software installation verification. The program will
     obtain all the manifests needed from version url and content url to
@@ -393,7 +462,10 @@ SUBCOMMANDS
 
     After obtaining the proper resources, all files that are under
     control of the software update program are verified according to the
-    manifest data
+    manifest data.
+
+    NOTE: This command has been deprecated, please consider using "swupd diagnose"
+    instead.
 
     - `-m, --manifest`
 
@@ -466,7 +538,6 @@ SUBCOMMANDS
         - ``--bundles os-core,vi``
 
             Only runs the verify operation on the os-core and vi bundles.
-
 
 EXIT STATUS
 ===========

--- a/src/main.c
+++ b/src/main.c
@@ -34,6 +34,7 @@ struct subcmd {
 	enum swupd_code (*mainfunc)(int, char **);
 };
 
+/* TODO(castulo): remove the deprecated verify command by end of July 2019 */
 static struct subcmd commands[] = {
 	{ "autoupdate", "Enable/disable automatic system updates", autoupdate_main },
 	{ "bundle-add", "Install a new bundle", bundle_add_main },
@@ -41,7 +42,8 @@ static struct subcmd commands[] = {
 	{ "bundle-list", "List installed bundles", bundle_list_main },
 	{ "hashdump", "Dump the HMAC hash of a file", hashdump_main },
 	{ "update", "Update to latest OS version", update_main },
-	{ "verify", "Verify content for OS version", verify_main },
+	{ "verify", "Verify content for OS version. NOTE: this command has been deprecated. Please use \"swupd diagnose\" instead.", verify_main },
+	{ "diagnose", "Verify content for OS version", verify_main },
 	{ "check-update", "Check if a new OS version is available", check_update_main },
 	{ "search-file", "Command to search files in Clear Linux bundles", search_main },
 	{ "info", "Show the version and the update URLs", info_main },
@@ -99,8 +101,16 @@ static int subcmd_index(char *arg)
 {
 	struct subcmd *entry = commands;
 	int i = 0;
-	size_t input_len = strlen(arg);
+	size_t input_len;
 	size_t cmd_len;
+
+	/* TODO(castulo): remove the deprecated command by end of July 2019 */
+	if (strcmp(arg, "verify") == 0) {
+		arg = "diagnose";
+		fprintf(stderr, "\nWarning: The verify command has been deprecated and will be removed soon.\n");
+		fprintf(stderr, "Please consider using \"swupd diagnose\" instead.\n\n");
+	}
+	input_len = strlen(arg);
 
 	while (entry->name != NULL) {
 		cmd_len = strlen(entry->name);

--- a/src/verify.c
+++ b/src/verify.c
@@ -117,7 +117,7 @@ void verify_set_picky_tree(const char *picky_tree)
 static void print_help(void)
 {
 	print("Usage:\n");
-	print("   swupd verify [OPTION...]\n\n");
+	print("   swupd diagnose [OPTION...]\n\n");
 
 	//TODO: Add documentation explaining this command
 
@@ -682,7 +682,7 @@ enum swupd_code verify_main(int argc, char **argv)
 
 	ret = swupd_init();
 	if (ret != 0) {
-		error("Failed verify initialization, exiting now.\n");
+		error("Failed diagnose initialization, exiting now.\n");
 		goto clean_args_and_exit;
 	}
 
@@ -771,14 +771,14 @@ enum swupd_code verify_main(int argc, char **argv)
 	if (!is_compatible_format(official_manifest->manifest_version)) {
 		if (cmdline_option_force) {
 			warn("the force option is specified; ignoring"
-			     " format mismatch for verify\n");
+			     " format mismatch for diagnose\n");
 		} else {
-			error("Mismatching formats detected when verifying %d"
+			error("Mismatching formats detected when diagnosing %d"
 			      " (expected: %s; actual: %d)\n",
 			      version, format_string, official_manifest->manifest_version);
 			int latest = get_latest_version(NULL);
 			if (latest > 0) {
-				info("Latest supported version to verify: %d\n", latest);
+				info("Latest supported version to diagnose: %d\n", latest);
 			}
 			ret = SWUPD_COULDNT_LOAD_MANIFEST;
 			goto clean_and_exit;
@@ -1056,7 +1056,7 @@ clean_and_exit:
 			}
 		} else {
 			/* This is just a verification */
-			info("Verify successful\n");
+			info("Diagnose successful\n");
 
 			if (counts.mismatch > 0 ||
 			    counts.missing > 0 ||
@@ -1071,7 +1071,7 @@ clean_and_exit:
 			print("Installation failed\n");
 		} else {
 			/* This is just a verification */
-			print("Verify did not fully succeed\n");
+			print("Diagnose did not fully succeed\n");
 		}
 	}
 

--- a/swupd.bash
+++ b/swupd.bash
@@ -27,7 +27,8 @@ _swupd()
     for ((i=COMP_CWORD-1;i>=0;i--))
     do case "${COMP_WORDS[$i]}" in
 	    ("$1")
-		opts="--help --version autoupdate bundle-add bundle-remove bundle-list hashdump update verify check-update search search-file info clean mirror os-install repair "
+	    #  TODO(castulo): remove the deprecated verify command by end of July 2019
+		opts="--help --version autoupdate bundle-add bundle-remove bundle-list hashdump update diagnose check-update search search-file info clean mirror os-install repair verify "
 	    break;;
 	    ("autoupdate")
 		opts="--help --enable --disable "
@@ -49,6 +50,9 @@ _swupd()
 		break;;
 	    ("verify")
 		opts="--help --manifest --path --url --port --contenturl --versionurl --fix --picky --picky-tree --picky-whitelist --install --format --quick --force --nosigcheck --ignore-time --statedir --certpath --time --no-scripts --no-boot-update --max-parallel-downloads --debug --quiet --json-output "
+		break;;
+	    ("diagnose")
+		opts="--help --manifest --path --url --port --contenturl --versionurl --picky --picky-tree --picky-whitelist --format --quick --force --nosigcheck --ignore-time --statedir --certpath --time --no-scripts --no-boot-update --max-parallel-downloads --debug --quiet --json-output "
 		break;;
 	    ("check-update")
 		opts="--help --url --versionurl --port --format --force --nosigcheck --path --statedir --debug --quiet --json-output "

--- a/test/functional/diagnose/diagnose-basics.bats
+++ b/test/functional/diagnose/diagnose-basics.bats
@@ -24,14 +24,14 @@ test_setup() {
 
 }
 
-@test "VER012: Verify shows modified files, new files and deleted files" {
+@test "DIA012: Diagnose shows modified files, new files and deleted files" {
 
 	# verify should show tracked files with a hash mismatch,
 	# it should also show tracked files that were marked to be removed,
 	# and it should show files that were added to bundles.
 	# verify should not show any of these changes in untracked files
 
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
@@ -46,7 +46,7 @@ test_setup() {
 		  2 files were missing
 		  2 files did not match
 		  1 file found which should be deleted
-		Verify successful
+		Diagnose successful
 	EOM
 	)
 	assert_regex_is_output "$expected_output"

--- a/test/functional/diagnose/diagnose-boot-file.bats
+++ b/test/functional/diagnose/diagnose-boot-file.bats
@@ -11,9 +11,9 @@ test_setup() {
 
 }
 
-@test "VER004: Verify a system that has a corrupt boot file" {
+@test "DIA004: Diagnose a system that has a corrupt boot file" {
 
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
 		Verifying version 10
@@ -21,7 +21,7 @@ test_setup() {
 		Hash mismatch for file: .*/target-dir/usr/lib/kernel/testfile
 		Inspected 7 files
 		  1 file did not match
-		Verify successful
+		Diagnose successful
 	EOM
 	)
 	assert_regex_is_output "$expected_output"

--- a/test/functional/diagnose/diagnose-client-certificate.bats
+++ b/test/functional/diagnose/diagnose-client-certificate.bats
@@ -66,19 +66,19 @@ global_teardown() {
 	destroy_test_environment "$TEST_NAME"
 }
 
-@test "VER007: Verify installed content on a system over HTTPS with a valid client certificate" {
+@test "DIA007: Diagnose installed content on a system over HTTPS with a valid client certificate" {
 
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
 
 	assert_status_is 0
 }
 
-@test "VER008: Try verifying installed content on a system over HTTPS with no client certificate" {
+@test "DIA008: Try diagnosing installed content on a system over HTTPS with no client certificate" {
 
 	# remove client certificate
 	sudo rm "$CLIENT_CERT"
 
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --debug"
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --debug"
 	assert_status_is "$SWUPD_CURL_INIT_FAILED"
 
 	expected_output=$(cat <<-EOM
@@ -88,12 +88,12 @@ global_teardown() {
 	assert_regex_in_output "$expected_output"
 }
 
-@test "VER009: Try verifying installed content on a system over HTTPS with an invalid client certificate" {
+@test "DIA009: Try diagnosing installed content on a system over HTTPS with an invalid client certificate" {
 
 	# make client certificate invalid
 	sudo sh -c "echo foo > $CLIENT_CERT"
 
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --debug"
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --debug"
 	assert_status_is "$SWUPD_CURL_INIT_FAILED"
 
 	expected_output=$(cat <<-EOM

--- a/test/functional/diagnose/diagnose-directory-tree-deleted.bats
+++ b/test/functional/diagnose/diagnose-directory-tree-deleted.bats
@@ -16,9 +16,9 @@ test_setup() {
 }
 
 
-@test "VER006: Verify a system that has a file that should be deleted" {
+@test "DIA006: Diagnose a system that has a file that should be deleted" {
 
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
 		Verifying version 10
@@ -28,7 +28,7 @@ test_setup() {
 		File that should be deleted: .*/target-dir/testdir1
 		Inspected 4 files
 		  3 files found which should be deleted
-		Verify successful
+		Diagnose successful
 	EOM
 	)
 	assert_regex_is_output "$expected_output"

--- a/test/functional/diagnose/diagnose-good.bats
+++ b/test/functional/diagnose/diagnose-good.bats
@@ -11,16 +11,16 @@ test_setup() {
 
 }
 
-@test "VER001: Verify installed content on a system that is fine" {
+@test "DIA001: Diagnose installed content on a system that is fine" {
 
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Verifying version 10
 		Verifying files
 		Inspected 11 files
-		Verify successful
+		Diagnose successful
 	EOM
 	)
 	assert_is_output "$expected_output"

--- a/test/functional/diagnose/diagnose-json.bats
+++ b/test/functional/diagnose/diagnose-json.bats
@@ -16,9 +16,9 @@ test_setup() {
 
 }
 
-@test "VER010: Verify a system using machine readable output" {
+@test "DIA010: Diagnose a system using machine readable output" {
 
-	run sudo sh -c "$SWUPD verify --json-output $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD diagnose --json-output $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
@@ -54,7 +54,7 @@ test_setup() {
 		\{ "type" : "progress", "currentStep" : 6, "totalSteps" : 6, "stepCompletion" : 100, "stepDescription" : "fix_files" \},
 		\{ "type" : "info", "msg" : "Inspected 17 files " \},
 		\{ "type" : "info", "msg" : "  2 files were missing " \},
-		\{ "type" : "info", "msg" : "Verify successful " \},
+		\{ "type" : "info", "msg" : "Diagnose successful " \},
 		\{ "type" : "end", "section" : "verify", "status" : 1 \}
 		\]
 	EOM

--- a/test/functional/diagnose/diagnose-missing-file.bats
+++ b/test/functional/diagnose/diagnose-missing-file.bats
@@ -11,9 +11,9 @@ test_setup() {
 
 }
 
-@test "VER002: Verify a system that is missing a file" {
+@test "DIA002: Diagnose a system that is missing a file" {
 
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
 		Verifying version 10
@@ -21,7 +21,7 @@ test_setup() {
 		Missing file: .*/target-dir/foo/test-file1
 		Inspected 7 files
 		  1 file was missing
-		Verify successful
+		Diagnose successful
 	EOM
 	)
 	assert_regex_is_output "$expected_output"

--- a/test/functional/diagnose/diagnose-picky-downgrade.bats
+++ b/test/functional/diagnose/diagnose-picky-downgrade.bats
@@ -12,9 +12,9 @@ test_setup() {
 
 }
 
-@test "VER011: Verify can show files that would be removed if not available in a previous version" {
+@test "DIA011: Diagnose can show files that would be removed if not available in a previous version" {
 
-	run sudo sh -c "$SWUPD verify --picky --manifest=10 --force $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD diagnose --picky --manifest=10 --force $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
@@ -30,7 +30,7 @@ test_setup() {
 		/usr/foo/
 		Inspected 19 files
 		  6 files found which should be deleted
-		Verify successful
+		Diagnose successful
 	EOM
 	)
 	assert_regex_is_output "$expected_output"

--- a/test/functional/diagnose/diagnose-picky.bats
+++ b/test/functional/diagnose/diagnose-picky.bats
@@ -12,19 +12,17 @@ test_setup() {
 	sudo touch "$TARGETDIR"/usr/file1
 	sudo mkdir -p "$TARGETDIR"/usr/foo/bar
 	sudo touch "$TARGETDIR"/usr/foo/bar/file2
-	sudo touch "$TARGETDIR"/usr/foo/bar/file3
-	sudo mkdir -p "$TARGETDIR"/usr/bat/baz
-	sudo touch "$TARGETDIR"/usr/bat/baz/file4
-	sudo touch "$TARGETDIR"/usr/bat/baz/file5
+	# create extra file outside of /usr (should be ignored by picky)
+	sudo touch "$TARGETDIR"/file3
 
 }
 
-@test "VER003: Verify directories in the whitelist are skipped during --picky" {
+@test "DIA005: Diagnose a system that has extra files in /usr" {
 
 	# --picky should find those files in /usr that are not in any manifest
-	# but it should skip those insde directories that are in the whitelist
+	# but it should not delete them (unless --fix is also used)
 
-	run sudo sh -c "$SWUPD verify --picky --picky-whitelist=/usr/foo $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD diagnose --picky $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
@@ -32,14 +30,13 @@ test_setup() {
 		Generating list of extra files under .*/target-dir/usr
 		/usr/share/defaults/swupd/versionurl
 		/usr/share/defaults/swupd/contenturl
+		/usr/foo/bar/file2
+		/usr/foo/bar/
+		/usr/foo/
 		/usr/file1
-		/usr/bat/baz/file5
-		/usr/bat/baz/file4
-		/usr/bat/baz/
-		/usr/bat/
-		Inspected 18 files
-		  7 files found which should be deleted
-		Verify successful
+		Inspected 17 files
+		  6 files found which should be deleted
+		Diagnose successful
 	EOM
 	)
 	assert_regex_is_output "$expected_output"

--- a/test/functional/repair/repair-format-mismatch-overdrive.bats
+++ b/test/functional/repair/repair-format-mismatch-overdrive.bats
@@ -22,7 +22,7 @@ test_setup() {
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Verifying version 40
-		Warning: the force option is specified; ignoring format mismatch for verify
+		Warning: the force option is specified; ignoring format mismatch for diagnose
 		Warning: the force or picky option is specified; ignoring version mismatch for repair
 		Verifying files
 		Starting download of remaining update content. This may take a while...

--- a/test/functional/repair/repair-format-mismatch.bats
+++ b/test/functional/repair/repair-format-mismatch.bats
@@ -20,8 +20,8 @@ test_setup() {
 	assert_status_is "$SWUPD_COULDNT_LOAD_MANIFEST"
 	expected_output=$(cat <<-EOM
 		Verifying version 40
-		Error: Mismatching formats detected when verifying 40 (expected: 1; actual: 2)
-		Latest supported version to verify: 20
+		Error: Mismatching formats detected when diagnosing 40 (expected: 1; actual: 2)
+		Latest supported version to diagnose: 20
 		Repair did not fully succeed
 	EOM
 	)

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -2986,7 +2986,7 @@ get_next_available_id() { # swupd_function
 		bundleadd) group=ADD;;
 		bundleremove) group=REM;;
 		bundlelist) group=LST;;
-		verify) group=VER;;
+		diagnose) group=DIA;;
 		update) group=UPD;;
 		checkupdate) group=CHK;;
 		search) group=SRH;;

--- a/test/real_content/real_content_lib.bash
+++ b/test/real_content/real_content_lib.bash
@@ -94,10 +94,10 @@ check_version() {
 
 verify_system() {
 
-	run sudo sh -c "$SWUPD verify --picky $SWUPD_OPTS 2>/dev/null"
+	run sudo sh -c "$SWUPD diagnose --picky $SWUPD_OPTS 2>/dev/null"
 	assert_status_is 0
 
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
 	assert_status_is 0
 
 	return

--- a/test/real_content/swupd_update.bats
+++ b/test/real_content/swupd_update.bats
@@ -7,7 +7,7 @@ load "real_content_lib"
 	# shellcheck disable=SC2153
 	print "Install minimal system with oldest version (${VERSION[0]})"
 
-	run sudo sh -c "$SWUPD verify --install $SWUPD_OPTS -m ${VERSION[0]} -F $FORMAT"
+	run sudo sh -c "$SWUPDos-install $SWUPD_OPTS -V ${VERSION[0]} -F $FORMAT"
 	assert_status_is 0
 	check_version "${VERSION[0]}"
 

--- a/test/real_content/swupd_update_fullfiles.bats
+++ b/test/real_content/swupd_update_fullfiles.bats
@@ -3,10 +3,10 @@
 load "real_content_lib"
 
 # Test massive fullfile downloads
-@test "RC002: Update from first to last with --fix" {
+@test "RC002: Update from first to last with repair" {
 	# shellcheck disable=SC2153
 	print "Install minimal system with oldest version (${VERSION[0]})"
-	run sudo sh -c "$SWUPD verify --install $SWUPD_OPTS -m ${VERSION[0]} -F $FORMAT"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS -V ${VERSION[0]} -F $FORMAT"
 	assert_status_is 0
 	check_version "${VERSION[0]}"
 
@@ -19,7 +19,7 @@ load "real_content_lib"
 
 	version=${VERSION[${#VERSION[@]} -1]}
 	print "Update system to last version ($version)"
-	run sudo sh -c "$SWUPD verify --fix --picky $SWUPD_OPTS -m ${version}"
+	run sudo sh -c "$SWUPD repair --picky $SWUPD_OPTS -m ${version}"
 	assert_status_is 0
 	check_version "$version"
 	verify_system

--- a/test/real_content/swupd_update_jump.bats
+++ b/test/real_content/swupd_update_jump.bats
@@ -6,7 +6,7 @@ load "real_content_lib"
 @test "RC003: Update from 2 distant versions" {
 	# shellcheck disable=SC2153
 	print "Install minimal system with oldest version (${VERSION[0]})"
-	run sudo sh -c "$SWUPD verify --install $SWUPD_OPTS -m ${VERSION[0]} -F $FORMAT"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS -V ${VERSION[0]} -F $FORMAT"
 	assert_status_is 0
 	check_version "${VERSION[0]}"
 

--- a/test/real_content/swupd_verify_install.bats
+++ b/test/real_content/swupd_verify_install.bats
@@ -18,7 +18,7 @@ load "real_content_lib"
 
 	# shellcheck disable=SC2153
 	print "Install complete system with newest version (${VERSION[$i]})"
-	run sudo sh -c "$SWUPD verify --install $SWUPD_OPTS -m ${VERSION[$i]} -F $FORMAT"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS -V ${VERSION[$i]} -F $FORMAT"
 	assert_status_is 0
 	check_version "${VERSION[$i]}"
 	verify_system


### PR DESCRIPTION
This PR renames the "verify" command to "diagnose" to make it
more straightforward for the user to understand the purpose of the
command.

Closes #918