### PR TITLE
curl: Don't look at content_url and version_url on is_url_allowed() f…

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -200,8 +200,9 @@ int swupd_curl_init(void)
 		return -1;
 	}
 
-	/* enforce the use of https */
-	if (!is_url_allowed(NULL)) {
+	/* enforce the use of https or file */
+	if (!is_url_allowed(version_url) ||
+	    (strcmp(content_url, version_url) != 0 && !is_url_allowed(content_url))) {
 		return -1;
 	}
 

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -1018,19 +1018,7 @@ void print_regexp_error(int errcode, regex_t *regexp)
 
 bool is_url_allowed(char *url)
 {
-	bool insecure = false;
-
-	if (url) {
-		if (strncmp(url, "http://", 7) == 0) {
-			insecure = true;
-		}
-	} else {
-		if (strncmp(version_url, "http://", 7) == 0 || strncmp(content_url, "http://", 7) == 0) {
-			insecure = true;
-		}
-	}
-
-	if (insecure) {
+	if (strncmp(url, "http://", 7) == 0) {
 		if (allow_insecure_http) {
 			warn("This is an insecure connection\n");
 			info("The --allow-insecure-http flag was used, be aware that this poses a threat to the system\n\n");


### PR DESCRIPTION
…unction

Instead of using the globals content_url and version_url in is_url_allowed()
we could use them in the function that calls it so is_url_allowed() is more
generic.