### PR TITLE
Adding a progress overflow protection

### DIFF
--- a/src/lib/progress.c
+++ b/src/lib/progress.c
@@ -97,6 +97,13 @@ void progress_report(double count, double max)
 
 		/* Only print when the percentage changes, so a maximum of 100 times per run */
 		int percentage = (int)(100 * (count / max));
+
+		/* we should never have a percentage bigger than 100% */
+		if (percentage > 100) {
+			debug("Progress percentage overflow %d%% (Count: %ld, Max: %ld)\n", percentage, (long)count, (long)max);
+			return;
+		}
+
 		if (percentage != last_percentage || step.current != last_step) {
 			if (progress_function) {
 				progress_function(step.description, step.current, step.total, percentage);


### PR DESCRIPTION
When reporting download progress, we should never have a percentage
bigger than 100%, but if for some reason we do (due to a bug), we don't
want that percentage slipping all the way to the end user.

This commit limits the percentage we display to 100 maximum.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>