### PR TITLE
Adding configuration file parser for swupd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ install:
 # Ubuntu's default umask is 0002, but this break's swupd hash calculations.
 before_script:
         - autoreconf --verbose --warnings=none --install --force
-        - ./configure CFLAGS="$CFLAGS -fsanitize=address -Werror" --prefix=/usr --with-fallback-capaths=$TRAVIS_BUILD_DIR/swupd_test_certificates --with-systemdsystemunitdir=/usr/lib/systemd/system
+        - ./configure CFLAGS="$CFLAGS -fsanitize=address -Werror" --prefix=/usr --with-fallback-capaths=$TRAVIS_BUILD_DIR/swupd_test_certificates --with-systemdsystemunitdir=/usr/lib/systemd/system --with-config-file-path=./testconfig
         - sudo find test/functional -exec chmod g-w {} \;
         - make &&
           sudo sh -c 'umask 0022 && make install' &&

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 SUFFIXES= .rst
 
-EXTRA_DIST = COPYING scripts/findstatic.pl swupd.bash
+EXTRA_DIST = COPYING scripts/findstatic.pl swupd.bash config
 
 AM_CFLAGS = -fPIE -fPIC -g -D_FORTIFY_SOURCE=2 -fno-common -std=gnu99 \
 	-O$(OPTIMIZE) \
@@ -36,6 +36,8 @@ swupd_SOURCES = \
 	src/alias.h \
 	src/lib/archives.c \
 	src/lib/archives.h \
+	src/lib/config_parser.c \
+	src/lib/config_parser.h \
 	src/autoupdate.c \
 	src/binary_loader.c \
 	src/bundle.c \
@@ -44,6 +46,8 @@ swupd_SOURCES = \
 	src/clr_bundle_add.c \
 	src/clr_bundle_ls.c \
 	src/clr_bundle_rm.c \
+	src/config_loader.c \
+	src/config_loader.h \
 	src/curl.c \
 	src/curl_async.c \
 	src/delta.c \
@@ -302,6 +306,7 @@ BATS = \
 	test/functional/update/update-with-old-mirror.bats \
 	test/functional/update/update-with-slightly-old-mirror.bats \
 	test/functional/usability/usa-completion-basic.bats \
+	test/functional/usability/usa-config-file.bats \
 	test/functional/usability/usa-download-retries.bats \
 	test/functional/usability/usa-external-modules.bats
 

--- a/config
+++ b/config
@@ -1,0 +1,314 @@
+# #####################
+# Config file for swupd
+# #####################
+
+[GLOBAL]
+
+#
+# Global options
+#
+
+# Use PATH to define the root directory for swupd commands (eg: a chroot or
+# btrfs subvol) (string value)
+#path=<PATH>
+
+# RFC-3986 encoded url for version string and content file
+# downloads (string value)
+# This option defines both; contenturl and versionurl
+#url=<URL>
+
+# Port number to connect to at the url for version string and content file
+# downloads (integer value)
+#port=<PORT #>
+
+# RFC-3986 encoded url for content file downloads (string value)
+#contenturl=<URL>
+
+# RFC-3986 encoded url for version file downloads (string value)
+#versionurl=<URL>
+
+# The format suffix for version file downloads
+# Possible values:
+# staging - used for testing purposes (string value)
+# 1,2,3...                            (integer value)
+#format=<FORMAT>
+
+# Specify alternate swupd state directory (string value)
+#statedir=<PATH>
+
+# Specify alternate path to swupd certificates (string value)
+#certpath=<PATH>
+
+# Set the maximum number of parallel downloads (integer value)
+#max_parallel_downloads=<# OF DOWNLOADS>
+
+# Maximum number of retries for download failures (integer value)
+#max_retries=<# OF RETRIES>
+
+# Initial delay between download retries, this will be doubled for each
+# retry (integer value)
+#retry_delay=<DELAY>
+
+# Print all output as a JSON stream (boolean value)
+#json_output=<true/false>
+
+# Ignore system/certificate time when validating signature (boolean value)
+#ignore_time=<true/false>
+
+# Show verbose time output for swupd operations (boolean value)
+#time=<true/false>
+
+# Do not attempt to enforce certificate or signature checking (boolean value)
+#nosigcheck=<true/false>
+
+# Do not install boot files to the boot partition (containers) (boolean value)
+#no_boot_update=<true/false>
+
+# Do not run the post-update scripts and boot update tool (boolean value)
+#no_scripts=<true/false>
+
+# Allow updates over insecure connections
+#allow_insecure_http=<true/false>
+
+# Quiet output. Print only important information and errors (boolean value)
+#quiet=<true/false>
+
+# Print extra information to help debugging problems (boolean value)
+#debug=<true/false>
+
+
+
+#
+# The sections below contain the options that apply specifically to
+# the commands referred to by the [<command>] sections.
+#
+# Note that some commands don't have local options, but even in those cases
+# global options can be specified to only apply to that command if set up
+# within the [<command>] section.
+#
+# Example: you could enable machine readable output (JSON) for every command
+# except for the "info" command by setting it like this
+# [GLOBAL]
+# json_output=true
+# [info]
+# json_output=false
+#
+
+
+[info]
+
+#
+# Options for the "swupd info" command
+#
+
+
+[autoupdate]
+
+#
+# Options for the "swupd autoupdate" command
+#
+
+
+[check-update]
+
+#
+# Options for the "swupd check-update" command
+#
+
+
+[update]
+
+#
+# Options for the "swupd update" command
+#
+
+# Update to the specified version
+# Possible values:
+# ..., 29890, 29900, 29910, ...                     (integer value)
+# latest - used to refer to the most recent version (string value)
+#version=<VERSION>
+
+# Ignore and continue if custom user content conflicts with upstream provided
+# content (boolean value)
+#allow_mix_collisions=<true/false>
+
+# Download all content, but do not actually install the update (boolean value)
+#download=<true/false>
+
+# Show current OS version and latest version available on server, eEquivalent
+# to "swupd check-update" (boolean value)
+#status=<true/false>
+
+# Do not delete the swupd state directory content after updating the
+# system (boolean value)
+#keepcache=<true/false>
+
+# Migrate to augmented upstream/mix content (boolean value)
+#migrate=<true/false>
+
+
+[bundle-add]
+
+#
+# Options for the "swupd bundle-add" command
+#
+
+# Do not check free disk space before adding bundle (boolean value)
+#skip_diskspace_check=<true/false>
+
+
+[bundle-remove]
+
+#
+# Options for the "swupd bundle-remove" command
+#
+
+
+[bundle-list]
+
+#
+# Options for the "swupd bundle-list" command
+#
+
+# List all available bundles for the current version of Clear
+# Linux (boolean value)
+#all=<true/false>
+
+# List bundles included by BUNDLE (string value)
+#deps=[BUNDLE]
+
+# List dependency tree of all bundles which have BUNDLE as a
+# dependency (string value)
+#has_dep=[BUNDLE]
+
+
+[search-file]
+
+#
+# Options for the "swupd search-file" command
+#
+
+# Search paths where libraries are located for a match (boolean value)
+#library=<true/false>
+
+# Search paths where binaries are located for a match (boolean value)
+#binary=<true/false>
+
+# Only display the top NUM results for each bundle (integer value)
+#top=[NUM]
+
+# Output all results in CSV format (machine-readable) (boolean value)
+#csv=<true/false>
+
+# Download all manifests then return, no search done (boolean value)
+#init=<true/false>
+
+# Sort the output. ORDER is one of the following values: (string value)
+# - 'alpha' to order alphabetically (default)
+# - 'size' to order by bundle size (smaller to larger)
+#order=[ORDER]
+
+
+[diagnose]
+
+#
+# Options for the "swupd diagnose" command
+#
+
+# Diagnose the system against manifest version V (integer value)
+#version=V
+
+# Attempt to proceed even if non-critical errors found (boolean value)
+#force=<true/false>
+
+# List files which should not exist (boolean value)
+#picky=<true/false>
+
+# Selects the sub-tree where --picky looks for extra files (string value)
+# Default: /usr (string value)
+#picky-tree=[PATH]
+
+# Any path completely matching the POSIX extended regular expression is ignored
+# by --picky, matched directories get skipped (string value)
+# Example: /var|/etc/machine-id
+# Default: /usr/lib/modules|/usr/lib/kernel|/usr/local|/usr/src
+#picky-whitelist=[RE]
+
+# Diagnose if BUNDLES are installed correctly (string value)
+# Example: --bundles=os-core,vi
+#bundles=[BUNDLES]
+
+
+[repair]
+
+#
+# Options for the "swupd repair" command
+#
+
+# Compare against version V to determine what needs to be
+# repaired (integer value)
+#version=V
+
+# Attempt to proceed even if non-critical errors found (boolean value)
+#force=<true/false>
+
+# Don't fix corrupt files, only fix missing files (boolean value)
+#quick=<true/false>
+
+# Repair BUNDLES that are not installed correctly (string value)
+# Example: --bundles=os-core,vi
+#bundles=[BUNDLES]
+
+# Remove files which should not exist (boolean value)
+#picky=<true/false>
+
+# Selects the sub-tree where --picky looks for extra files (string value)
+# Default: /usr
+#picky-tree=[PATH]
+
+# Any path completely matching the POSIX extended regular expression is ignored
+# by --picky, matched directories get skipped (string value)
+# Example: /var|/etc/machine-id
+# Default: /usr/lib/modules|/usr/lib/kernel|/usr/local|/usr/src
+#picky-whitelist=[RE]
+
+
+[os-install]
+
+#
+# Options for the "swupd os-install" command
+#
+
+# Attempt to proceed even if non-critical errors found (boolean value)
+#force=<true/false>
+
+# Include the specified BUNDLES in the OS installation (string value)
+# Example: --bundles=os-core,vi
+#bundles=[BUNDLES]
+
+# If the version to install is not the latest, it can be specified with this
+# option (string value)
+#version=V
+
+
+[mirror]
+
+#
+# Options for the "swupd mirror" command
+#
+
+
+[clean]
+
+#
+# Options for the "swupd clean" command
+#
+
+
+[hashdump]
+
+#
+# Options for the "swupd hashdump" command
+#
+
+

--- a/configure.ac
+++ b/configure.ac
@@ -222,6 +222,15 @@ AS_IF(
 )
 
 AC_ARG_WITH(
+  [config-file-path],
+  [AS_HELP_STRING([--with-config-file-path=PATHS], [List of directories to look for the configuration file])],
+  [config_file_path=${withval}],
+  [config_file_path="/etc/swupd:/run/swupd:/usr/share/defaults/swupd"]
+)
+AC_SUBST(CONFIG_FILE_PATH, [${config_file_path}])
+AC_DEFINE_UNQUOTED([CONFIG_FILE_PATH], ["${config_file_path}"], [List of directories to look for the configuration file])
+
+AC_ARG_WITH(
   [system-alias-path],
   [AS_HELP_STRING([--with-system-alias-path=PATH], [Default system alias path])],
   [system_alias_path=${withval}],
@@ -368,6 +377,7 @@ Configuration to build swupd-client:
   Format Identifier:			${FORMATID}
   Signature verification:		${SIGVERIFICATION}
   Update certificate path:		${cert_path}
+  Configuration file path(s):		${config_file_path}
   Use bzip compression:			${BZIP}
   Run Tests:				${TESTS}
   Use extended file attributes		${XATTR}

--- a/src/config_loader.c
+++ b/src/config_loader.c
@@ -1,0 +1,146 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2012-2019 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define _GNU_SOURCE
+
+#include "swupd.h"
+
+#define is_from_global_section(_section) (strcmp(_section, "global") == 0)
+#define is_from_command_section(_section, _command) (strcmp(_section, _command) == 0)
+
+static struct config_loader_data {
+	char *command;
+	const struct option *available_opts;
+	parse_opt_fn_t parse_global_opt;
+	parse_opt_fn_t parse_command_opt;
+	long_opt_default_fn_t longopt_default_global;
+} cl = { NULL, NULL, NULL, NULL, NULL };
+
+void config_loader_init(char *command, const struct option *options, parse_opt_fn_t global_parse, parse_opt_fn_t command_parse, long_opt_default_fn_t global_defaults)
+{
+	cl.command = command;
+	cl.available_opts = options;
+	cl.parse_global_opt = global_parse;
+	cl.parse_command_opt = command_parse;
+	cl.longopt_default_global = global_defaults;
+}
+
+bool config_loader_set_opt(char *section, char *opt, char *value)
+{
+	const struct option *options;
+	char *lvalue = NULL;
+	char *lsection = NULL;
+	char *flag = NULL;
+	size_t opt_len;
+	size_t flag_len;
+	bool ret = false;
+
+	/* make sure the config loader has been initialized */
+	if (!cl.command || !cl.available_opts || !cl.parse_global_opt || !cl.longopt_default_global) {
+		error("Configuration loader not initialized\n");
+		return false;
+	}
+	options = cl.available_opts;
+
+	/* set flag to indicate we are loading from a configuration file,
+	 * this is useful so we can overwrite these values when a conflicting
+	 * flag is provided as command argument */
+	global_set_opt_from_config(true);
+
+	/* replace all '_' used in config options with '-' used in flags */
+	flag = strdup_or_die(opt);
+	flag_len = strlen(flag);
+	for (unsigned int i = 0; flag[i]; i++) {
+		if (flag[i] == '_') {
+			flag[i] = '-';
+		}
+	}
+
+	/* options within a section are by default considered to be global */
+	if (section) {
+		lsection = str_tolower(section);
+		if (!is_from_global_section(lsection) && !is_from_command_section(lsection, cl.command)) {
+			/* values being parsed are from a command not currently
+			 * running, we are not interested in these */
+			ret = true;
+			goto exit;
+		}
+	}
+
+	/* search the option from within the available options */
+	while (options->name != NULL) {
+		opt_len = strlen(options->name);
+		if (flag_len == opt_len && strcmp(flag, options->name) == 0) {
+			lvalue = str_tolower(value);
+
+			/* some options don't have short options, only long, if this is the
+			 * case we need to assign the value directly to the variable pointed
+			 * by flag */
+			if (options->flag && options->has_arg == 0) {
+				if (strcmp(lvalue, "true") == 0) {
+					/* only set if flag=true */
+					*(options->flag) = options->val;
+				} else {
+					/* return to default value, this only makes sense for
+					 * global variable */
+					cl.longopt_default_global(options->name);
+				}
+				/* long option set */
+				ret = true;
+				break;
+			}
+
+			/* if it was not a long option try looking at the global short
+			 * options first... */
+			ret = cl.parse_global_opt(options->val, value);
+			if (ret) {
+				/* global option set */
+				break;
+			}
+
+			/* now try with the local short options... */
+
+			/* boolean options with a value of "false" only make sense in the
+			 * global section, if we find one of these in a command section we
+			 * can skip it. We don't have a way to know if the value is a boolean
+			 * or not, if the value is the "false" string, we will treat it as a
+			 * boolean false and will skip this option */
+			if (strcmp(lvalue, "false") == 0) {
+				/* we don't need to set anything for this */
+				ret = true;
+				break;
+			}
+
+			/* not all commands support local options */
+			if (cl.parse_command_opt) {
+				ret = cl.parse_command_opt(options->val, value);
+			}
+
+			break;
+		}
+		options++;
+	}
+
+exit:
+	global_set_opt_from_config(false);
+	free_string(&lvalue);
+	free_string(&lsection);
+	free_string(&flag);
+	return ret;
+}

--- a/src/config_loader.h
+++ b/src/config_loader.h
@@ -1,0 +1,28 @@
+#ifndef __CONFIG_LOADER__
+#define __CONFIG_LOADER__
+
+/**
+ * @file
+ * @brief Load options from a configuration file
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+
+/**
+ * @brief Type of function that sets options for a command based on parsed values
+ */
+typedef bool (*parse_opt_fn_t)(int opt, char *optarg);
+
+/**
+ * @brief Type of function that sets default values for long options
+ */
+typedef bool (*long_opt_default_fn_t)(const char *long_opt);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/lib/config_parser.c
+++ b/src/lib/config_parser.c
@@ -1,0 +1,116 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2012-2019 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define _GNU_SOURCE
+
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "config_parser.h"
+#include "log.h"
+#include "macros.h"
+#include "strings.h"
+
+#define CONFIG_LINE_MAXLEN (PATH_MAX * 2)
+
+bool config_parse(const char *filename, load_config_fn_t load_config_fn)
+{
+	FILE *config_file;
+	char line[CONFIG_LINE_MAXLEN];
+	char *line_ptr;
+	char *section = NULL;
+	char *key = NULL;
+	char *value = NULL;
+	bool ret = false;
+
+	config_file = fopen(filename, "rbm");
+	if (config_file == NULL) {
+		goto exit;
+	}
+
+	/* read the config file line by line */
+	while (!feof(config_file)) {
+
+		/* read next line */
+		if (fgets(line, CONFIG_LINE_MAXLEN, config_file) == NULL) {
+			break;
+		}
+
+		/* remove the line break from the current line */
+		line_ptr = strchr(line, '\n');
+		if (!line_ptr) {
+			goto close_and_exit;
+		}
+		*line_ptr = '\0';
+
+		/* check the line to see if it is a comment (start with ; or #) */
+		if (line[0] == ';' || line[0] == '#') {
+			continue;
+		}
+
+		/* check the line to see if the line is a section */
+		if (line[0] == '[' && *(line_ptr - 1) == ']') {
+			*(line_ptr - 1) = '\0';
+			free_string(&section);
+			section = strdup_or_die(line + 1);
+		}
+
+		/* check the line to see if it is a key/value pair */
+		line_ptr = strchr(line, '=');
+		if (!line_ptr) {
+			/* this is probably a blank line or something unrecognized,
+			 * ignore the line */
+			goto free_data;
+		}
+
+		*line_ptr = '\0';
+		key = strdup_or_die(line);
+		value = strdup_or_die(line_ptr + 1);
+
+		/* make sure we don't have empty key or value pairs */
+		if (key[0] == '\0' || value[0] == '\0') {
+			warn("Invalid key/value pair in the configuration file (key='%s', value='%s')\n", key, value);
+			goto free_data;
+		}
+		/* make sure we don't have more than one '=' per line */
+		line_ptr = strchr(value, '=');
+		if (line_ptr) {
+			warn("Invalid key/value pair in the configuration file ('%s=%s')\n", key, value);
+			goto free_data;
+		}
+
+		/* load the configuration value read in the application */
+		if (!load_config_fn(section, key, value)) {
+			warn("Unrecognized option '%s=%s' from section [%s] in the configuration file\n", key, value, section);
+		}
+	free_data:
+		free_string(&key);
+		free_string(&value);
+	}
+
+	/* we made it this far, config file parsed correctly */
+	ret = true;
+
+close_and_exit:
+	free_string(&section);
+	fclose(config_file);
+exit:
+	return ret;
+}

--- a/src/lib/config_parser.h
+++ b/src/lib/config_parser.h
@@ -1,0 +1,36 @@
+#ifndef __CONFIG_PARSER__
+#define __CONFIG_PARSER__
+
+/**
+ * @file
+ * @brief Configuration file parsing
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Function type to process the parsed key/values
+ */
+typedef bool (*load_config_fn_t)(char *section, char *key, char *value);
+
+/**
+ * @brief Parses the INI style configuration file and sets up the runtime environment
+ * based on the configuration values
+ * @param filename: the full path to the configuration file to parse
+ * @param load_config_fn: a pointer to a function that takes specific actions based
+ * on the key/value pairs
+ *
+ * @returns True if there were no errors when parsing and processing the parsed options,
+ *          False otherwise
+ */
+bool config_parse(const char *filename, load_config_fn_t load_config_fn);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/lib/formatter_json.h
+++ b/src/lib/formatter_json.h
@@ -6,6 +6,7 @@
  * @brief Format the output to print using JSON format.
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 
 #ifdef __cplusplus
@@ -13,9 +14,9 @@ extern "C" {
 #endif
 
 /**
- * @brief Enables the JSON formatter
+ * @brief Enables/Disables the JSON formatter
  */
-void set_json_format(void);
+void set_json_format(bool on);
 
 /**
  * @brief Generates the initial message of a JSON stream

--- a/src/lib/strings.c
+++ b/src/lib/strings.c
@@ -164,3 +164,18 @@ char *str_tolower(const char *str)
 
 	return str_lower;
 }
+
+bool strtobool(const char *str)
+{
+	char *str_lower;
+	bool ret = false;
+
+	str_lower = str_tolower(str);
+	if (strcmp(str_lower, "true") == 0) {
+		ret = true;
+	}
+
+	/* return false for everything else */
+	free_string(&str_lower);
+	return ret;
+}

--- a/src/lib/strings.h
+++ b/src/lib/strings.h
@@ -80,6 +80,12 @@ int strtoi_err_endptr(const char *str, char **endptr, int *value);
  */
 char *str_tolower(const char *str);
 
+/**
+ * Converts a string to a boolean. If the string is "true" then it is converted
+ * to a boolean true. Everything else is converted to a boolean false.
+ */
+bool strtobool(const char *str);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -48,13 +48,13 @@ static struct subcmd commands[] = {
 	{ "search", "Searches for the best bundle to install a binary or library", binary_loader_main },
 #endif
 	{ "search-file", "Command to search files in Clear Linux bundles", search_main },
-	{ "diagnose", "Verify content for OS version", verify_main },
+	{ "diagnose", "Verify content for OS version", diagnose_main },
 	{ "repair", "Repair local issues relative to server manifest (will not modify ignored files)", repair_main },
 	{ "os-install", "Install Clear Linux OS to a blank partition or directory", install_main },
 	{ "mirror", "Configure mirror url for swupd content", mirror_main },
 	{ "clean", "Clean cached files", clean_main },
 	{ "hashdump", "Dump the HMAC hash of a file", hashdump_main },
-	{ "verify", "NOTE: this command has been superseded, please use \"swupd diagnose\" instead", verify_main },
+	{ "verify", "NOTE: this command has been superseded, please use \"swupd diagnose\" instead", diagnose_main },
 	{ 0 }
 };
 

--- a/src/mirror.c
+++ b/src/mirror.c
@@ -236,8 +236,8 @@ void handle_mirror_if_stale(void)
 		 * since at the moment the cached_version is the outdated mirror version */
 		free_string(&version_url);
 		free_string(&content_url);
-		set_version_url(NULL);
-		set_content_url(NULL);
+		set_default_version_url();
+		set_default_content_url();
 		get_latest_version(ret_str);
 		goto out;
 	}

--- a/src/os_install.c
+++ b/src/os_install.c
@@ -148,7 +148,7 @@ enum swupd_code install_main(int argc, char **argv)
 	verify_set_option_version(cmdline_option_version);
 
 	/* install */
-	ret = verify_main(0, NULL);
+	ret = verify_main();
 
 	return ret;
 }

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -10,7 +10,9 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "config_loader.h"
 #include "lib/archives.h"
+#include "lib/config_parser.h"
 #include "lib/formatter_json.h"
 #include "lib/list.h"
 #include "lib/log.h"
@@ -195,8 +197,10 @@ extern char *cert_path;
 extern int update_server_port;
 extern char *default_format_path;
 extern bool set_path_prefix(char *path);
-extern int set_content_url(char *url);
-extern int set_version_url(char *url);
+extern void set_content_url(char *url);
+extern void set_version_url(char *url);
+extern int set_default_content_url(void);
+extern int set_default_version_url(void);
 
 extern void check_root(void);
 
@@ -369,6 +373,7 @@ enum swupd_code list_local_bundles();
 extern int link_or_rename(const char *orig, const char *dest);
 
 /* verify.c */
+extern enum swupd_code verify_main(void);
 extern void verify_set_command_verify(bool opt);
 extern void verify_set_option_force(bool opt);
 extern void verify_set_option_install(bool opt);
@@ -378,7 +383,7 @@ extern void verify_set_option_version(int ver);
 extern void verify_set_option_fix(bool opt);
 extern void verify_set_option_picky(bool opt);
 extern void verify_set_picky_whitelist(regex_t *whitelist);
-extern void verify_set_picky_tree(const char *picky_tree);
+extern void verify_set_picky_tree(char *picky_tree);
 
 /* repair.c */
 extern regex_t *compile_whitelist(const char *whitelist_pattern);
@@ -418,6 +423,10 @@ struct global_options {
 
 void global_print_help(void);
 int global_parse_options(int argc, char **argv, const struct global_options *opts);
+extern void global_set_opt_from_config(bool state);
+
+extern void config_loader_init(char *, const struct option *, parse_opt_fn_t, parse_opt_fn_t, long_opt_default_fn_t);
+extern bool config_loader_set_opt(char *section, char *key, char *value);
 
 enum swupd_code check_update();
 

--- a/src/swupd_internal.h
+++ b/src/swupd_internal.h
@@ -7,7 +7,6 @@ extern enum swupd_code bundle_remove_main(int argc, char **argv);
 extern enum swupd_code bundle_list_main(int argc, char **argv);
 extern enum swupd_code hashdump_main(int argc, char **argv);
 extern enum swupd_code update_main(int argc, char **argv);
-extern enum swupd_code verify_main(int argc, char **argv);
 extern enum swupd_code check_update_main(int argc, char **argv);
 extern enum swupd_code search_main(int argc, char **argv);
 extern enum swupd_code info_main(int argc, char **argv);
@@ -16,5 +15,6 @@ extern enum swupd_code mirror_main(int argc, char **argv);
 extern enum swupd_code binary_loader_main(int argc, char **argv);
 extern enum swupd_code install_main(int argc, char **argv);
 extern enum swupd_code repair_main(int argc, char **argv);
+extern enum swupd_code diagnose_main(int argc, char **argv);
 
 #endif

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -10,6 +10,8 @@ export THEME_DIRNAME
 export FUNC_DIR
 export SWUPD_DIR="$FUNC_DIR/../.."
 export SWUPD="$SWUPD_DIR/swupd"
+export SWUPD_CONFIG_DIR="$SWUPD_DIR"/testconfig
+export SWUPD_CONFIG_FILE="$SWUPD_CONFIG_DIR"/config
 
 # Exit codes
 export SWUPD_OK=0
@@ -1640,6 +1642,49 @@ destroy_test_fs() { # swupd_function
 	rm "$fsfile"
 
 }
+
+create_config_file() { # swupd_function
+
+	if [ -e "$SWUPD_CONFIG_FILE" ]; then
+		destroy_config_file
+	fi
+
+	mkdir -p "$SWUPD_CONFIG_DIR"
+	touch "$SWUPD_CONFIG_FILE"
+
+}
+
+destroy_config_file() { # swupd_function
+
+	rm -rf "$SWUPD_CONFIG_DIR"
+
+}
+
+add_option_to_config_file() { # swupd_function
+
+	local option=$1
+	local value=$2
+	local section=$3
+
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    add_option_to_config_file <option> <value> <section_name>
+			EOM
+		return
+	fi
+
+	validate_param "$option"
+	validate_param "$value"
+
+	if [ -n "$section" ]; then
+		echo "[$section]" >> "$SWUPD_CONFIG_FILE"
+	fi
+	echo "$option"="$value" >> "$SWUPD_CONFIG_FILE"
+
+}
+
 
 # creates a mirror of whatever is in web-dir
 # Parameters:

--- a/test/functional/usability/usa-config-file.bats
+++ b/test/functional/usability/usa-config-file.bats
@@ -1,0 +1,247 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n test-bundle -f /file_1 "$TEST_NAME"
+
+}
+
+test_setup() {
+
+	create_config_file
+
+}
+
+test_teardown() {
+
+	destroy_config_file
+
+}
+
+global_teardown() {
+
+	destroy_test_environment "$TEST_NAME"
+
+}
+
+@test "USA010: Use option without section in the configuration file" {
+
+	# Options without a section are considered to be global
+
+	add_option_to_config_file json_output true
+
+	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		{ "type" : "end", "section" : "bundle-add", "status" : 0 }
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle"
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		{ "type" : "end", "section" : "bundle-remove", "status" : 0 }
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+}
+
+@test "USA011: Set a global option in the configuration file" {
+
+	# Global options apply to all commands
+
+	add_option_to_config_file json_output true GLOBAL
+
+	run sudo sh -c "$SWUPD info $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		{ "type" : "end", "section" : "info", "status" : 0 }
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		{ "type" : "end", "section" : "check-update", "status" : 1 }
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+}
+
+@test "USA012: Set a global option locally for a command in the configuration file" {
+
+	# Global options defined within a command's section only apply to that command
+
+	add_option_to_config_file json_output true info
+
+	run sudo sh -c "$SWUPD info $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		{ "type" : "end", "section" : "info", "status" : 0 }
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Current OS version: 10
+		Latest server version: 10
+		There are no updates available
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+}
+
+@test "USA013: Set a global option and override it locally for a command in the configuration file" {
+
+	# If an option is defined globally and locally, local values should take precedence
+
+	add_option_to_config_file json_output true global
+	add_option_to_config_file json_output false check-update
+
+	run sudo sh -c "$SWUPD info $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		{ "type" : "end", "section" : "info", "status" : 0 }
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Current OS version: 10
+		Latest server version: 10
+		There are no updates available
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+}
+
+@test "USA014: Set a local option  in a command in the configuration file" {
+
+	# options set within the command section apply to the command only
+
+	add_option_to_config_file picky true diagnose
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Generating list of extra files under $TEST_DIRNAME/testfs/target-dir/usr
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+}
+
+@test "USA015: Override a global option from the configuration file with a command flag" {
+
+	# flags used with a command take precedence over options in the config file
+
+	add_option_to_config_file url http://someurl.com global
+
+	run sudo sh -c "$SWUPD info $SWUPD_OPTS -v http://anotherurl.com"
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Installed version: 10
+		Version URL:       http://anotherurl.com
+		Content URL:       http://someurl.com
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "USA016: Override a local option from the configuration file with a command flag" {
+
+	# flags used with a command take precedence over options in the config file
+
+	add_option_to_config_file picky true diagnose
+	add_option_to_config_file picky_tree /fake/path
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --picky-tree /usr/lib"
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Generating list of extra files under $TEST_DIRNAME/testfs/target-dir/usr/lib
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+}
+
+@test "USA017: Use an invalid section in the configuration file" {
+
+	# if invalid sections are found within the config file it should be ignored
+
+	add_option_to_config_file json_output true invalid_section
+
+	run sudo sh -c "$SWUPD info $SWUPD_OPTS"
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Installed version: 10
+		Version URL:       file://$TEST_DIRNAME/web-dir
+		Content URL:       file://$TEST_DIRNAME/web-dir
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "USA018: Use an invalid option within a valid section in the configuration file" {
+
+	# if invalid option for a valid section is found within the config file
+	# a warning should be generated and the option should be ignored
+
+	add_option_to_config_file invalid_option true global
+
+	run sudo sh -c "$SWUPD info $SWUPD_OPTS"
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Warning: Unrecognized option 'invalid_option=true' from section [global] in the configuration file
+		Installed version: 10
+		Version URL:       file://$TEST_DIRNAME/web-dir
+		Content URL:       file://$TEST_DIRNAME/web-dir
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "USA019: Use a bad option in the configuration file" {
+
+	# if a bad/corrupt option for a valid section is found within the config file
+	# a warning should be generated and the option should be ignored
+
+	add_option_to_config_file picky true diagnose
+	{ echo "picky-tree="; echo "=true"; echo "picky-tree=/some/path=/usr"; } >> "$SWUPD_CONFIG_FILE"
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Warning: Invalid key/value pair in the configuration file (key='picky-tree', value='')
+		Warning: Invalid key/value pair in the configuration file (key='', value='true')
+		Warning: Invalid key/value pair in the configuration file ('picky-tree=/some/path=/usr')
+		Diagnosing version 10
+		Generating list of extra files under $TEST_DIRNAME/testfs/target-dir/usr
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+}


### PR DESCRIPTION
swupd has many flags that can be used for fine tunning its
functionality. In some cases users may want to include a flag with every
swupd command they run.

This commit gives the ability to provide swupd flags via options in a
configuration file that swupd will read before running the command.

The configuration file is an INI style file tha  can include sections
so users can specify options that should only apply to a specific
command. The biggest advantage of this is to be able to fine tune the
flags that should apply for each command.

For example a user could set a global flag that would apply to every
swupd command, and then turn that flag off for a specific command by
unsetting it in the command's section.

Closes #952 

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>