### PR TITLE
bundle: Reorganize functions on bundle.c

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -22,7 +22,6 @@
 */
 
 #define _GNU_SOURCE
-#include <errno.h>
 #include <fcntl.h>
 #include <libgen.h>
 #include <stdbool.h>
@@ -43,45 +42,6 @@ static bool cmdline_option_force = false;
 void remove_set_option_force(bool opt)
 {
 	cmdline_option_force = opt;
-}
-
-/*
-* list_installable_bundles()
-* Parse the full manifest for the current version of the OS and print
-*   all available bundles.
-*/
-enum swupd_code list_installable_bundles()
-{
-	char *name;
-	struct list *list;
-	struct file *file;
-	struct manifest *MoM = NULL;
-	int current_version;
-	bool mix_exists;
-
-	current_version = get_current_version(globals.path_prefix);
-	if (current_version < 0) {
-		error("Unable to determine current OS version\n");
-		return SWUPD_CURRENT_VERSION_UNKNOWN;
-	}
-
-	mix_exists = (check_mix_exists() & system_on_mix());
-	MoM = load_mom(current_version, mix_exists, NULL);
-	if (!MoM) {
-		return SWUPD_COULDNT_LOAD_MOM;
-	}
-
-	list = MoM->manifests = list_sort(MoM->manifests, file_sort_filename);
-	while (list) {
-		file = list->data;
-		list = list->next;
-		name = get_printable_bundle_name(file->filename, file->is_experimental);
-		print("%s\n", name);
-		free_string(&name);
-	}
-
-	manifest_free(MoM);
-	return 0;
 }
 
 /* Finds out whether bundle_name is installed bundle on
@@ -122,7 +82,7 @@ static int find_manifest(const void *a, const void *b)
 }
 
 /* Return list of bundles that include bundle_name */
-static int required_by(struct list **reqd_by, const char *bundle_name, struct manifest *mom, int recursion, struct list *exclusions, char *msg)
+int required_by(struct list **reqd_by, const char *bundle_name, struct manifest *mom, int recursion, struct list *exclusions, char *msg)
 {
 	struct list *b, *i;
 	char *name;
@@ -222,187 +182,6 @@ static int required_by(struct list **reqd_by, const char *bundle_name, struct ma
 	}
 
 	return count;
-}
-
-/* Return recursive list of included bundles */
-enum swupd_code show_included_bundles(char *bundle_name)
-{
-	int ret = 0;
-	int current_version = CURRENT_OS_VERSION;
-	struct list *subs = NULL;
-	struct list *deps = NULL;
-	struct manifest *mom = NULL;
-
-	current_version = get_current_version(globals.path_prefix);
-	if (current_version < 0) {
-		error("Unable to determine current OS version\n");
-		ret = SWUPD_CURRENT_VERSION_UNKNOWN;
-		goto out;
-	}
-
-	mom = load_mom(current_version, false, NULL);
-	if (!mom) {
-		error("Cannot load official manifest MoM for version %i\n", current_version);
-		ret = SWUPD_COULDNT_LOAD_MOM;
-		goto out;
-	}
-
-	// add_subscriptions takes a list, so construct one with only bundle_name
-	struct list *bundles = NULL;
-	bundles = list_prepend_data(bundles, bundle_name);
-	ret = add_subscriptions(bundles, &subs, mom, true, 0);
-	list_free_list(bundles);
-	if (ret != add_sub_NEW) {
-		// something went wrong or there were no includes, print a message and exit
-		char *m = NULL;
-		if (ret & add_sub_ERR) {
-			string_or_die(&m, "Processing error");
-			ret = SWUPD_COULDNT_LOAD_MANIFEST;
-		} else if (ret & add_sub_BADNAME) {
-			string_or_die(&m, "Bad bundle name detected");
-			ret = SWUPD_INVALID_BUNDLE;
-		} else {
-			string_or_die(&m, "Unknown error");
-			ret = SWUPD_UNEXPECTED_CONDITION;
-		}
-
-		error("%s - Aborting\n", m);
-		free_string(&m);
-		goto out;
-	}
-	deps = recurse_manifest(mom, subs, NULL, false, NULL);
-	if (!deps) {
-		error("Cannot load included bundles\n");
-		ret = SWUPD_RECURSE_MANIFEST;
-		goto out;
-	}
-
-	/* deps now includes the bundle indicated by bundle_name
-	 * if deps only has one bundle in it, no included packages were found */
-	if (list_len(deps) == 1) {
-		info("No included bundles\n");
-		ret = SWUPD_OK;
-		goto out;
-	}
-
-	info("Bundles included by %s:\n\n", bundle_name);
-
-	struct list *iter;
-	iter = list_head(deps);
-	while (iter) {
-		struct manifest *included_bundle = iter->data;
-		iter = iter->next;
-		// deps includes the bundle_name bundle, skip it
-		if (strcmp(bundle_name, included_bundle->component) == 0) {
-			continue;
-		}
-
-		print("%s\n", included_bundle->component);
-	}
-
-	ret = SWUPD_OK;
-
-out:
-	if (mom) {
-		manifest_free(mom);
-	}
-
-	if (deps) {
-		list_free_list_and_data(deps, manifest_free_data);
-	}
-
-	if (subs) {
-		free_subscriptions(&subs);
-	}
-
-	return ret;
-}
-
-enum swupd_code show_bundle_reqd_by(const char *bundle_name, bool server)
-{
-	int ret = 0;
-	int version = CURRENT_OS_VERSION;
-	struct manifest *current_manifest = NULL;
-	struct list *subs = NULL;
-	struct list *reqd_by = NULL;
-	int number_of_reqd = 0;
-
-	if (!server && !is_installed_bundle(bundle_name)) {
-		info("Bundle \"%s\" does not seem to be installed\n", bundle_name);
-		info("       try passing --all to check uninstalled bundles\n");
-		ret = SWUPD_BUNDLE_NOT_TRACKED;
-		goto out;
-	}
-
-	version = get_current_version(globals.path_prefix);
-	if (version < 0) {
-		error("Unable to determine current OS version\n");
-		ret = SWUPD_CURRENT_VERSION_UNKNOWN;
-		goto out;
-	}
-
-	current_manifest = load_mom(version, false, NULL);
-	if (!current_manifest) {
-		error("Unable to download/verify %d Manifest.MoM\n", version);
-		ret = SWUPD_COULDNT_LOAD_MOM;
-		goto out;
-	}
-
-	if (!mom_search_bundle(current_manifest, bundle_name)) {
-		error("Bundle name %s is invalid, aborting dependency list\n", bundle_name);
-		ret = SWUPD_INVALID_BUNDLE;
-		goto out;
-	}
-
-	if (server) {
-		ret = add_included_manifests(current_manifest, &subs);
-		if (ret) {
-			error("Unable to load server manifest");
-			ret = SWUPD_COULDNT_LOAD_MANIFEST;
-			goto out;
-		}
-
-	} else {
-		/* load all tracked bundles into memory */
-		read_subscriptions(&subs);
-	}
-
-	/* load all submanifests */
-	current_manifest->submanifests = recurse_manifest(current_manifest, subs, NULL, server, NULL);
-	if (!current_manifest->submanifests) {
-		error("Cannot load MoM sub-manifests\n");
-		ret = SWUPD_RECURSE_MANIFEST;
-		goto out;
-	}
-
-	char *msg;
-	string_or_die(&msg, "%s bundles that have %s as a dependency:\n", server ? "All installable and installed" : "Installed", bundle_name);
-	number_of_reqd = required_by(&reqd_by, bundle_name, current_manifest, 0, NULL, msg);
-	free_string(&msg);
-	if (reqd_by == NULL) {
-		info("No bundles have %s as a dependency\n", bundle_name);
-		ret = SWUPD_OK;
-		goto out;
-	}
-	list_free_list_and_data(reqd_by, free);
-	info("\nBundle '%s' is required by %d bundle%s\n", bundle_name, number_of_reqd, number_of_reqd == 1 ? "" : "s");
-
-	ret = SWUPD_OK;
-
-out:
-	if (current_manifest) {
-		manifest_free(current_manifest);
-	}
-
-	if (ret) {
-		print("Bundle list failed\n");
-	}
-
-	if (subs) {
-		free_subscriptions(&subs);
-	}
-
-	return ret;
 }
 
 /*
@@ -649,67 +428,4 @@ out_deinit:
 	print("\nFailed to remove bundle(s)\n");
 
 	return ret_code;
-}
-
-/*
- * This function will read the BUNDLES_DIR (by default
- * /usr/share/clear/bundles/), get the list of local bundles and print
- * them sorted.
- */
-enum swupd_code list_local_bundles()
-{
-	char *name;
-	char *path = NULL;
-	struct list *bundles = NULL;
-	struct list *item = NULL;
-	struct manifest *MoM = NULL;
-	struct file *bundle_manifest = NULL;
-	int current_version;
-	bool mix_exists;
-
-	current_version = get_current_version(globals.path_prefix);
-	if (current_version < 0) {
-		goto skip_mom;
-	}
-
-	mix_exists = (check_mix_exists() & system_on_mix());
-	MoM = load_mom(current_version, mix_exists, NULL);
-	if (!MoM) {
-		warn("Could not determine which installed bundles are experimental\n");
-	}
-
-skip_mom:
-	string_or_die(&path, "%s/%s", globals.path_prefix, BUNDLES_DIR);
-
-	errno = 0;
-	bundles = get_dir_files_sorted(path);
-	if (!bundles && errno) {
-		error("couldn't open bundles directory");
-		free_string(&path);
-		return SWUPD_COULDNT_LIST_DIR;
-	}
-
-	item = bundles;
-
-	while (item) {
-		if (MoM) {
-			bundle_manifest = mom_search_bundle(MoM, basename((char *)item->data));
-		}
-		if (bundle_manifest) {
-			name = get_printable_bundle_name(bundle_manifest->filename, bundle_manifest->is_experimental);
-		} else {
-			string_or_die(&name, basename((char *)item->data));
-		}
-		print("%s\n", name);
-		free_string(&name);
-		free(item->data);
-		item = item->next;
-	}
-
-	list_free_list(bundles);
-
-	free_string(&path);
-	manifest_free(MoM);
-
-	return SWUPD_OK;
 }

--- a/src/bundle.h
+++ b/src/bundle.h
@@ -1,0 +1,34 @@
+#ifndef __BUNDLE__
+#define __BUNDLE__
+
+/**
+ * @file
+ * @brief Common bundle related operations
+ */
+
+#include "manifest.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Check if a bundle is installed in the system.
+ * @param bundle_name The name of the bundle.
+ *
+ * @return True if a bundle is installed and false otherwise.
+ */
+bool is_installed_bundle(const char *bundle_name);
+
+/**
+ * @brief Create a list of bundles required by bundle_name.
+ * TODO: Make this function more generic. Right now it's too specific for
+ * bundle-list and bundle-remove use cases.
+ */
+int required_by(struct list **reqd_by, const char *bundle_name, struct manifest *mom, int recursion, struct list *exclusions, char *msg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/bundle_list.c
+++ b/src/bundle_list.c
@@ -21,6 +21,7 @@
  */
 
 #define _GNU_SOURCE
+#include <errno.h>
 #include <getopt.h>
 #include <libgen.h>
 #include <string.h>
@@ -111,6 +112,289 @@ static bool parse_options(int argc, char **argv)
 	}
 
 	return true;
+}
+
+/*
+ * This function will read the BUNDLES_DIR (by default
+ * /usr/share/clear/bundles/), get the list of local bundles and print
+ * them sorted.
+ */
+static enum swupd_code list_local_bundles()
+{
+	char *name;
+	char *path = NULL;
+	struct list *bundles = NULL;
+	struct list *item = NULL;
+	struct manifest *MoM = NULL;
+	struct file *bundle_manifest = NULL;
+	int current_version;
+	bool mix_exists;
+
+	current_version = get_current_version(globals.path_prefix);
+	if (current_version < 0) {
+		goto skip_mom;
+	}
+
+	mix_exists = (check_mix_exists() & system_on_mix());
+	MoM = load_mom(current_version, mix_exists, NULL);
+	if (!MoM) {
+		warn("Could not determine which installed bundles are experimental\n");
+	}
+
+skip_mom:
+	string_or_die(&path, "%s/%s", globals.path_prefix, BUNDLES_DIR);
+
+	errno = 0;
+	bundles = get_dir_files_sorted(path);
+	if (!bundles && errno) {
+		error("couldn't open bundles directory");
+		free_string(&path);
+		return SWUPD_COULDNT_LIST_DIR;
+	}
+
+	item = bundles;
+
+	while (item) {
+		if (MoM) {
+			bundle_manifest = mom_search_bundle(MoM, basename((char *)item->data));
+		}
+		if (bundle_manifest) {
+			name = get_printable_bundle_name(bundle_manifest->filename, bundle_manifest->is_experimental);
+		} else {
+			string_or_die(&name, basename((char *)item->data));
+		}
+		print("%s\n", name);
+		free_string(&name);
+		free(item->data);
+		item = item->next;
+	}
+
+	list_free_list(bundles);
+
+	free_string(&path);
+	manifest_free(MoM);
+
+	return SWUPD_OK;
+}
+
+/* Return recursive list of included bundles */
+static enum swupd_code show_included_bundles(char *bundle_name)
+{
+	int ret = 0;
+	int current_version = CURRENT_OS_VERSION;
+	struct list *subs = NULL;
+	struct list *deps = NULL;
+	struct manifest *mom = NULL;
+
+	current_version = get_current_version(globals.path_prefix);
+	if (current_version < 0) {
+		error("Unable to determine current OS version\n");
+		ret = SWUPD_CURRENT_VERSION_UNKNOWN;
+		goto out;
+	}
+
+	mom = load_mom(current_version, false, NULL);
+	if (!mom) {
+		error("Cannot load official manifest MoM for version %i\n", current_version);
+		ret = SWUPD_COULDNT_LOAD_MOM;
+		goto out;
+	}
+
+	// add_subscriptions takes a list, so construct one with only bundle_name
+	struct list *bundles = NULL;
+	bundles = list_prepend_data(bundles, bundle_name);
+	ret = add_subscriptions(bundles, &subs, mom, true, 0);
+	list_free_list(bundles);
+	if (ret != add_sub_NEW) {
+		// something went wrong or there were no includes, print a message and exit
+		char *m = NULL;
+		if (ret & add_sub_ERR) {
+			string_or_die(&m, "Processing error");
+			ret = SWUPD_COULDNT_LOAD_MANIFEST;
+		} else if (ret & add_sub_BADNAME) {
+			string_or_die(&m, "Bad bundle name detected");
+			ret = SWUPD_INVALID_BUNDLE;
+		} else {
+			string_or_die(&m, "Unknown error");
+			ret = SWUPD_UNEXPECTED_CONDITION;
+		}
+
+		error("%s - Aborting\n", m);
+		free_string(&m);
+		goto out;
+	}
+	deps = recurse_manifest(mom, subs, NULL, false, NULL);
+	if (!deps) {
+		error("Cannot load included bundles\n");
+		ret = SWUPD_RECURSE_MANIFEST;
+		goto out;
+	}
+
+	/* deps now includes the bundle indicated by bundle_name
+	 * if deps only has one bundle in it, no included packages were found */
+	if (list_len(deps) == 1) {
+		info("No included bundles\n");
+		ret = SWUPD_OK;
+		goto out;
+	}
+
+	info("Bundles included by %s:\n\n", bundle_name);
+
+	struct list *iter;
+	iter = list_head(deps);
+	while (iter) {
+		struct manifest *included_bundle = iter->data;
+		iter = iter->next;
+		// deps includes the bundle_name bundle, skip it
+		if (strcmp(bundle_name, included_bundle->component) == 0) {
+			continue;
+		}
+
+		print("%s\n", included_bundle->component);
+	}
+
+	ret = SWUPD_OK;
+
+out:
+	if (mom) {
+		manifest_free(mom);
+	}
+
+	if (deps) {
+		list_free_list_and_data(deps, manifest_free_data);
+	}
+
+	if (subs) {
+		free_subscriptions(&subs);
+	}
+
+	return ret;
+}
+
+/*
+* list_installable_bundles()
+* Parse the full manifest for the current version of the OS and print
+*   all available bundles.
+*/
+static enum swupd_code list_installable_bundles()
+{
+	char *name;
+	struct list *list;
+	struct file *file;
+	struct manifest *MoM = NULL;
+	int current_version;
+	bool mix_exists;
+
+	current_version = get_current_version(globals.path_prefix);
+	if (current_version < 0) {
+		error("Unable to determine current OS version\n");
+		return SWUPD_CURRENT_VERSION_UNKNOWN;
+	}
+
+	mix_exists = (check_mix_exists() & system_on_mix());
+	MoM = load_mom(current_version, mix_exists, NULL);
+	if (!MoM) {
+		return SWUPD_COULDNT_LOAD_MOM;
+	}
+
+	list = MoM->manifests = list_sort(MoM->manifests, file_sort_filename);
+	while (list) {
+		file = list->data;
+		list = list->next;
+		name = get_printable_bundle_name(file->filename, file->is_experimental);
+		print("%s\n", name);
+		free_string(&name);
+	}
+
+	manifest_free(MoM);
+	return 0;
+}
+
+enum swupd_code show_bundle_reqd_by(const char *bundle_name, bool server)
+{
+	int ret = 0;
+	int version = CURRENT_OS_VERSION;
+	struct manifest *current_manifest = NULL;
+	struct list *subs = NULL;
+	struct list *reqd_by = NULL;
+	int number_of_reqd = 0;
+
+	if (!server && !is_installed_bundle(bundle_name)) {
+		info("Bundle \"%s\" does not seem to be installed\n", bundle_name);
+		info("       try passing --all to check uninstalled bundles\n");
+		ret = SWUPD_BUNDLE_NOT_TRACKED;
+		goto out;
+	}
+
+	version = get_current_version(globals.path_prefix);
+	if (version < 0) {
+		error("Unable to determine current OS version\n");
+		ret = SWUPD_CURRENT_VERSION_UNKNOWN;
+		goto out;
+	}
+
+	current_manifest = load_mom(version, false, NULL);
+	if (!current_manifest) {
+		error("Unable to download/verify %d Manifest.MoM\n", version);
+		ret = SWUPD_COULDNT_LOAD_MOM;
+		goto out;
+	}
+
+	if (!mom_search_bundle(current_manifest, bundle_name)) {
+		error("Bundle name %s is invalid, aborting dependency list\n", bundle_name);
+		ret = SWUPD_INVALID_BUNDLE;
+		goto out;
+	}
+
+	if (server) {
+		ret = add_included_manifests(current_manifest, &subs);
+		if (ret) {
+			error("Unable to load server manifest");
+			ret = SWUPD_COULDNT_LOAD_MANIFEST;
+			goto out;
+		}
+
+	} else {
+		/* load all tracked bundles into memory */
+		read_subscriptions(&subs);
+	}
+
+	/* load all submanifests */
+	current_manifest->submanifests = recurse_manifest(current_manifest, subs, NULL, server, NULL);
+	if (!current_manifest->submanifests) {
+		error("Cannot load MoM sub-manifests\n");
+		ret = SWUPD_RECURSE_MANIFEST;
+		goto out;
+	}
+
+	char *msg;
+	string_or_die(&msg, "%s bundles that have %s as a dependency:\n", server ? "All installable and installed" : "Installed", bundle_name);
+	number_of_reqd = required_by(&reqd_by, bundle_name, current_manifest, 0, NULL, msg);
+	free_string(&msg);
+	if (reqd_by == NULL) {
+		info("No bundles have %s as a dependency\n", bundle_name);
+		ret = SWUPD_OK;
+		goto out;
+	}
+	list_free_list_and_data(reqd_by, free);
+	info("\nBundle '%s' is required by %d bundle%s\n", bundle_name, number_of_reqd, number_of_reqd == 1 ? "" : "s");
+
+	ret = SWUPD_OK;
+
+out:
+	if (current_manifest) {
+		manifest_free(current_manifest);
+	}
+
+	if (ret) {
+		print("Bundle list failed\n");
+	}
+
+	if (subs) {
+		free_subscriptions(&subs);
+	}
+
+	return ret;
 }
 
 enum swupd_code bundle_list_main(int argc, char **argv)

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "bundle.h"
 #include "config_loader.h"
 #include "globals.h"
 #include "lib/archives.h"
@@ -313,22 +314,17 @@ extern int link_or_copy_all(const char *orig, const char *dest);
 extern int remove_files_from_fs(struct list *files);
 extern void print_pattern(const char *pattern, int times);
 extern void prettify_size(long size_in_bytes, char **pretty_size);
+extern int link_or_rename(const char *orig, const char *dest);
 
 /* subscription.c */
 struct list *free_list_file(struct list *item);
 struct list *free_bundle(struct list *item);
 extern void create_and_append_subscription(struct list **subs, const char *component);
 extern char *get_tracking_dir(void);
+extern int add_subscriptions(struct list *bundles, struct list **subs, struct manifest *mom, bool find_all, int recursion);
 
 /* bundle.c */
-extern bool is_installed_bundle(const char *bundle_name);
 extern enum swupd_code remove_bundles(struct list *bundles);
-extern enum swupd_code show_bundle_reqd_by(const char *bundle_name, bool server);
-extern enum swupd_code show_included_bundles(char *bundle_name);
-extern enum swupd_code list_installable_bundles();
-extern int add_subscriptions(struct list *bundles, struct list **subs, struct manifest *mom, bool find_all, int recursion);
-enum swupd_code list_local_bundles();
-extern int link_or_rename(const char *orig, const char *dest);
 
 /* verify.c */
 extern enum swupd_code verify_main(void);


### PR DESCRIPTION
Move functions specific from bundle_list to bundle_list.c. Keep in bundle.c only
generic bundle functions and create a bundle header file to export them.
Bundle-remove is still left to avoid rebase conflicts.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>