### PR TITLE
Suggestion: Check update

### DIFF
--- a/test/functional/checkupdate/chk-update-format-bump.bats
+++ b/test/functional/checkupdate/chk-update-format-bump.bats
@@ -34,15 +34,16 @@ test_setup() {
 @test "CHK011: Check if the check-update returns format no with --verbose" {
 
 	# check if verbose options holds
-	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS --verbose"
+	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS --verbose -F 1"
 
-	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Current OS version: 10 (format 1)
 		Latest server version: 40 (format 2)
+		Latest version in format 1: 20
 		There is a new OS version available: 40
 	EOM
 	)
 	assert_is_output "$expected_output"
+	assert_status_is "$SWUPD_OK"
 
 }

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1233,6 +1233,7 @@ bump_format() { # swupd_function
 	sudo cp -r "$new_version_path" "$middle_version_path"
 
 	# Update +10 format and versions
+	sudo sh -c "echo $format > $middle_version_path/format"
 	update_manifest -p "$mom" format "$format"
 	update_manifest -p "$mom" version "$middle_version"
 	update_manifest -p "$mom" previous "$version"


### PR DESCRIPTION
Suggested change on check-update --verbose. Print extra line with latest version in current format.o

The only 2 cases where this will be different from latest version is in the case of a format bump or
in the case where a format is explicitly stated using -F.

Some samples:

    $ swupd check-update --verbose
    
    current os version: 31130 (format 29) 
    latest server version: 31130 (format 29) 
    latest version in format 29: 31130
    there are no updates available

<BR>

    $ swupd check-update -F staging --verbose
    
    Current OS version: 31140 (format 29) 
    Latest server version: 31130 (format 29) 
    Latest version in format staging: 31140 (format 29) 
    There are no updates available

<BR>

    $ swupd check-update -F 28 --verbose
    
    Current OS version: 31130 (format 29) 
    Latest server version: 31130 (format 29) 
    Latest version in format 28: 30760
    There are no updates available
