### PR TITLE
Return correct code when bad path in picky-tree

### DIFF
--- a/src/extra_files.c
+++ b/src/extra_files.c
@@ -120,6 +120,12 @@ enum swupd_code walk_tree(struct manifest *manifest, const char *start, bool fix
 	/* Walk the tree, */
 	int rc;
 	int ret;
+
+	/* first make sure the path where we'll start looking actually exists */
+	if (!is_dir(start)) {
+		return SWUPD_COULDNT_LIST_DIR;
+	}
+
 	path_prefix_len = strlen(path_prefix);
 	path_whitelist = whitelist;
 	rc = nftw(start, &record_filename, 0, FTW_ACTIONRETVAL | FTW_PHYS | FTW_MOUNT);

--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -321,3 +321,17 @@ bool is_root(void)
 {
 	return getuid() == 0;
 }
+
+bool is_dir(const char *path)
+{
+	struct stat st;
+
+	if (stat(path, &st)) {
+		return false;
+	}
+	if ((st.st_mode & S_IFMT) != S_IFDIR) {
+		return false;
+	}
+
+	return true;
+}

--- a/src/lib/sys.h
+++ b/src/lib/sys.h
@@ -166,6 +166,12 @@ char *sys_path_join(const char *prefix, const char *path);
  * @brief Check if current user is root.
  */
 bool is_root(void);
+
+/**
+ * @brief Check if the path is a directory
+ */
+bool is_dir(const char *path);
+
 /**
  * @brief Run a systemctl command with the informed parameters.
  */


### PR DESCRIPTION
When using "diagnose --picky --picky-tree /fake/path" swupd was exiting
with error code 34 (SWUPD_OUT_OF_MEMORY_ERROR) which was incorrect.

This commit fixes the issue by returning the correct code 29
(SWUPD_COULDNT_LIST_DIR) in those situations.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>