### PR TITLE
Add Support for statedir-cache

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -246,6 +246,8 @@ BATS = \
 	test/functional/os-install/install-multiple.bats \
 	test/functional/os-install/install-no-fullfile-fallback.bats \
 	test/functional/os-install/install-no-packs.bats \
+	test/functional/os-install/install-statedir-cache.bats \
+	test/functional/os-install/install-statedir-cache-offline.bats \
 	test/functional/os-install/install-version.bats \
 	test/functional/repair/repair-add-missing-include-old.bats \
 	test/functional/repair/repair-add-missing-include.bats \

--- a/config
+++ b/config
@@ -306,6 +306,10 @@
 # option (string value)
 #version=V
 
+# After checking for content in the statedir, check the statedir-cache before
+# downloading it over the network
+#statedir-cache=[PATH]
+
 # Download all content, but do not actually install it (boolean value)
 #download=<true/false>
 

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -356,6 +356,10 @@ SUBCOMMANDS
 
             Installs bundles os-core and vi, along with os-core (installed by default).
 
+    - `-s, --statedir-cache=[PATH]`
+
+        After checking for content in the statedir, check the statedir-cache before downloading it over the network.
+
     - `--download`
 
         Do not perform an os-install, instead download all resources needed

--- a/src/globals.h
+++ b/src/globals.h
@@ -40,6 +40,7 @@ extern struct globals {
 	char *mounted_dirs;
 	char *path_prefix;
 	char *state_dir;
+	char *state_dir_cache;
 	char *version_url;
 	int max_retries;
 	int retry_delay;
@@ -78,6 +79,7 @@ void save_cmd(char **argv);
 
 bool set_path_prefix(char *path);
 bool set_default_urls(void);
+bool set_state_dir_cache(char *path);
 void set_default_path_prefix(void);
 
 #ifdef __cplusplus

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -912,6 +912,30 @@ int link_or_rename(const char *orig, const char *dest)
 	return 0;
 }
 
+/* Try to create a link to a file. If it fails, copy it.
+ * Return 0 on success or an error code on errors.*/
+int link_or_copy(const char *orig, const char *dest)
+{
+	/* Try doing a copy if hardlink fails */
+	if (link(orig, dest) != 0) {
+		return copy(orig, dest);
+	}
+
+	return 0;
+}
+
+/* Try to create a link to a file. If it fails, copy it with cp -a.
+ * Return 0 on success or an error code on errors.*/
+int link_or_copy_all(const char *orig, const char *dest)
+{
+	/* Try doing a copy if hardlink fails */
+	if (link(orig, dest) != 0) {
+		return copy_all(orig, dest);
+	}
+
+	return 0;
+}
+
 /* This function will break if the same HASH.tar full file is downloaded
  * multiple times in parallel. */
 int untar_full_download(void *data)

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -298,25 +298,35 @@ static void set_untracked_manifest_files(struct manifest *manifest)
 }
 
 /* Removes the extracted Manifest.<bundle> and accompanying tar file, cache file, and
- * the signature file */
+ * the signature file from the statedir and statedir-cache */
 static void remove_manifest_files(char *filename, int version, char *hash)
 {
 	char *file;
+	char *state_dirs[] = { globals.state_dir, globals.state_dir_cache };
+	int num_state_dirs = sizeof(state_dirs) / sizeof(state_dirs[0]);
+	int i;
 
 	warn("Removing corrupt Manifest.%s artifacts and re-downloading...\n", filename);
-	string_or_die(&file, "%s/%i/Manifest.%s", globals.state_dir, version, filename);
-	unlink(file);
-	free_string(&file);
-	string_or_die(&file, "%s/%i/Manifest.%s.tar", globals.state_dir, version, filename);
-	unlink(file);
-	free_string(&file);
-	string_or_die(&file, "%s/%i/Manifest.%s.sig", globals.state_dir, version, filename);
-	unlink(file);
-	free_string(&file);
-	if (hash != NULL) {
-		string_or_die(&file, "%s/%i/Manifest.%s.%s", globals.state_dir, version, filename, hash);
+
+	for (i = 0; i < num_state_dirs; i++) {
+		if (state_dirs[i] == NULL) {
+			continue;
+		}
+
+		string_or_die(&file, "%s/%i/Manifest.%s", state_dirs[i], version, filename);
 		unlink(file);
 		free_string(&file);
+		string_or_die(&file, "%s/%i/Manifest.%s.tar", state_dirs[i], version, filename);
+		unlink(file);
+		free_string(&file);
+		string_or_die(&file, "%s/%i/Manifest.%s.sig", state_dirs[i], version, filename);
+		unlink(file);
+		free_string(&file);
+		if (hash != NULL) {
+			string_or_die(&file, "%s/%i/Manifest.%s.%s", state_dirs[i], version, filename, hash);
+			unlink(file);
+			free_string(&file);
+		}
 	}
 }
 

--- a/src/os_install.c
+++ b/src/os_install.c
@@ -29,12 +29,14 @@ static bool cmdline_option_force = false;
 static struct list *cmdline_bundles = NULL;
 static char *path;
 static int cmdline_option_version = -1;
+static char *cmdline_option_statedir_cache = NULL;
 
 static const struct option prog_opts[] = {
 	{ "force", no_argument, 0, 'x' },
 	{ "bundles", required_argument, 0, 'B' },
 	{ "version", required_argument, 0, 'V' },
 	{ "manifest", required_argument, 0, 'm' },
+	{ "statedir-cache", required_argument, 0, 's' },
 	{ "download", no_argument, 0, FLAG_DOWNLOAD_ONLY },
 };
 
@@ -46,10 +48,11 @@ static void print_help(void)
 	global_print_help();
 
 	print("Options:\n");
-	print("   -x, --force             Attempt to proceed even if non-critical errors found\n");
-	print("   -B, --bundles=[BUNDLES] Include the specified BUNDLES in the OS installation. Example: --bundles=os-core,vi\n");
-	print("   -V, --version=[VER]     If the version to install is not the latest, it can be specified with this option\n");
-	print("   --download              Download all content, but do not actually install it\n");
+	print("   -x, --force                 Attempt to proceed even if non-critical errors found\n");
+	print("   -B, --bundles=[BUNDLES]     Include the specified BUNDLES in the OS installation. Example: --bundles=os-core,vi\n");
+	print("   -V, --version=[VER]         If the version to install is not the latest, it can be specified with this option\n");
+	print("   -s, --statedir-cache=[PATH] After checking for content in the statedir, check the statedir-cache before downloading it over the network\n");
+	print("   --download                  Download all content, but do not actually install it\n");
 	print("\n");
 }
 
@@ -73,6 +76,9 @@ static bool parse_opt(int opt, char *optarg)
 		return true;
 	case 'x':
 		cmdline_option_force = optarg_to_bool(optarg);
+		return true;
+	case 's':
+		cmdline_option_statedir_cache = strdup_or_die(optarg);
 		return true;
 	case 'B': {
 		char *arg_copy = strdup_or_die(optarg);
@@ -154,6 +160,7 @@ enum swupd_code install_main(int argc, char **argv)
 	/* set options needed for the install in the verify command */
 	verify_set_option_quick(true);
 	verify_set_option_install(true);
+	verify_set_option_statedir_cache(cmdline_option_statedir_cache);
 	verify_set_option_download(cmdline_option_download);
 	verify_set_option_force(cmdline_option_force);
 	verify_set_option_bundles(cmdline_bundles);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -308,6 +308,8 @@ extern void print_regexp_error(int errcode, regex_t *regexp);
 extern bool is_url_allowed(const char *url);
 extern bool is_url_insecure(const char *url);
 extern void remove_trailing_slash(char *url);
+extern int link_or_copy(const char *orig, const char *dest);
+extern int link_or_copy_all(const char *orig, const char *dest);
 
 /* subscription.c */
 struct list *free_list_file(struct list *item);
@@ -331,6 +333,7 @@ extern void verify_set_option_download(bool opt);
 extern void verify_set_command_verify(bool opt);
 extern void verify_set_option_force(bool opt);
 extern void verify_set_option_install(bool opt);
+extern void verify_set_option_statedir_cache(char *opt);
 extern void verify_set_option_quick(bool opt);
 extern void verify_set_option_bundles(struct list *bundles);
 extern void verify_set_option_version(int ver);

--- a/src/verify.c
+++ b/src/verify.c
@@ -47,6 +47,7 @@ static bool cmdline_command_verify = false;
 static bool cmdline_option_force = false;
 static bool cmdline_option_fix = false;
 static bool cmdline_option_picky = false;
+static char *cmdline_option_statedir_cache = NULL;
 static char *cmdline_option_picky_tree = NULL;
 static const char *cmdline_option_picky_whitelist = picky_whitelist_default;
 static bool cmdline_option_install = false;
@@ -111,6 +112,12 @@ void verify_set_option_bundles(struct list *bundles)
 void verify_set_option_version(int ver)
 {
 	version = ver;
+}
+
+void verify_set_option_statedir_cache(char *path)
+{
+	free_string(&cmdline_option_statedir_cache);
+	cmdline_option_statedir_cache = path;
 }
 
 void verify_set_option_fix(bool opt)
@@ -805,6 +812,14 @@ enum swupd_code verify_main(void)
 		steps_in_verify = 5;
 	}
 	progress_init_steps("verify", steps_in_verify);
+
+	if (cmdline_option_statedir_cache != NULL) {
+		ret = set_state_dir_cache(cmdline_option_statedir_cache);
+		if (ret != true) {
+			error("Failed to set statedir-cache\n");
+			goto clean_args_and_exit;
+		}
+	}
 
 	ret = swupd_init(SWUPD_ALL);
 	if (ret != 0) {

--- a/swupd.bash
+++ b/swupd.bash
@@ -64,7 +64,7 @@ _swupd()
 		opts="$global --version --picky --picky-tree --picky-whitelist --quick --force --extra-files-only "
 		break;;
 		("os-install")
-		opts="$global --version --force --bundles --download "
+		opts="$global --version --force --bundles --statedir-cache --download "
 		break;;
 		("mirror")
 		opts="$global --set --unset "

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -292,6 +292,7 @@ if [[ -n "$state" ]]; then
             '(help -x --force)'{-x,--force}'[Attempt to proceed even if non-critical errors found]'
             '(help -B --bundles)'{-B,--bundles=}'[Include the specified BUNDLES in the OS installation. Example: --bundles=os-core,vi]:diagnose: _swupd_all_bundles'
             '(help -V --version)'{-V,--version=}'[If the version to install is not the latest, it can be specified with this option]:version:()'
+            '(help -s --statedir-cache)'{-s,--statedir-cache=}'[After checking for content in the statedir, check the statedir-cache before downloading it over the network]'
             '(help status)--download[Download all content, but do not actually install it]'
           )
           _arguments $osinstall && ret=0

--- a/test/functional/os-install/install-statedir-cache-offline.bats
+++ b/test/functional/os-install/install-statedir-cache-offline.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+
+# Author: John Akre
+# Email: john.w.akre@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment -e "$TEST_NAME" 10
+	create_bundle -n os-core -f /core "$TEST_NAME"
+
+	statedir_cache_path="${TEST_DIRNAME}/testfs/statedir-cache"
+
+	# Populate statedir-cache
+	sudo mkdir -m 700 -p "$statedir_cache_path"
+	sudo mkdir -m 700 "$statedir_cache_path"/staged
+	sudo mkdir -m 755 "$statedir_cache_path"/10
+	sudo cp "$WEBDIR"/10/Manifest.MoM "$statedir_cache_path"/10
+	sudo cp "$WEBDIR"/10/Manifest.MoM.sig "$statedir_cache_path"/10
+	sudo cp "$WEBDIR"/10/Manifest.os-core "$statedir_cache_path"/10
+	sudo touch "$statedir_cache_path"/pack-os-core-from-0-to-10.tar
+	sudo rsync -r "$WEBDIR"/10/files/* "$statedir_cache_path"/staged --exclude="*.tar"
+
+}
+
+@test "INS021: Install with populated statedir-cache and no network" {
+
+	# The statedir-cache should be used to successfully perform the install
+	# without an internet connection.	
+
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --url=badurl --statedir-cache $statedir_cache_path -V 10"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Installing OS version 10
+		No packs need to be downloaded
+		Checking for corrupt files
+		No extra files need to be downloaded
+		Installing base OS and selected bundles
+		Inspected 2 files
+		  2 files were missing
+		    2 of 2 missing files were installed
+		    0 of 2 missing files were not installed
+		Calling post-update helper scripts
+		Installation successful
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/core
+	
+}
+
+@test "INS022: Install with missing manifest in statedir-cache and no network" {
+
+	# Swupd should attempt to download the missing manifest and fail.
+
+	sudo rm "$statedir_cache_path"/10/Manifest.os-core
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --url=badurl --statedir-cache $statedir_cache_path -V 10"
+
+	assert_status_is "$SWUPD_COULDNT_LOAD_MANIFEST"
+	expected_output=$(cat <<-EOM
+		Installing OS version 10
+		Error: Failed to connect to update server: badurl/10/Manifest.os-core.tar
+		Possible solutions for this problem are:
+		.Check if your network connection is working
+		.Fix the system clock
+		.Run 'swupd info' to check if the urls are correct
+		.Check if the server SSL certificate is trusted by your system \('clrtrust generate' may help\)
+		Error: Failed to retrieve 10 os-core manifest
+		Error: Unable to download manifest os-core version 10, exiting now
+		Installation failed
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
+	assert_file_not_exists "$TARGETDIR"/core
+	
+}
+
+@test "INS023: Install with missing MoM signature in statedir-cache with no network" {
+
+	# Swupd should attempt to download the signature and fail.
+
+	sudo rm "$statedir_cache_path"/10/Manifest.MoM.sig
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --url=badurl --statedir-cache $statedir_cache_path -V 10"
+
+	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
+	expected_output=$(cat <<-EOM
+		Installing OS version 10
+		Error: Failed to connect to update server: badurl/10/Manifest.MoM.sig
+		Possible solutions for this problem are:
+		.Check if your network connection is working
+		.Fix the system clock
+		.Run 'swupd info' to check if the urls are correct
+		.Check if the server SSL certificate is trusted by your system \('clrtrust generate' may help\)
+		Warning: Removing corrupt Manifest.MoM artifacts and re-downloading...
+		Error: Failed to retrieve 10 MoM manifest
+		Error: Unable to download/verify 10 Manifest.MoM
+		Installation failed
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
+	assert_file_not_exists "$TARGETDIR"/core
+	
+}
+
+@test "INS024: Install with missing fullfiles in statedir-cache with no network" {
+
+	# Swupd should attempt to download the fullfiles and fail.
+
+	sudo rm -r "$statedir_cache_path"/staged
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --url=badurl --statedir-cache $statedir_cache_path -V 10"
+
+	assert_status_is "$SWUPD_COULDNT_DOWNLOAD_FILE"
+	expected_output=$(cat <<-EOM
+		Installing OS version 10
+		No packs need to be downloaded
+		Checking for corrupt files
+		Error: Failed to connect to update server: badurl
+		Possible solutions for this problem are:
+		.Check if your network connection is working
+		.Fix the system clock
+		.Run 'swupd info' to check if the urls are correct
+		.Check if the server SSL certificate is trusted by your system \('clrtrust generate' may help\)
+		Error: Curl - Invalid parallel download handle
+		Error: Unable to download necessary files for this OS release
+		Installation failed
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
+	assert_file_not_exists "$TARGETDIR"/core
+
+}
+
+@test "INS025: Install with missing pack in statedir-cache with no network" {
+
+	# Swupd should fail to download the pack, but continue successfully.
+
+	sudo rm "$statedir_cache_path"/pack-os-core-from-0-to-10.tar
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --url=badurl --statedir-cache $statedir_cache_path -V 10"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Installing OS version 10
+		Error: Failed to connect to update server: badurl
+		Possible solutions for this problem are:
+		.Check if your network connection is working
+		.Fix the system clock
+		.Run 'swupd info' to check if the urls are correct
+		.Check if the server SSL certificate is trusted by your system \('clrtrust generate' may help\)
+		Error: zero pack downloads failed
+		Checking for corrupt files
+		No extra files need to be downloaded
+		Installing base OS and selected bundles
+		Inspected 2 files
+		  2 files were missing
+		    2 of 2 missing files were installed
+		    0 of 2 missing files were not installed
+		Calling post-update helper scripts
+		Installation successful
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/core
+
+}

--- a/test/functional/os-install/install-statedir-cache.bats
+++ b/test/functional/os-install/install-statedir-cache.bats
@@ -1,0 +1,147 @@
+#!/usr/bin/env bats
+
+# Author: John Akre
+# Email: john.w.akre@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment -e "$TEST_NAME" 10
+	create_bundle -n os-core -f /core "$TEST_NAME"
+
+	statedir_cache_path="${TEST_DIRNAME}/testfs/statedir-cache"
+
+	# Populate statedir-cache
+	sudo mkdir -m 700 -p "$statedir_cache_path"
+	sudo mkdir -m 700 "$statedir_cache_path"/staged
+	sudo mkdir -m 755 "$statedir_cache_path"/10
+	sudo cp "$WEBDIR"/10/Manifest.MoM "$statedir_cache_path"/10
+	sudo cp "$WEBDIR"/10/Manifest.MoM.sig "$statedir_cache_path"/10
+	sudo cp "$WEBDIR"/10/Manifest.os-core "$statedir_cache_path"/10
+	sudo touch "$statedir_cache_path"/pack-os-core-from-0-to-10.tar
+	sudo rsync -r "$WEBDIR"/10/files/* "$statedir_cache_path"/staged --exclude="*.tar"
+
+}
+
+@test "INS017: Install with populated statedir-cache and valid network" {
+
+	# The statedir-cache should be used for all update content, so the
+	# network should be unused.
+
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --statedir-cache $statedir_cache_path"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Installing OS version 10 (latest)
+		No packs need to be downloaded
+		Checking for corrupt files
+		No extra files need to be downloaded
+		Installing base OS and selected bundles
+		Inspected 2 files
+		  2 files were missing
+		    2 of 2 missing files were installed
+		    0 of 2 missing files were not installed
+		Calling post-update helper scripts
+		Installation successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/core
+	
+}
+
+@test "INS018: Install with no update content in the statedir-cache and valid network" {
+
+	# The statedir-cache will have no update content, so the network must be used
+	# as a fallback.
+
+	sudo rm "$statedir_cache_path"/10/Manifest.os-core
+	sudo rm "$statedir_cache_path"/pack-os-core-from-0-to-10.tar
+	sudo rm -r "$statedir_cache_path"/staged
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --statedir-cache $statedir_cache_path"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Installing OS version 10 (latest)
+		Downloading packs for:
+		 - os-core
+		Finishing packs extraction...
+		Checking for corrupt files
+		No extra files need to be downloaded
+		Installing base OS and selected bundles
+		Inspected 2 files
+		  2 files were missing
+		    2 of 2 missing files were installed
+		    0 of 2 missing files were not installed
+		Calling post-update helper scripts
+		Installation successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/core
+	
+}
+
+@test "INS019: Install with missing fullfiles in statedir-cache and valid network" {
+
+	# When fullfiles are missing from the statedir-cache, downloads over the network
+	# must be used to sucessfully install. The goal of this test case is to verify that
+	# missing fullfiles in the statedir-cache will fallback to network downloads, so packs
+	# must not be used to populate the staged directory with fullfiles.
+
+	sudo rm -r "$statedir_cache_path"/staged
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --statedir-cache $statedir_cache_path"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Installing OS version 10 (latest)
+		No packs need to be downloaded
+		Checking for corrupt files
+		Starting download of remaining update content. This may take a while...
+		Installing base OS and selected bundles
+		Inspected 2 files
+		  2 files were missing
+		    2 of 2 missing files were installed
+		    0 of 2 missing files were not installed
+		Calling post-update helper scripts
+		Installation successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/core
+	
+}
+
+@test "INS020: Install with corrupt manifest in statedir-cache and valid network" {
+
+	# Swupd should fallback to network downloads when the statedir-cache contains
+	# corrupt manifests.
+
+	sudo sh -c "echo invalid > ${statedir_cache_path}/10/Manifest.os-core"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --statedir-cache $statedir_cache_path"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Installing OS version 10 (latest)
+		Warning: Removing corrupt Manifest.os-core artifacts and re-downloading...
+		No packs need to be downloaded
+		Checking for corrupt files
+		No extra files need to be downloaded
+		Installing base OS and selected bundles
+		Inspected 2 files
+		  2 files were missing
+		    2 of 2 missing files were installed
+		    0 of 2 missing files were not installed
+		Calling post-update helper scripts
+		Installation successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/core
+	
+}


### PR DESCRIPTION
The `--statedir-cache` flag specifies a secondary statedir that will be checked before downloading files over the network. This flag is only supported for the `os-install` command.

The primary reason to use the statedir-cache is to enable the `os-install`
command to take advantage of hardlinks when installing content across
partitions. In this case, update content stored in the statedir-cache
(source partition) will be copied to the statedir (target partition) before
installing content into the target partition. Since the update content
will exist on the target partition before installation, hardlinks can be
used instead of copies.

NOTE: This PR depends on #1061 and the offline functional tests will fail due to this dependency.