### PR TITLE
Fix a bug in list_deduplicate

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -341,6 +341,7 @@ BATS = \
 UNIT_TESTS = \
 	test/unit/test_signature.test \
 	test/unit/test_strings.test \
+	test/unit/test_list.test \
 	test/unit/test_manifest.test
 
 EXTRA_DIST += test/unit/test_helper.h test/unit/data test/functional

--- a/src/lib/list.c
+++ b/src/lib/list.c
@@ -322,18 +322,23 @@ int list_strcmp(const void *a, const void *b)
 struct list *list_deduplicate(struct list *list, comparison_fn_t comparison_fn, list_free_data_fn_t list_free_data_fn)
 {
 	struct list *iter = NULL;
-	void *item1, *item2;
+	void *item1, *item2 = NULL;
 
-	list = list_head(list);
+	iter = list = list_head(list);
 
-	for (iter = list; iter && iter->next; iter = iter->next) {
+	while (iter && iter->next) {
 
 		item1 = iter->data;
 		item2 = iter->next->data;
 
 		if (comparison_fn(item1, item2) == 0) {
 			list_free_item(iter->next, list_free_data_fn);
+			/* an item was removed from the list, do not move to
+			 * the next element, we need to re-check the same element
+			 * against the new next item */
+			continue;
 		}
+		iter = iter->next;
 	}
 
 	return list;

--- a/test/unit/test_list.c
+++ b/test/unit/test_list.c
@@ -1,0 +1,54 @@
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "../../src/lib/strings.h"
+#include "../../src/lib/list.h"
+#include "test_helper.h"
+
+void test_list_deduplicate()
+{
+	struct list *list = NULL;
+	char *str;
+
+	// Deduplicating an empty list
+	list = list_deduplicate(NULL, list_strcmp, NULL);
+	check(list == NULL);
+
+	// Deduplicating a list of a single element
+	list = list_prepend_data(list, "A");
+	list = list_deduplicate(list, list_strcmp, NULL);
+
+	str = string_join(", ", list);
+	check(strcmp("A", str) == 0);
+	free(str);
+
+	// Deduplicating a list of odd number of identical elements
+	list = list_append_data(list, "A");
+	list = list_append_data(list, "A");
+	list = list_append_data(list, "B");
+	list = list_append_data(list, "B");
+	list = list_append_data(list, "C");
+	list = list_append_data(list, "D");
+	list = list_append_data(list, "D");
+	list = list_append_data(list, "D");
+	list = list_append_data(list, "D");
+	list = list_append_data(list, "E");
+	list = list_append_data(list, "E");
+	list = list_append_data(list, "E");
+	list = list_head(list);
+	list = list_deduplicate(list, list_strcmp, NULL);
+
+	str = string_join(", ", list);
+	check(strcmp("A, B, C, D, E", str) == 0);
+	free(str);
+	list_free_list(list);
+
+}
+
+int main() {
+	test_list_deduplicate();
+
+	return 0;
+}


### PR DESCRIPTION
Function list_deduplicate was not removing all duplicates when there were multiple duplicates of some element.