### PR TITLE
Don't check network when listing bundles locally

### DIFF
--- a/src/clr_bundle_ls.c
+++ b/src/clr_bundle_ls.c
@@ -116,6 +116,7 @@ static bool parse_options(int argc, char **argv)
 enum swupd_code bundle_list_main(int argc, char **argv)
 {
 	int ret;
+	int init_option = SWUPD_ALL;
 	const int steps_in_bundlelist = 1;
 
 	/* there is no need to report in progress for bundle-list at this time */
@@ -126,8 +127,12 @@ enum swupd_code bundle_list_main(int argc, char **argv)
 	}
 	progress_init_steps("bundle-list", steps_in_bundlelist);
 
-	if (cmdline_local && !is_root()) {
-		ret = swupd_init(SWUPD_NO_ROOT);
+	if (cmdline_local) {
+		init_option |= SWUPD_NO_NETWORK;
+		if (!is_root()) {
+			init_option |= SWUPD_NO_ROOT;
+		}
+		ret = swupd_init(init_option);
 	} else {
 		ret = swupd_init(SWUPD_ALL);
 	}


### PR DESCRIPTION
When listing local bundles swupd doesn't really require network to
list them, it only requires it to report which of those local bundles are
experimental.

This commit allows users to run the command to list local bundles
without checking for network connectivity.

Closes #895

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>