### PR TITLE
Display distribution on swupd info

### DIFF
--- a/src/info.c
+++ b/src/info.c
@@ -29,12 +29,14 @@ enum swupd_code print_update_conf_info()
 	int current_version = get_current_version(path_prefix);
 	bool dist_string_found = get_distribution_string(path_prefix, dist_string);
 
-	if (current_version < 0 || !dist_string_found) {
+	// Set distribution string 'unknown' when not found.
+	info("Distribution:      %s\n", dist_string_found ? dist_string : "unknown");
+
+	if (current_version < 0) {
 		error("Unable to determine current OS version\n");
 		info("Installed version: unknown\n");
 		ret = SWUPD_CURRENT_VERSION_UNKNOWN;
 	} else {
-		info("Distribution:      %s\n", dist_string);
 		info("Installed version: %d\n", current_version);
 	}
 	info("Version URL:       %s\n", version_url);

--- a/src/info.c
+++ b/src/info.c
@@ -25,13 +25,16 @@
 enum swupd_code print_update_conf_info()
 {
 	enum swupd_code ret = SWUPD_OK;
-
+	char dist_string[LINE_MAX];
 	int current_version = get_current_version(path_prefix);
-	if (current_version < 0) {
+	bool dist_string_found = get_distribution_string(path_prefix, dist_string);
+
+	if (current_version < 0 || !dist_string_found) {
 		error("Unable to determine current OS version\n");
 		info("Installed version: unknown\n");
 		ret = SWUPD_CURRENT_VERSION_UNKNOWN;
 	} else {
+		info("Distribution:      %s\n", dist_string);
 		info("Installed version: %d\n", current_version);
 	}
 	info("Version URL:       %s\n", version_url);

--- a/src/lib/config_parser.c
+++ b/src/lib/config_parser.c
@@ -78,32 +78,29 @@ bool config_parse(const char *filename, load_config_fn_t load_config_fn)
 		if (!line_ptr) {
 			/* this is probably a blank line or something unrecognized,
 			 * ignore the line */
-			goto free_data;
+			continue;
 		}
 
 		*line_ptr = '\0';
-		key = strdup_or_die(line);
-		value = strdup_or_die(line_ptr + 1);
+		key = line;
+		value = line_ptr + 1;
 
 		/* make sure we don't have empty key or value pairs */
 		if (key[0] == '\0' || value[0] == '\0') {
 			warn("Invalid key/value pair in the configuration file (key='%s', value='%s')\n", key, value);
-			goto free_data;
+			continue;
 		}
 		/* make sure we don't have more than one '=' per line */
 		line_ptr = strchr(value, '=');
 		if (line_ptr) {
 			warn("Invalid key/value pair in the configuration file ('%s=%s')\n", key, value);
-			goto free_data;
+			continue;
 		}
 
 		/* load the configuration value read in the application */
 		if (!load_config_fn(section, key, value)) {
 			warn("Unrecognized option '%s=%s' from section [%s] in the configuration file\n", key, value, section);
 		}
-	free_data:
-		free_string(&key);
-		free_string(&value);
 	}
 
 	/* we made it this far, config file parsed correctly */

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -209,6 +209,7 @@ extern enum swupd_code walk_tree(struct manifest *, const char *, bool, const re
 extern int get_latest_version(char *v_url);
 extern enum swupd_code read_versions(int *current_version, int *server_version, char *path_prefix);
 extern int get_current_version(char *path_prefix);
+extern bool get_distribution_string(char *path_prefix, char *dist);
 
 extern bool ignore(struct file *file);
 extern void apply_heuristics(struct file *file);

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -91,23 +91,24 @@ local -a global_opts; global_opts=(
   '(help)--debug[Print extra information to help debugging problems]'
   '(help -j --json-output)'{-j,--json-output}'[Print all output as a JSON stream]'
   + options
-  '(help status -p --path)'{-p,--path=}'[Use \[PATH...\] as the path to verify (eg\: a chroot or btrfs subvol)]:path:_path_files -/'
+  '(help status -p --path)'{-p,--path=}'[Use \[PATH\] as the path to verify (eg\: a chroot or btrfs subvol)]:path:_path_files -/'
   '(help status -u --url)'{-u,--url=}'[RFC-3986 encoded url for version string and content file downloads]:url:_urls'
   '(help status -P --port)'{-P,--port=}'[Port number to connect to at the url for version string and content file downloads]:port:_ports'
   '(help status -c --contenturl)'{-c,--contenturl=}'[RFC-3986 encoded url for content file downloads]:url:_urls'
   '(help status -v --versionurl)'{-v,--versionurl=}'[RFC-3986 encoded url for version file downloads]:url:_urls'
   '(help status -F --format)'{-F,--format=}'[\[staging,1,2,etc.\]\:the format suffix for version file downloads]:format:()'
-  '(help status -n --nosigcheck)'{-n,--nosigcheck}'[Do not attempt to enforce certificate or signature checking]'
-  '(help status -I --ignore-time)'{-I,--ignore-time}'[Ignore system/certificate time when validating signature]'
   '(help status -S --statedir)'{-S,--statedir=}'[Specify alternate swupd state directory]:statedir:_path_files -/'
   '(help status -C --certpath)'{-C,--certpath=}'[Specify alternate path to swupd certificates]:certpath:_path_files -/'
-  '(help status -t --time)'{-t,--time}'[Show verbose time output for swupd operations]'
-  '(help status -N --no-scripts)'{-N,--no-scripts}'[Do not run the post-update scripts and boot update tool]'
-  '(help status -b --no-boot-update)'{-b,--no-boot-update}'[Do not install boot files to the boot partition (containers)]'
   '(help status -W --max-parallel-downloads)'{-W,--max-parallel-downloads=}'[Set the maximum number of parallel downloads]:downloadThreads:()'
   '(help status -r --max-retries)'{-r,--max-retries=}'[Maximum number of retries for download failures]:maxRetries:()'
   '(help status -d --retry-delay)'{-d,--retry-delay}'[Initial delay between download retries, this will be doubled for each retry]:retryDelay:()'
-  '(help status --wait-for-scripts )--wait-for-scripts[Wait for the post-update scripts to complete]'
+  '(help status -n --nosigcheck)'{-n,--nosigcheck}'[Do not attempt to enforce certificate or signature checking]'
+  '(help status -I --ignore-time)'{-I,--ignore-time}'[Ignore system/certificate time when validating signature]'
+  '(help status -t --time)'{-t,--time}'[Show verbose time output for swupd operations]'
+  '(help status -N --no-scripts)'{-N,--no-scripts}'[Do not run the post-update scripts and boot update tool]'
+  '(help status -b --no-boot-update)'{-b,--no-boot-update}'[Do not install boot files to the boot partition (containers)]'
+  '(help status)--no-progress[Don`t print progress report]'
+  '(help status)--wait-for-scripts[Wait for the post-update scripts to complete]'
 )
 
 _arguments -C \
@@ -158,7 +159,7 @@ if [[ -n "$state" ]]; then
         update)
           local -a updates; updates=(
             $global_opts
-            '(help status --download )--download[Download all content, but do not actually install the update]'
+            '(help status)--download[Download all content, but do not actually install the update]'
             '(help status -k --keepcache)'{-k,--keepcache}'[Do not delete the swupd state directory content after updating the system]'
             '(help status -T --migrate)'{-T,--migrate}'[Migrate to augmented upstream/mix content]'
             '(help status -a --allow-mix-collisions)'{-a,--allow-mix-collisions}'[Ignore and continue if custom user content conflicts with upstream provided content]'
@@ -172,6 +173,7 @@ if [[ -n "$state" ]]; then
         bundle-add)
           local -a addbundle; addbundle=(
             $global_opts
+            '(help)--skip-optional[Do not install optional bundles (also-add falg in Manifests)]'
             '(help)--skip-diskspace-check[Do not check free disk space before adding bundle]'
             '*:bundle-add:_swupd_bundle_add'
           )

--- a/test/functional/mirror/mirror-allow-http.bats
+++ b/test/functional/mirror/mirror-allow-http.bats
@@ -54,6 +54,7 @@ global_teardown() {
 		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
 		Warning: The mirror was set up using HTTP. In order for autoupdate to continue working you will need to set allow_insecure_http=true in the swupd configuration file. Alternatively you can set the mirror using HTTPS (recommended)
 		Set upstream mirror to http://example.com/swupd-file
+		Distribution:      Clear Linux Software for Intel Architecture
 		Installed version: 10
 		Version URL:       http://example.com/swupd-file
 		Content URL:       http://example.com/swupd-file

--- a/test/functional/mirror/mirror-createdir-negative.bats
+++ b/test/functional/mirror/mirror-createdir-negative.bats
@@ -38,6 +38,7 @@ global_teardown() {
 	expected_output=$(cat <<-EOM
 		.*/etc/swupd: not a directory
 		Warning: Unable to set mirror url
+		Distribution:      Clear Linux Software for Intel Architecture
 		Installed version: 10
 		Version URL:       file://.*/web-dir
 		Content URL:       file://.*/web-dir
@@ -59,6 +60,7 @@ global_teardown() {
 	expected_output=$(cat <<-EOM
 		.*/etc/swupd: not a directory
 		Warning: Unable to set mirror url
+		Distribution:      Clear Linux Software for Intel Architecture
 		Installed version: 10
 		Version URL:       file://.*/web-dir
 		Content URL:       file://.*/web-dir

--- a/test/functional/mirror/mirror-createdir.bats
+++ b/test/functional/mirror/mirror-createdir.bats
@@ -34,6 +34,7 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Set upstream mirror to https://example.com/swupd-file
+		Distribution:      Clear Linux Software for Intel Architecture
 		Installed version: 10
 		Version URL:       https://example.com/swupd-file
 		Content URL:       https://example.com/swupd-file
@@ -54,6 +55,7 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Set upstream mirror to https://example.com/swupd-file
+		Distribution:      Clear Linux Software for Intel Architecture
 		Installed version: 10
 		Version URL:       https://example.com/swupd-file
 		Content URL:       https://example.com/swupd-file
@@ -75,6 +77,7 @@ global_teardown() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Set upstream mirror to https://example.com/swupd-file
+		Distribution:      Clear Linux Software for Intel Architecture
 		Installed version: 10
 		Version URL:       https://example.com/swupd-file
 		Content URL:       https://example.com/swupd-file

--- a/test/functional/mirror/mirror-json.bats
+++ b/test/functional/mirror/mirror-json.bats
@@ -27,6 +27,7 @@ test_setup() {
 		{ "type" : "info", "msg" : "The --allow-insecure-http flag was used, be aware that this poses a threat to the system  " },
 		{ "type" : "warning", "msg" : "The mirror was set up using HTTP. In order for autoupdate to continue working you will need to set allow_insecure_http=true in the swupd configuration file. Alternatively you can set the mirror using HTTPS (recommended)  " },
 		{ "type" : "info", "msg" : "Set upstream mirror to http://example.com/swupd-file " },
+		{ "type" : "info", "msg" : "Distribution:      Clear Linux Software for Intel Architecture " },
 		{ "type" : "info", "msg" : "Installed version: 10 " },
 		{ "type" : "info", "msg" : "Version URL:       http://example.com/swupd-file " },
 		{ "type" : "info", "msg" : "Content URL:       http://example.com/swupd-file " },

--- a/test/functional/usability/usa-config-file.bats
+++ b/test/functional/usability/usa-config-file.bats
@@ -160,6 +160,7 @@ global_teardown() {
 	run sudo sh -c "$SWUPD info $SWUPD_OPTS -v http://anotherurl.com"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
+		Distribution:      Clear Linux Software for Intel Architecture
 		Installed version: 10
 		Version URL:       http://anotherurl.com
 		Content URL:       http://someurl.com
@@ -195,6 +196,7 @@ global_teardown() {
 	run sudo sh -c "$SWUPD info $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
+		Distribution:      Clear Linux Software for Intel Architecture
 		Installed version: 10
 		Version URL:       file://$TEST_DIRNAME/web-dir
 		Content URL:       file://$TEST_DIRNAME/web-dir
@@ -215,6 +217,7 @@ global_teardown() {
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Warning: Unrecognized option 'invalid_option=true' from section [global] in the configuration file
+		Distribution:      Clear Linux Software for Intel Architecture
 		Installed version: 10
 		Version URL:       file://$TEST_DIRNAME/web-dir
 		Content URL:       file://$TEST_DIRNAME/web-dir

--- a/test/functional/usability/usa-config-file.bats
+++ b/test/functional/usability/usa-config-file.bats
@@ -7,6 +7,13 @@ load "../testlib"
 
 global_setup() {
 
+	# Skip this test for local development because it needs an special config
+	# flag. To run this test locally, configure swupd with
+	# --with-config-file-path=./testconfig and run: TRAVIS=true make check
+	if [ -z "${TRAVIS}" ]; then
+		return
+	fi
+
 	create_test_environment "$TEST_NAME"
 	create_bundle -n test-bundle -f /file_1 "$TEST_NAME"
 
@@ -14,6 +21,9 @@ global_setup() {
 
 test_setup() {
 
+	if [ -z "$TRAVIS" ]; then
+		skip "This test is intended to run only in Travis (use TRAVIS=true to run it anyway)..."
+	fi
 	create_config_file
 
 }


### PR DESCRIPTION
Display distribution information on swupd info which is from PRETTY_NAME filed
in os-release file to support distinguishable version information display
in down streams.

Signed-off-by: Brandon Hong <brandon.hong@intel.com>