### PR TITLE
verify command as superseded instead of deprecated

### DIFF
--- a/src/extra_files.c
+++ b/src/extra_files.c
@@ -158,6 +158,7 @@ enum swupd_code walk_tree(struct manifest *manifest, const char *start, bool fix
 			/* Account for these files not in the manifest as inspected also */
 			counts->checked++;
 			counts->extraneous++;
+			counts->picky_extraneous++;
 			/* Logic to avoid printing out all the files in a
 			 * directory when the directory itself is not present */
 			if (skip_dir) {

--- a/src/main.c
+++ b/src/main.c
@@ -34,7 +34,8 @@ struct subcmd {
 	enum swupd_code (*mainfunc)(int, char **);
 };
 
-/* TODO(castulo): remove the deprecated verify command by end of July 2019 */
+// TODO(castulo): remove the superseded command from the help menu by end of November 2019,
+// so it is not visible but the command must remain available in the back so we don't break users
 static struct subcmd commands[] = {
 	{ "info", "Show the version and the update URLs", info_main },
 	{ "autoupdate", "Enable/disable automatic system updates", autoupdate_main },
@@ -53,7 +54,7 @@ static struct subcmd commands[] = {
 	{ "mirror", "Configure mirror url for swupd content", mirror_main },
 	{ "clean", "Clean cached files", clean_main },
 	{ "hashdump", "Dump the HMAC hash of a file", hashdump_main },
-	{ "verify", "NOTE: this command has been deprecated, please use \"swupd diagnose\" instead", verify_main },
+	{ "verify", "NOTE: this command has been superseded, please use \"swupd diagnose\" instead", verify_main },
 	{ 0 }
 };
 
@@ -104,11 +105,11 @@ static int subcmd_index(char *arg)
 	size_t input_len;
 	size_t cmd_len;
 
-	/* TODO(castulo): remove the deprecated command by end of July 2019 */
 	if (strcmp(arg, "verify") == 0) {
+		verify_set_command_verify(true); // set to true so we know the "verify" command was used
 		arg = "diagnose";
-		fprintf(stderr, "\nWarning: The verify command has been deprecated and will be removed soon.\n");
-		fprintf(stderr, "Please consider using \"swupd diagnose\" instead.\n\n");
+		fprintf(stderr, "\nWarning: The verify command has been superseded\n");
+		fprintf(stderr, "Please consider using \"swupd diagnose\" instead\n\n");
 	}
 	input_len = strlen(arg);
 

--- a/src/repair.c
+++ b/src/repair.c
@@ -64,7 +64,6 @@ static void print_help(void)
 	print("   -Y, --picky             Remove files which should not exist\n");
 	print("   -X, --picky-tree=[PATH] Selects the sub-tree where --picky looks for extra files. Default: /usr\n");
 	print("   -w, --picky-whitelist=[RE] Any path completely matching the POSIX extended regular expression is ignored by --picky. Matched directories get skipped. Example: /var|/etc/machine-id. Default: %s\n", picky_whitelist_default);
-	print("   -m, --manifest=V        NOTE: this flag has been deprecated. Please use -V instead\n");
 	print("\n");
 }
 

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -162,6 +162,7 @@ struct file_counts {
 	int extraneous;
 	int deleted;
 	int not_deleted;
+	int picky_extraneous;
 };
 
 extern bool verify_esp_only;
@@ -365,6 +366,7 @@ enum swupd_code list_local_bundles();
 extern int link_or_rename(const char *orig, const char *dest);
 
 /* verify.c */
+extern void verify_set_command_verify(bool opt);
 extern void verify_set_option_force(bool opt);
 extern void verify_set_option_install(bool opt);
 extern void verify_set_option_quick(bool opt);

--- a/src/update.c
+++ b/src/update.c
@@ -579,7 +579,8 @@ static void print_help(void)
 
 	global_print_help();
 
-	// TODO(castulo): remove the deprecated options by end of November 2019
+	// TODO(castulo): remove the superseded -m option from the help menu by end of November 2019,
+	// so it is not visible but the option must remain available in the back so we don't break users
 	print("Options:\n");
 	print("   -V, --version=V         Update to version V, also accepts 'latest' (default)\n");
 	print("   -d, --download          Download all content, but do not actually install the update\n");
@@ -587,7 +588,7 @@ static void print_help(void)
 	print("   -k, --keepcache         Do not delete the swupd state directory content after updating the system\n");
 	print("   -T, --migrate           Migrate to augmented upstream/mix content\n");
 	print("   -a, --allow-mix-collisions	Ignore and continue if custom user content conflicts with upstream provided content\n");
-	print("   -m, --manifest=V        NOTE: this flag has been deprecated. Please use -V instead\n");
+	print("   -m, --manifest=V        NOTE: this flag has been superseded. Please use -V instead\n");
 	print("\n");
 }
 

--- a/test/functional/diagnose/diagnose-basics.bats
+++ b/test/functional/diagnose/diagnose-basics.bats
@@ -35,7 +35,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
-		Verifying version 20
+		Diagnosing version 20
 		Verifying files
 		Missing file: .*/target-dir/baz
 		Missing file: .*/target-dir/baz/file_3
@@ -46,6 +46,7 @@ test_setup() {
 		  2 files were missing
 		  2 files did not match
 		  1 file found which should be deleted
+		Use "swupd repair" to correct the problems in the system
 		Diagnose successful
 	EOM
 	)

--- a/test/functional/diagnose/diagnose-boot-file.bats
+++ b/test/functional/diagnose/diagnose-boot-file.bats
@@ -16,11 +16,12 @@ test_setup() {
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		Hash mismatch for file: .*/target-dir/usr/lib/kernel/testfile
 		Inspected 7 files
 		  1 file did not match
+		Use "swupd repair" to correct the problems in the system
 		Diagnose successful
 	EOM
 	)

--- a/test/functional/diagnose/diagnose-directory-tree-deleted.bats
+++ b/test/functional/diagnose/diagnose-directory-tree-deleted.bats
@@ -21,13 +21,14 @@ test_setup() {
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		File that should be deleted: .*/target-dir/testdir1/testdir2/testfile
 		File that should be deleted: .*/target-dir/testdir1/testdir2
 		File that should be deleted: .*/target-dir/testdir1
 		Inspected 4 files
 		  3 files found which should be deleted
+		Use "swupd repair" to correct the problems in the system
 		Diagnose successful
 	EOM
 	)

--- a/test/functional/diagnose/diagnose-good.bats
+++ b/test/functional/diagnose/diagnose-good.bats
@@ -17,7 +17,7 @@ test_setup() {
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		Inspected 11 files
 		Diagnose successful

--- a/test/functional/diagnose/diagnose-json.bats
+++ b/test/functional/diagnose/diagnose-json.bats
@@ -25,7 +25,7 @@ test_setup() {
 		\[
 		\{ "type" : "start", "section" : "verify" \},
 		\{ "type" : "progress", "currentStep" : 1, "totalSteps" : 6, "stepCompletion" : 100, "stepDescription" : "get_versions" \},
-		\{ "type" : "info", "msg" : "Verifying version 10 " \},
+		\{ "type" : "info", "msg" : "Diagnosing version 10 " \},
 		\{ "type" : "progress", "currentStep" : 2, "totalSteps" : 6, "stepCompletion" : 100, "stepDescription" : "cleanup_download_dir" \},
 		\{ "type" : "progress", "currentStep" : 3, "totalSteps" : 6, "stepCompletion" : 100, "stepDescription" : "load_manifests" \},
 		\{ "type" : "progress", "currentStep" : 4, "totalSteps" : 6, "stepCompletion" : 100, "stepDescription" : "consolidate_files" \},
@@ -54,6 +54,7 @@ test_setup() {
 		\{ "type" : "progress", "currentStep" : 6, "totalSteps" : 6, "stepCompletion" : 100, "stepDescription" : "fix_files" \},
 		\{ "type" : "info", "msg" : "Inspected 17 files " \},
 		\{ "type" : "info", "msg" : "  2 files were missing " \},
+		\{ "type" : "info", "msg" : "Use 'swupd repair' to correct the problems in the system " \},
 		\{ "type" : "info", "msg" : "Diagnose successful " \},
 		\{ "type" : "end", "section" : "verify", "status" : 1 \}
 		\]

--- a/test/functional/diagnose/diagnose-missing-file.bats
+++ b/test/functional/diagnose/diagnose-missing-file.bats
@@ -16,11 +16,12 @@ test_setup() {
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		Missing file: .*/target-dir/foo/test-file1
 		Inspected 7 files
 		  1 file was missing
+		Use "swupd repair" to correct the problems in the system
 		Diagnose successful
 	EOM
 	)

--- a/test/functional/diagnose/diagnose-picky-downgrade.bats
+++ b/test/functional/diagnose/diagnose-picky-downgrade.bats
@@ -18,7 +18,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Warning: Bundle "test-bundle2" is invalid, skipping it...
 		Warning: One or more installed bundles are not available at version 10.
 		Generating list of extra files under .*/target-dir/usr
@@ -30,6 +30,7 @@ test_setup() {
 		/usr/foo/
 		Inspected 19 files
 		  6 files found which should be deleted
+		Use "swupd repair --picky" to correct the problems in the system
 		Diagnose successful
 	EOM
 	)

--- a/test/functional/diagnose/diagnose-picky-whitelist.bats
+++ b/test/functional/diagnose/diagnose-picky-whitelist.bats
@@ -28,7 +28,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Generating list of extra files under .*/target-dir/usr
 		/usr/share/defaults/swupd/versionurl
 		/usr/share/defaults/swupd/contenturl
@@ -39,6 +39,7 @@ test_setup() {
 		/usr/bat/
 		Inspected 18 files
 		  7 files found which should be deleted
+		Use "swupd repair --picky" to correct the problems in the system
 		Diagnose successful
 	EOM
 	)

--- a/test/functional/diagnose/diagnose-picky.bats
+++ b/test/functional/diagnose/diagnose-picky.bats
@@ -26,7 +26,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Generating list of extra files under .*/target-dir/usr
 		/usr/share/defaults/swupd/versionurl
 		/usr/share/defaults/swupd/contenturl
@@ -36,6 +36,7 @@ test_setup() {
 		/usr/file1
 		Inspected 17 files
 		  6 files found which should be deleted
+		Use "swupd repair --picky" to correct the problems in the system
 		Diagnose successful
 	EOM
 	)

--- a/test/functional/repair/repair-add-missing-include-old.bats
+++ b/test/functional/repair/repair-add-missing-include-old.bats
@@ -25,7 +25,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 100
+		Diagnosing version 100
 		Verifying files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files

--- a/test/functional/repair/repair-add-missing-include.bats
+++ b/test/functional/repair/repair-add-missing-include.bats
@@ -24,7 +24,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files

--- a/test/functional/repair/repair-basics.bats
+++ b/test/functional/repair/repair-basics.bats
@@ -35,7 +35,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 20
+		Diagnosing version 20
 		Verifying files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
@@ -87,7 +87,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 20
+		Diagnosing version 20
 		Verifying files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
@@ -145,7 +145,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 20
+		Diagnosing version 20
 		Verifying files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files

--- a/test/functional/repair/repair-boot-file-deleted.bats
+++ b/test/functional/repair/repair-boot-file-deleted.bats
@@ -22,7 +22,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		Adding any missing files
 		Repairing modified files

--- a/test/functional/repair/repair-boot-file.bats
+++ b/test/functional/repair/repair-boot-file.bats
@@ -22,7 +22,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files

--- a/test/functional/repair/repair-boot-skip.bats
+++ b/test/functional/repair/repair-boot-skip.bats
@@ -22,7 +22,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		Adding any missing files
 		Repairing modified files

--- a/test/functional/repair/repair-bundle.bats
+++ b/test/functional/repair/repair-bundle.bats
@@ -23,7 +23,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
@@ -52,7 +52,7 @@ test_setup() {
 	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --bundles test-bundle3"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
@@ -84,7 +84,7 @@ test_setup() {
 	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --bundles test-bundle1,test-bundle2"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files

--- a/test/functional/repair/repair-directory-tree-deleted.bats
+++ b/test/functional/repair/repair-directory-tree-deleted.bats
@@ -23,7 +23,7 @@ test_setup() {
 	run sudo sh -c "$SWUPD repair $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		Adding any missing files
 		Repairing modified files

--- a/test/functional/repair/repair-empty-dir-deleted.bats
+++ b/test/functional/repair/repair-empty-dir-deleted.bats
@@ -20,7 +20,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		Adding any missing files
 		Repairing modified files

--- a/test/functional/repair/repair-format-mismatch-overdrive.bats
+++ b/test/functional/repair/repair-format-mismatch-overdrive.bats
@@ -21,7 +21,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 40
+		Diagnosing version 40
 		Warning: the force option is specified; ignoring format mismatch for diagnose
 		Warning: the force or picky option is specified; ignoring version mismatch for repair
 		Verifying files

--- a/test/functional/repair/repair-format-mismatch.bats
+++ b/test/functional/repair/repair-format-mismatch.bats
@@ -19,7 +19,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MANIFEST"
 	expected_output=$(cat <<-EOM
-		Verifying version 40
+		Diagnosing version 40
 		Error: Mismatching formats detected when diagnosing 40 (expected: 1; actual: 2)
 		Latest supported version to diagnose: 20
 		Repair did not fully succeed

--- a/test/functional/repair/repair-ghosted.bats
+++ b/test/functional/repair/repair-ghosted.bats
@@ -19,7 +19,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		Adding any missing files
 		Repairing modified files

--- a/test/functional/repair/repair-json.bats
+++ b/test/functional/repair/repair-json.bats
@@ -25,7 +25,7 @@ test_setup() {
 		\[
 		\{ "type" : "start", "section" : "verify" \},
 		\{ "type" : "progress", "currentStep" : 1, "totalSteps" : 8, "stepCompletion" : 100, "stepDescription" : "get_versions" \},
-		\{ "type" : "info", "msg" : "Verifying version 10 " \},
+		\{ "type" : "info", "msg" : "Diagnosing version 10 " \},
 		\{ "type" : "progress", "currentStep" : 2, "totalSteps" : 8, "stepCompletion" : 100, "stepDescription" : "cleanup_download_dir" \},
 		\{ "type" : "progress", "currentStep" : 3, "totalSteps" : 8, "stepCompletion" : 100, "stepDescription" : "load_manifests" \},
 		\{ "type" : "progress", "currentStep" : 4, "totalSteps" : 8, "stepCompletion" : 100, "stepDescription" : "consolidate_files" \},

--- a/test/functional/repair/repair-missing-file.bats
+++ b/test/functional/repair/repair-missing-file.bats
@@ -20,7 +20,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files

--- a/test/functional/repair/repair-no-disk-space.bats
+++ b/test/functional/repair/repair-no-disk-space.bats
@@ -40,7 +40,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
-		Verifying version 20
+		Diagnosing version 20
 		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/20/Manifest.MoM.tar'
 		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
 		Error: Failed to retrieve 20 MoM manifest
@@ -69,7 +69,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MANIFEST"
 	expected_output=$(cat <<-EOM
-		Verifying version 20
+		Diagnosing version 20
 		Warning: the force or picky option is specified; ignoring version mismatch for repair
 		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/20/Manifest.test-bundle.tar'
 		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
@@ -93,7 +93,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_DOWNLOAD_FILE"
 	expected_output=$(cat <<-EOM
-		Verifying version 20
+		Diagnosing version 20
 		Warning: the force or picky option is specified; ignoring version mismatch for repair
 		Verifying files
 		Starting download of remaining update content. This may take a while...

--- a/test/functional/repair/repair-picky-downgrade.bats
+++ b/test/functional/repair/repair-picky-downgrade.bats
@@ -21,7 +21,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_INVALID_BUNDLE"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Warning: the force or picky option is specified; ignoring version mismatch for repair
 		Warning: Bundle "test-bundle2" is invalid, skipping it...
 		Error: Unable to verify. One or more currently installed bundles are not available at version 10. Use --force to override
@@ -43,7 +43,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Warning: the force or picky option is specified; ignoring version mismatch for repair
 		Warning: Bundle "test-bundle2" is invalid, skipping it...
 		Warning: One or more installed bundles that are not available at version 10 will be removed.
@@ -87,7 +87,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Warning: the force or picky option is specified; ignoring version mismatch for repair
 		Warning: Bundle "test-bundle2" is invalid, skipping it...
 		Warning: One or more installed bundles that are not available at version 10 will be removed.

--- a/test/functional/repair/repair-picky-ghosted-missing.bats
+++ b/test/functional/repair/repair-picky-ghosted-missing.bats
@@ -21,7 +21,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		Adding any missing files
 		Repairing modified files

--- a/test/functional/repair/repair-picky-ghosted.bats
+++ b/test/functional/repair/repair-picky-ghosted.bats
@@ -19,7 +19,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Verifying files
 		Adding any missing files
 		Repairing modified files

--- a/test/functional/repair/repair-skip-scripts.bats
+++ b/test/functional/repair/repair-skip-scripts.bats
@@ -22,7 +22,7 @@ test_setup() {
 	assert_status_is "$SWUPD_OK"
 	# check for the warning
 	expected_output=$(cat <<-EOM
-		Verifying version 20
+		Diagnosing version 20
 		Verifying files
 		Adding any missing files
 		Repairing modified files

--- a/test/functional/repair/repair-unsafe-to-delete.bats
+++ b/test/functional/repair/repair-unsafe-to-delete.bats
@@ -25,7 +25,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 20
+		Diagnosing version 20
 		Verifying files
 		Adding any missing files
 		Repairing modified files

--- a/test/functional/repair/repair-version-mismatch-overdrive.bats
+++ b/test/functional/repair/repair-version-mismatch-overdrive.bats
@@ -23,7 +23,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Warning: the force or picky option is specified; ignoring version mismatch for repair
 		Verifying files
 		Starting download of remaining update content. This may take a while...

--- a/test/functional/repair/repair-version-mismatch.bats
+++ b/test/functional/repair/repair-version-mismatch.bats
@@ -19,7 +19,7 @@ test_setup() {
 	run sudo sh -c "$SWUPD repair -m 10 $SWUPD_OPTS"
 	assert_status_is "$SWUPD_INVALID_OPTION"
 	expected_output=$(cat <<-EOM
-		Verifying version 10
+		Diagnosing version 10
 		Error: Repairing to a different version requires --force or --picky
 		Repair did not fully succeed
 	EOM


### PR DESCRIPTION
The verify command has been superseded by diagnose, the --fix option has
been superseded by the repair command, and the --install option has been
superseded by the os-install command. This commit changes the messages
displayed to the user from showing the commands as "deprecated" to the
more accurate "superseded" description. It also fixes some other
mismatches in output when using the new commands.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>