### PR TITLE
Fix logger format when printing debug messages

### DIFF
--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -1,7 +1,7 @@
 /*
  *   Software Updater - client side
  *
- *      Copyright © 2012-2016 Intel Corporation.
+ *      Copyright © 2012-2019 Intel Corporation.
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -20,50 +20,86 @@
 #define _GNU_SOURCE
 
 #include <ctype.h>
+#include <limits.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "log.h"
+
 #define DEBUG_HEADER_SIZE 50
+#define LINE_MAX _POSIX2_LINE_MAX
 
 static void log_internal(FILE *out, const char *file, int line, const char *label, const char *format, va_list args_list);
 static int cur_log_level = LOG_INFO;
 static log_fn_t log_function = log_internal;
 
-static void log_internal(FILE *out, const char *file, int line, const char *label, const char *format, va_list args_list)
+static void print_debug_info(FILE *out, const char *file, int line)
 {
 	char time_str[50];
 	struct tm *timeinfo;
 	int printed;
+	time_t currtime;
 
-	/* if the message starts with '\n' add a line break before the message */
-	while (strncmp(format, "\n", 1) == 0 || strncmp(format, "\r", 1) == 0) {
-		if (out == stdout || out == stderr) {
+	time(&currtime);
+	timeinfo = localtime(&currtime);
+	strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", timeinfo);
+	printed = fprintf(out, "%s (%s:%d)", time_str, file, line);
+	if (printed < DEBUG_HEADER_SIZE) {
+		fprintf(out, "%*c", 50 - printed, ' ');
+	}
+}
+
+static void log_internal(FILE *out, const char *file, int line, const char *label, const char *format, va_list args_list)
+{
+
+	char msg[LINE_MAX];
+
+	/* do not print the carriage return found at the beginning of the message if
+	 * in debug mode or if printing to a file, that would mess up the output */
+	while (strncmp(format, "\r", 1) == 0) {
+		if (cur_log_level != LOG_DEBUG && isatty(fileno(out))) {
 			fprintf(out, "%c", format[0]);
 		}
 		format++;
 	}
 
+	/* print the line breaks found at the beginning of the message */
+	while (strncmp(format, "\n", 1) == 0) {
+		if (cur_log_level == LOG_DEBUG) {
+			print_debug_info(out, file, line);
+		}
+		fprintf(out, "%c", format[0]);
+		format++;
+	}
+
+	/* if we don't have anything else to print, finish here */
+	if (strcmp(format, "") == 0) {
+		return;
+	}
+
 	// In debug mode, print more information
 	if (cur_log_level == LOG_DEBUG) {
-		time_t currtime;
-		time(&currtime);
-		timeinfo = localtime(&currtime);
-		strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", timeinfo);
-
-		printed = fprintf(out, "%s (%s:%d)", time_str, file, line);
-		if (printed < DEBUG_HEADER_SIZE) {
-			fprintf(out, "%*c", 50 - printed, ' ');
-		}
+		print_debug_info(out, file, line);
 	}
 
 	if (label) {
 		fprintf(out, "%s: ", label);
 	}
-	vfprintf(out, format, args_list);
-	fflush(out);
+
+	/* all debug messages need to finish with a line break, even if the
+	 * user didn't add one to the message, otherwise the output will be
+	 * messed up
+	 * Note that the "\n" could have been provided as an argument to the
+	 * string, as in this example: info("example%s", flag ? "" : "\n")
+	 * so we need to pass the string to a variable first to inspect it */
+	vsnprintf(msg, LINE_MAX, format, args_list);
+	fprintf(out, "%s", msg);
+	if ((cur_log_level == LOG_DEBUG) && (msg[strlen(msg) - 1] != '\n')) {
+		fprintf(out, "\n");
+	}
 }
 
 void log_set_level(int log_level)

--- a/src/lib/progress.c
+++ b/src/lib/progress.c
@@ -113,16 +113,12 @@ void progress_report(double count, double max)
 			if (progress_function) {
 				progress_function(step.description, step.current, step.total, percentage);
 			} else {
-				info("\t...%d%%", percentage);
-				if (!isatty(fileno(stdout))) {
-					/* if not in a tty add new lines so every percentage
-					 * is in its own line */
-					info("\n");
-				} else if (percentage == 100) {
-					/* add a line break once we reach 100% */
-					info("\n");
+				if (isatty(fileno(stdout))) {
+					info("\t...%d%%%s", percentage, percentage != 100 ? "\r" : "\n");
 				} else {
-					info("\r");
+					/* if printing to a file print every percentage
+					 * in its own line */
+					info("\t...%d%%\n", percentage);
 				}
 			}
 			fflush(stdout);


### PR DESCRIPTION
Debug messages need to be treated a little differently from other
messages, since they include more information, like the time, file and
line of code. So certain things like having carriage returns and
messages with only a line break should not be allowed since they would
mess up the debug output.

This commit fixes that issue

Closes #1009

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>