### PR TITLE
Adding --wait-for-scripts flag

### DIFF
--- a/config
+++ b/config
@@ -79,6 +79,8 @@
 # Don't report progress (boolean value)
 #no_progress=<true/false>
 
+# Wait for the post-update scripts to complete (boolean value)
+#wait_for_scripts=<true/false>
 
 
 #

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -129,6 +129,10 @@ used to modify the core behavior and resources that swupd uses.
 
    Don't print progress report on commands that informs the percentage left in current operation.
 
+- ``--wait-for-scripts``
+
+   Wait for the post-update scripts to complete
+
 SUBCOMMANDS
 ===========
 

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -1042,7 +1042,7 @@ static enum swupd_code install_bundles(struct list *bundles, struct list **subs,
 	/* step 7: Run any scripts that are needed to complete update */
 	timelist_timer_start(global_times, "Run Scripts");
 	progress_set_step(7, "run_scripts");
-	scripts_run_post_update(false);
+	scripts_run_post_update(wait_for_scripts);
 	timelist_timer_stop(global_times); // closing: Run Scripts
 	progress_complete_step();
 

--- a/src/globals.c
+++ b/src/globals.c
@@ -35,6 +35,7 @@
 #include "swupd.h"
 
 #define NO_PROGRESS 1000
+#define WAIT_FOR_SCRIPTS 1001
 
 int allow_insecure_http = 0;
 bool allow_mix_collisions = false;
@@ -63,6 +64,7 @@ bool keepcache = false;
 timelist *global_times = NULL;
 int max_retries = 3;
 int retry_delay = 10;
+bool wait_for_scripts = false;
 
 /* NOTE: Today the content and version server urls are the same in
  * all cases.  It is highly likely these will eventually differ, eg:
@@ -623,6 +625,7 @@ static const struct option global_opts[] = {
 	{ "retry-delay", required_argument, 0, 'd' },
 	{ "json-output", no_argument, 0, 'j' },
 	{ "allow-insecure-http", no_argument, &allow_insecure_http, 1 },
+	{ "wait-for-scripts", no_argument, 0, WAIT_FOR_SCRIPTS },
 	{ 0, 0, 0, 0 }
 };
 
@@ -735,14 +738,19 @@ static bool global_parse_opt(int opt, char *optarg)
 			set_json_format(true);
 		}
 		return true;
-
 	case NO_PROGRESS:
 		if (optarg != NULL) {
 			progress_disable(strtobool(optarg));
 		} else {
 			progress_disable(true);
 		}
-
+		return true;
+	case WAIT_FOR_SCRIPTS:
+		if (optarg != NULL) {
+			wait_for_scripts = strtobool(optarg);
+		} else {
+			wait_for_scripts = true;
+		}
 		return true;
 	default:
 		return false;
@@ -813,6 +821,7 @@ void global_print_help(void)
 	print("   --quiet                 Quiet output. Print only important information and errors\n");
 	print("   --debug                 Print extra information to help debugging problems\n");
 	print("   --no-progress           Don't print progress report\n");
+	print("   --wait-for-scripts      Wait for the post-update scripts to complete\n");
 	print("\n");
 }
 

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -177,6 +177,7 @@ extern bool ignore_state;
 extern bool ignore_orphans;
 extern bool no_scripts;
 extern bool no_boot_update;
+extern bool wait_for_scripts;
 extern char *format_string;
 extern char *path_prefix;
 extern bool init_globals(void);

--- a/src/update.c
+++ b/src/update.c
@@ -466,7 +466,7 @@ version_check:
 	if (on_new_format() && (requested_version == -1 || (requested_version > new_current_version))) {
 		re_update = true;
 	}
-	scripts_run_post_update(re_update);
+	scripts_run_post_update(re_update || wait_for_scripts);
 	progress_complete_step();
 	timelist_timer_stop(global_times); // closing: Run post-update scripts
 

--- a/src/verify.c
+++ b/src/verify.c
@@ -1013,7 +1013,7 @@ brick_the_system_and_clean_curl:
 		need_update_bootloader = true;
 		timelist_timer_start(global_times, "Run Scripts");
 		info("\n");
-		scripts_run_post_update(false);
+		scripts_run_post_update(wait_for_scripts);
 		timelist_timer_stop(global_times);
 	}
 

--- a/swupd.bash
+++ b/swupd.bash
@@ -23,7 +23,7 @@ _swupd()
     # $1 is the command being completed, $2 is the current word being expanded
     local opts IFS=$' \t\n'
     local -i i installed
-    local global="--help --url --contenturl --versionurl --port --path --format --nosigcheck --ignore-time --statedir --certpath  --time --no-scripts --no-boot-update --max-parallel-downloads --max-retries --retry-delay --json-output  --allow-insecure-http --debug --quiet --no-progress "
+    local global="--help --url --contenturl --versionurl --port --path --format --nosigcheck --ignore-time --statedir --certpath  --time --no-scripts --no-boot-update --max-parallel-downloads --max-retries --retry-delay --json-output  --allow-insecure-http --debug --quiet --no-progress --wait-for-scripts "
     COMPREPLY=()
     for ((i=COMP_CWORD-1;i>=0;i--))
     do case "${COMP_WORDS[$i]}" in

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -107,6 +107,7 @@ local -a global_opts; global_opts=(
   '(help status -W --max-parallel-downloads)'{-W,--max-parallel-downloads=}'[Set the maximum number of parallel downloads]:downloadThreads:()'
   '(help status -r --max-retries)'{-r,--max-retries=}'[Maximum number of retries for download failures]:maxRetries:()'
   '(help status -d --retry-delay)'{-d,--retry-delay}'[Initial delay between download retries, this will be doubled for each retry]:retryDelay:()'
+  '(help status --wait-for-scripts )--wait-for-scripts[Wait for the post-update scripts to complete]'
 )
 
 _arguments -C \


### PR DESCRIPTION
When running tasks that require to run post update scripts in swupd,
for most users we don't want to wait for the scripts to finish running,
those can be run in the background so we can finish the task faster.
However for some users like DevOps, clr-installer, and QA, it is useful
to have a way to instruct swupd to wait until these scripts have finish
running.

This commit adds a way of doing this by introducing the
--wait-for-scripts flag.

Closes #909

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>