### PR TITLE
Use lowercase URL comparison for is_url_allowed()

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -1028,7 +1028,7 @@ void print_regexp_error(int errcode, regex_t *regexp)
 
 bool is_url_allowed(char *url)
 {
-	if (strncmp(url, "http://", 7) == 0) {
+	if (strncasecmp(url, "http://", 7) == 0) {
 		if (allow_insecure_http) {
 			warn("This is an insecure connection\n");
 			info("The --allow-insecure-http flag was used, be aware that this poses a threat to the system\n\n");


### PR DESCRIPTION
The URL value must be set to lowercase to prevent support for mixed case
or uppercase HTTP strings without the --allow-insecure-http flag.

Signed-off-by: John Akre <john.w.akre@intel.com>