### PR TITLE
test: Don't check the hashes twice on real tests

### DIFF
--- a/test/real_content/real_content_lib.bash
+++ b/test/real_content/real_content_lib.bash
@@ -93,9 +93,6 @@ verify_system() {
 	run sudo sh -c "$SWUPD diagnose --picky $SWUPD_OPTS 2>/dev/null"
 	assert_status_is 0
 
-	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
-	assert_status_is 0
-
 	return
 }
 


### PR DESCRIPTION
Diagnose picky behavior has changed so now we can use just one call
to swupd to verify if there's no extra file and no corruption.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>