### PR TITLE
swupd.zsh: Multiple Improvement

### DIFF
--- a/swupd.zsh
+++ b/swupd.zsh
@@ -101,7 +101,7 @@ local -a installed all_bundles
 #           swupd hashdump [-p|--path=FOO] BAR
 (( $+functions[_swupd_hashdump] )) ||
   _swupd_hashdump () {
-    local -a words=(${words[2,-1]}) dumppath dummy
+    local -a words=(${words[2,-1]}) dumppath
     # Anonymous function to get the path
     () {
       zparseopts -E -a dumppath 'p:' '-path:' '-path\=:'
@@ -149,7 +149,7 @@ local -a global_opts; global_opts=(
 # Level-1 completion for sub-command and options to swupd
 _arguments -C \
            '(-)'{-h,--help}'[Show help options]' \
-           '(-)'{-v,--version}'[Output version information and exit]:version:->ops' \
+           '(-)'{-v,--version}'[Output version information and exit]' \
            ':swupd subcommand:->subcmd' \
            '*:: :->args' \
   && ret=0

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -317,7 +317,7 @@ if [[ -n "$state" ]]; then
           local -a hashdumps; hashdumps=(
             '(-)'{-h,--help}'[Show help options]'
             '(-h --help -n --no-xattrs)'{-n,--no-xattrs}'[Ignore extended attributes]'
-            '(-h --help -p --path)'{-p,--path}'[Use \[PATH...\] for leading path to filename]:dumppath: _path_files -/'
+            '(-h --help -p --path)'{-p,--path=}'[Use \[PATH...\] for leading path to filename]:dumppath: _path_files -/'
             '(-h --help --debug)--quiet[Quiet output. Print only important information and errors]'
             '(-h --help --quiet)--debug[Print extra information to help debugging problems]'
             ':hashdump: _swupd_hashdump'


### PR DESCRIPTION
This should be consistent to the `swupd` client up to 8590464

---

1.  Added bundle name completion for `swupd search FOO [--deps=|--has-deps=]`,
2.  Improved completion for `swupd search-file [-B=|-l=]`.
    - For `-B`, only files in /usr/bin directory are listed
    - For `-l`, only `.a` or `.so` files under `/usr/lib` or `/usr/lib64` are
      listed
3.  Completions for `diagnose` and `repair` are handled separtely because of
    non-trivial differences in descriptions of certain options.
4.  `--quiet` and `--debug` options of `swupd hashdump` are mutually exclusive
    since only one of them takes effect when both are supplied.
5.  If `-p|--path=` option and its argument is supplied to `swupd hashdump`,
    completions for the non-option argument is generated by the `zsh`'s native
    `_path_files` function, instead of external program `find`. This path
    completion support partial match, e.g. `/u/s/z/5/f` is completed to 
    `/usr/share/zsh/5.7.1/functions`. This implementation also supports relative
    path and  filename expansion (~).
6.  Improved the way how all available bundles are extracted from Manifest file,
    it's about 4 times faster in my test.
7.  For completions of bundle names, now the filtering of bundles already in the
    buffers is achieved by array difference instead of for loop, which is also
    considerably faster.
8.  Multiple helper functions are combined into into three.
    - `_swupd_installed_bundles`
      - Arguments of `swupd bundle-remove`
      - Option arguments of `swupd bundle diagnose|repair -b|--bundles=`
      - Option arguments of `swupd bundle-list -D|--deps=|--has-deps=`
    - `_swupd_all_bundles`
      - Arguments of `swupd bundle-add`, with installed bundles filtered out
      - Option arguments of `swupd os-install -b|--bundles=`
    - `_swupd_hashdump`
      - Arguments of `swupd hashdump`
9.  In an argument/option specification, if the `action` part calls a function,
    A space is prepended so that any words following the function name is passed
    to the function itself. (See `man zshcompsys`)
10. Changed the wording and ordering of certain options so they're in consistent
    with help message.