### PR TITLE
test: Add missing NULL parameter to run_command() call

### DIFF
--- a/test/unit/test_signature.c
+++ b/test/unit/test_signature.c
@@ -33,7 +33,7 @@ static int sign(const char *private_key, const char *public_key, const char *fil
 	ret = run_command("/usr/bin/openssl", "smime", "-sign",
 			   "-binary", "-in", file, "-signer", public_key,
 			   "-inkey", private_key, "-outform", "DER", "-out",
-			   file_sig);
+			   file_sig, NULL);
 
 	if (ret != 0) {
 		print_error("Sign failed");


### PR DESCRIPTION
Last parameter was missing on a run_command() call and tests were breaking for some specific configurations.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>