### PR TITLE
bundle.c: Return included manifest loading errors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -252,6 +252,7 @@ BATS = \
 	test/functional/repair/repair-boot-file-deleted.bats \
 	test/functional/repair/repair-boot-file.bats \
 	test/functional/repair/repair-boot-skip.bats \
+	test/functional/repair/repair-deleted-include-manifest.bats \
 	test/functional/repair/repair-directory-tree-deleted.bats \
 	test/functional/repair/repair-empty-dir-deleted.bats \
 	test/functional/repair/repair-flags.bats \
@@ -288,6 +289,7 @@ BATS = \
 	test/functional/update/update-boot-skip.bats \
 	test/functional/update/update-bundle-removed.bats \
 	test/functional/update/update-client-certificate.bats \
+	test/functional/update/update-deleted-include-manifest.bats \
 	test/functional/update/update-download.bats \
 	test/functional/update/update-fail-to-get-mom.bats \
 	test/functional/update/update-ignore-also-add.bats \

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -732,21 +732,13 @@ int add_subscriptions(struct list *bundles, struct list **subs, struct manifest 
 		}
 
 		if (manifest->includes) {
-			int r = add_subscriptions(manifest->includes, subs, mom, find_all, recursion + 1);
-			if (r & add_sub_ERR) {
-				free_manifest(manifest);
-				goto out;
-			}
-			ret |= r; /* merge in recursive call results */
+			/* merge in recursive call results */
+			ret |= add_subscriptions(manifest->includes, subs, mom, find_all, recursion + 1);
 		}
 
 		if (!globals.skip_optional_bundles && manifest->optional) {
-			int r = add_subscriptions(manifest->optional, subs, mom, find_all, recursion + 1);
-			if (r & add_sub_ERR) {
-				free_manifest(manifest);
-				goto out;
-			}
-			ret |= r; /* merge in recursive call results */
+			/* merge in recursive call results */
+			ret |= add_subscriptions(manifest->optional, subs, mom, find_all, recursion + 1);
 		}
 
 		free_manifest(manifest);

--- a/test/functional/repair/repair-deleted-include-manifest.bats
+++ b/test/functional/repair/repair-deleted-include-manifest.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+# Author: John Akre
+# Email: john.w.akre@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle1 -f /test-file1 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /test-file2 "$TEST_NAME"
+	create_version "$TEST_NAME" 100 10
+	update_bundle "$TEST_NAME" test-bundle1 --header-only
+	add_dependency_to_manifest "$WEBDIR"/100/Manifest.test-bundle1 test-bundle2
+	set_current_version "$TEST_NAME" 100
+
+	# Delete the included manifest
+	sudo rm "$WEBDIR"/10/Manifest.test-bundle2
+	sudo rm "$WEBDIR"/10/pack-test-bundle2-from-0.tar
+	sudo rm "$WEBDIR"/10/Manifest.test-bundle2.tar
+}
+
+@test "REP033: Report error when an included manifest is deleted" {
+
+	run sudo sh -c "$SWUPD repair $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_COULDNT_LOAD_MANIFEST"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 100
+		Error: Failed to retrieve 10 test-bundle2 manifest
+		Error: Unable to download manifest test-bundle2 version 10, exiting now
+		Repair did not fully succeed
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}

--- a/test/functional/update/update-deleted-include-manifest.bats
+++ b/test/functional/update/update-deleted-include-manifest.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+# Author: John Akre
+# Email: john.w.akre@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n test-bundle1 -f /foo/testfile1 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /bar/testfile2 "$TEST_NAME"
+	create_version -p "$TEST_NAME" 100 10
+	update_bundle "$TEST_NAME" test-bundle1 --header-only
+	add_dependency_to_manifest "$WEBDIR"/100/Manifest.test-bundle1 test-bundle2
+
+	# Delete the included manifest
+	sudo rm "$WEBDIR"/10/Manifest.test-bundle2
+	sudo rm "$WEBDIR"/10/pack-test-bundle2-from-0.tar
+	sudo rm "$WEBDIR"/10/Manifest.test-bundle2.tar
+
+}
+
+@test "UPD058: Report error when an included manifest is deleted" {
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_RECURSE_MANIFEST"
+	expected_output=$(cat <<-EOM
+		Update started
+		Preparing to update from 10 to 100
+		Error: Failed to retrieve 10 test-bundle2 manifest
+		Error: Unable to download manifest test-bundle2 version 10, exiting now
+		Update failed
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}


### PR DESCRIPTION
Previously, errors when adding included manifests were thrown away which
resulted in swupd operations that could succeed, even when failing to
load an included manifest. Now when an included manifest fails to load,
swupd will return a failure.

Signed-off-by: John Akre <john.w.akre@intel.com>