### PR TITLE
Fix bug in mirror-allow-http.bats test

### DIFF
--- a/test/functional/mirror/mirror-allow-http.bats
+++ b/test/functional/mirror/mirror-allow-http.bats
@@ -82,7 +82,7 @@ global_teardown() {
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --allow-insecure-http -u http://cdn.download.clearlinux.org/update"
 
 	# Error is because server doesn't respond to this manifest, but connection was created
-	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
+	assert_status_is_not "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Warning: This is an insecure connection
 		The --allow-insecure-http flag was used, be aware that this poses a threat to the system


### PR DESCRIPTION
This test is yielding different results depending on if it is being run
in a system that has a proxy set up o there is no proxy.
This is happening because when usnig a non existing  server, if
there is a proxy set up, the proxy does respond during curl
initialization instead of the specified server, which allows swupd to
initialize only to fail further down the process when requesting the MoM
to the server. If the system where the test is run doesn't have a proxy
set up, curl fails to initialize since it gets no reply from the server,
which causes swupd to fail initialization, so swupd exits earlier in the
process and with different exit code.

This commit fixes the ambiguity of the test by not checking for an exit
code explicitelly but only making sure it does get an error code.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>