### PR TITLE
bundle-list: local bundle list should work without root

### DIFF
--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -124,11 +124,15 @@ enum swupd_code bundle_list_main(int argc, char **argv)
 	}
 	progress_init_steps("bundle-list", steps_in_bundlelist);
 
-	ret = swupd_init(SWUPD_ALL);
+	if (cmdline_local && !is_root()) {
+		ret = swupd_init(SWUPD_NO_ROOT);
+	} else {
+		ret = swupd_init(SWUPD_ALL);
+	}
 	/* if swupd fails to initialize, the only list command we can still attempt is
 	 * listing locally installed bundles (with the limitation of not showing what
 	 * bundles are experimental) */
-	if (ret != 0 && !cmdline_local) {
+	if (ret != 0) {
 		error("Failed updater initialization. Exiting now\n");
 		goto finish;
 	}

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -43,7 +43,7 @@
 
 void check_root(void)
 {
-	if (getuid() != 0) {
+	if (!is_root()) {
 		error("This program must be run as root..aborting.\n\n");
 		exit(EXIT_FAILURE);
 	}

--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -316,3 +316,8 @@ char *sys_path_join(const char *prefix, const char *path)
 
 	return str_or_die("%.*s%c%s", len, prefix, PATH_SEPARATOR, path);
 }
+
+bool is_root(void)
+{
+	return getuid() == 0;
+}

--- a/src/lib/sys.h
+++ b/src/lib/sys.h
@@ -163,6 +163,10 @@ char *sys_dirname(const char *path);
 char *sys_path_join(const char *prefix, const char *path);
 
 /**
+ * @brief Check if current user is root.
+ */
+bool is_root(void);
+/**
  * @brief Run a systemctl command with the informed parameters.
  */
 #define systemctl_cmd(...) run_command_quiet(SYSTEMCTL, __VA_ARGS__)


### PR DESCRIPTION
When we changed the init swupd function we stopped supporting bundle-list as root.
Adding this back on.