### PR TITLE
Makefile.am: add files to distribution

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -310,6 +310,8 @@ UNIT_TESTS = \
 	test/unit/test_strings.test \
 	test/unit/test_manifest.test
 
+EXTRA_DIST += test/unit/test_helper.h test/unit/data test/functional
+
 dist_check_SCRIPTS = $(BATS)
 # Must be run before all other tests
 dist_check_SCRIPTS += test/functional/generate-cert.prereq


### PR DESCRIPTION
A compressed distribution tarball created via

$ make dist

is missing some files needed to run the standard
sequence of build commands:

$ ./configure
$ make
$ make check

In particular, when running "make check" we get:

../../test/unit/test_signature.c:9:10: fatal error: test_helper.h: No such file or directory
    9 | #include "test_helper.h"
      |          ^~~~~~~~~~~~~~~
compilation terminated.

This patch modifies the distribiton tarrball by adding files/folders:

1. test/unit/test_helper.h (to fix the above build error)
2. test/unit/data  (files reference by the test/unit/ binaries
3. test/functional (files referenced by Makefile)

With this patch "make check" reports:

Testsuite summary for swupd-client 3.20.0
============================================================================

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>