### PR TITLE
abort: Don't use abort unless is an OOM error

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -207,7 +207,8 @@ enum swupd_code compute_hash(struct file *file, char *filename)
 	}
 	blob = mmap(NULL, file->stat.st_size, PROT_READ, MAP_PRIVATE, fileno(fl), 0);
 	if (blob == MAP_FAILED && file->stat.st_size != 0) {
-		abort();
+		fclose(fl);
+		return SWUPD_COMPUTE_HASH_ERROR;
 	}
 
 	hmac_compute_key(filename, &file->stat, key, &key_len, file->use_xattrs);

--- a/src/lib/progress.c
+++ b/src/lib/progress.c
@@ -64,7 +64,7 @@ void progress_set_step(unsigned int current_step, char *desc)
 		} else {
 			debug("The current step (%d) has to be greater than 0 and smaller than the total steps (%d)\n", current_step, step.total);
 		}
-		abort();
+		return;
 	}
 	step.current = current_step;
 	step.description = desc;


### PR DESCRIPTION
We should fail with a correct return code on errors, instead of aborting.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>