### PR TITLE
Wait until the config file is deleted in tests

### DIFF
--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -249,9 +249,22 @@ validate_param() {
 validate_number() {
 
 	local param=$1
-	if ! [[ $param =~ ^[0-9]+([.][0-9]+)?$ ]] ; then
+	if ! [[ $param =~ ^[0-9]+([.][0-9]+)?$ ]]; then
 		terminate "Bad parameter provided, expecting a number"
 	fi
+
+}
+
+wait_for_deletion() {
+
+	local param=$1
+	local timeout=5  # arbitrary timeout
+	local wait_milisecs=0
+
+	until [ $((wait_milisecs / 1000)) -eq "$timeout" ] || [ ! -e "$param" ]; do
+		sleep 0.1
+		wait_milisecs=$((wait_milisecs + 100))
+	done
 
 }
 
@@ -1658,6 +1671,10 @@ create_config_file() { # swupd_function
 destroy_config_file() { # swupd_function
 
 	rm -rf "$SWUPD_CONFIG_DIR"
+	# we need to make sure the config file is deleted before
+	# another test is run so it does not interfere with it since
+	# the config file is common and shared by all commands
+	wait_for_deletion "$SWUPD_CONFIG_DIR"
 
 }
 


### PR DESCRIPTION
When running tests that use the config file, it is important to make
sure the config file from the previous test is deleted before the next
test is run. This is necessary since config files are not contained to
the test environment of each test as the rest of the test resources. So
a config file from one test can affect the output of another test if we
don't wait.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>