### PR TITLE
Testlib fixes

### DIFF
--- a/test/functional/bundleadd/add-client-certificate.bats
+++ b/test/functional/bundleadd/add-client-certificate.bats
@@ -2,10 +2,10 @@
 
 load "../testlib"
 
-server_pub="$PWD/$TEST_NAME"_1/server-pub.pem
-server_key="$PWD/$TEST_NAME"_1/server-key.pem
-client_pub="$PWD/$TEST_NAME"_1/client-pub.pem
-client_key="$PWD/$TEST_NAME"_1/client-key.pem
+server_pub="$PWD/$TEST_NAME"/server-pub.pem
+server_key="$PWD/$TEST_NAME"/server-key.pem
+client_pub="$PWD/$TEST_NAME"/client-pub.pem
+client_key="$PWD/$TEST_NAME"/client-key.pem
 
 global_setup() {
 

--- a/test/functional/bundlelist/list-client-certificate.bats
+++ b/test/functional/bundlelist/list-client-certificate.bats
@@ -2,10 +2,10 @@
 
 load "../testlib"
 
-server_pub="$PWD/$TEST_NAME"_1/server-pub.pem
-server_key="$PWD/$TEST_NAME"_1/server-key.pem
-client_pub="$PWD/$TEST_NAME"_1/client-pub.pem
-client_key="$PWD/$TEST_NAME"_1/client-key.pem
+server_pub="$PWD/$TEST_NAME"/server-pub.pem
+server_key="$PWD/$TEST_NAME"/server-key.pem
+client_pub="$PWD/$TEST_NAME"/client-pub.pem
+client_key="$PWD/$TEST_NAME"/client-key.pem
 
 global_setup() {
 

--- a/test/functional/bundleremove/remove-client-certificate.bats
+++ b/test/functional/bundleremove/remove-client-certificate.bats
@@ -2,10 +2,10 @@
 
 load "../testlib"
 
-server_pub="$PWD/$TEST_NAME"_1/server-pub.pem
-server_key="$PWD/$TEST_NAME"_1/server-key.pem
-client_pub="$PWD/$TEST_NAME"_1/client-pub.pem
-client_key="$PWD/$TEST_NAME"_1/client-key.pem
+server_pub="$PWD/$TEST_NAME"/server-pub.pem
+server_key="$PWD/$TEST_NAME"/server-key.pem
+client_pub="$PWD/$TEST_NAME"/client-pub.pem
+client_key="$PWD/$TEST_NAME"/client-key.pem
 
 global_setup() {
 

--- a/test/functional/checkupdate/chk-update-client-certificate.bats
+++ b/test/functional/checkupdate/chk-update-client-certificate.bats
@@ -2,10 +2,10 @@
 
 load "../testlib"
 
-server_pub="$PWD/$TEST_NAME"_1/server-pub.pem
-server_key="$PWD/$TEST_NAME"_1/server-key.pem
-client_pub="$PWD/$TEST_NAME"_1/client-pub.pem
-client_key="$PWD/$TEST_NAME"_1/client-key.pem
+server_pub="$PWD/$TEST_NAME"/server-pub.pem
+server_key="$PWD/$TEST_NAME"/server-key.pem
+client_pub="$PWD/$TEST_NAME"/client-pub.pem
+client_key="$PWD/$TEST_NAME"/client-key.pem
 
 global_setup() {
 

--- a/test/functional/diagnose/diagnose-client-certificate.bats
+++ b/test/functional/diagnose/diagnose-client-certificate.bats
@@ -2,10 +2,10 @@
 
 load "../testlib"
 
-server_pub="$PWD/$TEST_NAME"_1/server-pub.pem
-server_key="$PWD/$TEST_NAME"_1/server-key.pem
-client_pub="$PWD/$TEST_NAME"_1/client-pub.pem
-client_key="$PWD/$TEST_NAME"_1/client-key.pem
+server_pub="$PWD/$TEST_NAME"/server-pub.pem
+server_key="$PWD/$TEST_NAME"/server-key.pem
+client_pub="$PWD/$TEST_NAME"/client-pub.pem
+client_key="$PWD/$TEST_NAME"/client-key.pem
 
 global_setup() {
 

--- a/test/functional/diagnose/diagnose-verify-flags.bats
+++ b/test/functional/diagnose/diagnose-verify-flags.bats
@@ -5,7 +5,7 @@
 
 load "../testlib"
 
-@test "Verify conflicting flags" {
+@test "DIA017: Verify conflicting flags" {
 
 	# Some flags are mutually exclusive
 

--- a/test/functional/generate-cert.prereq
+++ b/test/functional/generate-cert.prereq
@@ -10,7 +10,7 @@ test_teardown() {
 	:
 }
 
-@test "Generate certificate for signing Manifest.MoM" {
+@test "PRQ001: Generate certificate for signing Manifest.MoM" {
 
   run sudo sh -c "rm -rf "$TEST_ROOT_DIR"/private.pem "$TEST_ROOT_DIR"/Swupd_Root.pem"
   generate_certificate "$TEST_ROOT_DIR"/private.pem "$TEST_ROOT_DIR"/Swupd_Root.pem "$FUNC_DIR"/certattributes.cnf

--- a/test/functional/search/search-client-certificate.bats
+++ b/test/functional/search/search-client-certificate.bats
@@ -2,10 +2,10 @@
 
 load "../testlib"
 
-server_pub="$PWD/$TEST_NAME"_1/server-pub.pem
-server_key="$PWD/$TEST_NAME"_1/server-key.pem
-client_pub="$PWD/$TEST_NAME"_1/client-pub.pem
-client_key="$PWD/$TEST_NAME"_1/client-key.pem
+server_pub="$PWD/$TEST_NAME"/server-pub.pem
+server_key="$PWD/$TEST_NAME"/server-key.pem
+client_pub="$PWD/$TEST_NAME"/client-pub.pem
+client_key="$PWD/$TEST_NAME"/client-key.pem
 
 global_setup() {
 

--- a/test/functional/update/update-client-certificate.bats
+++ b/test/functional/update/update-client-certificate.bats
@@ -2,10 +2,10 @@
 
 load "../testlib"
 
-server_pub="$PWD/$TEST_NAME"_1/server-pub.pem
-server_key="$PWD/$TEST_NAME"_1/server-key.pem
-client_pub="$PWD/$TEST_NAME"_1/client-pub.pem
-client_key="$PWD/$TEST_NAME"_1/client-key.pem
+server_pub="$PWD/$TEST_NAME"/server-pub.pem
+server_key="$PWD/$TEST_NAME"/server-key.pem
+client_pub="$PWD/$TEST_NAME"/client-pub.pem
+client_key="$PWD/$TEST_NAME"/client-key.pem
 
 global_setup() {
 


### PR DESCRIPTION
This PR includes several fixes and improvements for the swupd test library.
- It adds a `debug_msg` function to print messages for troubleshooting tests.
- It enables printing the debug messages and saving a copy of the test environment separately using two environment variables: DEBUG_TEST and KEEP_ENV.
- It add a `--force` flag to `destroy_test_environment()` to force the removal of an environment even when the `KEEP_ENV` variable is set to true. This is useful to remove leftover environments before starting a new execution.
- It fixes an issue with the logic of the library to call the `global_setup()` and `global_teardown()` functions. The functions were being called correctly when running the tests using "make check" but they were not being called when running the tests using "bats \<directory\>/".
- Adds a missing test ID in a test.