### PR TITLE
test: Support running tests in a different directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,8 @@ test-driver
 test-suite.log
 test/*.gcno
 test/documentation/manpages/test.log
-test/functional/Swupd_Root.pem
-test/functional/private.pem
+Swupd_Root.pem
+private.pem
 test/**/*.log
 test/unit/test_*.test
 verifytime

--- a/Makefile.am
+++ b/Makefile.am
@@ -382,7 +382,7 @@ coverage-clean:
 endif
 
 distclean-local:
-	rm -rf aclocal.m4 ar-lib autom4te.cache config.guess config.h.in config.h.in~ config.sub configure depcomp install-sh ltmain.sh m4 Makefile.in missing compile $(MANPAGES)
+	rm -rf aclocal.m4 ar-lib autom4te.cache config.guess config.h.in config.h.in~ config.sub configure depcomp install-sh ltmain.sh m4 Makefile.in missing compile Swupd_Root.pem private.pem $(MANPAGES)
 
 install-exec-hook:
 	perl $(top_srcdir)/scripts/findstatic.pl */*.o | grep -v Checking ||:

--- a/test/functional/generate-cert.prereq
+++ b/test/functional/generate-cert.prereq
@@ -12,8 +12,8 @@ test_teardown() {
 
 @test "Generate certificate for signing Manifest.MoM" {
 
-  run sudo sh -c "rm -rf "$FUNC_DIR"/private.pem "$FUNC_DIR"/Swupd_Root.pem"
-  generate_certificate "$FUNC_DIR"/private.pem "$FUNC_DIR"/Swupd_Root.pem "$FUNC_DIR"/certattributes.cnf
+  run sudo sh -c "rm -rf "$TEST_ROOT_DIR"/private.pem "$TEST_ROOT_DIR"/Swupd_Root.pem"
+  generate_certificate "$TEST_ROOT_DIR"/private.pem "$TEST_ROOT_DIR"/Swupd_Root.pem "$FUNC_DIR"/certattributes.cnf
 
 }
 

--- a/test/functional/signature/key-rotation.bats
+++ b/test/functional/signature/key-rotation.bats
@@ -12,7 +12,7 @@ test_setup() {
 	export SWUPD_OPTS_EXTRA="$SWUPD_OPTS_NO_FMT_NO_CERT -C $TARGETDIR$CERT_PATH"
 
 	create_version -r "$TEST_NAME" 20 10
-	update_bundle "$TEST_NAME" os-core --add "$CERT_PATH":"$FUNC_DIR"/Swupd_Root.pem
+	update_bundle "$TEST_NAME" os-core --add "$CERT_PATH":"$TEST_ROOT_DIR"/Swupd_Root.pem
 	bump_format "$TEST_NAME"
 
 	# Rotate the key inside the content. We need to sign release 30 using old root key and sign the release 40 and 50 using the new key. And include the new key in releases 30, 40 and 50.


### PR DESCRIPTION
All files that are written by tests should be written in the directory
where the tests were executed and not the directory where code is.

Make distcheck now works fine

Fixes #343

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>