### PR TITLE
globals: Use ifdef instead of if to check for precompiler defined const

### DIFF
--- a/src/curl_async.c
+++ b/src/curl_async.c
@@ -534,6 +534,7 @@ int swupd_curl_parallel_download_enqueue(struct swupd_curl_parallel_handle *h, c
 	unlink(file->file.path);
 
 	progress = calloc(1, sizeof(struct file_progress));
+	ON_NULL_ABORT(progress);
 	progress->overall_progress = h->data;
 	file->progress = progress;
 

--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -84,7 +84,14 @@ int run_command_full_params(const char *stdout_file, const char *stderr_file, ch
 	/* replace the stdin with /dev/null. the underlying commands should never be
 	 * run interactively. */
 	null_fd = open("/dev/null", O_RDONLY);
-	dup2(null_fd, 0);
+	if (null_fd < 0) {
+		goto error_child;
+	}
+	if (dup2(null_fd, 0) < 0) {
+		close(null_fd);
+		goto error_child;
+
+	}
 	close(null_fd);
 
 	if (replace_fd(STDOUT_FILENO, stdout_file) < 0) {


### PR DESCRIPTION
Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>