### PR TITLE
swupd.bash: faster bundle-add

### DIFF
--- a/swupd.bash
+++ b/swupd.bash
@@ -96,7 +96,7 @@ _swupd()
 		fi
 		if [ -n "$MoM" ]
 		then
-		    opts+="$( sed '1,/^$/d; s/^.*\t/ /; /.*\.I\..*/d' "$MoM" | LC_ALL=C sort )"
+		    opts+="$( sed '/^[^M]/d' "$MoM" | cut -f4 | LC_ALL=C sort )"
 		fi ;;
 	    ("bundle-remove")
 		opts+=" $(unset CDPATH; test -d /usr/share/clear/bundles && \


### PR DESCRIPTION
I tried several implementation and found this is the fastest one.

```bash
#!/usr/bin/bash
MoM=/var/tmp/swupd/Manifest.MoM

start=$(date +%s%N)
sed '1,/^$/d; s/^.*\t/ /; /.*\.I\..*/d;s/\n/ /g' "$MoM" &> /dev/null 
end=$(date +%s%N)
echo "Current" "$(expr $end - $start)"

start=$(date +%s%N)
awk '/M.../{print $4}' "$MoM" &> /dev/null
end=$(date +%s%N)
echo "awk    " "$(expr $end - $start)"

start=$(date +%s%N)
sed -e '/M\.\.\./!d;s/.*      //' "$MoM" &> /dev/null
sed '/^[^M]/d;' "$MoM" &>/dev/null 
end=$(date +%s%N)
echo "sed    " "$(expr $end - $start)"

start=$(date +%s%N)
awk '/M.../' "$MoM" | cut -f4 &> /dev/null
end=$(date +%s%N)
echo "awk|cut" "$(expr $end - $start)"

start=$(date +%s%N)
sed '/^[^M]/d' "$MoM" | cut -f4 &> /dev/null
end=$(date +%s%N)
echo "sed|cut" "$(expr $end - $start)"
```

the result is in nanoseconds

```
Current 4672004
awk     1934649
sed     2425911
awk|cut 1881427
sed|cut 1579226
```
