### PR TITLE
manifest: Remove code from load_mom() that is unrleated to loading th…

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -59,7 +59,7 @@ enum swupd_code list_installable_bundles()
 	}
 
 	mix_exists = (check_mix_exists() & system_on_mix());
-	MoM = load_mom(current_version, false, mix_exists, NULL);
+	MoM = load_mom(current_version, mix_exists, NULL);
 	if (!MoM) {
 		return SWUPD_COULDNT_LOAD_MOM;
 	}
@@ -92,7 +92,7 @@ static int load_bundle_manifest(const char *bundle_name, struct list *subs, int 
 
 	*submanifest = NULL;
 
-	mom = load_mom(version, false, false, NULL);
+	mom = load_mom(version, false, NULL);
 	if (!mom) {
 		return SWUPD_COULDNT_LOAD_MOM;
 	}
@@ -208,7 +208,7 @@ enum swupd_code show_included_bundles(char *bundle_name)
 		goto out;
 	}
 
-	mom = load_mom(current_version, false, false, NULL);
+	mom = load_mom(current_version, false, NULL);
 	if (!mom) {
 		error("Cannot load official manifest MoM for version %i\n", current_version);
 		ret = SWUPD_COULDNT_LOAD_MOM;
@@ -308,7 +308,7 @@ enum swupd_code show_bundle_reqd_by(const char *bundle_name, bool server)
 		goto out;
 	}
 
-	current_manifest = load_mom(version, server, false, NULL);
+	current_manifest = load_mom(version, false, NULL);
 	if (!current_manifest) {
 		error("Unable to download/verify %d Manifest.MoM\n", version);
 		ret = SWUPD_COULDNT_LOAD_MOM;
@@ -564,7 +564,7 @@ enum swupd_code remove_bundles(char **bundles)
 			info("Removing bundle: %s\n", bundle);
 		}
 
-		current_mom = load_mom(current_version, false, mix_exists, NULL);
+		current_mom = load_mom(current_version, mix_exists, NULL);
 		if (!current_mom) {
 			error("Unable to download/verify %d Manifest.MoM\n", current_version);
 			ret = SWUPD_COULDNT_LOAD_MOM;
@@ -1130,7 +1130,7 @@ enum swupd_code install_bundles_frontend(char **bundles)
 
 	mix_exists = (check_mix_exists() & system_on_mix());
 
-	mom = load_mom(current_version, false, mix_exists, NULL);
+	mom = load_mom(current_version, mix_exists, NULL);
 	if (!mom) {
 		error("Cannot load official manifest MoM for version %i\n", current_version);
 		ret = SWUPD_COULDNT_LOAD_MOM;
@@ -1203,7 +1203,7 @@ enum swupd_code list_local_bundles()
 	}
 
 	mix_exists = (check_mix_exists() & system_on_mix());
-	MoM = load_mom(current_version, false, mix_exists, NULL);
+	MoM = load_mom(current_version, mix_exists, NULL);
 	if (!MoM) {
 		warn("Could not determine which installed bundles are experimental\n");
 	}

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -400,7 +400,7 @@ out:
  * loaded into memory, this function will return NULL. If err is passed, it is set
  * with the error code.
  */
-struct manifest *load_mom(int version, bool latest, bool mix_exists, int *err)
+struct manifest *load_mom(int version, bool mix_exists, int *err)
 {
 	struct manifest *manifest = NULL;
 	int ret = 0;
@@ -465,20 +465,6 @@ retry_load:
 		}
 	}
 
-	/* Make a copy of the Manifest for the completion code */
-	if (latest) {
-		char *momdir;
-		char *momfile;
-
-		string_or_die(&momdir, "%s/var/tmp/swupd", globals.path_prefix);
-		string_or_die(&momfile, "%s/Manifest.MoM", momdir);
-		swupd_rm(momfile);
-		mkdir_p(momdir);
-
-		copy(filename, momfile);
-		free_string(&momdir);
-		free_string(&momfile);
-	}
 	free_string(&filename);
 	free_string(&url);
 	return manifest;

--- a/src/search-file.c
+++ b/src/search-file.c
@@ -621,7 +621,7 @@ enum swupd_code search_file_main(int argc, char **argv)
 	progress_complete_step();
 
 	progress_set_step(2, "load_manifests"); // will be closed within download_all_manifests
-	mom = load_mom(current_version, false, false, NULL);
+	mom = load_mom(current_version, false, NULL);
 	if (!mom) {
 		error("Cannot load official manifest MoM for version %i\n", current_version);
 		return SWUPD_COULDNT_LOAD_MOM;

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -171,7 +171,7 @@ extern void apply_heuristics(struct file *file);
 extern int file_sort_filename(const void *a, const void *b);
 extern int file_sort_filename_reverse(const void *a, const void *b);
 extern int file_sort_hash(const void *a, const void *b);
-extern struct manifest *load_mom(int version, bool latest, bool mix_exists, int *err);
+extern struct manifest *load_mom(int version, bool mix_exists, int *err);
 extern struct manifest *load_manifest(int version, struct file *file, struct manifest *mom, bool header_only, int *err);
 extern struct manifest *load_manifest_full(int version, bool mix);
 extern struct list *create_update_list(struct manifest *server);

--- a/src/verify.c
+++ b/src/verify.c
@@ -903,9 +903,9 @@ enum swupd_code verify_main(void)
 	 * disable checks for mixer state so the user can easily switch back to their
 	 * normal update stream */
 	if (version != sys_version) {
-		official_manifest = load_mom(version, false, false, NULL);
+		official_manifest = load_mom(version, false, NULL);
 	} else {
-		official_manifest = load_mom(version, false, system_on_mix(), NULL);
+		official_manifest = load_mom(version, system_on_mix(), NULL);
 	}
 
 	if (!official_manifest) {


### PR DESCRIPTION
…e mom

Saving mom for autocompletion is something we should do in another function.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>