### PR TITLE
Showing indirect bundles installed by bundle-add

### DIFF
--- a/test/functional/bundleadd/add-also-add-flag.bats
+++ b/test/functional/bundleadd/add-also-add-flag.bats
@@ -43,6 +43,7 @@ test_setup() {
 		Installing bundle(s) files...
 		Calling post-update helper scripts
 		Successfully installed 1 bundle
+		3 bundles were installed as dependencies
 	EOM
 	)
 	assert_is_output "$expected_output"
@@ -71,6 +72,7 @@ test_setup() {
 		Installing bundle(s) files...
 		Calling post-update helper scripts
 		Successfully installed 1 bundle
+		1 bundle was installed as dependency
 	EOM
 	)
 	assert_is_output "$expected_output"


### PR DESCRIPTION
When installing a bundle using bundle-add, swupd also installs any
dependency not already installed in the system (if any). When the
bundle-add operation is complete, swupd reports how many of the
requested bundles were successfully installed and how many failed, but
if there are bundles that got installed as a side effect because they
are dependencies of the requested bundle(s), they are not included in
the summary of bundle-add.

This commit adds the number of dependencies installed in the summary of
bundle-add so it provides a more accurate view of the changes in the
system.

Closes #679 

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>