### PR TITLE
Adding flag validation to the swupd build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
         include:
                 - stage: "Static Analysis"
                   name: "Static Analysis & Unit Tests"
-                  script: make compliant && make shellcheck && sudo sh -c 'umask 0022 && make unit-check' && make docs-coverage
+                  script: make compliant && make shellcheck && make check-flags && sudo sh -c 'umask 0022 && make unit-check' && make docs-coverage
                 - stage: test
                   name: "Functional Tests - update (group 1)"
                   script: env TESTS="$GROUP1" make -e check

--- a/Makefile.am
+++ b/Makefile.am
@@ -412,6 +412,7 @@ shellcheck:
 
 shellcheck-all:
 	shellcheck swupd.bash
+	shellcheck scripts/flag_validator.bash
 	find -name "*.bats" -exec sh -c "\
 		echo checking {}; \
 		sed 's/^@.*/func() {/' {} | \
@@ -421,6 +422,9 @@ shellcheck-all:
 
 check-test-ids:
 	test/functional/check_ids.bash
+
+check-flags:
+	scripts/flag_validator.bash
 
 release:
 	@git rev-parse v$(PACKAGE_VERSION) &> /dev/null; \

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -168,7 +168,7 @@ SUBCOMMANDS
         are available. It will return 0 with succeeded and a different value
         of 0 with failed.
 
-    - `-d, --deps={bundle}`
+    - `--deps={bundle}`
 
         Lists all bundle dependencies of the passed bundle, including
         recursively included bundles.
@@ -281,7 +281,7 @@ SUBCOMMANDS
         <path>/etc/swupd/mirror_contenturl and
         <path>/etc/swupd/mirror_versionurl
 
-    - `-u, --unset`
+    - `-U, --unset`
 
         Remove the content and version URL configuration by removing
         <path>/etc/swupd
@@ -378,7 +378,7 @@ SUBCOMMANDS
 
             Only runs the repair operation on the os-core and vi bundles.
 
-``search {string}``
+``search-file {string}``
 
     Search for matching paths in manifest data. The specified {string}
     is matched in any part of the path listed in manifests, and all
@@ -396,7 +396,7 @@ SUBCOMMANDS
 
         Restrict search to designated dynamic shared library paths.
 
-    - `-b, --binary`
+    - `-B, --binary`
 
         Restrict search to designated program binary paths.
 
@@ -433,7 +433,7 @@ SUBCOMMANDS
         available on the version url server, and what version number is
         available.
 
-    - `-d, --download`
+    - `--download`
 
         Do not perform an update, instead download all resources needed
         to perform the update, and exit.

--- a/scripts/flag_validator.bash
+++ b/scripts/flag_validator.bash
@@ -1,0 +1,183 @@
+#!/bin/bash
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SWUPD_DIR="$SCRIPTS_DIR"/..
+SWUPD="$SWUPD_DIR"/swupd
+
+swupd_commands=(info autoupdate check-update update bundle-add bundle-remove bundle-list search-file diagnose repair os-install mirror clean hashdump)
+conflict=0
+
+count_global_flags() {
+
+	sudo "$SWUPD" info --help | grep -oe "-.," | cut -c2 | wc -l
+
+}
+
+get_global_flags() {
+
+	sudo "$SWUPD" info --help | grep -oe "-.," | cut -c2 | tr '\n' ' '
+
+}
+
+count_command_flags() {
+
+	local command=$1
+	sudo "$SWUPD" "$command" --help | sed -n '/^Options:/,$p' | grep -oe "-.," | cut -c2 | wc -l
+
+}
+
+get_command_flags() {
+
+	local command=$1
+	sudo "$SWUPD" "$command" --help | sed -n '/^Options:/,$p' | grep -oe "-.," | cut -c2 | tr '\n' ' '
+
+}
+
+find_global_flag_conflict() {
+
+	local flags_count
+	local unique_flags_count
+
+	# global flags have to be compared only against other global flags
+	flags_count=$(count_global_flags)
+	unique_flags_count=$(get_global_flags | tr ' ' '\n' | sort -u | wc -l)
+	if [ "$flags_count" != "$unique_flags_count" ]; then
+		echo "Conflict found: There is a duplicated global flag"
+		conflict=1
+	fi
+
+}
+
+find_command_flag_conflict() {
+
+	local command=$1
+	local flags_count
+	local unique_flags_count
+	declare -a local_flags
+	declare -a global_flags
+
+	# first let's make sure there are no duplicated local flags
+	flags_count=$(count_command_flags "$command")
+	unique_flags_count=$(get_command_flags "$command" | tr ' ' '\n' | sort -u | wc -l)
+	if [ "$flags_count" != "$unique_flags_count" ]; then
+		echo "Conflict found: There is a duplicated flag in the $command command"
+		conflict=1
+	fi
+
+	# local flags have to be compared against global flags too
+	IFS=" " read -r -a global_flags <<< "$(get_global_flags)"
+	IFS=" " read -r -a local_flags <<< "$(get_command_flags "$command")"
+	for local_flag in "${local_flags[@]}"; do
+		for global_flag in "${global_flags[@]}"; do
+			if [ "$local_flag" == "$global_flag" ]; then
+				echo "Conflict found: The flag '-$local_flag' from 'swupd $command' already exists as a global flag"
+				conflict=1
+			fi
+		done
+	done
+
+}
+
+validate_existing_flags() {
+
+	find_global_flag_conflict
+
+	for cmd in "${swupd_commands[@]}"; do
+		find_command_flag_conflict "$cmd"
+	done
+
+	if [ "$conflict" -eq 1 ]; then
+		exit 1
+	fi
+	echo "No conflicts found with the flags"
+
+}
+
+validate_flag() {
+
+	local command=$1
+	local cmd_flag=$2
+	declare -a flags
+
+	find_global_flag_conflict
+	IFS=" " read -r -a flags <<< "$(get_global_flags)"
+	for f in "${flags[@]}"; do
+		if [ "$cmd_flag" == "$f" ]; then
+			echo "Conflict found: The flag '-$f' from 'swupd $command' already exists as a global flag"
+			exit 1
+		fi
+	done
+
+	if [ "$command" != "global" ]; then
+		find_command_flag_conflict "$command"
+		IFS=" " read -r -a flags <<< "$(get_command_flags "$command")"
+		for f in "${flags[@]}"; do
+			if [ "$cmd_flag" == "$f" ]; then
+				echo "Conflict found: The flag '-$f' already exists in 'swupd $command'"
+				exit 1
+			fi
+		done
+	fi
+
+	echo "No conflicts found with the 'swupd $command -$cmd_flag' flag"
+
+}
+
+usage() {
+
+	cat <<-EOM
+
+		Validates that the flags used in swupd are not duplicated
+
+		Usage:
+		    flag_validator.bash <command> <flag>
+
+		Example:
+		    flag_validator.bash bundle-add w
+
+		Notes:
+		    If run with no argument, it validates the existing flags
+		    If run with the <command> <flag> arguments, it validate that <flag> is a valid option for <command>
+		    If <flag> is a global option, use "global <flag>"
+
+	EOM
+
+}
+
+# Entry point
+arg=$1
+flag=$2
+
+if [ "$arg" == "--help" ] || [ "$arg" == "-h" ]; then
+	usage
+	exit
+fi
+
+# If run with no argument, it validates the existing flags
+if [ -z "$arg" ]; then
+	validate_existing_flags
+	exit
+fi
+
+# If run with the <command> <flag> arguments, it validates
+# that <flag> is a valid option for <command>
+if [ -z "$flag" ]; then
+	echo "Error: Mandatory argument missing"
+	usage
+	exit 1
+fi
+
+swupd_commands+=("global")
+for val in "${swupd_commands[@]}"; do
+	if [ "$val" == "$arg" ]; then
+		# remove the '-' if it has one
+		flag=$(echo "$flag" | tr --delete '-')
+		validate_flag "$arg" "$flag"
+		exit "$conflict"
+	fi
+done
+
+echo "Error: The provided command '$arg' is invalid"
+echo "Available commands:"
+echo "${swupd_commands[@]}" | tr ' ' '\n'
+exit 1

--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -28,6 +28,8 @@
 #include "config.h"
 #include "swupd.h"
 
+#define DEPS_FLAG 1000
+
 static bool cmdline_option_all = false;
 static char *cmdline_option_has_dep = NULL;
 static char *cmdline_option_deps = NULL;
@@ -54,14 +56,14 @@ static void print_help(void)
 
 	print("Options:\n");
 	print("   -a, --all               List all available bundles for the current version of Clear Linux\n");
-	print("   -d, --deps=[BUNDLE]     List bundles included by BUNDLE\n");
 	print("   -D, --has-dep=[BUNDLE]  List dependency tree of all bundles which have BUNDLE as a dependency\n");
+	print("   --deps=[BUNDLE]         List bundles included by BUNDLE\n");
 	print("\n");
 }
 
 static const struct option prog_opts[] = {
 	{ "all", no_argument, 0, 'a' },
-	{ "deps", required_argument, 0, 'd' },
+	{ "deps", required_argument, 0, DEPS_FLAG },
 	{ "has-dep", required_argument, 0, 'D' },
 };
 
@@ -77,7 +79,7 @@ static bool parse_opt(int opt, char *optarg)
 		atexit(free_has_dep);
 		cmdline_local = false;
 		return true;
-	case 'd':
+	case DEPS_FLAG:
 		string_or_die(&cmdline_option_deps, "%s", optarg);
 		atexit(free_deps);
 		cmdline_local = false;

--- a/src/mirror.c
+++ b/src/mirror.c
@@ -44,13 +44,13 @@ static void print_help(void)
 
 	print("Options:\n");
 	print("   -s, --set               set mirror url\n");
-	print("   -u, --unset             unset mirror url\n");
+	print("   -U, --unset             unset mirror url\n");
 	print("\n");
 }
 
 static const struct option prog_opts[] = {
 	{ "set", required_argument, 0, 's' },
-	{ "unset", no_argument, 0, 'u' },
+	{ "unset", no_argument, 0, 'U' },
 };
 
 static bool parse_opt(int opt, char *optarg)
@@ -63,7 +63,7 @@ static bool parse_opt(int opt, char *optarg)
 		}
 		set = optarg;
 		return true;
-	case 'u':
+	case 'U':
 		if (set != NULL) {
 			error("cannot set and unset at the same time\n");
 			return false;

--- a/src/search.c
+++ b/src/search.c
@@ -488,7 +488,7 @@ static void print_help(void)
 
 	print("Options:\n");
 	print("   -l, --library           Search paths where libraries are located for a match\n");
-	print("   -b, --binary            Search paths where binaries are located for a match\n");
+	print("   -B, --binary            Search paths where binaries are located for a match\n");
 	print("   -T, --top=[NUM]         Only display the top NUM results for each bundle\n");
 	print("   -m, --csv               Output all results in CSV format (machine-readable)\n");
 	print("   -i, --init              Download all manifests then return, no search done\n");
@@ -498,7 +498,7 @@ static void print_help(void)
 }
 
 static const struct option prog_opts[] = {
-	{ "binary", no_argument, 0, 'b' },
+	{ "binary", no_argument, 0, 'B' },
 	{ "csv", no_argument, 0, 'm' },
 	{ "init", no_argument, 0, 'i' },
 	{ "library", no_argument, 0, 'l' },
@@ -538,7 +538,7 @@ static bool parse_opt(int opt, char *optarg)
 	case 'i':
 		init = true;
 		return true;
-	case 'b':
+	case 'B':
 		search_type |= SEARCH_TYPE_BIN;
 		return true;
 	default:


### PR DESCRIPTION
swupd supports global flags and supports local flags that are specific
to subcommands. Flags that are specific to subcommands can be reused in
a different subcommand. Global flags should be unique and should not be
reused as local flags to avoid conflicts.

This commit adds a bash script that checks that the flags currently used
in swupd are valid (have no conflicts with other flags from the same
command or with the global flags). This script will be run as part of
the build process so in case an invalid flag is found the build will be
stopped. Alternatively, the script can be used by developers to validate
a new flag during the implementation time.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>