### PR TITLE
Fix download progress for fullfiles

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -77,6 +77,18 @@ int file_sort_filename_reverse(const void *a, const void *b)
 	return -ret;
 }
 
+int file_sort_hash(const void *a, const void *b)
+{
+	struct file *A, *B;
+	int ret;
+	A = (struct file *)a;
+	B = (struct file *)b;
+
+	ret = strcmp(A->hash, B->hash);
+
+	return ret;
+}
+
 static struct manifest *manifest_from_file(int version, char *component, bool header_only, bool is_mix)
 {
 	char *filename;

--- a/src/packs.c
+++ b/src/packs.c
@@ -155,8 +155,8 @@ static int download_pack(struct swupd_curl_parallel_handle *download_handle, int
 
 static double packs_query_total_download_size(struct list *subs, struct manifest *mom)
 {
-	double size = 0;
-	double total_size = 0;
+	long size = 0;
+	long total_size = 0;
 	struct sub *sub = NULL;
 	struct list *list = NULL;
 	struct file *bundle = NULL;
@@ -187,12 +187,12 @@ static double packs_query_total_download_size(struct list *subs, struct manifest
 		}
 
 		count++;
-		debug("Pack: %s (%.2lf Mb)\n", url, size / 1000000);
+		debug("Pack: %s (%.2lf Mb)\n", url, (double)size / 1000000);
 		free_string(&url);
 	}
 
 	debug("Number of packs to download: %d\n", count);
-	debug("Total size of packs to be downloaded: %.2lf Mb\n", total_size / 1000000);
+	debug("Total size of packs to be downloaded: %.2lf Mb\n", (double)total_size / 1000000);
 	return total_size;
 }
 
@@ -204,7 +204,7 @@ int download_subscribed_packs(struct list *subs, struct manifest *mom, bool requ
 	struct sub *sub = NULL;
 	struct stat stat;
 	struct file *bundle = NULL;
-	struct download_progress download_progress = { 0, 0, 0 };
+	struct download_progress download_progress = { 0, 0 };
 	int err;
 	unsigned int list_length;
 	unsigned int complete = 0;
@@ -264,8 +264,8 @@ int download_subscribed_packs(struct list *subs, struct manifest *mom, bool requ
 	}
 
 	/* show the packs size only if > 1 Mb */
-	string_or_die(&packs_size, "(%.2lf Mb) ", download_progress.total_download_size / 1000000);
-	info("Downloading packs %sfor:\n", (download_progress.total_download_size / 1000000) > 1 ? packs_size : "");
+	string_or_die(&packs_size, "(%.2lf Mb) ", (double)download_progress.total_download_size / 1000000);
+	info("Downloading packs %sfor:\n", ((double)download_progress.total_download_size / 1000000) > 1 ? packs_size : "");
 	free_string(&packs_size);
 	for (iter = list_head(need_download); iter; iter = iter->next) {
 		sub = iter->data;

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -211,6 +211,7 @@ extern void apply_heuristics(struct file *file);
 
 extern int file_sort_filename(const void *a, const void *b);
 extern int file_sort_filename_reverse(const void *a, const void *b);
+extern int file_sort_hash(const void *a, const void *b);
 extern struct manifest *load_mom(int version, bool latest, bool mix_exists, int *err);
 extern struct manifest *load_manifest(int version, struct file *file, struct manifest *mom, bool header_only, int *err);
 extern struct manifest *load_manifest_full(int version, bool mix);

--- a/src/swupd_progress.h
+++ b/src/swupd_progress.h
@@ -14,10 +14,17 @@ extern "C" {
 
 #include <curl/curl.h>
 
+/* struct to hold information about the overall download progress (including many files) */
 struct download_progress {
-	double total_download_size; /* total number of bytes to download */
-	double current;		    /* number of bytes that has been already downloaded */
-	double dlprev;		    /* previous download read provided by curl */
+	long total_download_size; /* total number of bytes to download */
+	long downloaded;	  /* total of bytes downloaded so far */
+};
+
+/* struct to hold information about one file download progress */
+struct file_progress {
+	long file_size;
+	long downloaded;
+	struct download_progress *overall_progress;
 };
 
 /**


### PR DESCRIPTION
When the download progress of fullfiles was being calculated it was
being done considering as if the files were being downloaded serially
not in parallel. This was causing an error in the calculation of the
download progress.

This commit fixes the issue by considering the files are being downloaded
in parallel when calculating the download progress.

Closes #939

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>