### PR TITLE
Progress overlap

### DIFF
--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -38,6 +38,14 @@ static void log_internal(FILE *out, const char *file, int line, const char *labe
 	struct tm *timeinfo;
 	int printed;
 
+	/* if the message starts with '\n' add a line break before the message */
+	while (strncmp(format, "\n", 1) == 0 || strncmp(format, "\r", 1) == 0) {
+		if (out == stdout || out == stderr) {
+			fprintf(out, "%c", format[0]);
+		}
+		format++;
+	}
+
 	// In debug mode, print more information
 	if (cur_log_level == LOG_DEBUG) {
 		time_t currtime;
@@ -55,6 +63,7 @@ static void log_internal(FILE *out, const char *file, int line, const char *labe
 		fprintf(out, "%s: ", label);
 	}
 	vfprintf(out, format, args_list);
+	fflush(out);
 }
 
 void log_set_level(int log_level)

--- a/src/lib/progress.c
+++ b/src/lib/progress.c
@@ -113,7 +113,7 @@ void progress_report(double count, double max)
 			if (progress_function) {
 				progress_function(step.description, step.current, step.total, percentage);
 			} else {
-				info("\r\t...%d%%", percentage);
+				info("\t...%d%%", percentage);
 				if (!isatty(fileno(stdout))) {
 					/* if not in a tty add new lines so every percentage
 					 * is in its own line */
@@ -121,6 +121,8 @@ void progress_report(double count, double max)
 				} else if (percentage == 100) {
 					/* add a line break once we reach 100% */
 					info("\n");
+				} else {
+					info("\r");
 				}
 			}
 			fflush(stdout);

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -3252,7 +3252,7 @@ use_ignore_list() {
 	# if selected, remove things in the ignore list from the actual output
 	if [ "$ignore_enabled" = true ]; then
 		# always remove blank lines, lines with only dots and lines with progress percentage
-		filtered_output=$(echo "$output" | sed -E '/^$/d' | sed -E '/^\.+$/d' | sed -E '/^.\t\.\.\.[0-9]{1,3}%$/d')
+		filtered_output=$(echo "$output" | sed -E '/^$/d' | sed -E '/^\.+$/d' | sed -E '/^\t\.\.\.[0-9]{1,3}%$/d')
 		# now remove lines that are included in any of the ignore-lists
 		# there are 3 possible ignore-lists that the function is going
 		# to recognize (in order of precedence):


### PR DESCRIPTION
Fix format of do_staging when reporting progress

The function do_staging is regularly used within a loop to stage all the files for a given bundle-add or update, repair, etc. However when the loop contains a progress report (with a percentage), if there are errors in the do_staging function, they get printed in the same line as the percentage, messing up the output. Like this:

    ...22%Warning: Update target directory does not exist: some_file...

This commit fixes that output by adding a carriage return at the beginning of each message do_staging could print so it would overlap with the percentage value effectively deleting it.