### PR TITLE
Warn user setting mirror to http

### DIFF
--- a/src/mirror.c
+++ b/src/mirror.c
@@ -200,6 +200,15 @@ static enum swupd_code set_mirror_url(char *url)
 		goto out;
 	}
 
+	/* if mirror is http, warn user about needing to set
+	 * allow_insecure_http=true in order for auto-update to continue working */
+	if (strncmp(url, "http://", 7) == 0) {
+		warn("The mirror was set up using HTTP. In order for autoupdate "
+		     "to continue working you will need to set allow_insecure_http=true "
+		     "in the swupd configuration file. Alternatively you can set the "
+		     "mirror using HTTPS (recommended)\n\n");
+	}
+
 out:
 	free_string(&content_path);
 	free_string(&version_path);

--- a/test/functional/mirror/mirror-allow-http.bats
+++ b/test/functional/mirror/mirror-allow-http.bats
@@ -52,6 +52,7 @@ global_teardown() {
 	expected_output=$(cat <<-EOM
 		Warning: This is an insecure connection
 		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
+		Warning: The mirror was set up using HTTP. In order for autoupdate to continue working you will need to set allow_insecure_http=true in the swupd configuration file. Alternatively you can set the mirror using HTTPS (recommended)
 		Set upstream mirror to http://example.com/swupd-file
 		Installed version: 10
 		Version URL:       http://example.com/swupd-file

--- a/test/functional/mirror/mirror-json.bats
+++ b/test/functional/mirror/mirror-json.bats
@@ -25,6 +25,7 @@ test_setup() {
 		{ "type" : "start", "section" : "mirror" },
 		{ "type" : "warning", "msg" : "This is an insecure connection " },
 		{ "type" : "info", "msg" : "The --allow-insecure-http flag was used, be aware that this poses a threat to the system  " },
+		{ "type" : "warning", "msg" : "The mirror was set up using HTTP. In order for autoupdate to continue working you will need to set allow_insecure_http=true in the swupd configuration file. Alternatively you can set the mirror using HTTPS (recommended)  " },
 		{ "type" : "info", "msg" : "Set upstream mirror to http://example.com/swupd-file " },
 		{ "type" : "info", "msg" : "Installed version: 10 " },
 		{ "type" : "info", "msg" : "Version URL:       http://example.com/swupd-file " },


### PR DESCRIPTION
If a user sets a mirror that uses http, it is going to cause autoupdates
to stop working since autoupdate would need the --allow-insecure-http
flag to continue with the insecure connection. In order for autoupdate
to work the user will need to add the key/value allow-insecure-http=true
in the swupd config file.

This commit warns the user about this when setting up a mirror with http
so they can take steps to re-enable autoupdate.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>