### PR TITLE
log: Print download sizes in MB and not Mb

### DIFF
--- a/src/fullfile.c
+++ b/src/fullfile.c
@@ -105,12 +105,12 @@ static double fullfile_query_total_download_size(struct list *files)
 		}
 
 		count++;
-		debug("File: %s (%.2lf Mb)\n", url, (double)size / 1000000);
+		debug("File: %s (%.2lf MB)\n", url, (double)size / 1000000);
 		free_string(&url);
 	}
 
 	debug("Number of files to download: %d\n", count);
-	debug("Total size of files to be downloaded: %.2lf Mb\n", (double)total_size / 1000000);
+	debug("Total size of files to be downloaded: %.2lf MB\n", (double)total_size / 1000000);
 	return total_size;
 }
 

--- a/src/packs.c
+++ b/src/packs.c
@@ -187,12 +187,12 @@ static double packs_query_total_download_size(struct list *subs, struct manifest
 		}
 
 		count++;
-		debug("Pack: %s (%.2lf Mb)\n", url, (double)size / 1000000);
+		debug("Pack: %s (%.2lf MB)\n", url, (double)size / 1000000);
 		free_string(&url);
 	}
 
 	debug("Number of packs to download: %d\n", count);
-	debug("Total size of packs to be downloaded: %.2lf Mb\n", (double)total_size / 1000000);
+	debug("Total size of packs to be downloaded: %.2lf MB\n", (double)total_size / 1000000);
 	return total_size;
 }
 
@@ -263,8 +263,8 @@ int download_subscribed_packs(struct list *subs, struct manifest *mom, bool requ
 		download_progress.total_download_size = 0;
 	}
 
-	/* show the packs size only if > 1 Mb */
-	string_or_die(&packs_size, "(%.2lf Mb) ", (double)download_progress.total_download_size / 1000000);
+	/* show the packs size only if > 1 MB */
+	string_or_die(&packs_size, "(%.2lf MB) ", (double)download_progress.total_download_size / 1000000);
 	info("Downloading packs %sfor:\n", ((double)download_progress.total_download_size / 1000000) > 1 ? packs_size : "");
 	free_string(&packs_size);
 	for (iter = list_head(need_download); iter; iter = iter->next) {

--- a/test/functional/bundleadd/add-no-disk-space.bats
+++ b/test/functional/bundleadd/add-no-disk-space.bats
@@ -113,7 +113,7 @@ test_setup() {
 		Warning: This is an insecure connection
 		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
 		Loading required manifests...
-		Downloading packs \\(.* Mb\\) for:
+		Downloading packs \\(.* MB\\) for:
 		 - test-bundle
 		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/pack-test-bundle-from-0.tar'
 		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?


### PR DESCRIPTION
MB stands for Megabyte and Mb stands for Megabit, so use the correct
unit.

Fixes #1044

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>