### PR TITLE
Enabling --bundles for diagnose and repair

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -223,6 +223,7 @@ BATS = \
 	test/functional/diagnose/diagnose-also-add.bats \
 	test/functional/diagnose/diagnose-basics.bats \
 	test/functional/diagnose/diagnose-boot-file.bats \
+	test/functional/diagnose/diagnose-bundles.bats \
 	test/functional/diagnose/diagnose-client-certificate.bats \
 	test/functional/diagnose/diagnose-directory-tree-deleted.bats \
 	test/functional/diagnose/diagnose-flags.bats \
@@ -232,7 +233,6 @@ BATS = \
 	test/functional/diagnose/diagnose-picky-downgrade.bats \
 	test/functional/diagnose/diagnose-picky-whitelist.bats \
 	test/functional/diagnose/diagnose-picky.bats \
-	test/functional/diagnose/diagnose-verify-flags.bats \
 	test/functional/hashdump/hashdump-file-hash.bats \
 	test/functional/mirror/mirror-createdir-negative.bats \
 	test/functional/mirror/mirror-createdir.bats \
@@ -255,6 +255,7 @@ BATS = \
 	test/functional/repair/repair-boot-file-deleted.bats \
 	test/functional/repair/repair-boot-file.bats \
 	test/functional/repair/repair-boot-skip.bats \
+	test/functional/repair/repair-bundles.bats \
 	test/functional/repair/repair-deleted-include-manifest.bats \
 	test/functional/repair/repair-directory-tree-deleted.bats \
 	test/functional/repair/repair-empty-dir-deleted.bats \
@@ -333,7 +334,8 @@ BATS = \
 	test/functional/usability/usa-config-file.bats \
 	test/functional/usability/usa-download-retries.bats \
 	test/functional/usability/usa-external-modules.bats \
-	test/functional/verify-legacy/verify-bundle.bats
+	test/functional/verify-legacy/verify-bundle.bats \
+	test/functional/verify-legacy/verify-flags.bats
 
 
 UNIT_TESTS = \

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -437,6 +437,17 @@ SUBCOMMANDS
         Like --picky, but it only removes extra files. It omits checking
         hash values, and for missing files, directories and/or symlinks.
 
+    - `--bundles`
+
+      Forces swupd to only repair the (comma separated) list of bundles
+      provided.
+
+      Examples:
+
+        - ``--bundles os-core,vi``
+
+            Repairs only bundles os-core and vi.
+
 ``search``
 
     Swupd search functionality is provided by swupd-search binary available

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -303,6 +303,17 @@ SUBCOMMANDS
         Like --picky, but it only looks for extra files. It omits checking
         hash values, and for missing files, directories and/or symlinks.
 
+    - `--bundles`
+
+      Forces swupd to only diagnose the (comma separated) list of bundles
+      provided.
+
+      Examples:
+
+        - ``--bundles os-core,vi``
+
+            Diagnoses only bundles os-core and vi.
+
 ``hashdump {path}``
 
     Calculates and print the Manifest hash for a specific file on disk.

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -624,8 +624,7 @@ enum swupd_code remove_bundles(char **bundles)
 			goto out_free_mom;
 		}
 
-		current_mom->files = files_from_bundles(current_mom->submanifests);
-		current_mom->files = consolidate_files(current_mom->files);
+		current_mom->files = consolidate_files_from_bundles(current_mom->submanifests);
 
 		/* Now that we have the consolidated list of all files, load bundle to be removed submanifest */
 		ret = load_bundle_manifest(bundle, subs, current_version, &bundle_manifest);
@@ -842,14 +841,12 @@ static enum swupd_code install_bundles(struct list *bundles, struct list **subs,
 	progress_set_step(2, "consolidate_files");
 
 	/* get all files already installed in the target system */
-	installed_files = files_from_bundles(installed_bundles);
-	installed_files = consolidate_files(installed_files);
+	installed_files = consolidate_files_from_bundles(installed_bundles);
 	mom->files = installed_files;
 	installed_files = filter_out_deleted_files(installed_files);
 
 	/* get all the files included in the bundles to be added */
-	to_install_files = files_from_bundles(to_install_bundles);
-	to_install_files = consolidate_files(to_install_files);
+	to_install_files = consolidate_files_from_bundles(to_install_bundles);
 	to_install_files = filter_out_deleted_files(to_install_files);
 
 	/* from the list of files to be installed, remove those files already in the target system */

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -782,6 +782,16 @@ end:
 	return ret;
 }
 
+struct list *consolidate_files_from_bundles(struct list *bundles)
+{
+	/* bundles is a pointer to a list of manifests */
+	struct list *files = NULL;
+
+	files = files_from_bundles(bundles);
+	files = consolidate_files(files);
+	return files;
+}
+
 struct list *files_from_bundles(struct list *bundles)
 {
 	struct list *files = NULL;

--- a/src/lib/list.c
+++ b/src/lib/list.c
@@ -338,3 +338,46 @@ struct list *list_deduplicate(struct list *list, comparison_fn_t comparison_fn, 
 
 	return list;
 }
+
+struct list *list_filter_common_elements(struct list *list1, struct list *list2, comparison_fn_t comparison_fn, list_free_data_fn_t list_free_data_fn)
+{
+	struct list *iter1, *iter2 = NULL;
+	struct list *preserver = NULL;
+	void *item1, *item2 = NULL;
+	int comp;
+
+	preserver = iter1 = list_head(list1);
+	iter2 = list_head(list2);
+
+	while (iter1 && iter2) {
+
+		item1 = iter1->data;
+		item2 = iter2->data;
+
+		/* if the criteria has not been met, there is nothing to be done,
+		 * just move the pointers to the next elements appropriately */
+		comp = comparison_fn(item1, item2);
+		if (comp < 0) {
+			iter1 = iter1->next;
+			continue;
+		} else if (comp > 0) {
+			iter2 = iter2->next;
+			continue;
+		}
+
+		/* the condition was met */
+
+		/* preserver was pointing to the first element of
+		 * the list, if we are removing it, redirect it so it
+		 * points to the new first element of the list */
+		if (preserver == iter1) {
+			preserver = iter1->next;
+		}
+		iter1 = list_free_item(iter1, list_free_data_fn);
+		/* the iter1 pointer was already moved by list_free_item
+		 * so only move iter2 to the next element in the list */
+		iter2 = iter2->next;
+	}
+
+	return preserver;
+}

--- a/src/lib/list.c
+++ b/src/lib/list.c
@@ -318,3 +318,23 @@ int list_strcmp(const void *a, const void *b)
 {
 	return strcmp((const char *)a, (const char *)b);
 }
+
+struct list *list_deduplicate(struct list *list, comparison_fn_t comparison_fn, list_free_data_fn_t list_free_data_fn)
+{
+	struct list *iter = NULL;
+	void *item1, *item2;
+
+	list = list_head(list);
+
+	for (iter = list; iter && iter->next; iter = iter->next) {
+
+		item1 = iter->data;
+		item2 = iter->next->data;
+
+		if (comparison_fn(item1, item2) == 0) {
+			list_free_item(iter->next, list_free_data_fn);
+		}
+	}
+
+	return list;
+}

--- a/src/lib/list.h
+++ b/src/lib/list.h
@@ -120,4 +120,10 @@ void *list_search(struct list *list, const void *item, comparison_fn_t compariso
  */
 int list_strcmp(const void *a, const void *b);
 
+/**
+ * @brief removes duplicated elements from a list
+ *
+ */
+struct list *list_deduplicate(struct list *list, comparison_fn_t comparison_fn, list_free_data_fn_t list_free_data_fn);
+
 #endif

--- a/src/lib/list.h
+++ b/src/lib/list.h
@@ -21,7 +21,11 @@ struct list {
 	struct list *next;
 };
 
-/** @brief Callback to compare two datas in a list. */
+/**
+ * @brief Callback to compare two datas in a list.
+ * The comparison_fn should behave similar to strcmp(), returning 0 if
+ * it is a match, and "< 0" or "> 0" if it is not.
+ */
 typedef int (*comparison_fn_t)(const void *a, const void *b);
 
 /** @brief Callback to free data used in list. */
@@ -125,5 +129,14 @@ int list_strcmp(const void *a, const void *b);
  *
  */
 struct list *list_deduplicate(struct list *list, comparison_fn_t comparison_fn, list_free_data_fn_t list_free_data_fn);
+
+/**
+ * @brief Filters any element from list1 that happens to be in list2 as long as it meets the criteria
+ *
+ * Function requirements:
+ * - list1 and list2 are sorted
+ * - the comparison_fn should behave similar to strcmp(), returning 0 if it's a match, and "< 0" or "> 0" if it's not
+ */
+struct list *list_filter_common_elements(struct list *list1, struct list *list2, comparison_fn_t comparison_fn, list_free_data_fn_t list_free_data_fn);
 
 #endif

--- a/src/lib/strings.c
+++ b/src/lib/strings.c
@@ -111,6 +111,19 @@ error:
 	return NULL;
 }
 
+struct list *string_split(const char *separator, const char *string_to_split)
+{
+	struct list *split = NULL;
+	char *string_copy = strdup_or_die(string_to_split);
+	char *token = strtok(string_copy, separator);
+	while (token) {
+		split = list_prepend_data(split, strdup_or_die(token));
+		token = strtok(NULL, separator);
+	}
+	free(string_copy);
+	return split;
+}
+
 int strtoi_err_endptr(const char *str, char **endptr, int *value)
 {
 	long num;

--- a/src/lib/strings.h
+++ b/src/lib/strings.h
@@ -43,6 +43,11 @@ void free_string(char **s);
 char *string_join(const char *separator, struct list *string);
 
 /**
+ * Split a string by separator.
+ */
+struct list *string_split(const char *separator, const char *string_to_split);
+
+/**
  * Safely convert string to integer avoiding overflows
  *
  * The strtol function is commonly used to convert a string to a number and

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -299,6 +299,7 @@ void update_motd(int new_release);
 void delete_motd(void);
 extern int get_dirfd_path(const char *fullname);
 extern enum swupd_code verify_fix_path(char *targetpath, struct manifest *manifest);
+extern struct list *consolidate_files_from_bundles(struct list *bundles);
 extern struct list *files_from_bundles(struct list *bundles);
 extern bool version_files_consistent(void);
 extern bool string_in_list(char *string_to_check, struct list *list_to_check);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -337,7 +337,7 @@ extern void verify_set_option_force(bool opt);
 extern void verify_set_option_install(bool opt);
 extern void verify_set_option_statedir_cache(char *opt);
 extern void verify_set_option_quick(bool opt);
-extern void verify_set_option_bundles(struct list *bundles);
+extern void verify_set_option_bundles(struct list *opt_bundles);
 extern void verify_set_option_version(int ver);
 extern void verify_set_option_fix(bool opt);
 extern void verify_set_option_picky(bool opt);

--- a/src/update.c
+++ b/src/update.c
@@ -411,8 +411,7 @@ version_check:
 	}
 
 	/* consolidate the current collective manifests down into one in memory */
-	current_manifest->files = files_from_bundles(current_manifest->submanifests);
-	current_manifest->files = consolidate_files(current_manifest->files);
+	current_manifest->files = consolidate_files_from_bundles(current_manifest->submanifests);
 	latest_subs = list_clone(current_subs);
 	set_subscription_versions(server_manifest, current_manifest, &latest_subs);
 	link_submanifests(current_manifest, server_manifest, current_subs, latest_subs, false);
@@ -442,8 +441,7 @@ version_check:
 	}
 
 	/* consolidate the new collective manifests down into one in memory */
-	server_manifest->files = files_from_bundles(server_manifest->submanifests);
-	server_manifest->files = consolidate_files(server_manifest->files);
+	server_manifest->files = consolidate_files_from_bundles(server_manifest->submanifests);
 	set_subscription_versions(server_manifest, current_manifest, &latest_subs);
 	link_submanifests(current_manifest, server_manifest, current_subs, latest_subs, true);
 

--- a/src/update.c
+++ b/src/update.c
@@ -193,14 +193,12 @@ int add_included_manifests(struct manifest *mom, struct list **subs)
 	/* Pass the current version here, not the new, otherwise we will never
 	 * hit the Manifest delta path. */
 	ret = add_subscriptions(subbed, subs, mom, true, 0);
-	if (ret & (add_sub_ERR | add_sub_BADNAME)) {
-		ret = -ret;
-	} else {
-		ret = 0;
-	}
 	list_free_list(subbed);
+	if (ret & (add_sub_ERR | add_sub_BADNAME)) {
+		return ret;
+	}
 
-	return ret;
+	return 0;
 }
 
 static bool need_new_upstream(int server)
@@ -424,7 +422,7 @@ version_check:
 	timelist_timer_start(globals.global_times, "Add included bundle manifests");
 	ret = add_included_manifests(server_manifest, &latest_subs);
 	if (ret) {
-		if (ret == -add_sub_BADNAME) {
+		if (ret & add_sub_BADNAME) {
 			/* this means a bundle(s) was removed in a future version */
 			warn("One or more installed bundles are no longer available at version %d\n",
 			     server_version);

--- a/src/verify.c
+++ b/src/verify.c
@@ -1084,12 +1084,10 @@ enum swupd_code verify_main(void)
 
 	timelist_timer_start(globals.global_times, "Consolidate files from bundles");
 	progress_set_step(4, "consolidate_files");
-	all_files = files_from_bundles(all_submanifests);
-	all_files = consolidate_files(all_files);
+	all_files = consolidate_files_from_bundles(all_submanifests);
 	official_manifest->files = all_files;
 	if (cmdline_option_bundles) {
-		bundles_files = files_from_bundles(bundles_submanifests);
-		bundles_files = consolidate_files(bundles_files);
+		bundles_files = consolidate_files_from_bundles(bundles_submanifests);
 		/* we need to make sure the files from the selected bundles
 		 * are compared against the full list of consolidated files
 		 * from all bundles so we don't end up deleting a file that

--- a/src/verify.c
+++ b/src/verify.c
@@ -963,7 +963,7 @@ enum swupd_code verify_main(void)
 	/* if one or more of the installed bundles were not found in the manifest,
 	 * continue only if --force was used since the bundles could be removed */
 	if (ret) {
-		if (ret == -add_sub_BADNAME) {
+		if (ret & add_sub_BADNAME) {
 			if (cmdline_option_force) {
 				if (cmdline_option_picky && cmdline_option_fix) {
 					warn("One or more installed bundles that are not "

--- a/swupd.bash
+++ b/swupd.bash
@@ -58,7 +58,7 @@ _swupd()
 		opts="$global --library --binary --top --csv --init --order "
 		break;;
 		("diagnose")
-		opts="$global --version --picky --picky-tree --picky-whitelist --quick --force --extra-files-only "
+		opts="$global --version --picky --picky-tree --picky-whitelist --quick --force --extra-files-only --bundles "
 		break;;
 		("repair")
 		opts="$global --version --picky --picky-tree --picky-whitelist --quick --force --extra-files-only "

--- a/swupd.bash
+++ b/swupd.bash
@@ -61,7 +61,7 @@ _swupd()
 		opts="$global --version --picky --picky-tree --picky-whitelist --quick --force --extra-files-only --bundles "
 		break;;
 		("repair")
-		opts="$global --version --picky --picky-tree --picky-whitelist --quick --force --extra-files-only "
+		opts="$global --version --picky --picky-tree --picky-whitelist --quick --force --extra-files-only --bundles "
 		break;;
 		("os-install")
 		opts="$global --version --force --bundles --statedir-cache --download "

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -285,6 +285,7 @@ if [[ -n "$state" ]]; then
             '(help -w --picky-whitelist)'{-w,--picky-whitelist=}'[Directories that match the regex get skipped. Example: /var|/etc/machine-id. Default: /usr/lib/modules|/usr/lib/kernel|/usr/local|/usr/src]:picky-whitelist:()'
             '(help -X --picky-tree)'{-X,--picky-tree=}'[Selects the sub-tree where --picky and --extra-files-only looks for extra files. Default\: /usr]:picky-tree: _path_files -/'
             '(help)--extra-files-only[Only remove files which should not exist]'
+            '(help -B --bundles)'{-B,--bundles=}'[Forces swupd to only repair the specified BUNDLES. Example: --bundles=os-core,vi]:bundles:()'
           )
           _arguments $repair && ret=0
           ;;

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -271,6 +271,7 @@ if [[ -n "$state" ]]; then
             '(help -X --picky-tree)'{-X,--picky-tree=}'[Selects the sub-tree where --picky and --extra-files-only looks for extra files. Default\: /usr]:picky-tree: _path_files -/'
             '(help -w --picky-whitelist)'{-w,--picky-whitelist=}'[Directories that match the regex get skipped. Example\: /var|/etc/machine-id. Default\: /usr/lib/modules|/usr/lib/kernel|/usr/local|/usr/src]:picky-whitelist:()'
             '(help)--extra-files-only[Only list files which should not exist]'
+            '(help -B --bundles)'{-B,--bundles=}'[Forces swupd to only diagnose the specified BUNDLES. Example: --bundles=os-core,vi]:bundles:()'
           )
           _arguments $diagnoses && ret=0
           ;;

--- a/test/functional/diagnose/diagnose-bundles.bats
+++ b/test/functional/diagnose/diagnose-bundles.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle1 -f /foo/test-file1,/common "$TEST_NAME"
+	file_hash=$(get_hash_from_manifest "$WEBDIR"/10/Manifest.test-bundle1 /common)
+	file_path="$WEBDIR"/10/files/"$file_hash"
+	create_bundle -L -n test-bundle2 -f /bar/test-file2,/common:"$file_path" "$TEST_NAME"
+	create_bundle -L -n test-bundle3 -f /baz/test-file3,/common:"$file_path" "$TEST_NAME"
+	create_bundle -n test-bundle4 -f /bat/test-file4,/common:"$file_path" "$TEST_NAME"
+
+}
+
+@test "DIA017: Diagnose bundles only checks specified bundles" {
+
+	sudo rm -f "$TARGETDIR"/foo/test-file1
+	sudo rm -f "$TARGETDIR"/common
+	sudo rm -f "$TARGETDIR"/foo/test-file3
+
+	# users can diagnose only specific bundles
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --bundles test-bundle1,test-bundle2"
+
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Limiting diagnose to the following bundles:
+		 - test-bundle1
+		 - test-bundle2
+		Checking for missing files
+		 -> Missing file: $PATH_PREFIX/common
+		 -> Missing file: $PATH_PREFIX/foo/test-file1
+		Checking for corrupt files
+		Checking for extraneous files
+		Inspected 7 files
+		  2 files were missing
+		Use "swupd repair" to correct the problems in the system
+		Diagnose successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "DIA018: Diagnose bundles requires --force to continue when there is an invalid bundle" {
+
+	sudo rm -f "$TARGETDIR"/foo/test-file1
+	sudo rm -f "$TARGETDIR"/common
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --bundles bad-name,test-bundle1"
+
+	assert_status_is "$SWUPD_INVALID_BUNDLE"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Warning: Bundle "bad-name" is invalid or no longer available
+		Limiting diagnose to the following bundles:
+		 - test-bundle1
+		Error: One or more of the provided bundles are not available at version 10
+		Please make sure the name of the provided bundles are correct, or use --force to override
+		Diagnose did not fully succeed
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --bundles bad-name,test-bundle1 --force"
+
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Warning: Bundle "bad-name" is invalid or no longer available
+		Limiting diagnose to the following bundles:
+		 - test-bundle1
+		Checking for missing files
+		 -> Missing file: $PATH_PREFIX/common
+		 -> Missing file: $PATH_PREFIX/foo/test-file1
+		Checking for corrupt files
+		Checking for extraneous files
+		Inspected 4 files
+		  2 files were missing
+		Use "swupd repair" to correct the problems in the system
+		Diagnose successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "DIA019: Diagnose bundles do not report deleted files needed by other bundles" {
+
+	update_manifest "$WEBDIR"/10/Manifest.test-bundle1 file-status /foo/test-file1 .d..
+	update_manifest "$WEBDIR"/10/Manifest.test-bundle1 file-status /common .d..
+
+	# if a file is marked as deleted in a bundle being diagnosed in isolation
+	# but another bundle needs that file, it should not be reported as extraneous
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --bundles test-bundle1,test-bundle3"
+
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Limiting diagnose to the following bundles:
+		 - test-bundle1
+		 - test-bundle3
+		Checking for missing files
+		Checking for corrupt files
+		Checking for extraneous files
+		 -> File that should be deleted: $PATH_PREFIX/foo/test-file1
+		Inspected 7 files
+		  1 file found which should be deleted
+		Use "swupd repair" to correct the problems in the system
+		Diagnose successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "DIA020: Try diagnosing a bundle that is not installed" {
+
+	# if a user tries to diagnose a bundle that is not installed,
+	# it should warn the user about it
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --bundles test-bundle4"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Warning: Bundle "test-bundle4" is not installed, skipping it...
+		No valid bundles were specified, nothing to be done
+		Diagnose successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "DIA021: Diagnose a list of bundles that include a bundle not installed" {
+
+	# if a user tries to diagnose a list that includes a bundle that is not installed,
+	# it should warn the user about it, it should ignore it and continue
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --bundles test-bundle4,test-bundle1"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Warning: Bundle "test-bundle4" is not installed, skipping it...
+		Limiting diagnose to the following bundles:
+		 - test-bundle1
+		Checking for missing files
+		Checking for corrupt files
+		Checking for extraneous files
+		Inspected 4 files
+		Diagnose successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/diagnose/diagnose-flags.bats
+++ b/test/functional/diagnose/diagnose-flags.bats
@@ -41,4 +41,32 @@ load "../testlib"
 	assert_status_is "$SWUPD_INVALID_OPTION"
 	assert_in_output "Error: 'latest' not supported for --version"
 
+	# --fix not supported
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --fix"
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	assert_in_output "diagnose: unrecognized option '--fix'"
+
+	# --install not supported
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --install"
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	assert_in_output "diagnose: unrecognized option '--install'"
+
+	# --bundles with --picky
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --bundles vim --picky"
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	assert_in_output "Error: --bundles and --picky options are mutually exclusive"
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --picky --bundles vim"
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	assert_in_output "Error: --bundles and --picky options are mutually exclusive"
+
+	# --bundles with --extra-files-only
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --bundles vim --extra-files-only"
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	assert_in_output "Error: --bundles and --extra-files-only options are mutually exclusive"
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --extra-files-only --bundles vim"
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	assert_in_output "Error: --bundles and --extra-files-only options are mutually exclusive"
+
 }

--- a/test/functional/os-install/install-bad.bats
+++ b/test/functional/os-install/install-bad.bats
@@ -23,7 +23,7 @@ test_setup() {
 	assert_status_is "$SWUPD_INVALID_BUNDLE"
 	expected_output=$(cat <<-EOM
 		Installing OS version 10 (latest)
-		Warning: Bundle "bad-name" is invalid, skipping it...
+		Warning: Bundle "bad-name" is invalid or no longer available
 		Error: One or more of the provided bundles are not available at version 10
 		Please make sure the name of the provided bundles are correct, or use --force to override
 		Installation failed
@@ -43,7 +43,7 @@ test_setup() {
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Installing OS version 10 (latest)
-		Warning: Bundle "bad-name" is invalid, skipping it...
+		Warning: Bundle "bad-name" is invalid or no longer available
 		Downloading packs for:
 		 - os-core
 		 - test-bundle

--- a/test/functional/repair/repair-bundles.bats
+++ b/test/functional/repair/repair-bundles.bats
@@ -1,0 +1,180 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle1 -f /foo/test-file1,/common "$TEST_NAME"
+	file_hash=$(get_hash_from_manifest "$WEBDIR"/10/Manifest.test-bundle1 /common)
+	file_path="$WEBDIR"/10/files/"$file_hash"
+	create_bundle -L -n test-bundle2 -f /bar/test-file2,/common:"$file_path" "$TEST_NAME"
+	create_bundle -L -n test-bundle3 -f /baz/test-file3,/common:"$file_path" "$TEST_NAME"
+	create_bundle -n test-bundle4 -f /bat/test-file4,/common:"$file_path" "$TEST_NAME"
+
+}
+
+@test "REP033: Repair bundles only fixes specified bundles" {
+
+	sudo rm -f "$TARGETDIR"/foo/test-file1
+	sudo rm -f "$TARGETDIR"/common
+	sudo rm -f "$TARGETDIR"/foo/test-file3
+
+	# users can diagnose only specific bundles
+
+	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --bundles test-bundle1,test-bundle2"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Limiting diagnose to the following bundles:
+		 - test-bundle1
+		 - test-bundle2
+		Checking for corrupt files
+		Starting download of remaining update content. This may take a while...
+		Adding any missing files
+		 -> Missing file: $PATH_PREFIX/common -> fixed
+		 -> Missing file: $PATH_PREFIX/foo/test-file1 -> fixed
+		Repairing corrupt files
+		Removing extraneous files
+		Inspected 7 files
+		  2 files were missing
+		    2 of 2 missing files were replaced
+		    0 of 2 missing files were not replaced
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "REP034: Repair bundles requires --force to continue when there is an invalid bundle" {
+
+	sudo rm -f "$TARGETDIR"/foo/test-file1
+	sudo rm -f "$TARGETDIR"/common
+	write_to_protected_file -a "$TARGETDIR"/usr/share/clear/bundles/test-bundle1 "something"
+
+	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --bundles bad-name,test-bundle1"
+
+	assert_status_is "$SWUPD_INVALID_BUNDLE"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Warning: Bundle "bad-name" is invalid or no longer available
+		Limiting diagnose to the following bundles:
+		 - test-bundle1
+		Error: One or more of the provided bundles are not available at version 10
+		Please make sure the name of the provided bundles are correct, or use --force to override
+		Repair did not fully succeed
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --bundles bad-name,test-bundle1 --force"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Warning: Bundle "bad-name" is invalid or no longer available
+		Limiting diagnose to the following bundles:
+		 - test-bundle1
+		Checking for corrupt files
+		Starting download of remaining update content. This may take a while...
+		Adding any missing files
+		 -> Missing file: $PATH_PREFIX/common -> fixed
+		 -> Missing file: $PATH_PREFIX/foo/test-file1 -> fixed
+		Repairing corrupt files
+		 -> Hash mismatch for file: $PATH_PREFIX/usr/share/clear/bundles/test-bundle1 -> fixed
+		Removing extraneous files
+		Inspected 4 files
+		  2 files were missing
+		    2 of 2 missing files were replaced
+		    0 of 2 missing files were not replaced
+		  1 file did not match
+		    1 of 1 files were repaired
+		    0 of 1 files were not repaired
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "REP035: Repair bundles do not delete files needed by other bundles" {
+
+	update_manifest "$WEBDIR"/10/Manifest.test-bundle1 file-status /foo/test-file1 .d..
+	update_manifest "$WEBDIR"/10/Manifest.test-bundle1 file-status /common .d..
+	write_to_protected_file -a "$TARGETDIR"/usr/share/clear/bundles/test-bundle1 "something"
+
+	# if a file is marked as deleted in a bundle being repaired in isolation
+	# but another bundle needs that file, it should not be deleted
+
+	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --bundles test-bundle1,test-bundle3"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Limiting diagnose to the following bundles:
+		 - test-bundle1
+		 - test-bundle3
+		Checking for corrupt files
+		Starting download of remaining update content. This may take a while...
+		Adding any missing files
+		Repairing corrupt files
+		 -> Hash mismatch for file: $PATH_PREFIX/usr/share/clear/bundles/test-bundle1 -> fixed
+		Removing extraneous files
+		 -> File that should be deleted: $PATH_PREFIX/foo/test-file1 -> deleted
+		Inspected 7 files
+		  1 file did not match
+		    1 of 1 files were repaired
+		    0 of 1 files were not repaired
+		  1 file found which should be deleted
+		    1 of 1 files were deleted
+		    0 of 1 files were not deleted
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "REP036: Repair a list of bundles that include a bundle not installed" {
+
+	sudo rm -f "$TARGETDIR"/foo/test-file1
+	sudo rm -f "$TARGETDIR"/common
+
+	# if a user repairs a list of bundles that include one not installed,
+	# it should warn the user about it, it should ignore the uninstalled bundle
+	# and continue
+
+	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --bundles test-bundle1,test-bundle4"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Warning: Bundle "test-bundle4" is not installed, skipping it...
+		Limiting diagnose to the following bundles:
+		 - test-bundle1
+		Checking for corrupt files
+		Starting download of remaining update content. This may take a while...
+		Adding any missing files
+		 -> Missing file: $PATH_PREFIX/common -> fixed
+		 -> Missing file: $PATH_PREFIX/foo/test-file1 -> fixed
+		Repairing corrupt files
+		Removing extraneous files
+		Inspected 4 files
+		  2 files were missing
+		    2 of 2 missing files were replaced
+		    0 of 2 missing files were not replaced
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/verify-legacy/verify-bundle.bats
+++ b/test/functional/verify-legacy/verify-bundle.bats
@@ -23,9 +23,9 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Warning: The --fix option has been superseded
 		Please consider using "swupd repair" instead
-		Warning: Using the --bundles option may have some undesired side effects
-		 - verify will remove files marked as deleted in --bundles, this can corrupt other bundles not listed in --bundles
 		Verifying version 10
+		Limiting verify to the following bundles:
+		 - test-bundle2
 		Checking for corrupt files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
@@ -56,9 +56,9 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Warning: The --fix option has been superseded
 		Please consider using "swupd repair" instead
-		Warning: Using the --bundles option may have some undesired side effects
-		 - verify will remove files marked as deleted in --bundles, this can corrupt other bundles not listed in --bundles
 		Verifying version 10
+		Limiting verify to the following bundles:
+		 - test-bundle3
 		Checking for corrupt files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
@@ -90,9 +90,10 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Warning: The --fix option has been superseded
 		Please consider using "swupd repair" instead
-		Warning: Using the --bundles option may have some undesired side effects
-		 - verify will remove files marked as deleted in --bundles, this can corrupt other bundles not listed in --bundles
 		Verifying version 10
+		Limiting verify to the following bundles:
+		 - test-bundle1
+		 - test-bundle2
 		Checking for corrupt files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
@@ -115,40 +116,26 @@ test_setup() {
 
 }
 
-@test "VER004: Verify bundle warns users about possible undesired side effects when using --bundles" {
-
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --fix --bundles test-bundle1"
-	assert_status_is "$SWUPD_OK"
-	expected_output=$(cat <<-EOM
-		Warning: Using the --bundles option may have some undesired side effects
-		 - verify will remove files marked as deleted in --bundles, this can corrupt other bundles not listed in --bundles
-	EOM
-	)
-	assert_in_output "$expected_output"
-
-}
-
-@test "VER005: Verify bundle warns users about possible undesired side effects when using --bundles + --extra-files-only" {
+@test "VER004: Verify bundle warns users about possible undesired side effects when using --bundles + --extra-files-only" {
 
 	# with --extra-files-only
 	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --fix --extra-files-only --bundles test-bundle1"
 	expected_output=$(cat <<-EOM
-		Warning: Using the --bundles option may have some undesired side effects
-		 - verify will remove all files in /usr that are not part of --bundles unless listed in the --picky-whitelist
+		Warning: Using the --bundles option with --extra-files-only may have some undesired side effects
+		verify will remove all files in /usr that are not part of --bundles unless listed in the --picky-whitelist
 	EOM
 	)
 	assert_in_output "$expected_output"
 
 }
 
-@test "VER006: Verify bundle warns users about possible undesired side effects when using --bundles + --picky" {
+@test "VER005: Verify bundle warns users about possible undesired side effects when using --bundles + --picky" {
 
 	# with --picky
 	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --fix --picky --bundles test-bundle1"
 	expected_output=$(cat <<-EOM
-		Warning: Using the --bundles option may have some undesired side effects
-		 - verify will remove files marked as deleted in --bundles, this can corrupt other bundles not listed in --bundles
-		 - verify will remove all files in /usr that are not part of --bundles unless listed in the --picky-whitelist
+		Warning: Using the --bundles option with --picky may have some undesired side effects
+		verify will remove all files in /usr that are not part of --bundles unless listed in the --picky-whitelist
 	EOM
 	)
 	assert_in_output "$expected_output"

--- a/test/functional/verify-legacy/verify-flags.bats
+++ b/test/functional/verify-legacy/verify-flags.bats
@@ -5,7 +5,7 @@
 
 load "../testlib"
 
-@test "DIA017: Verify conflicting flags" {
+@test "VER006: Verify conflicting flags" {
 
 	# Some flags are mutually exclusive
 
@@ -72,10 +72,5 @@ load "../testlib"
 	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --manifest=latest"
 	assert_status_is "$SWUPD_INVALID_OPTION"
 	assert_in_output "Error: '--manifest latest' only supported with the --install option"
-
-	# --bundles without --fix
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --bundles os-core"
-	assert_status_is "$SWUPD_INVALID_OPTION"
-	assert_in_output "Error: --bundles option require the --fix option"
 
 }


### PR DESCRIPTION
The PR addresses the following things:
- This PR enables the `-B` / `--bundles` option to diagnose or repair only the specified list of bundles in a safe way.
- When using `--bundles` and a file is being marked as deleted for one of the specified bundles, it makes sure it is not needed by any of the other installed bundles before deleting it.
- Disallow the use of `--bundles` together with `--picky` or `--extra-files-only` for `diagnose` or `repair`. That combination of options is only allowed for `verify` for backward compatibility.

Closes #1035 