### PR TITLE
Adding bundle-info and verify-legacy tests to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
                 - UPDATE_SUBGROUP2_TOTAL="$((UPDATE_TOTAL - UPDATE_SUBGROUP1_TOTAL))"
                 - UPDATE_SUBGROUP1="$(find test/functional/update -name *.bats | head -n $UPDATE_SUBGROUP1_TOTAL | tr '\n' ' ')"
                 - UPDATE_SUBGROUP2="$(find test/functional/update -name *.bats | tail -n $UPDATE_SUBGROUP2_TOTAL | tr '\n' ' ')"
-                - GROUP1="$UPDATE_SUBGROUP1"
+                - GROUP1="$UPDATE_SUBGROUP1 $(find test/functional/{bundleinfo,verify-legacy} -name *.bats -printf '%p ')"
                 - GROUP2="$UPDATE_SUBGROUP2 $(find test/functional/{checkupdate,hashdump,mirror,usability} -name *.bats \( ! -name usa-config-file.bats \) -printf '%p ')"
                 - GROUP3="$(find test/functional/{diagnose,search,os-install,repair} -name *.bats -printf '%p ')"
                 - GROUP4="$(find test/functional/{bundleadd,bundleremove,bundlelist,signature} -name *.bats -printf '%p ')"
@@ -27,7 +27,7 @@ jobs:
                   name: "Static Analysis & Unit Tests"
                   script: make compliant && make shellcheck && make check-flags && sudo sh -c 'umask 0022 && make unit-check' && make docs-coverage
                 - stage: test
-                  name: "Functional Tests - update (group 1)"
+                  name: "Functional Tests - update (group 1), bundle-info, verify-legacy"
                   script: env TESTS="$GROUP1" make -e check
                 - stage: test
                   name: "Functional Tests - update (group 2), checkupdate, hashdump, mirror, usability"

--- a/test/functional/bundleinfo/bundle-info-files.bats
+++ b/test/functional/bundleinfo/bundle-info-files.bats
@@ -84,7 +84,7 @@ global_teardown() {
 		Bundle size:
 		 - Size of bundle: .* KB
 		 - Maximum amount of disk size the bundle will take if installed \(includes dependencies\): .* KB
-		Directly included bundles \(1\):
+		Direct dependencies \(1\):
 		 - test-bundle2
 		Files in bundle \(includes dependencies\):
 		 - /bar
@@ -118,7 +118,7 @@ global_teardown() {
 		Bundle size:
 		 - Size of bundle: .* KB
 		 - Maximum amount of disk size the bundle will take if installed \(includes dependencies\): .* KB
-		Directly included bundles \(1\):
+		Direct dependencies \(1\):
 		 - test-bundle2
 		Files in bundle \(includes dependencies\):
 		 - /bar

--- a/test/functional/bundleinfo/bundle-info-includes.bats
+++ b/test/functional/bundleinfo/bundle-info-includes.bats
@@ -62,10 +62,10 @@ global_teardown() {
 		Bundle size:
 		 - Size of bundle: .* KB
 		 - Maximum amount of disk size the bundle will take if installed \(includes dependencies\): .* KB
-		Directly included bundles \(2\):
+		Direct dependencies \(2\):
 		 - test-bundle2
 		 - test-bundle3 \(optional\)
-		Indirectly included bundles \(1\):
+		Indirect dependencies \(1\):
 		 - test-bundle4
 	EOM
 	)
@@ -90,11 +90,11 @@ global_teardown() {
 		Bundle size:
 		 - Size of bundle: .* KB
 		 - Maximum amount of disk size the bundle will take if installed \(includes dependencies\): .* KB
-		Directly included bundles \(3\):
+		Direct dependencies \(3\):
 		 - test-bundle2
 		 - test-bundle5
 		 - test-bundle3 \(optional\)
-		Indirectly included bundles \(1\):
+		Indirect dependencies \(1\):
 		 - test-bundle4
 	EOM
 	)


### PR DESCRIPTION
Adding functional tests related to the bundle-info and verify (legacy) commands to be run in Travis as part of the CI.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>