### PR TITLE
Add full path to swupd binary before re-update

### DIFF
--- a/src/update.c
+++ b/src/update.c
@@ -551,8 +551,19 @@ clean_curl:
 			return SWUPD_INVALID_BINARY;
 		}
 
+		/* we need to resolve the whole path to swupd first, proc/self/exe
+		 * is a symbolic link to the executable that is running the current process */
+		char swupd_binary[LINE_MAX];
+		int path_length;
+		path_length = readlink("/proc/self/exe", swupd_binary, sizeof(swupd_binary));
+		if (path_length <= 0 || path_length >= LINE_MAX) {
+			error("Could not determine the swupd path\n");
+			return -1;
+		}
+		swupd_binary[path_length] = '\0';
+
 		/* Run the swupd_argv saved from main */
-		return execv(swupd_argv[0], swupd_argv);
+		return execv(swupd_binary, swupd_argv);
 	}
 
 	return ret;


### PR DESCRIPTION
When swupd is updating a system and it has to go over a format bump, the
update is run twice. First to get to the lower boundary of the format
bump and then it run again to go from the upper boundary of the format
bump to the desired version.
The second time the update was being run, swupd was being executed without
considering the environment, so the PATH variable was not being read,
this was causing swupd to fail to re execute itself for the second
update unless the user had run swupd specifying the full path in the
first place.

This commit fixes the issue by resolving the full path to swupd before
re executing itself.

Closes #942