### PR TITLE
Prevent swupd from running interactive commands. 

### DIFF
--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -58,7 +58,6 @@ int run_command_full_params(const char *stdout_file, const char *stderr_file, ch
 {
 	int pid, ret, child_ret;
 	const char *cmd = params[0];
-	;
 
 	pid = fork();
 	if (pid < 0) {

--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -58,6 +58,7 @@ int run_command_full_params(const char *stdout_file, const char *stderr_file, ch
 {
 	int pid, ret, child_ret;
 	const char *cmd = params[0];
+	int null_fd;
 
 	pid = fork();
 	if (pid < 0) {
@@ -79,6 +80,13 @@ int run_command_full_params(const char *stdout_file, const char *stderr_file, ch
 	}
 
 	// Child
+
+	/* replace the stdin with /dev/null. the underlying commands should never be
+	 * run interactively. */
+	null_fd = open("/dev/null", O_RDONLY);
+	dup2(null_fd, 0);
+	close(null_fd);
+
 	if (replace_fd(STDOUT_FILENO, stdout_file) < 0) {
 		goto error_child;
 	}


### PR DESCRIPTION
Replace stdin with /dev/null for children. This addresses the issue with
hangs when running update hooks which for whatever reason may expect
interactive input.