### PR TITLE
update: Download search-files indexes on update

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -89,7 +89,7 @@ swupd_SOURCES = \
 	src/repair.c \
 	src/scripts.c \
 	src/scripts.h \
-	src/search.c \
+	src/search-file.c \
 	src/signature.c \
 	src/signature.h \
 	src/staging.c \

--- a/config
+++ b/config
@@ -151,6 +151,8 @@
 # Migrate to augmented upstream/mix content (boolean value)
 #migrate=<true/false>
 
+# Update the index used by search-file to speed up searches (boolean value)
+#update_search_file_index=<true/false>
 
 [bundle-add]
 

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -519,6 +519,11 @@ SUBCOMMANDS
         Do not delete the swupd state directory content after updating the
         system.
 
+    - `--update-search-file-index`
+
+        Update the index used by search-file to speed up searches. Don't
+        enable this if you have download or space restrictions.
+
 ``verify``
 
     Perform system software installation verification. The program will

--- a/src/main.c
+++ b/src/main.c
@@ -60,7 +60,7 @@ static struct subcmd commands[] = {
 #ifdef EXTERNAL_MODULES_SUPPORT
 	{ "search", "Searches for the best bundle to install a binary or library (depends on os-core-search bundle)", external_search_main },
 #endif
-	{ "search-file", "Command to search files in Clear Linux bundles", search_main },
+	{ "search-file", "Command to search files in Clear Linux bundles", search_file_main },
 	{ "diagnose", "Verify content for OS version", diagnose_main },
 	{ "repair", "Repair local issues relative to server manifest (will not modify ignored files)", repair_main },
 	{ "os-install", "Install Clear Linux OS to a blank partition or directory", install_main },

--- a/src/search-file.c
+++ b/src/search-file.c
@@ -592,7 +592,7 @@ static bool parse_options(int argc, char **argv)
 	return true;
 }
 
-enum swupd_code search_main(int argc, char **argv)
+enum swupd_code search_file_main(int argc, char **argv)
 {
 
 	int ret = SWUPD_OK, search_ret = SWUPD_OK;

--- a/src/search-file.c
+++ b/src/search-file.c
@@ -431,7 +431,7 @@ static double query_total_download_size(struct list *list)
 /* download_manifests()
  * Download all manifests and return a list of manifest headers.
  */
-static enum swupd_code download_all_manifests(struct manifest *mom, struct list **manifest_list)
+enum swupd_code download_all_manifests(struct manifest *mom, struct list **manifest_list)
 {
 	struct manifest *manifest = NULL;
 	struct list *list;
@@ -470,7 +470,11 @@ static enum swupd_code download_all_manifests(struct manifest *mom, struct list 
 			}
 		}
 
-		*manifest_list = list_prepend_data(*manifest_list, manifest);
+		if (manifest_list) {
+			*manifest_list = list_prepend_data(*manifest_list, manifest);
+		} else {
+			free_manifest(manifest);
+		}
 		progress_report(complete, total);
 	}
 

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -365,6 +365,7 @@ extern enum swupd_code print_update_conf_info(void);
 extern void handle_mirror_if_stale(void);
 
 extern enum swupd_code clean_statedir(bool all, bool dry_run);
+enum swupd_code download_all_manifests(struct manifest *mom, struct list **manifest_list);
 
 /* Parameter parsing in global.c */
 extern struct global_const global;

--- a/src/swupd_internal.h
+++ b/src/swupd_internal.h
@@ -8,7 +8,7 @@ extern enum swupd_code bundle_list_main(int argc, char **argv);
 extern enum swupd_code hashdump_main(int argc, char **argv);
 extern enum swupd_code update_main(int argc, char **argv);
 extern enum swupd_code check_update_main(int argc, char **argv);
-extern enum swupd_code search_main(int argc, char **argv);
+extern enum swupd_code search_file_main(int argc, char **argv);
 extern enum swupd_code info_main(int argc, char **argv);
 extern enum swupd_code clean_main(int argc, char **argv);
 extern enum swupd_code mirror_main(int argc, char **argv);

--- a/src/update.c
+++ b/src/update.c
@@ -38,10 +38,12 @@
 #include "swupd.h"
 
 #define FLAG_DOWNLOAD_ONLY 2000
+#define FLAG_UPDATE_SEARCH_FILE_INDEX 2001
 
 static bool allow_mix_collisions = false;
 static int requested_version = -1;
 static bool download_only = false;
+static bool update_search_file_index = false;
 static bool keepcache = false;
 
 int nonpack;
@@ -480,6 +482,12 @@ version_check:
 		re_update = true;
 	}
 	scripts_run_post_update(re_update || globals.wait_for_scripts);
+
+	/* Downloadng search-file index */
+	if (update_search_file_index) {
+		download_all_manifests(server_manifest, NULL);
+	}
+
 	progress_complete_step();
 	timelist_timer_stop(globals.global_times); // closing: Run post-update scripts
 
@@ -586,6 +594,7 @@ static bool cmd_line_status = false;
 
 static const struct option prog_opts[] = {
 	{ "download", no_argument, 0, FLAG_DOWNLOAD_ONLY },
+	{ "update-search-file-index", no_argument, 0, FLAG_UPDATE_SEARCH_FILE_INDEX },
 	{ "version", required_argument, 0, 'V' },
 	{ "manifest", required_argument, 0, 'm' },
 	{ "status", no_argument, 0, 's' },
@@ -613,6 +622,7 @@ static void print_help(void)
 	print("   -a, --allow-mix-collisions	Ignore and continue if custom user content conflicts with upstream provided content\n");
 	print("   -m, --manifest=V        NOTE: this flag has been superseded. Please use -V instead\n");
 	print("   --download              Download all content, but do not actually install the update\n");
+	print("   --update-search-file-index Update the index used by search-file to speed up searches (Don't enable this if you have download or space restrictions)\n");
 	print("\n");
 }
 
@@ -649,6 +659,9 @@ static bool parse_opt(int opt, char *optarg)
 		return true;
 	case FLAG_DOWNLOAD_ONLY:
 		download_only = optarg_to_bool(optarg);
+		return true;
+	case FLAG_UPDATE_SEARCH_FILE_INDEX:
+		update_search_file_index = optarg_to_bool(optarg);
 		return true;
 	default:
 		return false;

--- a/swupd.bash
+++ b/swupd.bash
@@ -40,7 +40,7 @@ _swupd()
 		opts="$global "
 		break;;
 		("update")
-		opts="$global --download --status --force --migrate --allow-mix-collisions --keepcache "
+		opts="$global --download --status --force --migrate --allow-mix-collisions --keepcache --update-search-file-index "
 		break;;
 	    ("bundle-add")
 		opts="$global --skip-diskspace-check "

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -197,6 +197,7 @@ if [[ -n "$state" ]]; then
           local -a updates; updates=(
             $global_opts
             '(help status)--download[Download all content, but do not actually install the update]'
+            '(help status)--update-search-file-index[Update the index used by search-file to speed up searches]'
             '(help status -k --keepcache)'{-k,--keepcache}'[Do not delete the swupd state directory content after updating the system]'
             '(help status -T --migrate)'{-T,--migrate}'[Migrate to augmented upstream/mix content]'
             '(help status -a --allow-mix-collisions)'{-a,--allow-mix-collisions}'[Ignore and continue if custom user content conflicts with upstream provided content]'

--- a/test/functional/search/search-content-check-negative.bats
+++ b/test/functional/search/search-content-check-negative.bats
@@ -39,12 +39,12 @@ global_teardown() {
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
-		Downloading Clear Linux manifests \\(.* MB\\)
+		Downloading all Clear Linux manifests
 		Searching for 'fake-file'
 		Search term not found
 	EOM
 	)
-	assert_regex_is_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 

--- a/test/functional/search/search-content-check-positive.bats
+++ b/test/functional/search/search-content-check-positive.bats
@@ -40,11 +40,11 @@ global_teardown() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Downloading Clear Linux manifests \\(.* MB\\)
+		Downloading all Clear Linux manifests
 		Successfully retrieved manifests. Exiting
 	EOM
 	)
-	assert_regex_is_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 

--- a/test/functional/search/search-experimental.bats
+++ b/test/functional/search/search-experimental.bats
@@ -45,11 +45,11 @@ global_teardown() {
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
-		Downloading Clear Linux manifests \\(.* MB\\)
+		Downloading all Clear Linux manifests
 		Searching for 'test-bundle1'
 	EOM
 	)
-	assert_regex_in_output "$expected_output"
+	assert_in_output "$expected_output"
 
 }
 

--- a/test/functional/search/search-no-disk-space.bats
+++ b/test/functional/search/search-no-disk-space.bats
@@ -59,7 +59,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_RECURSE_MANIFEST"
 	expected_output=$(cat <<-EOM
-		Downloading Clear Linux manifests \\(.* MB\\)
+		Downloading all Clear Linux manifests
 		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/10/Manifest.test-bundle1.tar'
 		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?
 		Error: Failed to retrieve 10 test-bundle1 manifest

--- a/test/functional/update/update-search-file-index.bats
+++ b/test/functional/update/update-search-file-index.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n test-bundle1 -f /foo/test-file1 "$TEST_NAME"
+	create_version -p "$TEST_NAME" 100 10
+	update_bundle "$TEST_NAME" os-core --add /foo
+
+}
+
+@test "UPD059: Download search-file index on update" {
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS --update-search-file-index"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Update started
+		Preparing to update from 10 to 100
+		Downloading packs for:
+		 - os-core
+		Finishing packs extraction...
+		Statistics for going from version 10 to version 100:
+		    changed bundles   : 1
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 0
+		    new files         : 1
+		    deleted files     : 0
+		No extra files need to be downloaded
+		Staging file content
+		Applying update
+		Update was applied
+		Calling post-update helper scripts
+		Downloading Clear Linux manifests (.*)
+		Update successful - System updated from version 10 to version 100
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+	assert_file_exists "$STATEDIR"/10/Manifest.test-bundle1
+}
+
+@test "UPD060: Don't download search-file index on update" {
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Update started
+		Preparing to update from 10 to 100
+		Downloading packs for:
+		 - os-core
+		Finishing packs extraction...
+		Statistics for going from version 10 to version 100:
+		    changed bundles   : 1
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 0
+		    new files         : 1
+		    deleted files     : 0
+		No extra files need to be downloaded
+		Staging file content
+		Applying update
+		Update was applied
+		Calling post-update helper scripts
+		Update successful - System updated from version 10 to version 100
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+	assert_file_not_exists "$STATEDIR"/10/Manifest.test-bundle1
+}
+

--- a/test/functional/update/update-search-file-index.bats
+++ b/test/functional/update/update-search-file-index.bats
@@ -34,11 +34,11 @@ test_setup() {
 		Applying update
 		Update was applied
 		Calling post-update helper scripts
-		Downloading Clear Linux manifests (.*)
+		Downloading all Clear Linux manifests
 		Update successful - System updated from version 10 to version 100
 	EOM
 	)
-	assert_regex_is_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_file_exists "$STATEDIR"/10/Manifest.test-bundle1
 }
 


### PR DESCRIPTION
If --update-search-file-index flag is used on update, all search-file indexes, i.e.
all Manifests will be downloaded on update. This shouldn't be used if you have
disk or network restrictions, but it shouldn't be very download intensive after the
first usage because delta manifests are going to be used.