### PR TITLE
Fix a line break when running "swupd repair"

### DIFF
--- a/src/fullfile.c
+++ b/src/fullfile.c
@@ -206,7 +206,6 @@ int download_fullfiles(struct list *files, int *num_downloads)
 			progress_report(complete, list_length);
 		}
 	}
-	info("\n");
 	list_free_list(need_download);
 
 	return swupd_curl_parallel_download_end(download_handle, num_downloads);

--- a/src/verify.c
+++ b/src/verify.c
@@ -227,6 +227,7 @@ static int get_required_files(struct manifest *official_manifest, struct list *s
 	if (ret) {
 		error("Unable to download necessary files for this OS release\n");
 	}
+	info("\n");
 
 	return ret;
 }


### PR DESCRIPTION
There was a bug with the line breaks during `swupd verify --fix` or `swupd repair` that was causing the output to look like this.

```
Verifying version 29620
Verifying files
	...100%
Starting download of remaining update content. This may take a while...
	...66528%Adding any missing files
	...100%
Repairing modified files
```

This PR fixes that by moving the line break to the appropriate place.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>