### PR TITLE
Show format number

### DIFF
--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -145,6 +145,10 @@ used to modify the core behavior and resources that swupd uses.
 
    Print only important information and errors.
 
+- ``--verbose``
+
+   Enable verbosity for commands.
+
 - ``--debug``
 
    Print extra information to help debugging problems.

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -46,6 +46,8 @@ enum swupd_code check_update()
 {
 	int current_version, server_version;
 	enum swupd_code ret = SWUPD_OK;
+	int server_format = -1;
+	int current_format = -1;
 
 	current_version = get_current_version(globals.path_prefix);
 	server_version = version_get_absolute_latest();
@@ -63,11 +65,32 @@ enum swupd_code check_update()
 		ret = SWUPD_SERVER_CONNECTION_ERROR;
 	}
 
-	if (current_version > 0) {
-		info("Current OS version: %d\n", current_version);
+	if (log_get_level() >= LOG_INFO_VERBOSE) {
+		/* Retrieve latest_format */
+		/* Sending latest server_version to get the latest format */
+		server_format = get_server_format(server_version);
+		/* Retrieve current format */
+		current_format = get_current_format();
 	}
+
+	if (current_version > 0) {
+		info("Current OS version: %d", current_version);
+		if (current_format > 0) {
+			info_verbose(" (format %d)", current_format);
+		} else {
+			info_verbose(" (format unknown)");
+		}
+		info("\n");
+	}
+
 	if (server_version > 0) {
-		info("Latest server version: %d\n", server_version);
+		info("Latest server version: %d", server_version);
+		if (server_format > 0) {
+			info_verbose(" (format %d)", server_format);
+		} else {
+			info_verbose(" (format unknown)");
+		}
+		info("\n");
 	}
 
 	if (ret != SWUPD_OK) {

--- a/src/globals.c
+++ b/src/globals.c
@@ -41,6 +41,7 @@
 #define FLAG_QUIET 1002
 #define FLAG_DEBUG 1003
 #define FLAG_ALLOW_INSECURE_HTTP 1004
+#define FLAG_VERBOSE 1005
 
 struct globals globals = {
 	.sigcheck = true,
@@ -60,6 +61,7 @@ static int max_parallel_downloads = -1;
 static int log_level = LOG_INFO;
 static bool quiet = false;
 static bool debug = false;
+static bool verbose = false;
 
 /* Sets the content_url global variable */
 static void set_content_url(char *url)
@@ -492,6 +494,7 @@ static const struct option global_opts[] = {
 	{ "json-output", no_argument, 0, 'j' },
 	{ "allow-insecure-http", no_argument, 0, FLAG_ALLOW_INSECURE_HTTP },
 	{ "wait-for-scripts", no_argument, 0, FLAG_WAIT_FOR_SCRIPTS },
+	{ "verbose", no_argument, 0, FLAG_VERBOSE },
 	{ 0, 0, 0, 0 }
 };
 
@@ -595,6 +598,9 @@ static bool global_parse_opt(int opt, char *optarg)
 	case FLAG_ALLOW_INSECURE_HTTP:
 		globals.allow_insecure_http = optarg_to_bool(optarg);
 		return true;
+	case FLAG_VERBOSE:
+		verbose = true;
+		return true;
 	default:
 		return false;
 	}
@@ -649,6 +655,7 @@ void global_print_help(void)
 	print("   -j, --json-output       Print all output as a JSON stream\n");
 	print("   --allow-insecure-http   Allow updates over insecure connections\n");
 	print("   --quiet                 Quiet output. Print only important information and errors\n");
+	print("   --verbose               Enable verbosity for commands\n");
 	print("   --debug                 Print extra information to help debugging problems\n");
 	print("   --no-progress           Don't print progress report\n");
 	print("   --wait-for-scripts      Wait for the post-update scripts to complete\n");
@@ -742,6 +749,8 @@ int global_parse_options(int argc, char **argv, const struct global_options *opt
 		log_level = LOG_DEBUG;
 	} else if (quiet) {
 		log_level = LOG_ERROR;
+	} else if (verbose) {
+		log_level = LOG_INFO_VERBOSE;
 	}
 	log_set_level(log_level);
 

--- a/src/info.c
+++ b/src/info.c
@@ -18,14 +18,20 @@
  */
 
 #define _GNU_SOURCE
-#include <stdio.h>
-
+#include "lib/log.h"
 #include "swupd.h"
 
 enum swupd_code print_update_conf_info()
 {
 	enum swupd_code ret = SWUPD_OK;
 	char dist_string[LINE_MAX];
+	int current_format = -1;
+
+	if (log_get_level() >= LOG_INFO_VERBOSE) {
+		/* Retrieve current format */
+		current_format = get_current_format();
+	}
+
 	int current_version = get_current_version(globals.path_prefix);
 	bool dist_string_found = get_distribution_string(globals.path_prefix, dist_string);
 
@@ -37,7 +43,13 @@ enum swupd_code print_update_conf_info()
 		info("Installed version: unknown\n");
 		ret = SWUPD_CURRENT_VERSION_UNKNOWN;
 	} else {
-		info("Installed version: %d\n", current_version);
+		info("Installed version: %d", current_version);
+		if (current_format > 0) {
+			info_verbose(" (format %d)", current_format);
+		} else {
+			info_verbose(" (format unknown)");
+		}
+		info("\n");
 	}
 	info("Version URL:       %s\n", globals.version_url);
 	info("Content URL:       %s\n", globals.content_url);
@@ -51,7 +63,6 @@ static void print_help(void)
 	print("   swupd info [OPTION...]\n\n");
 
 	global_print_help();
-	print("\n");
 }
 
 static const struct global_options opts = {

--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -102,6 +102,11 @@ static void log_internal(FILE *out, const char *file, int line, const char *labe
 	}
 }
 
+int log_get_level(void)
+{
+	return cur_log_level;
+}
+
 void log_set_level(int log_level)
 {
 	cur_log_level = log_level;

--- a/src/lib/log.h
+++ b/src/lib/log.h
@@ -20,8 +20,10 @@ extern "C" {
 #define LOG_WARN 4
 /** @brief Only show messages printed info(), warn(), error() and print(). */
 #define LOG_INFO 6
+/** @brief Only show messages printed info_verbose(), info(), warn(), error() and print(). */
+#define LOG_INFO_VERBOSE 8
 /** @brief Print all messages. */
-#define LOG_DEBUG 8
+#define LOG_DEBUG 10
 
 /**
  * @brief Log callback functions.
@@ -33,6 +35,11 @@ typedef void (*log_fn_t)(FILE *out, const char *file, int line, const char *labe
  * @brief Set the log function to use. Replaces the default (printf).
  */
 void log_set_function(log_fn_t log_fn);
+
+/**
+ * @brief Get the current log level.
+ */
+int log_get_level(void);
 
 /**
  * @brief Set the minimum priority log to be printed by log functions.
@@ -53,6 +60,8 @@ void log_full(int log_level, FILE *out, const char *file, int line, const char *
 #define warn(_fmt, ...) log_full(LOG_WARN, stderr, __FILE__, __LINE__, "Warning", _fmt, ##__VA_ARGS__);
 /** @brief Print messages using LOG_INFO level. */
 #define info(_fmt, ...) log_full(LOG_INFO, stdout, __FILE__, __LINE__, NULL, _fmt, ##__VA_ARGS__);
+/** @brief Print messages using LOG_INFO_VERBOSE level. */
+#define info_verbose(_fmt, ...) log_full(LOG_INFO_VERBOSE, stdout, __FILE__, __LINE__, NULL, _fmt, ##__VA_ARGS__);
 /** @brief Print messages using LOG_DEBUG level. */
 #define debug(_fmt, ...) log_full(LOG_DEBUG, stdout, __FILE__, __LINE__, "Debug", _fmt, ##__VA_ARGS__);
 

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -164,6 +164,8 @@ extern int get_absolute_latest_version(void);
 extern enum swupd_code read_versions(int *current_version, int *server_version, char *path_prefix);
 extern int get_current_version(char *path_prefix);
 extern bool get_distribution_string(char *path_prefix, char *dist);
+extern int get_current_format(void);
+extern int get_server_format(int server_version);
 
 extern bool ignore(struct file *file);
 extern void apply_heuristics(struct file *file);

--- a/swupd.bash
+++ b/swupd.bash
@@ -23,7 +23,7 @@ _swupd()
     # $1 is the command being completed, $2 is the current word being expanded
     local opts IFS=$' \t\n'
     local -i i installed
-    local global="--help --url --contenturl --versionurl --port --path --format --nosigcheck --ignore-time --statedir --certpath  --time --no-scripts --no-boot-update --max-parallel-downloads --max-retries --retry-delay --json-output  --allow-insecure-http --debug --quiet --no-progress --wait-for-scripts "
+    local global="--help --url --contenturl --versionurl --port --path --format --nosigcheck --ignore-time --statedir --certpath  --time --no-scripts --no-boot-update --max-parallel-downloads --max-retries --retry-delay --json-output  --allow-insecure-http --debug --verbose --quiet --no-progress --wait-for-scripts"
     COMPREPLY=()
     for ((i=COMP_CWORD-1;i>=0;i--))
     do case "${COMP_WORDS[$i]}" in

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -123,6 +123,7 @@ local -a global_opts; global_opts=(
   '(-)'{-h,--help}'[Show help options]'
   + '(msg)'
   '(help)--quiet[Quiet output. Print only important information and errors]'
+  '(help)--verbose[Enables verbosity on some of the commands]'
   '(help)--debug[Print extra information to help debugging problems]'
   '(help -j --json-output)'{-j,--json-output}'[Print all output as a JSON stream]'
   + options

--- a/test/functional/checkupdate/chk-update-format-bump.bats
+++ b/test/functional/checkupdate/chk-update-format-bump.bats
@@ -30,3 +30,19 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+
+@test "CHK011: Check if the check-update returns format no with --verbose" {
+
+	# check if verbose options holds
+	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS --verbose"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Current OS version: 10 (format 1)
+		Latest server version: 40 (format 2)
+		There is a new OS version available: 40
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/checkupdate/chk-update-json.bats
+++ b/test/functional/checkupdate/chk-update-json.bats
@@ -24,8 +24,8 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		[
 		{ "type" : "start", "section" : "check-update" },
-		{ "type" : "info", "msg" : "Current OS version: 10 " },
-		{ "type" : "info", "msg" : "Latest server version: 20 " },
+		{ "type" : "info", "msg" : "Current OS version: 10" },
+		{ "type" : "info", "msg" : "Latest server version: 20" },
 		{ "type" : "info", "msg" : "There is a new OS version available: 20 " },
 		{ "type" : "end", "section" : "check-update", "status" : 0 }
 		]

--- a/test/functional/mirror/mirror-json.bats
+++ b/test/functional/mirror/mirror-json.bats
@@ -28,7 +28,7 @@ test_setup() {
 		{ "type" : "warning", "msg" : "The mirror was set up using HTTP. In order for autoupdate to continue working you will need to set allow_insecure_http=true in the swupd configuration file. Alternatively you can set the mirror using HTTPS (recommended)  " },
 		{ "type" : "info", "msg" : "Mirror url set " },
 		{ "type" : "info", "msg" : "Distribution:      Swupd Test Distro " },
-		{ "type" : "info", "msg" : "Installed version: 10 " },
+		{ "type" : "info", "msg" : "Installed version: 10" },
 		{ "type" : "info", "msg" : "Version URL:       http://example.com/swupd-file " },
 		{ "type" : "info", "msg" : "Content URL:       http://example.com/swupd-file " },
 		{ "type" : "end", "section" : "mirror", "status" : 0 }


### PR DESCRIPTION
Now, we have global option
and info_verbose logging level.
For this PR, we have verbose for info,
check-update which shows format versions.
This also helps future implementations leverage
the use of a verbose option for their own need.

commands:
swupd check-update --verbose
swupd info --verbose