### PR TITLE
bundle: Support circular includes/also-adds

### DIFF
--- a/src/update.c
+++ b/src/update.c
@@ -162,7 +162,7 @@ int add_included_manifests(struct manifest *mom, struct list **subs)
 
 	/* Pass the current version here, not the new, otherwise we will never
 	 * hit the Manifest delta path. */
-	ret = add_subscriptions(subbed, subs, mom, false, 0);
+	ret = add_subscriptions(subbed, subs, mom, true, 0);
 	if (ret & (add_sub_ERR | add_sub_BADNAME)) {
 		ret = -ret;
 	} else {

--- a/test/functional/bundleadd/add-also-add-flag.bats
+++ b/test/functional/bundleadd/add-also-add-flag.bats
@@ -11,9 +11,13 @@ test_setup() {
 	create_bundle -n test-bundle1 -f /foo/test-file1 "$TEST_NAME"
 	create_bundle -n test-bundle2 -f /bar/test-file2 "$TEST_NAME"
 	create_bundle -n test-bundle3 -f /baz/test-file3 "$TEST_NAME"
+	create_bundle -n test-bundle4 -f /bat/test-file4 "$TEST_NAME"
 	# add test-bundle2 as a dependency of test-bundle1 and test-bundle3 as optional
 	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
 	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle1 test-bundle3
+	# add circular dependency for also-add
+	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle3 test-bundle4
+	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle4 test-bundle3
 
 }
 
@@ -22,14 +26,20 @@ test_setup() {
 	# An optional bundle is not required to be installed in the system while includes
 	# are. Swupd will install optional bundles on bundle-add unless specified otherwise
 	# by using the --skip--optional flag.
+	# circular reference between also-add should be allowed
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
-		No packs need to be downloaded
-		Starting download of remaining update content. This may take a while...
+		Downloading packs for:
+		 - test-bundle4
+		 - test-bundle3
+		 - test-bundle2
+		 - test-bundle1
+		Finishing packs extraction...
+		No extra files need to be downloaded
 		Installing bundle(s) files...
 		Calling post-update helper scripts
 		Successfully installed 1 bundle

--- a/test/functional/os-install/install-also-add.bats
+++ b/test/functional/os-install/install-also-add.bats
@@ -27,8 +27,8 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Installing OS version 10 (latest)
 		Downloading packs for:
-		 - test-bundle2
 		 - test-bundle3
+		 - test-bundle2
 		 - test-bundle1
 		 - os-core
 		Finishing packs extraction...

--- a/test/functional/update/update-include.bats
+++ b/test/functional/update/update-include.bats
@@ -42,12 +42,12 @@ test_setup() {
 		Update started.
 		Preparing to update from 10 to 100
 		Downloading packs for:
-		 - test-bundle3
-		 - test-bundle4
 		 - test-bundle6
 		 - test-bundle5
-		 - test-bundle2
+		 - test-bundle4
 		 - test-bundle7
+		 - test-bundle2
+		 - test-bundle3
 		 - test-bundle1
 		Finishing packs extraction...
 		Statistics for going from version 10 to version 100:


### PR DESCRIPTION
Circular includes shoudn't exist, but we can handle that without crashing.
Also-add circular includes are common and expected. So we just add the
first occurence found.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>