### PR TITLE
Track bundles specified in os-install

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -184,6 +184,66 @@ int required_by(struct list **reqd_by, const char *bundle_name, struct manifest 
 	return count;
 }
 
+void track_bundle_in_statedir(const char *bundle_name, const char *state_dir)
+{
+	int ret = 0;
+	char *src;
+	char *tracking_dir;
+
+	tracking_dir = mk_full_filename(state_dir, "bundles");
+
+	/* if state_dir_parent/bundles doesn't exist or is empty, assume this is
+	 * the first time tracking installed bundles. Since we don't know what the
+	 * user installed themselves just copy the entire system tracking directory
+	 * into the state tracking directory. */
+	if (!is_populated_dir(tracking_dir)) {
+		char *rmfile;
+		ret = rm_rf(tracking_dir);
+		if (ret) {
+			goto out;
+		}
+		src = mk_full_filename(globals.path_prefix, "/usr/share/clear/bundles");
+		/* at the point this function is called <bundle_name> is already
+		 * installed on the system and therefore has a tracking file under
+		 * /usr/share/clear/bundles. A simple cp -a of that directory will
+		 * accurately track that bundle as manually installed. */
+		ret = copy_all(src, state_dir);
+		free_string(&src);
+		if (ret) {
+			goto out;
+		}
+		/* remove uglies that live in the system tracking directory */
+		rmfile = mk_full_filename(tracking_dir, ".MoM");
+		(void)unlink(rmfile);
+		free_string(&rmfile);
+		/* set perms on the directory correctly */
+		ret = chmod(tracking_dir, S_IRWXU);
+		if (ret) {
+			goto out;
+		}
+	}
+
+	char *tracking_file = mk_full_filename(tracking_dir, bundle_name);
+	int fd = open(tracking_file, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+	free_string(&tracking_file);
+	if (fd < 0) {
+		ret = -1;
+		goto out;
+	}
+	close(fd);
+
+out:
+	if (ret) {
+		debug("Issue creating tracking file in %s for %s\n", tracking_dir, bundle_name);
+	}
+	free_string(&tracking_dir);
+}
+
+void track_bundle(const char *bundle_name)
+{
+	track_bundle_in_statedir(bundle_name, globals.state_dir);
+}
+
 /*
  * remove_tracked removes the tracking file in
  * path_prefix/state_dir_parent/bundles if it exists to untrack as manually

--- a/src/bundle.h
+++ b/src/bundle.h
@@ -27,6 +27,26 @@ bool is_installed_bundle(const char *bundle_name);
  */
 int required_by(struct list **reqd_by, const char *bundle_name, struct manifest *mom, int recursion, struct list *exclusions, char *msg);
 
+/**
+ * @brief Creates a tracking file in the tracking directory within the
+ * specified state directory.
+ * If there are no tracked files in that directory (directory is empty
+ * or does not exist), copy the tracking directory at
+ * path_prefix/usr/share/clear/bundles to the tracking directory to
+ * initiate the tracking files.
+ * This function does not return an error code because weird state in this
+ * directory must be handled gracefully whenever encountered.
+ * @param bundle_name The name of the bundle.
+ * @param state_dir The path to the state directory.
+ */
+void track_bundle_in_statedir(const char *bundle_name, const char *state_dir);
+
+/**
+ * @brief Similar to track_bundle_in_statedir() but uses the global state_dir.
+ * @param bundle_name The name of the bundle.
+ */
+void track_bundle(const char *bundle_name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -156,7 +156,7 @@ static int ensure_root_owned_dir(const char *dirname)
 	return true; /* doesn't exist now */
 }
 
-bool is_populated_dir(char *dirname)
+bool is_populated_dir(const char *dirname)
 {
 	int n = 0;
 	struct dirent *d;
@@ -175,13 +175,13 @@ bool is_populated_dir(char *dirname)
 	return false;
 }
 
-static int create_state_dirs(const char *state_dir_path)
+int create_state_dirs(const char *state_dir_path)
 {
 	int ret = 0;
 	unsigned int i;
 	char *dir;
 #define STATE_DIR_COUNT (sizeof(state_dirs) / sizeof(state_dirs[0]))
-	const char *state_dirs[] = { "delta", "staged", "download", "telemetry" };
+	const char *state_dirs[] = { "delta", "staged", "download", "telemetry", "bundles" };
 
 	// check for existence
 	if (ensure_root_owned_dir(state_dir_path)) {

--- a/src/os_install.c
+++ b/src/os_install.c
@@ -162,10 +162,6 @@ enum swupd_code install_main(int argc, char **argv)
 	 */
 	const int steps_in_os_install = 9;
 
-	/* add os-core to the list of bundles to install to make sure
-	 * it is included regardless of user selection */
-	cmdline_bundles = list_prepend_data(cmdline_bundles, strdup_or_die("os-core"));
-
 	if (!parse_options(argc, argv)) {
 		print("\n");
 		print_help();

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -58,6 +58,11 @@ struct list *free_list_file(struct list *item)
 	return list_free_item(item, free_file_data);
 }
 
+int subscription_bundlename_strcmp(const void *a, const void *b)
+{
+	return strcmp(((struct sub *)a)->component, (const char *)b);
+}
+
 static int subscription_sort_component(const void *a, const void *b)
 {
 	struct sub *A, *B;

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -279,7 +279,7 @@ extern struct file *search_file_in_manifest(struct manifest *manifest, const cha
 extern char *mk_full_filename(const char *prefix, const char *path);
 extern bool is_directory_mounted(const char *filename);
 extern bool is_under_mounted_directory(const char *filename);
-extern bool is_populated_dir(char *dirname);
+extern bool is_populated_dir(const char *dirname);
 
 /* filedesc.c */
 extern void dump_file_descriptor_leaks(void);
@@ -315,6 +315,7 @@ extern int remove_files_from_fs(struct list *files);
 extern void print_pattern(const char *pattern, int times);
 extern void prettify_size(long size_in_bytes, char **pretty_size);
 extern int link_or_rename(const char *orig, const char *dest);
+extern int create_state_dirs(const char *state_dir_path);
 
 /* subscription.c */
 struct list *free_list_file(struct list *item);
@@ -322,6 +323,7 @@ struct list *free_bundle(struct list *item);
 extern void create_and_append_subscription(struct list **subs, const char *component);
 extern char *get_tracking_dir(void);
 extern int add_subscriptions(struct list *bundles, struct list **subs, struct manifest *mom, bool find_all, int recursion);
+extern int subscription_bundlename_strcmp(const void *a, const void *b);
 
 /* bundle.c */
 extern enum swupd_code remove_bundles(struct list *bundles);

--- a/test/functional/os-install/install-bad.bats
+++ b/test/functional/os-install/install-bad.bats
@@ -10,6 +10,7 @@ test_setup() {
 	create_test_environment -e "$TEST_NAME" 10
 	create_bundle -n os-core -f /core "$TEST_NAME"
 	create_bundle -n test-bundle -f /file_1,/file_2 "$TEST_NAME"
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle os-core
 
 }
 

--- a/test/functional/os-install/install-multiple.bats
+++ b/test/functional/os-install/install-multiple.bats
@@ -12,6 +12,10 @@ test_setup() {
 	create_bundle -n test-bundle1 -f /file_1,/file_2 "$TEST_NAME"
 	create_bundle -n test-bundle2 -f /foo/file_3 "$TEST_NAME"
 	create_bundle -n test-bundle3 -f /bar/file_4 "$TEST_NAME"
+	# os-core is always included by all manifests
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 os-core
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle2 os-core
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle3 os-core
 
 }
 
@@ -50,9 +54,13 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/core
 	assert_file_exists "$TARGETDIR"/foo/file_3
 	assert_file_exists "$TARGETDIR"/bar/file_4
+	assert_file_exists "$TARGETDIR"/var/lib/swupd/bundles/test-bundle2
+	assert_file_exists "$TARGETDIR"/var/lib/swupd/bundles/test-bundle3
 	# make sure non specified bundles were not installed
 	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
 	assert_file_not_exists "$TARGETDIR"/file_1
 	assert_file_not_exists "$TARGETDIR"/file_2
+	assert_file_not_exists "$TARGETDIR"/var/lib/swupd/bundles/test-bundle1
+	assert_file_not_exists "$TARGETDIR"/var/lib/swupd/bundles/os-core
 
 }

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1625,7 +1625,7 @@ create_test_environment() { # swupd_function
 
 	# state files & dirs
 	debug_msg "Creating a state dir"
-	sudo mkdir -p "$statedir"/{staged,download,delta,telemetry}
+	sudo mkdir -p "$statedir"/{staged,download,delta,telemetry,bundles}
 	sudo chmod -R 0700 "$statedir"
 
 	# export environment variables that are dependent of the test env


### PR DESCRIPTION
When os-install is used to install an OS and the --bundles option is used
to specify some bundles that should be installed in the system along
with the OS, the bundles specified should be tracked.

Closes #1153

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>