### PR TITLE
Makefile: Clean manpages only on distclean

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -360,9 +360,6 @@ MANPAGES = \
 
 dist_man_MANS = \
 	$(MANPAGES)
-
-clean-local:
-	rm -rf $(MANPAGES)
 endif
 
 if COVERAGE
@@ -378,7 +375,7 @@ coverage-clean:
 endif
 
 distclean-local:
-	rm -rf aclocal.m4 ar-lib autom4te.cache config.guess config.h.in config.h.in~ config.sub configure depcomp install-sh ltmain.sh m4 Makefile.in missing compile
+	rm -rf aclocal.m4 ar-lib autom4te.cache config.guess config.h.in config.h.in~ config.sub configure depcomp install-sh ltmain.sh m4 Makefile.in missing compile $(MANPAGES)
 
 install-exec-hook:
 	perl $(top_srcdir)/scripts/findstatic.pl */*.o | grep -v Checking ||:


### PR DESCRIPTION
Manpages are created in make dist so we should clean them only on distclean.
For example if you run:

$ make dist
$ tar xf swupd-client-version.tar.gz && cd swupd-client
$ make clean

All manpages are going to be deleted and the source files aren't available on
the tarball. So you are going to be blocked in a build.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>