### PR TITLE
version: Turn on partially the latest signature check

### DIFF
--- a/src/check_update.c
+++ b/src/check_update.c
@@ -68,7 +68,7 @@ enum swupd_code check_update()
 		ret = SWUPD_CURRENT_VERSION_UNKNOWN;
 	}
 
-	if (server_version == -SWUPD_SIGNATURE_VERIFICATION_FAILED) {
+	if (server_version == -SWUPD_ERROR_SIGNATURE_VERIFICATION) {
 		ret = SWUPD_SIGNATURE_VERIFICATION_FAILED;
 		error("Unable to determine the server version as signature verification failed\n");
 	} else if (server_version < 0) {
@@ -83,7 +83,7 @@ enum swupd_code check_update()
 		/* Retrieve current format */
 		current_format = get_current_format();
 		latest_version_in_format = get_latest_version(NULL);
-		if (latest_version_in_format == -SWUPD_SIGNATURE_VERIFICATION_FAILED) {
+		if (latest_version_in_format == -SWUPD_ERROR_SIGNATURE_VERIFICATION) {
 			ret = SWUPD_SIGNATURE_VERIFICATION_FAILED;
 			error("Unable to determine the latest version in format as signature verification failed\n");
 		} else if (latest_version_in_format < 0) {

--- a/src/mirror.c
+++ b/src/mirror.c
@@ -300,7 +300,7 @@ int handle_mirror_if_stale(void)
 	 * with the server earlier. Another possible explanation for this if the signature
 	 * for central_version dont verify
 	 */
-	if (central_version == -SWUPD_SIGNATURE_VERIFICATION_FAILED) {
+	if (central_version == -SWUPD_ERROR_SIGNATURE_VERIFICATION) {
 		warn("Cannot determine upstream version since signature verification for path: %s failed\n", ret_str);
 		warn("Unable to determine if the mirror is up to date\n");
 		goto out;

--- a/src/swupd_exit_codes.h
+++ b/src/swupd_exit_codes.h
@@ -50,4 +50,14 @@ enum swupd_code {
 
 };
 
+/*
+ * Swupd specific errno codes.
+ * Functions that return int for error in swupd should always use a negative
+ * number for errors, ideally from errno table. If there's no standard errno
+ * code that is similar to what you are trying to return, add the constant
+ * here and use it. Don't use values from enum swupd_code because they will
+ * clash with errno codes.
+ */
+#define SWUPD_ERROR_SIGNATURE_VERIFICATION 126
+
 #endif

--- a/test/functional/signature/version-sig-check.bats
+++ b/test/functional/signature/version-sig-check.bats
@@ -7,8 +7,6 @@ load "../testlib"
 
 test_setup() {
 
-	#TODO: Remove on FB 30
-	skip "Skipping until FB 30 - feature disabled"
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle1 -f /file_1 "$TEST_NAME"
 	create_version -p "$TEST_NAME" 20 10
@@ -18,6 +16,8 @@ test_setup() {
 
 @test "SIG019: Verify signature for absolute latest version with swupd check-update" {
 
+	#TODO: Remove on FB 30
+	skip "Skipping until FB 30 - feature disabled"
 	# absolute latest version get checked during check-update
 	sudo sh -c "mv $WEBDIR/version/latest_version.sig $WEBDIR/version/latest_version_bad_name.sig"
 	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"


### PR DESCRIPTION
Turning on again, but partially the signature check for latest version file.
 - If signature is missing (i.e. older mixer was used to generate the update),
swupd will print warnings and proceed.
 - If signature is wrong, swupd will print error messages and fail the operation.
This isn't suppose to happen even if users are using old mixers.
 - If flag --nosigcheck is used swupd will print warnings and proceed.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>