### PR TITLE
Multiple configuration files

### DIFF
--- a/config
+++ b/config
@@ -161,6 +161,9 @@
 # Do not check free disk space before adding bundle (boolean value)
 #skip_diskspace_check=<true/false>
 
+# Do not install optional bundles, also-add flag in Manifests (boolean value)
+#skip_optional=<true/false>
+
 
 [bundle-remove]
 

--- a/configure.ac
+++ b/configure.ac
@@ -225,7 +225,7 @@ AC_ARG_WITH(
   [config-file-path],
   [AS_HELP_STRING([--with-config-file-path=PATHS], [List of directories to look for the configuration file])],
   [config_file_path=${withval}],
-  [config_file_path="/etc/swupd:/run/swupd:/usr/share/defaults/swupd"]
+  [config_file_path="/usr/share/defaults/swupd:/run/swupd:/etc/swupd"]
 )
 AC_SUBST(CONFIG_FILE_PATH, [${config_file_path}])
 AC_DEFINE_UNQUOTED([CONFIG_FILE_PATH], ["${config_file_path}"], [List of directories to look for the configuration file])

--- a/src/clr_bundle_add.c
+++ b/src/clr_bundle_add.c
@@ -64,10 +64,10 @@ static bool parse_opt(int opt, UNUSED_PARAM char *optarg)
 {
 	switch (opt) {
 	case FLAG_SKIP_OPTIONAL:
-		globals.skip_optional_bundles = true;
+		globals.skip_optional_bundles = optarg_to_bool(optarg);
 		return true;
 	case FLAG_SKIP_DISKSPACE_CHECK:
-		globals.skip_diskspace_check = true;
+		globals.skip_diskspace_check = optarg_to_bool(optarg);
 		return true;
 	default:
 		return false;

--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -71,8 +71,8 @@ static bool parse_opt(int opt, char *optarg)
 {
 	switch (opt) {
 	case 'a':
-		cmdline_option_all = true;
-		cmdline_local = false;
+		cmdline_option_all = optarg_to_bool(optarg);
+		cmdline_local = !cmdline_option_all;
 		return true;
 	case 'D':
 		string_or_die(&cmdline_option_has_dep, "%s", optarg);

--- a/src/config_loader.c
+++ b/src/config_loader.c
@@ -71,20 +71,8 @@ bool config_loader_set_opt(char *section, char *opt, char *value, void *data)
 				break;
 			}
 
-			/* now try with the local short options... */
-
-			/* boolean options with a value of "false" only make sense in the
-			 * global section, if we find one of these in a command section we
-			 * can skip it. We don't have a way to know if the value is a boolean
-			 * or not, if the value is the "false" string, we will treat it as a
-			 * boolean false and will skip this option */
-			if (strcmp(lvalue, "false") == 0) {
-				/* we don't need to set anything for this */
-				ret = true;
-				break;
-			}
-
-			/* not all commands support local options */
+			/* now try with the local short options...
+			 * not all commands support local options */
 			if (cl->parse_command_opt) {
 				ret = cl->parse_command_opt(options->val, value);
 			}

--- a/src/globals.c
+++ b/src/globals.c
@@ -42,8 +42,6 @@
 #define FLAG_DEBUG 1003
 #define FLAG_ALLOW_INSECURE_HTTP 1004
 
-#define optarg_to_bool(_optarg) (_optarg ? strtobool(_optarg) : true)
-
 struct globals globals = {
 	.sigcheck = true,
 	.timecheck = true,
@@ -584,10 +582,10 @@ void global_print_help(void)
 	print("\n");
 }
 
-void load_flags_in_config(char *command, struct option *opts_array, const struct global_options *opts)
+static bool load_flags_in_config(char *command, struct option *opts_array, const struct global_options *opts)
 {
-#ifdef CONFIG_FILE_PATH
 	bool config_found = false;
+#ifdef CONFIG_FILE_PATH
 	// load configuration values from the config file
 	struct config_loader_data loader_data = { command, opts_array, global_parse_opt, opts->parse_opt };
 	struct stat st;
@@ -596,28 +594,25 @@ void load_flags_in_config(char *command, struct option *opts_array, const struct
 	char *str = strdup_or_die(CONFIG_FILE_PATH);
 
 	for (char *tok = strtok_r(str, ":", &ctx); tok; tok = strtok_r(NULL, ":", &ctx)) {
+		/* load values from all configuration files found, starting from
+		 * the least important to the most one since values will be overwritten
+		 * if found more than once */
 		if (stat(tok, &st)) {
 			continue;
 		}
 		if ((st.st_mode & S_IFMT) != S_IFDIR) {
 			continue;
 		}
-		debug("Looking for config file in path %s\n", tok);
 		string_or_die(&config_file, "%s/config", tok);
-		config_found = config_parse(config_file, config_loader_set_opt, &loader_data);
-		free_string(&config_file);
-		if (config_found) {
-			debug("Using configuration file %s\n", tok);
-			break;
+		if (config_parse(config_file, config_loader_set_opt, &loader_data)) {
+			config_found = true;
 		}
+		free_string(&config_file);
 	}
 
 	free_string(&str);
-	if (!config_found) {
-		debug("Configuration file not found in %s\n", CONFIG_FILE_PATH);
-		debug("No configuration file will be used\n\n");
-	}
 #endif
+	return config_found;
 }
 
 int global_parse_options(int argc, char **argv, const struct global_options *opts)
@@ -626,6 +621,7 @@ int global_parse_options(int argc, char **argv, const struct global_options *opt
 	int num_global_opts, opt;
 	char *optstring;
 	int ret = 0;
+	bool config_found;
 
 	if (!opts) {
 		return -EINVAL;
@@ -645,7 +641,7 @@ int global_parse_options(int argc, char **argv, const struct global_options *opt
 	optstring = generate_optstring(opts_array,
 				       num_global_opts + opts->longopts_len);
 
-	load_flags_in_config(argv[0], opts_array, opts);
+	config_found = load_flags_in_config(argv[0], opts_array, opts);
 
 	// parse and load flags from command line
 	while ((opt = getopt_long(argc, argv, optstring, opts_array, NULL)) != -1) {
@@ -675,6 +671,10 @@ int global_parse_options(int argc, char **argv, const struct global_options *opt
 		log_level = LOG_ERROR;
 	}
 	log_set_level(log_level);
+
+	if (!config_found) {
+		debug("No configuration file was found\n");
+	}
 
 end:
 	free(optstring);

--- a/src/globals.h
+++ b/src/globals.h
@@ -16,6 +16,8 @@
 extern "C" {
 #endif
 
+#define optarg_to_bool(_optarg) (_optarg ? strtobool(_optarg) : true)
+
 /*
  * Global variables
  */

--- a/src/os_install.c
+++ b/src/os_install.c
@@ -72,7 +72,7 @@ static bool parse_opt(int opt, char *optarg)
 		}
 		return true;
 	case 'x':
-		cmdline_option_force = true;
+		cmdline_option_force = optarg_to_bool(optarg);
 		return true;
 	case 'B': {
 		char *arg_copy = strdup_or_die(optarg);
@@ -91,7 +91,7 @@ static bool parse_opt(int opt, char *optarg)
 		return true;
 	}
 	case FLAG_DOWNLOAD_ONLY:
-		cmdline_option_download = true;
+		cmdline_option_download = optarg_to_bool(optarg);
 		return true;
 	default:
 		return false;

--- a/src/repair.c
+++ b/src/repair.c
@@ -85,13 +85,13 @@ static bool parse_opt(int opt, char *optarg)
 		}
 		return true;
 	case 'x':
-		cmdline_option_force = true;
+		cmdline_option_force = optarg_to_bool(optarg);
 		return true;
 	case 'q':
-		cmdline_option_quick = true;
+		cmdline_option_quick = optarg_to_bool(optarg);
 		return true;
 	case 'Y':
-		cmdline_option_picky = true;
+		cmdline_option_picky = optarg_to_bool(optarg);
 		return true;
 	case 'X':
 		if (optarg[0] != '/') {
@@ -105,7 +105,7 @@ static bool parse_opt(int opt, char *optarg)
 		cmdline_option_picky_whitelist = strdup_or_die(optarg);
 		return true;
 	case FLAG_EXTRA_FILES_ONLY:
-		cmdline_extra_files_only = true;
+		cmdline_extra_files_only = optarg_to_bool(optarg);
 		return true;
 	default:
 		return false;

--- a/src/search.c
+++ b/src/search.c
@@ -65,6 +65,8 @@ static char *search_string = NULL;
 static bool csv_format = false;
 static bool init = false;
 static enum search_type search_type = SEARCH_TYPE_ALL;
+static bool cmdline_option_library = false;
+static bool cmdline_option_binary = false;
 static int num_results = INT_MAX;
 static int sort = SORT_TYPE_ALPHA_BUNDLES_ONLY;
 static bool regexp = false;
@@ -532,16 +534,16 @@ static bool parse_opt(int opt, char *optarg)
 		}
 		return true;
 	case 'm':
-		csv_format = true;
+		csv_format = optarg_to_bool(optarg);
 		return true;
 	case 'l':
-		search_type |= SEARCH_TYPE_LIB;
+		cmdline_option_library = optarg_to_bool(optarg);
 		return true;
 	case 'i':
-		init = true;
+		init = optarg_to_bool(optarg);
 		return true;
 	case 'B':
-		search_type |= SEARCH_TYPE_BIN;
+		cmdline_option_binary = optarg_to_bool(optarg);
 		return true;
 	case FLAG_REGEXP:
 		regexp = true;
@@ -565,6 +567,13 @@ static bool parse_options(int argc, char **argv)
 
 	if (optind < 0) {
 		return false;
+	}
+
+	if (cmdline_option_library) {
+		search_type |= SEARCH_TYPE_LIB;
+	}
+	if (cmdline_option_binary) {
+		search_type |= SEARCH_TYPE_BIN;
 	}
 
 	search_string = optind < argc ? argv[optind] : "";

--- a/src/update.c
+++ b/src/update.c
@@ -635,20 +635,20 @@ static bool parse_opt(int opt, char *optarg)
 		}
 		return true;
 	case 'a':
-		allow_mix_collisions = true;
+		allow_mix_collisions = optarg_to_bool(optarg);
 		return true;
 	case 's':
-		cmd_line_status = true;
+		cmd_line_status = optarg_to_bool(optarg);
 		return true;
 	case 'T':
-		globals.migrate = true;
+		globals.migrate = optarg_to_bool(optarg);
 		error("Attempting to migrate to your mix content...\n\n");
 		return true;
 	case 'k':
-		keepcache = true;
+		keepcache = optarg_to_bool(optarg);
 		return true;
 	case FLAG_DOWNLOAD_ONLY:
-		download_only = true;
+		download_only = optarg_to_bool(optarg);
 		return true;
 	default:
 		return false;

--- a/src/verify.c
+++ b/src/verify.c
@@ -580,7 +580,7 @@ static bool parse_opt(int opt, char *optarg)
 		cmdline_option_fix = true;
 		return true;
 	case 'x':
-		cmdline_option_force = true;
+		cmdline_option_force = optarg_to_bool(optarg);
 		return true;
 	case 'i':
 		warn("\nThe --install option has been superseded\n");
@@ -590,10 +590,10 @@ static bool parse_opt(int opt, char *optarg)
 		cmdline_option_quick = true;
 		return true;
 	case 'q':
-		cmdline_option_quick = true;
+		cmdline_option_quick = optarg_to_bool(optarg);
 		return true;
 	case 'Y':
-		cmdline_option_picky = true;
+		cmdline_option_picky = optarg_to_bool(optarg);
 		return true;
 	case 'X':
 		if (optarg[0] != '/') {
@@ -626,7 +626,7 @@ static bool parse_opt(int opt, char *optarg)
 		return true;
 	}
 	case FLAG_EXTRA_FILES_ONLY:
-		cmdline_option_extra_files_only = true;
+		cmdline_option_extra_files_only = optarg_to_bool(optarg);
 		return true;
 	default:
 		return false;


### PR DESCRIPTION
Enable the ability to provide many paths for the configuration file and read configuration from all of them. If the same option is defined in more than one configuration file it will just be overwritten by the one last read.