### PR TITLE
Require a force flag to continue with insecure URL

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -200,6 +200,11 @@ int swupd_curl_init(void)
 		return -1;
 	}
 
+	/* enforce the use of https */
+	if (!is_url_allowed(NULL)) {
+		return -1;
+	}
+
 	ret = check_connection(NULL);
 	if (ret == 0) {
 		return 0;

--- a/src/globals.c
+++ b/src/globals.c
@@ -33,6 +33,7 @@
 #include "config.h"
 #include "lib/log.h"
 #include "swupd.h"
+bool allow_insecure_http = false;
 bool allow_mix_collisions = false;
 bool migrate = false;
 bool sigcheck = true;
@@ -578,6 +579,7 @@ static const struct option global_opts[] = {
 	{ "max-retries", required_argument, 0, 'r' },
 	{ "retry-delay", required_argument, 0, 'd' },
 	{ "json-output", no_argument, 0, 'j' },
+	{ "allow-insecure-http", no_argument, 0, 'E' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -666,6 +668,9 @@ static bool global_parse_opt(int opt, char *optarg)
 	case 'j':
 		set_json_format();
 		return true;
+	case 'E':
+		allow_insecure_http = true;
+		return true;
 	default:
 		return false;
 	}
@@ -728,6 +733,7 @@ void global_print_help(void)
 	print("   -r, --max-retries       Maximum number of retries for download failures\n");
 	print("   -d, --retry-delay       Initial delay between download retries, this will be doubled for each retry\n");
 	print("   -j, --json-output       Print all output as a JSON stream\n");
+	print("   -E, --allow-insecure-http Allow updates over insecure connections\n");
 	print("   --quiet                 Quiet output. Print only important information and errors\n");
 	print("   --debug                 Print extra information to help debugging problems\n");
 	print("\n");

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -1015,3 +1015,31 @@ void print_regexp_error(int errcode, regex_t *regexp)
 
 	    free(error_buffer);
 }
+
+bool is_url_allowed(char *url)
+{
+	bool insecure = false;
+
+	if (url) {
+		if (strncmp(url, "http://", 7) == 0) {
+			insecure = true;
+		}
+	} else {
+		if (strncmp(version_url, "http://", 7) == 0 || strncmp(content_url, "http://", 7) == 0) {
+			insecure = true;
+		}
+	}
+
+	if (insecure) {
+		if (allow_insecure_http) {
+			warn("This is an insecure connection\n");
+			info("The --allow-insecure-http flag was used, be aware that this poses a threat to the system\n\n");
+		} else {
+			error("This is an insecure connection\n");
+			info("Use the --allow-insecure-http flag to proceed\n");
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/src/mirror.c
+++ b/src/mirror.c
@@ -177,6 +177,12 @@ static enum swupd_code set_mirror_url(char *url)
 	char *content_path;
 	char *version_path;
 	int ret = SWUPD_OK;
+
+	/* enforce the use of https */
+	if (!is_url_allowed(url)) {
+		return SWUPD_INVALID_OPTION;
+	}
+
 	/* concatenate path_prefix and configuration paths if necessary
 	 * if path_prefix is NULL the second argument will be returned */
 	content_path = mk_full_filename(path_prefix, MIRROR_CONTENT_URL_PATH);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -89,6 +89,7 @@ enum swupd_init_config {
 
 struct header;
 
+extern bool allow_insecure_http;
 extern bool allow_mix_collisions;
 extern bool verbose_time;
 extern bool migrate;
@@ -349,6 +350,7 @@ extern bool is_current_version(int version);
 extern bool on_new_format(void);
 extern char *get_printable_bundle_name(const char *bundle_name, bool is_experimental);
 extern void print_regexp_error(int errcode, regex_t *regexp);
+extern bool is_url_allowed(char *url);
 
 /* subscription.c */
 struct list *free_list_file(struct list *item);

--- a/swupd.bash
+++ b/swupd.bash
@@ -23,7 +23,7 @@ _swupd()
     # $1 is the command being completed, $2 is the current word being expanded
     local opts IFS=$' \t\n'
     local -i i installed
-    local global="--help --url --contenturl --versionurl --port --path --format --nosigcheck --ignore-time --statedir --certpath  --time --no-scripts --no-boot-update --max-parallel-downloads --max-retries --retry-delay --json-output --debug --quiet "
+    local global="--help --url --contenturl --versionurl --port --path --format --nosigcheck --ignore-time --statedir --certpath  --time --no-scripts --no-boot-update --max-parallel-downloads --max-retries --retry-delay --json-output  --allow-insecure-http --debug --quiet "
     COMPREPLY=()
     for ((i=COMP_CWORD-1;i>=0;i--))
     do case "${COMP_WORDS[$i]}" in

--- a/swupd.bash
+++ b/swupd.bash
@@ -23,6 +23,7 @@ _swupd()
     # $1 is the command being completed, $2 is the current word being expanded
     local opts IFS=$' \t\n'
     local -i i installed
+    local global="--help --url --contenturl --versionurl --port --path --format --nosigcheck --ignore-time --statedir --certpath  --time --no-scripts --no-boot-update --max-parallel-downloads --max-retries --retry-delay --json-output --debug --quiet "
     COMPREPLY=()
     for ((i=COMP_CWORD-1;i>=0;i--))
     do case "${COMP_WORDS[$i]}" in
@@ -30,53 +31,53 @@ _swupd()
 	    #  TODO(castulo): remove the deprecated verify command by end of July 2019
 		opts="--help --version autoupdate bundle-add bundle-remove bundle-list hashdump update diagnose check-update search search-file info clean mirror os-install repair verify "
 	    break;;
+	    ("info")
+		opts="$global "
+		break;;
 	    ("autoupdate")
 		opts="--help --enable --disable "
 		break;;
+	    ("check-update")
+		opts="$global "
+		break;;
+		("update")
+		opts="$global --download --status --force --migrate --allow-mix-collisions --keepcache "
+		break;;
 	    ("bundle-add")
-		opts="--help --url --contenturl --versionurl --port --path --format --force --nosigcheck --ignore-time --statedir --certpath --time --no-scripts --no-boot-update --max-parallel-downloads --json-output --debug --quiet "
+		opts="$global --skip-diskspace-check "
 		break;;
 	    ("bundle-remove")
-		opts="--help --path --url --contenturl --versionurl --port --format --force --nosigcheck --ignore-time --statedir --certpath --debug --quiet --json-output "
+		opts="$global "
 		break;;
 	    ("bundle-list")
-		opts="--help --all --url --contenturl --versionurl --path --format --nosigcheck --ignore-time --statedir --certpath --deps --has-dep --debug --quiet --json-output "
+		opts="$global --all --deps --has-dep "
+		break;;
+		("search")
+		opts="--help --all --quiet --verbose "
+		break;;
+		("search-file")
+		opts="$global --library --binary --top --csv --init --order "
+		break;;
+		("diagnose")
+		opts="$global --version --picky --picky-tree --picky-whitelist --quick --force --bundles "
+		break;;
+		("repair")
+		opts="$global --version --picky --picky-tree --picky-whitelist --quick --force --bundles "
+		break;;
+		("os-install")
+		opts="$global --version --force --bundles "
+		break;;
+		("mirror")
+		opts="$global --set --unset "
+		break;;
+	    ("clean")
+		opts="$global --all --dry-run "
 		break;;
 	    ("hashdump")
 		opts="--help --no-xattrs --path --debug --quiet "
 		break;;
-	    ("update")
-		opts="--help --download --url --port --contenturl --versionurl --status --format --path --force --nosigcheck --ignore-time --statedir --certpath --time --no-scripts --no-boot-update --migrate --allow-mix-collisions --max-parallel-downloads --keepcache --debug --quiet --json-output "
-		break;;
 	    ("verify")
-		opts="--help --manifest --path --url --port --contenturl --versionurl --fix --picky --picky-tree --picky-whitelist --install --format --quick --force --nosigcheck --ignore-time --statedir --certpath --time --no-scripts --no-boot-update --max-parallel-downloads --debug --quiet --json-output "
-		break;;
-	    ("diagnose")
-		opts="--help --manifest --path --url --port --contenturl --versionurl --picky --picky-tree --picky-whitelist --format --quick --force --nosigcheck --ignore-time --statedir --certpath --time --no-scripts --no-boot-update --max-parallel-downloads --debug --quiet --json-output "
-		break;;
-	    ("check-update")
-		opts="--help --url --versionurl --port --format --force --nosigcheck --path --statedir --debug --quiet --json-output "
-		break;;
-	    ("search")
-		opts="--help"
-		break;;
-	    ("search-file")
-		opts="--help --library --binary --top --csv --init --ignore-time --url --contenturl --versionurl --port --path --format --statedir --certpath --regexp --debug --quiet --json-output "
-		break;;
-	    ("info")
-		opts="--debug --quiet --json-output "
-		break;;
-	    ("clean")
-		opts="--all --dry-run --statedir --help --debug --quiet --json-output "
-		break;;
-	    ("mirror")
-		opts="--help --set --unset --path --debug --quiet --json-output "
-		break;;
-	    ("os-install")
-		opts="--help --version --path --url --port --contenturl --versionurl --format --force --nosigcheck --ignore-time --statedir --certpath --time --no-scripts --no-boot-update --max-parallel-downloads --debug --quiet --json-output "
-		break;;
-	    ("repair")
-		opts="--help --manifest --path --url --port --contenturl --versionurl --picky --picky-tree --picky-whitelist --format --quick --force --nosigcheck --ignore-time --statedir --certpath --time --no-scripts --no-boot-update --max-parallel-downloads --debug --quiet --json-output "
+		opts="$global --version --manifest --fix --picky --picky-tree --picky-whitelist --install --quick --force --install "
 		break;;
 	esac
     done

--- a/test/functional/bundleadd/add-no-disk-space.bats
+++ b/test/functional/bundleadd/add-no-disk-space.bats
@@ -106,10 +106,12 @@ test_setup() {
 	start_web_server -r
 	set_upstream_server "$TEST_NAME" http://localhost:"$(get_web_server_port "$TEST_NAME")"/"$TEST_NAME"/web-dir
 
-	run sudo sh -c "timeout 30 $SWUPD bundle-add --skip-diskspace-check $SWUPD_OPTS test-bundle"
+	run sudo sh -c "timeout 30 $SWUPD bundle-add --skip-diskspace-check --allow-insecure-http $SWUPD_OPTS test-bundle"
 
 	assert_status_is "$SWUPD_COULDNT_DOWNLOAD_FILE"
 	expected_output=$(cat <<-EOM
+		Warning: This is an insecure connection
+		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
 		Loading required manifests...
 		Downloading packs \\(.* Mb\\) for:
 		 - test-bundle

--- a/test/functional/checkupdate/chk-update-slow-server.bats
+++ b/test/functional/checkupdate/chk-update-slow-server.bats
@@ -23,9 +23,11 @@ test_teardown() {
 
 @test "CHK003: Check for available updates with a slow server" {
 
-	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD check-update --allow-insecure-http $SWUPD_OPTS"
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Warning: This is an insecure connection
+		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
 		Current OS version: 10
 		Latest server version: 99990
 		There is a new OS version available: 99990

--- a/test/functional/mirror/mirror-createdir-negative.bats
+++ b/test/functional/mirror/mirror-createdir-negative.bats
@@ -32,10 +32,12 @@ global_teardown() {
 	sudo rm -rf "$TARGETDIR"/etc/swupd
 	sudo touch "$TARGETDIR"/etc/swupd
 
-	run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+	run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file --allow-insecure-http $SWUPD_OPTS_MIRROR"
 
 	assert_status_is_not 0
 	expected_output=$(cat <<-EOM
+		Warning: This is an insecure connection
+		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
 		.*/etc/swupd: not a directory
 		Warning: Unable to set mirror url
 		Installed version: 10
@@ -53,10 +55,12 @@ global_teardown() {
 	sudo touch "$TARGETDIR"/foo
 	sudo ln -s "$(realpath "$TARGETDIR"/foo)" "$TARGETDIR"/etc/swupd
 
-	run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+	run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file --allow-insecure-http $SWUPD_OPTS_MIRROR"
 
 	assert_status_is_not 0
 	expected_output=$(cat <<-EOM
+		Warning: This is an insecure connection
+		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
 		.*/etc/swupd: not a directory
 		Warning: Unable to set mirror url
 		Installed version: 10

--- a/test/functional/mirror/mirror-createdir.bats
+++ b/test/functional/mirror/mirror-createdir.bats
@@ -29,10 +29,12 @@ global_teardown() {
 
 @test "MIR001: Setting a mirror when /etc/swupd doesn't exist" {
 
-	run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+	run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file --allow-insecure-http $SWUPD_OPTS_MIRROR"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Warning: This is an insecure connection
+		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
 		Set upstream mirror to http://example.com/swupd-file
 		Installed version: 10
 		Version URL:       http://example.com/swupd-file
@@ -49,10 +51,12 @@ global_teardown() {
 
 	sudo mkdir -p "$TARGETDIR"/etc/swupd
 
-	run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+	run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file --allow-insecure-http $SWUPD_OPTS_MIRROR"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Warning: This is an insecure connection
+		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
 		Set upstream mirror to http://example.com/swupd-file
 		Installed version: 10
 		Version URL:       http://example.com/swupd-file
@@ -70,10 +74,12 @@ global_teardown() {
 	sudo mkdir "$TARGETDIR"/foo
 	sudo ln -s "$(realpath "$TARGETDIR"/foo)" "$TARGETDIR"/etc/swupd
 
-	run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file $SWUPD_OPTS_MIRROR"
+	run sudo sh -c "$SWUPD mirror -s http://example.com/swupd-file --allow-insecure-http $SWUPD_OPTS_MIRROR"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Warning: This is an insecure connection
+		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
 		Set upstream mirror to http://example.com/swupd-file
 		Installed version: 10
 		Version URL:       http://example.com/swupd-file

--- a/test/functional/mirror/mirror-json.bats
+++ b/test/functional/mirror/mirror-json.bats
@@ -17,12 +17,14 @@ test_setup() {
 	# command is created as a JSON stream that can be read and parsed by other
 	# applications interested into knowing real time status of the command
 
-	run sudo sh -c "$SWUPD mirror --json-output -s http://example.com/swupd-file $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD mirror --json-output -s http://example.com/swupd-file --allow-insecure-http $SWUPD_OPTS"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		[
 		{ "type" : "start", "section" : "mirror" },
+		{ "type" : "warning", "msg" : "This is an insecure connection " },
+		{ "type" : "info", "msg" : "The --allow-insecure-http flag was used, be aware that this poses a threat to the system  " },
 		{ "type" : "info", "msg" : "Set upstream mirror to http://example.com/swupd-file " },
 		{ "type" : "info", "msg" : "Installed version: 10 " },
 		{ "type" : "info", "msg" : "Version URL:       http://example.com/swupd-file " },

--- a/test/functional/update/update-non-responsive.bats
+++ b/test/functional/update/update-non-responsive.bats
@@ -46,10 +46,12 @@ test_teardown() {
 	# if the upstream server is unresponsive the update should fail after 2 minute
 	# timeout with a useful message
 
-	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD update --allow-insecure-http $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_CURL_INIT_FAILED"
 	expected_output=$(cat <<-EOM
+		Warning: This is an insecure connection
+		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
 		Error: Curl - Communicating with server timed out
 		Error: Updater failed to initialize, exiting now.
 	EOM
@@ -68,10 +70,12 @@ test_teardown() {
 	write_to_protected_file "$TARGETDIR"/etc/swupd/mirror_versionurl http://localhost:"$port"/
 	write_to_protected_file "$TARGETDIR"/etc/swupd/mirror_contenturl http://localhost:"$port"/
 
-	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD update --allow-insecure-http $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_CURL_INIT_FAILED"
 	expected_output=$(cat <<-EOM
+		Warning: This is an insecure connection
+		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
 		Error: Curl - Communicating with server timed out
 		Error: Updater failed to initialize, exiting now.
 	EOM

--- a/test/functional/update/update-slow-server.bats
+++ b/test/functional/update/update-slow-server.bats
@@ -33,10 +33,12 @@ test_teardown() {
 
 @test "UPD025: Updating a system using a slow server" {
 
-	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD update --allow-insecure-http $SWUPD_OPTS"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Warning: This is an insecure connection
+		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
 		Update started.
 		Preparing to update from 10 to 100
 		Downloading packs for:

--- a/test/functional/usability/usa-download-retries.bats
+++ b/test/functional/usability/usa-download-retries.bats
@@ -22,10 +22,12 @@ test_setup() {
 	# Users should be able to configure the retry of a failed download using
 	# two options --max-retries and --retry-delay
 
-	run sudo sh -c "$SWUPD bundle-add --max-retries 4 --retry-delay 0 $SWUPD_OPTS test-bundle"
+	run sudo sh -c "$SWUPD bundle-add --max-retries 4 --retry-delay 0 --allow-insecure-http $SWUPD_OPTS test-bundle"
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
+		Warning: This is an insecure connection
+		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
 		Error: Curl - Download failed: response (204) -  'http://localhost:$port/10/Manifest.MoM.tar'
 		Retry #1 downloading from http://localhost:$port/10/Manifest.MoM.tar
 		Error: Curl - Download failed: response (204) -  'http://localhost:$port/10/Manifest.MoM.tar'
@@ -49,10 +51,12 @@ test_setup() {
 	# Users should be able to turn off download retries entirely by setting the
 	# value to 0
 
-	run sudo sh -c "$SWUPD bundle-add --max-retries 0 $SWUPD_OPTS test-bundle"
+	run sudo sh -c "$SWUPD bundle-add --max-retries 0 --allow-insecure-http $SWUPD_OPTS test-bundle"
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
+		Warning: This is an insecure connection
+		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
 		Error: Curl - Download failed: response (204) -  'http://localhost:$port/10/Manifest.MoM.tar'
 		Download retries is disabled
 		Error: Failed to retrieve 10 MoM manifest
@@ -67,10 +71,12 @@ test_setup() {
 
 	# All failed downloads by default are atttempted 3 times
 
-	run sudo sh -c "$SWUPD bundle-add --retry-delay 1 $SWUPD_OPTS test-bundle"
+	run sudo sh -c "$SWUPD bundle-add --retry-delay 1 --allow-insecure-http $SWUPD_OPTS test-bundle"
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
+		Warning: This is an insecure connection
+		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
 		Error: Curl - Download failed: response (204) -  'http://localhost:$port/10/Manifest.MoM.tar'
 		Waiting 1 seconds before retrying the download
 		Retry #1 downloading from http://localhost:$port/10/Manifest.MoM.tar


### PR DESCRIPTION
Currently users can set content and version urls based on http or https
protocols. This pose a security risk if users decide to use http.

This commit blocks swupd from working with http unless is specifically
allowed by using the --allow-insecure-http flag.

Closes #953 