### PR TITLE
also-add: Update, diagnose and repair shoudn't consider the also-add …

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -218,6 +218,7 @@ BATS = \
 	test/functional/checkupdate/chk-update-no-target-content.bats \
 	test/functional/checkupdate/chk-update-slow-server.bats \
 	test/functional/checkupdate/chk-update-version-match.bats \
+	test/functional/diagnose/diagnose-also-add.bats \
 	test/functional/diagnose/diagnose-basics.bats \
 	test/functional/diagnose/diagnose-boot-file.bats \
 	test/functional/diagnose/diagnose-client-certificate.bats \
@@ -232,6 +233,7 @@ BATS = \
 	test/functional/mirror/mirror-createdir-negative.bats \
 	test/functional/mirror/mirror-createdir.bats \
 	test/functional/mirror/mirror-json.bats \
+	test/functional/os-install/install-also-add.bats \
 	test/functional/os-install/install-bad.bats \
 	test/functional/os-install/install-basics.bats \
 	test/functional/os-install/install-json.bats \
@@ -252,6 +254,7 @@ BATS = \
 	test/functional/repair/repair-format-mismatch-overdrive.bats \
 	test/functional/repair/repair-format-mismatch.bats \
 	test/functional/repair/repair-ghosted.bats \
+	test/functional/repair/repair-ignore-also-add.bats \
 	test/functional/repair/repair-json.bats \
 	test/functional/repair/repair-missing-file.bats \
 	test/functional/repair/repair-no-disk-space.bats \
@@ -282,6 +285,7 @@ BATS = \
 	test/functional/update/update-client-certificate.bats \
 	test/functional/update/update-download.bats \
 	test/functional/update/update-fail-to-get-mom.bats \
+	test/functional/update/update-ignore-also-add.bats \
 	test/functional/update/update-include-old-bundle-with-tracked-file.bats \
 	test/functional/update/update-include-old-bundle.bats \
 	test/functional/update/update-include.bats \

--- a/src/update.c
+++ b/src/update.c
@@ -692,6 +692,9 @@ enum swupd_code update_main(int argc, char **argv)
 		print_help();
 		return SWUPD_INVALID_OPTION;
 	}
+
+	/* Update should always ignore optional bundles */
+	skip_optional_bundles = true;
 	progress_init_steps("update", steps_in_update);
 
 	ret = swupd_init(SWUPD_ALL);

--- a/src/verify.c
+++ b/src/verify.c
@@ -700,6 +700,12 @@ enum swupd_code verify_main(void)
 		goto clean_args_and_exit;
 	}
 
+	/* Unless we are installing a new bundle we shoudn't include optional
+	* bundles to the bundle list. */
+	if (!cmdline_option_install) {
+		skip_optional_bundles = true;
+	}
+
 	/* Get the current system version and the version to verify against */
 	timelist_timer_start(global_times, "Get versions");
 	progress_set_step(1, "get_versions");

--- a/test/functional/bundleadd/add-also-add-flag.bats
+++ b/test/functional/bundleadd/add-also-add-flag.bats
@@ -25,7 +25,7 @@ test_setup() {
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1"
 
-	assert_status_is 0
+	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		No packs need to be downloaded
@@ -53,7 +53,7 @@ test_setup() {
 
 	run sudo sh -c "$SWUPD bundle-add --skip-optional $SWUPD_OPTS test-bundle1"
 
-	assert_status_is 0
+	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		No packs need to be downloaded

--- a/test/functional/diagnose/diagnose-also-add.bats
+++ b/test/functional/diagnose/diagnose-also-add.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+
+# Author: Otavio Pontes
+# Email: otavio.pontes@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n test-bundle1 -f /foo/test-file1 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /bar/test-file2 "$TEST_NAME"
+	create_bundle -n test-bundle3 -f /bar/test-file3 "$TEST_NAME"
+
+	# Create bundle dependencies
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.os-core test-bundle1
+	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.os-core test-bundle2
+	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle1 test-bundle3
+
+}
+
+@test "DIA013: Diagnose a system that has a missing also-add" {
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Checking for missing files
+		.* Missing file: .*/target-dir/foo
+		.* Missing file: .*/target-dir/foo/test-file1
+		.* Missing file: .*/target-dir/usr/share/clear/bundles/test-bundle1
+		Checking for corrupt files
+		Checking for extraneous files
+		Inspected 5 files
+		  3 files were missing
+		Use "swupd repair" to correct the problems in the system
+		Diagnose successful
+
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}
+
+@test "DIA014: Diagnose a system after a bundle-remove of an also-add" {
+
+	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1"
+	assert_status_is "$SWUPD_OK"
+	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGETDIR"/foo/test-file1
+	assert_file_exists "$TARGETDIR"/bar/test-file3
+
+	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle3"
+	assert_status_is "$SWUPD_OK"
+	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGETDIR"/foo/test-file1
+	assert_file_not_exists "$TARGETDIR"/bar/test-file3
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Checking for missing files
+		Checking for corrupt files
+		Checking for extraneous files
+		Inspected 5 files
+		Diagnose successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+}

--- a/test/functional/os-install/install-also-add.bats
+++ b/test/functional/os-install/install-also-add.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+# Author: Otavio Pontes
+# Email: otavio.pontes@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n test-bundle1 -f /foo/test-file1 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /bar/test-file2 "$TEST_NAME"
+	create_bundle -n test-bundle3 -f /bar/test-file3 "$TEST_NAME"
+
+	# Create bundle dependencies
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.os-core test-bundle1
+	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.os-core test-bundle2
+	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle2 test-bundle3
+
+}
+
+@test "INS014: Install should include also-add bundles" {
+
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH --path $TARGETDIR"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Installing OS version 10 (latest)
+		Downloading packs for:
+		 - test-bundle2
+		 - test-bundle3
+		 - test-bundle1
+		 - os-core
+		Finishing packs extraction...
+		Checking for corrupt files
+		No extra files need to be downloaded
+		Installing base OS and selected bundles
+		Inspected 10 files
+		  8 files were missing
+		    8 of 8 missing files were installed
+		    0 of 8 missing files were not installed
+		Calling post-update helper scripts
+		Installation successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGETDIR"/foo/test-file1
+	assert_file_exists "$TARGETDIR"/bar/test-file2
+	assert_file_exists "$TARGETDIR"/bar/test-file3
+
+}

--- a/test/functional/repair/repair-ignore-also-add.bats
+++ b/test/functional/repair/repair-ignore-also-add.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+# Author: Otavio Pontes
+# Email: otavio.pontes@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n test-bundle1 -f /foo/test-file1 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /bar/test-file2 "$TEST_NAME"
+	create_bundle -n test-bundle3 -f /bar/test-file3 "$TEST_NAME"
+
+	# Create bundle dependencies
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.os-core test-bundle1
+	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.os-core test-bundle2
+	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle1 test-bundle3
+
+}
+
+@test "REP031: Repairs a system that has a missing also-add" {
+
+	run sudo sh -c "$SWUPD repair $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Checking for corrupt files
+		Starting download of remaining update content. This may take a while...
+		Adding any missing files
+		.* Missing file: .*/target-dir/foo -> fixed
+		.* Missing file: .*/target-dir/foo/test-file1 -> fixed
+		.* Missing file: .*/target-dir/usr/share/clear/bundles/test-bundle1 -> fixed
+		Repairing corrupt files
+		Removing extraneous files
+		Inspected 5 files
+		  3 files were missing
+		    3 of 3 missing files were replaced
+		    0 of 3 missing files were not replaced
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGETDIR"/foo/test-file1
+	assert_file_not_exists "$TARGETDIR"/bar/test-file2
+
+}
+
+@test "REP032: Repairs a system after removing an also-add" {
+
+	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1"
+	assert_status_is "$SWUPD_OK"
+	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGETDIR"/foo/test-file1
+	assert_file_exists "$TARGETDIR"/bar/test-file3
+
+	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle3"
+	assert_status_is "$SWUPD_OK"
+	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGETDIR"/foo/test-file1
+	assert_file_not_exists "$TARGETDIR"/bar/test-file3
+
+	run sudo sh -c "$SWUPD repair $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Checking for corrupt files
+		Adding any missing files
+		Repairing corrupt files
+		Removing extraneous files
+		Inspected 5 files
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGETDIR"/foo/test-file1
+	assert_file_not_exists "$TARGETDIR"/bar/test-file3
+
+}

--- a/test/functional/update/update-ignore-also-add.bats
+++ b/test/functional/update/update-ignore-also-add.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+# Author: Otavio Pontes
+# Email: otavio.pontes@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	# create the test env with two bundles (one installed)
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle1 -f /foo/testfile1 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /bar/testfile2 "$TEST_NAME"
+	# create a new version 100
+	create_version -p "$TEST_NAME" 100 10
+	# modify test-bundle1 and test-bundle2
+	update_bundle "$TEST_NAME" test-bundle1 --update /foo/testfile1
+	update_bundle "$TEST_NAME" test-bundle2 --update /bar/testfile2
+
+	# add dependencies
+	add_dependency_to_manifest -o "$WEBDIR"/100/Manifest.test-bundle1 test-bundle2
+
+}
+
+@test "UPD057: Update a system where nested dependencies are added in the newer version" {
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Update started.
+		Preparing to update from 10 to 100
+		Downloading packs for:
+		 - test-bundle1
+		Finishing packs extraction...
+		Statistics for going from version 10 to version 100:
+		    changed bundles   : 1
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 1
+		    new files         : 0
+		    deleted files     : 0
+		No extra files need to be downloaded
+		Staging file content
+		Applying update
+		Update was applied.
+		Calling post-update helper scripts
+		Update successful. System updated from version 10 to version 100
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/foo/testfile1
+	assert_file_not_exists "$TARGETDIR"/bar/testfile2
+
+}


### PR DESCRIPTION
…bundles

In the case that we have a bundle installed as also-add and removed later,
repair shouldn't reinstall that bundle. The same is valid for diagnose and update.
Os-install is the only exception. We should always install all bundles that are
listed as also-add in os-install.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>