### PR TITLE
Fixing false positive in a functional test

### DIFF
--- a/test/functional/update/update-json.bats
+++ b/test/functional/update/update-json.bats
@@ -61,13 +61,17 @@ test_setup() {
 		{ "type" : "info", "msg" : "Update was applied. " },
 		{ "type" : "info", "msg" : "Calling post-update helper scripts. " },
 		{ "type" : "progress", "currentStep" : 11, "totalSteps" : 11, "stepCompletion" : 100, "stepDescription" : "run_postupdate_scripts" },
-		{ "type" : "info", "msg" : "Update took 0.0 seconds, 0 MB transferred " },
-		{ "type" : "info", "msg" : "Update successful. System updated from version 10 to version 20 " },
-		{ "type" : "end", "section" : "update", "status" : 0 }
-		]
+	EOM
+	)
+	expected_output3=$(cat <<-EOM
+		\{ "type" : "info", "msg" : "Update took ... seconds, 0 MB transferred " \},
+		\{ "type" : "info", "msg" : "Update successful. System updated from version 10 to version 20 " \},
+		\{ "type" : "end", "section" : "update", "status" : 0 \}
+		\]
 	EOM
 	)
 	assert_in_output "$expected_output1"
 	assert_in_output "$expected_output2"
+	assert_regex_in_output "$expected_output3"
 
 }


### PR DESCRIPTION
The update/update-json.bats functional test is giving a false positive
since one hardcoded value (time) was taking longer to run in a local
environment.
This commit fixes the issue by using a regex to accept any time value.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>