### PR TITLE
os-install: Add download flag

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -239,6 +239,7 @@ BATS = \
 	test/functional/os-install/install-also-add.bats \
 	test/functional/os-install/install-bad.bats \
 	test/functional/os-install/install-basics.bats \
+	test/functional/os-install/install-download.bats \
 	test/functional/os-install/install-json.bats \
 	test/functional/os-install/install-latest-missing.bats \
 	test/functional/os-install/install-multiple.bats \

--- a/config
+++ b/config
@@ -301,6 +301,9 @@
 # option (string value)
 #version=V
 
+# Download all content, but do not actually install it (boolean value)
+#download=<true/false>
+
 
 [mirror]
 

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -356,6 +356,11 @@ SUBCOMMANDS
 
             Installs bundles os-core and vi, along with os-core (installed by default).
 
+    - `--download`
+
+        Do not perform an os-install, instead download all resources needed
+        to perform the os-install, and exit.
+
 ``repair``
 
     Correct any issues found. This will overwrite incorrect file content,

--- a/src/os_install.c
+++ b/src/os_install.c
@@ -22,6 +22,9 @@
 #include "swupd.h"
 #include "swupd_internal.h"
 
+#define FLAG_DOWNLOAD_ONLY 2000
+
+static bool cmdline_option_download = false;
 static bool cmdline_option_force = false;
 static struct list *cmdline_bundles = NULL;
 static char *path;
@@ -32,6 +35,7 @@ static const struct option prog_opts[] = {
 	{ "bundles", required_argument, 0, 'B' },
 	{ "version", required_argument, 0, 'V' },
 	{ "manifest", required_argument, 0, 'm' },
+	{ "download", no_argument, 0, FLAG_DOWNLOAD_ONLY },
 };
 
 static void print_help(void)
@@ -45,6 +49,7 @@ static void print_help(void)
 	print("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	print("   -B, --bundles=[BUNDLES] Include the specified BUNDLES in the OS installation. Example: --bundles=os-core,vi\n");
 	print("   -V, --version=[VER]     If the version to install is not the latest, it can be specified with this option\n");
+	print("   --download              Download all content, but do not actually install it\n");
 	print("\n");
 }
 
@@ -85,6 +90,9 @@ static bool parse_opt(int opt, char *optarg)
 		}
 		return true;
 	}
+	case FLAG_DOWNLOAD_ONLY:
+		cmdline_option_download = true;
+		return true;
 	default:
 		return false;
 	}
@@ -146,6 +154,7 @@ enum swupd_code install_main(int argc, char **argv)
 	/* set options needed for the install in the verify command */
 	verify_set_option_quick(true);
 	verify_set_option_install(true);
+	verify_set_option_download(cmdline_option_download);
 	verify_set_option_force(cmdline_option_force);
 	verify_set_option_bundles(cmdline_bundles);
 	verify_set_option_version(cmdline_option_version);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -326,6 +326,7 @@ extern int link_or_rename(const char *orig, const char *dest);
 
 /* verify.c */
 extern enum swupd_code verify_main(void);
+extern void verify_set_option_download(bool opt);
 extern void verify_set_command_verify(bool opt);
 extern void verify_set_option_force(bool opt);
 extern void verify_set_option_install(bool opt);

--- a/swupd.bash
+++ b/swupd.bash
@@ -64,7 +64,7 @@ _swupd()
 		opts="$global --version --picky --picky-tree --picky-whitelist --quick --force --extra-files-only "
 		break;;
 		("os-install")
-		opts="$global --version --force --bundles "
+		opts="$global --version --force --bundles --download "
 		break;;
 		("mirror")
 		opts="$global --set --unset "

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -291,6 +291,7 @@ if [[ -n "$state" ]]; then
             '(help -x --force)'{-x,--force}'[Attempt to proceed even if non-critical errors found]'
             '(help -B --bundles)'{-B,--bundles=}'[Include the specified BUNDLES in the OS installation. Example: --bundles=os-core,vi]:diagnose: _swupd_all_bundles'
             '(help -V --version)'{-V,--version=}'[If the version to install is not the latest, it can be specified with this option]:version:()'
+            '(help status)--download[Download all content, but do not actually install it]'
           )
           _arguments $osinstall && ret=0
           ;;

--- a/test/functional/os-install/install-download.bats
+++ b/test/functional/os-install/install-download.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+# Author: John Akre
+# Email: john.w.akre@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment -e "$TEST_NAME" 10
+	create_bundle -n os-core -f /core "$TEST_NAME"
+
+}
+
+@test "INS015: Download os-install content without installing" {
+
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH --download $TARGETDIR" 
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Installing OS version 10 (latest)
+		Downloading packs for:
+		 - os-core
+		Finishing packs extraction...
+		Checking for corrupt files
+		No extra files need to be downloaded
+		Installation files downloaded
+	EOM
+	)
+
+	assert_is_output "$expected_output"
+	assert_file_not_exists "$TARGETDIR"/core
+
+	assert_file_exists "$STATEDIR"/10/Manifest.MoM
+	assert_file_exists "$STATEDIR"/10/Manifest.os-core
+
+	core_hash=$(get_hash_from_manifest "$STATEDIR"/10/Manifest.os-core "/core")
+	assert_file_exists "$STATEDIR"/staged/"$core_hash"
+
+}

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -232,7 +232,7 @@ validate_path() {
 validate_item() {
 
 	local vfile=$1
-	if [ -z "$vfile" ] || [ ! -e "$vfile" ]; then
+	if sudo sh -c "[ -z $vfile ] || [ ! -e $vfile ]"; then
 		terminate "Please provide a valid file"
 	fi
 


### PR DESCRIPTION
When the --download flag is set for the os-install command, update
content will be downloaded to the statedir and no content will be
installed.

Signed-off-by: John Akre <john.w.akre@intel.com>