### PR TITLE
test: Change the prefix of real content tests

### DIFF
--- a/test/real_content/swupd_repair_fullfiles.bats
+++ b/test/real_content/swupd_repair_fullfiles.bats
@@ -3,7 +3,7 @@
 load "real_content_lib"
 
 # Test massive fullfile downloads
-@test "RC002: Repair a big system" {
+@test "RCT002: Repair a big system" {
 	# shellcheck disable=SC2153
 	print "Install minimal system with newest version"
 	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS -F $FORMAT"

--- a/test/real_content/swupd_update.bats
+++ b/test/real_content/swupd_update.bats
@@ -3,7 +3,7 @@
 load "real_content_lib"
 
 # Test update in delta pack range
-@test "RC001: Incremental Updates" {
+@test "RCT001: Incremental Updates" {
 	# shellcheck disable=SC2153
 	print "Install minimal system with oldest version (${VERSION[0]})"
 

--- a/test/real_content/swupd_update_jump.bats
+++ b/test/real_content/swupd_update_jump.bats
@@ -3,7 +3,7 @@
 load "real_content_lib"
 
 # Test update out of the delta pack range
-@test "RC003: Update from 2 distant versions" {
+@test "RCT003: Update from 2 distant versions" {
 	# shellcheck disable=SC2153
 	print "Install minimal system with oldest version (${VERSION[0]})"
 	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS -V ${VERSION[0]} -F $FORMAT"


### PR DESCRIPTION
Now 3 characters are enforced on test prefix, so renaming the real content
tests to RCT

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>