### PR TITLE
Adding the -V / --version flag to swupd commands

### DIFF
--- a/src/repair.c
+++ b/src/repair.c
@@ -40,6 +40,7 @@ static regex_t picky_whitelist_buffer;
 
 static const struct option prog_opts[] = {
 	{ "force", no_argument, 0, 'x' },
+	{ "version", required_argument, 0, 'V' },
 	{ "manifest", required_argument, 0, 'm' },
 	{ "picky", no_argument, 0, 'Y' },
 	{ "picky-tree", required_argument, 0, 'X' },
@@ -56,13 +57,14 @@ static void print_help(void)
 	global_print_help();
 
 	print("Options:\n");
-	print("   -m, --manifest=M        Repair against manifest version M\n");
+	print("   -V, --version=V         Compare against version V to repair\n");
 	print("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	print("   -q, --quick             Don't compare hashes, only fix missing files\n");
 	print("   -B, --bundles=[BUNDLES] Ensure BUNDLES are installed correctly. Example: --bundles=os-core,vi\n");
 	print("   -Y, --picky             Remove files which should not exist\n");
 	print("   -X, --picky-tree=[PATH] Selects the sub-tree where --picky looks for extra files. Default: /usr\n");
 	print("   -w, --picky-whitelist=[RE] Any path completely matching the POSIX extended regular expression is ignored by --picky. Matched directories get skipped. Example: /var|/etc/machine-id. Default: %s\n", picky_whitelist_default);
+	print("   -m, --manifest=V        NOTE: this flag has been deprecated. Please use -V instead\n");
 	print("\n");
 }
 
@@ -72,6 +74,7 @@ static bool parse_opt(int opt, char *optarg)
 
 	switch (opt) {
 	case 'm':
+	case 'V':
 		err = strtoi_err(optarg, &cmdline_option_version);
 		if (err < 0 || cmdline_option_version < 0) {
 			error("Invalid --manifest argument: %s\n\n", optarg);

--- a/src/update.c
+++ b/src/update.c
@@ -562,6 +562,7 @@ static bool cmd_line_status = false;
 
 static const struct option prog_opts[] = {
 	{ "download", no_argument, 0, 'd' },
+	{ "version", required_argument, 0, 'V' },
 	{ "manifest", required_argument, 0, 'm' },
 	{ "status", no_argument, 0, 's' },
 	{ "keepcache", no_argument, 0, 'k' },
@@ -578,13 +579,15 @@ static void print_help(void)
 
 	global_print_help();
 
+	// TODO(castulo): remove the deprecated options by end of November 2019
 	print("Options:\n");
-	print("   -m, --manifest=M        Update to version M, also accepts 'latest' (default)\n");
+	print("   -V, --version=V         Update to version V, also accepts 'latest' (default)\n");
 	print("   -d, --download          Download all content, but do not actually install the update\n");
 	print("   -s, --status            Show current OS version and latest version available on server. Equivalent to \"swupd check-update\"\n");
 	print("   -k, --keepcache         Do not delete the swupd state directory content after updating the system\n");
 	print("   -T, --migrate           Migrate to augmented upstream/mix content\n");
 	print("   -a, --allow-mix-collisions	Ignore and continue if custom user content conflicts with upstream provided content\n");
+	print("   -m, --manifest=V        NOTE: this flag has been deprecated. Please use -V instead\n");
 	print("\n");
 }
 
@@ -594,6 +597,7 @@ static bool parse_opt(int opt, char *optarg)
 
 	switch (opt) {
 	case 'm':
+	case 'V':
 		if (strcmp("latest", optarg) == 0) {
 			requested_version = -1;
 			return true;

--- a/src/verify.c
+++ b/src/verify.c
@@ -60,6 +60,7 @@ static const struct option prog_opts[] = {
 	{ "fix", no_argument, 0, 'f' },
 	{ "force", no_argument, 0, 'x' },
 	{ "install", no_argument, 0, 'i' },
+	{ "version", required_argument, 0, 'V' },
 	{ "manifest", required_argument, 0, 'm' },
 	{ "picky", no_argument, 0, 'Y' },
 	{ "picky-tree", required_argument, 0, 'X' },
@@ -123,9 +124,9 @@ static void print_help(void)
 
 	global_print_help();
 
-	// TODO(castulo): remove the deprecated options by end of July 2019
+	// TODO(castulo): remove the deprecated options by end of November 2019
 	print("Options:\n");
-	print("   -m, --manifest=M        Verify against manifest version M\n");
+	print("   -V, --version=V         Verify against manifest version V\n");
 	print("   -f, --fix               Fix local issues relative to server manifest (will not modify ignored files). NOTE: This option has been deprecated, please consider using \"swupd repair\" instead.\n");
 	print("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	print("   -Y, --picky             List (without --fix) or remove (with --fix) files which should not exist\n");
@@ -134,6 +135,7 @@ static void print_help(void)
 	print("   -i, --install           Similar to \"--fix\" but optimized for install all files to empty directory. NOTE: This option has been deprecated, please consider using \"swupd os-install\" instead.\n");
 	print("   -q, --quick             Don't compare hashes, only fix missing files\n");
 	print("   -B, --bundles=[BUNDLES] Ensure BUNDLES are installed correctly. Example: --bundles=os-core,vi\n");
+	print("   -m, --manifest=V        NOTE: this flag has been deprecated. Please use -V instead\n");
 	print("\n");
 }
 
@@ -521,6 +523,7 @@ static bool parse_opt(int opt, char *optarg)
 
 	switch (opt) {
 	case 'm':
+	case 'V':
 		if (strcmp("latest", optarg) == 0) {
 			version = -1;
 			return true;

--- a/test/functional/diagnose/diagnose-picky-downgrade.bats
+++ b/test/functional/diagnose/diagnose-picky-downgrade.bats
@@ -14,7 +14,7 @@ test_setup() {
 
 @test "DIA011: Diagnose can show files that would be removed if not available in a previous version" {
 
-	run sudo sh -c "$SWUPD diagnose --picky --manifest=10 --force $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD diagnose --picky --version=10 --force $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM

--- a/test/functional/repair/repair-format-mismatch-overdrive.bats
+++ b/test/functional/repair/repair-format-mismatch-overdrive.bats
@@ -17,7 +17,7 @@ test_setup() {
 @test "REP018: Repair can be forced to continue when there is a format mismatch" {
 
 	# the -x option bypasses the fatal error
-	run sudo sh -c "$SWUPD repair --format=1 --manifest=40 --force $SWUPD_OPTS_NO_FMT"
+	run sudo sh -c "$SWUPD repair --format=1 --version=40 --force $SWUPD_OPTS_NO_FMT"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM

--- a/test/functional/repair/repair-format-mismatch.bats
+++ b/test/functional/repair/repair-format-mismatch.bats
@@ -15,7 +15,7 @@ test_setup() {
 
 @test "REP017: Repair enforces the use of the correct format" {
 
-	run sudo sh -c "$SWUPD repair --format=1 --manifest=40 $SWUPD_OPTS_NO_FMT"
+	run sudo sh -c "$SWUPD repair --format=1 --version=40 $SWUPD_OPTS_NO_FMT"
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MANIFEST"
 	expected_output=$(cat <<-EOM

--- a/test/functional/repair/repair-no-disk-space.bats
+++ b/test/functional/repair/repair-no-disk-space.bats
@@ -36,7 +36,7 @@ test_setup() {
 	# fill up all the space in the disk
 	sudo dd if=/dev/zero of="$TEST_NAME"/testfs/dummy >& /dev/null || print "Using all space left in disk"
 
-	run sudo sh -c "timeout 30 $SWUPD repair --force --manifest=20 $SWUPD_OPTS"
+	run sudo sh -c "timeout 30 $SWUPD repair --force --version=20 $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
@@ -65,7 +65,7 @@ test_setup() {
 	sudo mv "$big_manifest" "$WEBDIR"/20/Manifest.test-bundle
 	sudo mv "$big_manifest".tar "$WEBDIR"/20/Manifest.test-bundle.tar
 
-	run sudo sh -c "timeout 30 $SWUPD repair --force --manifest=20 $SWUPD_OPTS"
+	run sudo sh -c "timeout 30 $SWUPD repair --force --version=20 $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MANIFEST"
 	expected_output=$(cat <<-EOM
@@ -89,7 +89,7 @@ test_setup() {
 
 	fhash=$(get_hash_from_manifest "$WEBDIR"/20/Manifest.test-bundle /test-file)
 
-	run sudo sh -c "timeout 30 $SWUPD repair --force --manifest=20 $SWUPD_OPTS"
+	run sudo sh -c "timeout 30 $SWUPD repair --force --version=20 $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_COULDNT_DOWNLOAD_FILE"
 	expected_output=$(cat <<-EOM

--- a/test/functional/repair/repair-picky-downgrade.bats
+++ b/test/functional/repair/repair-picky-downgrade.bats
@@ -17,7 +17,7 @@ test_setup() {
 
 @test "REP025: Repair using an older version won't remove an installed bundle that was not available then" {
 
-	run sudo sh -c "$SWUPD repair --picky --manifest=10 $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD repair --picky --version=10 $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_INVALID_BUNDLE"
 	expected_output=$(cat <<-EOM
@@ -39,7 +39,7 @@ test_setup() {
 
 @test "REP026: Repair can be forced to remove installed bundles that were not available in a previous version" {
 
-	run sudo sh -c "$SWUPD repair --picky --manifest=10 --force $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD repair --picky --version=10 --force $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -83,7 +83,7 @@ test_setup() {
 
 @test "REP027: Repair can remove files in a specified location that were not available in a previous version" {
 
-	run sudo sh -c "$SWUPD repair --picky --picky-tree=/bar --manifest=10 --force $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD repair --picky --picky-tree=/bar --version=10 --force $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM


### PR DESCRIPTION
swupd uses the -m / --manifest flag for some commands to specify what
version to use for that specfic action. For example using "swupd verify
--install --manifest=10" will attempt to install the OS with version 10.
The problem is that this flag doesn't really hint users about what the
flag is used for, specially if the user is not familiar with swupd / mixer
internals.

This commit adds a replacement flag -V / --version that will have the
exact same functionality of -m / --manifest which will be deprecated.
The deprecated flag should be removed in 6 months time.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>