### PR TITLE
Show the real latest version using check-update

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -213,6 +213,7 @@ BATS = \
 	test/functional/bundleremove/remove-parse-args.bats \
 	test/functional/bundleremove/remove-with-dependency.bats \
 	test/functional/checkupdate/chk-update-client-certificate.bats \
+	test/functional/checkupdate/chk-update-format-bump.bats \
 	test/functional/checkupdate/chk-update-json.bats \
 	test/functional/checkupdate/chk-update-new-version.bats \
 	test/functional/checkupdate/chk-update-no-server-content.bats \

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -47,7 +47,7 @@ enum swupd_code check_update()
 	int current_version, server_version;
 	enum swupd_code ret;
 
-	ret = read_versions(&current_version, &server_version, globals.path_prefix);
+	ret = read_versions(&current_version, &server_version, globals.path_prefix, true);
 
 	if (current_version > 0) {
 		info("Current OS version: %d\n", current_version);

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -45,9 +45,19 @@ static void print_help(void)
 enum swupd_code check_update()
 {
 	int current_version, server_version;
-	enum swupd_code ret;
+	enum swupd_code ret = SWUPD_OK;
 
-	ret = read_versions(&current_version, &server_version, globals.path_prefix, true);
+	current_version = get_current_version(globals.path_prefix);
+	server_version = version_get_absolute_latest();
+
+	if (current_version < 0) {
+		error("Unable to determine current OS version\n");
+		ret = SWUPD_CURRENT_VERSION_UNKNOWN;
+	}
+	if (server_version < 0) {
+		error("Unable to determine the server version\n");
+		ret = SWUPD_SERVER_CONNECTION_ERROR;
+	}
 
 	if (current_version > 0) {
 		info("Current OS version: %d\n", current_version);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -162,7 +162,7 @@ extern enum swupd_code walk_tree(struct manifest *, const char *, bool, const re
 
 extern int get_latest_version(char *v_url);
 extern int get_absolute_latest_version(void);
-extern enum swupd_code read_versions(int *current_version, int *server_version, char *path_prefix, bool absolute);
+extern enum swupd_code read_versions(int *current_version, int *server_version, char *path_prefix);
 extern int get_current_version(char *path_prefix);
 extern bool get_distribution_string(char *path_prefix, char *dist);
 
@@ -181,6 +181,7 @@ extern void link_submanifests(struct manifest *m1, struct manifest *m2, struct l
 
 extern int get_value_from_path(char **contents, const char *path, bool is_abs_path);
 extern int get_version_from_path(const char *abs_path);
+extern int version_get_absolute_latest(void);
 
 static inline int bsearch_file_helper(const void *A, const void *B)
 {

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -161,7 +161,8 @@ extern int main_verify(int current_version);
 extern enum swupd_code walk_tree(struct manifest *, const char *, bool, const regex_t *, struct file_counts *);
 
 extern int get_latest_version(char *v_url);
-extern enum swupd_code read_versions(int *current_version, int *server_version, char *path_prefix);
+extern int get_absolute_latest_version(void);
+extern enum swupd_code read_versions(int *current_version, int *server_version, char *path_prefix, bool absolute);
 extern int get_current_version(char *path_prefix);
 extern bool get_distribution_string(char *path_prefix, char *dist);
 

--- a/src/update.c
+++ b/src/update.c
@@ -203,7 +203,7 @@ static enum swupd_code check_versions(int *current_version, int *server_version,
 {
 	int ret;
 
-	ret = read_versions(current_version, server_version, path_prefix, false);
+	ret = read_versions(current_version, server_version, path_prefix);
 	if (ret != SWUPD_OK) {
 		return ret;
 	}

--- a/src/update.c
+++ b/src/update.c
@@ -203,7 +203,7 @@ static enum swupd_code check_versions(int *current_version, int *server_version,
 {
 	int ret;
 
-	ret = read_versions(current_version, server_version, path_prefix);
+	ret = read_versions(current_version, server_version, path_prefix, false);
 	if (ret != SWUPD_OK) {
 		return ret;
 	}

--- a/src/version.c
+++ b/src/version.c
@@ -195,14 +195,10 @@ bool get_distribution_string(char *path_prefix, char *dist)
 	return true;
 }
 
-enum swupd_code read_versions(int *current_version, int *server_version, char *path_prefix, bool absolute)
+enum swupd_code read_versions(int *current_version, int *server_version, char *path_prefix)
 {
 	*current_version = get_current_version(path_prefix);
-	if (absolute) {
-		*server_version = version_get_absolute_latest();
-	} else {
-		*server_version = get_latest_version(NULL);
-	}
+	*server_version = get_latest_version(NULL);
 
 	if (*current_version < 0) {
 		error("Unable to determine current OS version\n");

--- a/test/functional/checkupdate/chk-update-format-bump.bats
+++ b/test/functional/checkupdate/chk-update-format-bump.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment -r "$TEST_NAME" 10 1
+	bump_format "$TEST_NAME"
+	create_version -r "$TEST_NAME" 40 30 2
+
+}
+
+@test "CHK010: Check for available updates accross format bumps" {
+
+	# check-update should return the latest available version regardless
+	# of if it is in a different format
+
+	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Current OS version: 10
+		Latest server version: 40
+		There is a new OS version available: 40
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1356,6 +1356,7 @@ create_version() { # swupd_function
 	sudo mkdir -p "$env_name"/web-dir/"$version"/{files,delta}
 	sudo mkdir -p "$env_name"/web-dir/version/format"$format"
 	write_to_protected_file "$env_name"/web-dir/version/format"$format"/latest "$version"
+	write_to_protected_file "$env_name"/web-dir/version/latest_version "$version"
 	if [ "$format" = staging ]; then
 		format=1
 	fi

--- a/test/functional/update/update-status-no-target-content.bats
+++ b/test/functional/update/update-status-no-target-content.bats
@@ -5,7 +5,7 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment -e "$TEST_NAME"
-	set_latest_version "$TEST_NAME" 100
+	create_version "$TEST_NAME" 100
 	sudo rm -f "$TARGETDIR"/usr/lib/os-release
 
 }

--- a/test/functional/update/update-status.bats
+++ b/test/functional/update/update-status.bats
@@ -5,7 +5,7 @@ load "../testlib"
 global_setup() {
 
 	create_test_environment -e "$TEST_NAME"
-	set_latest_version "$TEST_NAME" 100
+	create_version "$TEST_NAME" 100
 
 }
 


### PR DESCRIPTION
When running the check-update command we get the latest version for the
format we are currently in, but we really want to get the latest version
regardless of the format.

This commit fixes the issue.

Closes #482

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>