### PR TITLE
sys: Use function from sys instead of mk_full_filename

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -190,7 +190,7 @@ void track_bundle_in_statedir(const char *bundle_name, const char *state_dir)
 	char *src;
 	char *tracking_dir;
 
-	tracking_dir = mk_full_filename(state_dir, "bundles");
+	tracking_dir = sys_path_join(state_dir, "bundles");
 
 	/* if state_dir_parent/bundles doesn't exist or is empty, assume this is
 	 * the first time tracking installed bundles. Since we don't know what the
@@ -202,7 +202,7 @@ void track_bundle_in_statedir(const char *bundle_name, const char *state_dir)
 		if (ret) {
 			goto out;
 		}
-		src = mk_full_filename(globals.path_prefix, "/usr/share/clear/bundles");
+		src = sys_path_join(globals.path_prefix, "/usr/share/clear/bundles");
 		/* at the point this function is called <bundle_name> is already
 		 * installed on the system and therefore has a tracking file under
 		 * /usr/share/clear/bundles. A simple cp -a of that directory will
@@ -213,7 +213,7 @@ void track_bundle_in_statedir(const char *bundle_name, const char *state_dir)
 			goto out;
 		}
 		/* remove uglies that live in the system tracking directory */
-		rmfile = mk_full_filename(tracking_dir, ".MoM");
+		rmfile = sys_path_join(tracking_dir, ".MoM");
 		(void)unlink(rmfile);
 		free_string(&rmfile);
 		/* set perms on the directory correctly */
@@ -223,7 +223,7 @@ void track_bundle_in_statedir(const char *bundle_name, const char *state_dir)
 		}
 	}
 
-	char *tracking_file = mk_full_filename(tracking_dir, bundle_name);
+	char *tracking_file = sys_path_join(tracking_dir, bundle_name);
 	int fd = open(tracking_file, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
 	free_string(&tracking_file);
 	if (fd < 0) {
@@ -252,7 +252,7 @@ void track_bundle(const char *bundle_name)
 static void remove_tracked(const char *bundle)
 {
 	char *destdir = get_tracking_dir();
-	char *tracking_file = mk_full_filename(destdir, bundle);
+	char *tracking_file = sys_path_join(destdir, bundle);
 	free_string(&destdir);
 	/* we don't care about failures here since any weird state in the tracking
 	 * dir MUST be handled gracefully */

--- a/src/bundle_add.c
+++ b/src/bundle_add.c
@@ -115,7 +115,7 @@ static int check_disk_space_availability(struct list *to_install_bundles)
 
 	timelist_timer_start(globals.global_times, "Check disk space availability");
 	bundle_size = get_manifest_list_contentsize(to_install_bundles);
-	filepath = mk_full_filename(globals.path_prefix, "/usr/");
+	filepath = sys_path_join(globals.path_prefix, "/usr/");
 
 	/* Calculate free space on filepath */
 	fs_free = get_available_space(filepath);

--- a/src/curl.c
+++ b/src/curl.c
@@ -86,7 +86,7 @@ CURLcode swupd_curl_set_optional_client_cert(CURL *curl)
 	CURLcode curl_ret = CURLE_OK;
 	char *client_cert_path;
 
-	client_cert_path = mk_full_filename(globals.path_prefix, SSL_CLIENT_CERT);
+	client_cert_path = sys_path_join(globals.path_prefix, SSL_CLIENT_CERT);
 	if (access(client_cert_path, F_OK) == 0) {
 		curl_ret = curl_easy_setopt(curl, CURLOPT_SSLCERT, client_cert_path);
 		if (curl_ret != CURLE_OK) {

--- a/src/hashdump.c
+++ b/src/hashdump.c
@@ -115,7 +115,7 @@ enum swupd_code hashdump_main(int argc, char **argv)
 	file.filename = strdup_or_die(argv[optind]);
 	// Accept relative paths if no path_prefix set on command line
 	if (use_prefix) {
-		fullname = mk_full_filename(globals.path_prefix, file.filename);
+		fullname = sys_path_join(globals.path_prefix, file.filename);
 	} else {
 		fullname = strdup_or_die(file.filename);
 	}

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -269,35 +269,6 @@ static void get_mounted_directories(void)
 	fclose(file);
 }
 
-// prepends prefix to an path (eg: the global path_prefix to a
-// file->filename or some other path prefix and path), insuring there
-// is no duplicate '/' at the strings' junction and no trailing '/'
-char *mk_full_filename(const char *prefix, const char *path)
-{
-	char *fname = NULL;
-	size_t len = 0;
-
-	if (!path) {
-		return NULL;
-	}
-
-	if (prefix) {
-		len = strlen(prefix);
-	}
-	//Remove trailing '/' at the end of prefix
-	while (len && prefix[len - 1] == '/') {
-		len--;
-	}
-
-	//make sure a '/' will always be added between prefix and path
-	if (path[0] == '/') {
-		string_or_die(&fname, "%.*s%s", len, prefix, path);
-	} else {
-		string_or_die(&fname, "%.*s/%s", len, prefix, path);
-	}
-	return fname;
-}
-
 // expects filename w/o path_prefix prepended
 bool is_directory_mounted(const char *filename)
 {
@@ -309,7 +280,7 @@ bool is_directory_mounted(const char *filename)
 		return false;
 	}
 
-	tmp = mk_full_filename(globals.path_prefix, filename);
+	tmp = sys_path_join(globals.path_prefix, filename);
 	string_or_die(&fname, ":%s:", tmp);
 	free_string(&tmp);
 
@@ -343,7 +314,7 @@ bool is_under_mounted_directory(const char *filename)
 	while (token != NULL) {
 		string_or_die(&mountpoint, "%s/", token);
 
-		tmp = mk_full_filename(globals.path_prefix, filename);
+		tmp = sys_path_join(globals.path_prefix, filename);
 		string_or_die(&fname, ":%s:", tmp);
 		free_string(&tmp);
 
@@ -586,7 +557,7 @@ enum swupd_code verify_fix_path(char *targetpath, struct manifest *target_MoM)
 		free_string(&tar_dotfile);
 		free_string(&url);
 
-		target = mk_full_filename(globals.path_prefix, path);
+		target = sys_path_join(globals.path_prefix, path);
 
 		/* Search for the file in the manifest, to get the hash for the file */
 		file = search_file_in_manifest(target_MoM, path);
@@ -1117,5 +1088,5 @@ void prettify_size(long size_in_bytes, char **pretty_size)
 }
 char *get_tracking_dir(void)
 {
-	return mk_full_filename(globals.state_dir, "bundles");
+	return sys_path_join(globals.state_dir, "bundles");
 }

--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -363,9 +363,7 @@ char *sys_path_join(const char *prefix, const char *path)
 		prefix = "";
 	}
 
-	if (prefix) {
-		len = strlen(prefix);
-	}
+	len = strlen(prefix);
 
 	//Remove trailing '/' at the end of prefix
 	while (len && prefix[len - 1] == PATH_SEPARATOR) {

--- a/src/mirror.c
+++ b/src/mirror.c
@@ -118,8 +118,8 @@ static int unset_mirror_url()
 	char *content_path;
 	char *version_path;
 	int ret1 = 0, ret2 = 0;
-	content_path = mk_full_filename(globals.path_prefix, MIRROR_CONTENT_URL_PATH);
-	version_path = mk_full_filename(globals.path_prefix, MIRROR_VERSION_URL_PATH);
+	content_path = sys_path_join(globals.path_prefix, MIRROR_CONTENT_URL_PATH);
+	version_path = sys_path_join(globals.path_prefix, MIRROR_VERSION_URL_PATH);
 
 	ret1 = sys_rm(content_path);
 	ret2 = sys_rm(version_path);
@@ -203,7 +203,7 @@ static enum swupd_code set_new_url(const char *url, const char *url_path)
 
 	/* concatenate path_prefix and configuration paths if necessary
 	 * if path_prefix is NULL the second argument will be returned */
-	path = mk_full_filename(globals.path_prefix, url_path);
+	path = sys_path_join(globals.path_prefix, url_path);
 
 	/* write url to path_prefix/MIRROR_VERSION_URL_PATH */
 	ret = write_to_path(url, path);
@@ -253,8 +253,8 @@ static bool mirror_is_set(void)
 	char *version_path;
 	char *content_path;
 
-	version_path = mk_full_filename(globals.path_prefix, MIRROR_VERSION_URL_PATH);
-	content_path = mk_full_filename(globals.path_prefix, MIRROR_CONTENT_URL_PATH);
+	version_path = sys_path_join(globals.path_prefix, MIRROR_VERSION_URL_PATH);
+	content_path = sys_path_join(globals.path_prefix, MIRROR_CONTENT_URL_PATH);
 	mirror_set = sys_filelink_exists(version_path) && sys_filelink_exists(content_path);
 
 	free_string(&version_path);
@@ -278,7 +278,7 @@ int handle_mirror_if_stale(void)
 	// Force curl to be initialized with mirror url
 	get_latest_version("");
 
-	fullpath = mk_full_filename(globals.path_prefix, DEFAULT_VERSION_URL_PATH);
+	fullpath = sys_path_join(globals.path_prefix, DEFAULT_VERSION_URL_PATH);
 	ret = get_value_from_path(&ret_str, fullpath, true);
 	if (ret != 0 || ret_str == NULL) {
 		/* no versionurl file here, might not exist under --path argument */

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -276,7 +276,6 @@ void deduplicate_files_from_manifest(struct manifest **m1, struct manifest *m2);
 extern struct file *mom_search_bundle(struct manifest *mom, const char *bundlename);
 extern struct file *search_file_in_manifest(struct manifest *manifest, const char *filename);
 
-extern char *mk_full_filename(const char *prefix, const char *path);
 extern bool is_directory_mounted(const char *filename);
 extern bool is_under_mounted_directory(const char *filename);
 extern bool is_populated_dir(const char *dirname);

--- a/src/update.c
+++ b/src/update.c
@@ -207,7 +207,7 @@ static bool is_installed_and_verified(struct file *file)
 		return false;
 	}
 
-	char *fullname = mk_full_filename(globals.path_prefix, file->filename);
+	char *fullname = sys_path_join(globals.path_prefix, file->filename);
 
 	if (verify_file(file, fullname)) {
 		free_string(&fullname);

--- a/src/verify.c
+++ b/src/verify.c
@@ -229,7 +229,7 @@ static int check_files_hash(struct list *files)
 			goto progress;
 		}
 
-		fullname = mk_full_filename(globals.path_prefix, f->filename);
+		fullname = sys_path_join(globals.path_prefix, f->filename);
 		valid = cmdline_option_quick ? verify_file_lazy(fullname) : verify_file(f, fullname);
 		free_string(&fullname);
 		if (valid) {
@@ -333,7 +333,7 @@ static void add_missing_files(struct manifest *official_manifest, bool repair)
 			goto progress;
 		}
 
-		fullname = mk_full_filename(globals.path_prefix, file->filename);
+		fullname = sys_path_join(globals.path_prefix, file->filename);
 		memset(&local, 0, sizeof(struct file));
 		local.filename = file->filename;
 		populate_file_struct(&local, fullname);
@@ -403,7 +403,7 @@ static void check_and_fix_one(struct file *file, struct manifest *official_manif
 	}
 
 	/* compare the hash and report mismatch */
-	fullname = mk_full_filename(globals.path_prefix, file->filename);
+	fullname = sys_path_join(globals.path_prefix, file->filename);
 	if (verify_file(file, fullname)) {
 		goto end;
 	}
@@ -499,7 +499,7 @@ static void remove_orphaned_files(struct manifest *official_manifest, bool repai
 			goto progress;
 		}
 
-		fullname = mk_full_filename(globals.path_prefix, file->filename);
+		fullname = sys_path_join(globals.path_prefix, file->filename);
 
 		if (lstat(fullname, &sb) != 0) {
 			/* correctly, the file is not present */
@@ -753,7 +753,7 @@ static enum swupd_code deal_with_extra_files(struct manifest *manifest, bool fix
 {
 	enum swupd_code ret;
 
-	char *start = mk_full_filename(globals.path_prefix, cmdline_option_picky_tree);
+	char *start = sys_path_join(globals.path_prefix, cmdline_option_picky_tree);
 	info("\n%s extra files under %s\n", fix ? "Removing" : "Checking for", start);
 	ret = walk_tree(manifest, start, fix, picky_whitelist, &counts);
 	free_string(&start);
@@ -799,8 +799,8 @@ static bool init_tracking_dir(const char *state_dir, const char *init_file)
 	/* add a temporary control file to the tracking
 	 * directory so it is not empty to avoid tracking
 	 * all installed bundles */
-	tracking_dir = mk_full_filename(state_dir, "bundles");
-	tracking_file = mk_full_filename(tracking_dir, init_file);
+	tracking_dir = sys_path_join(state_dir, "bundles");
+	tracking_file = sys_path_join(tracking_dir, init_file);
 	int fd = open(tracking_file, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
 	free_string(&tracking_dir);
 	free_string(&tracking_file);
@@ -1184,7 +1184,7 @@ brick_the_system_and_clean_curl:
 	if (cmdline_option_install && cmdline_option_bundles) {
 		/* this is a fresh install so the tracking directory
 		 * needs to be created */
-		char *new_os_statedir = mk_full_filename(globals.path_prefix, "/var/lib/swupd");
+		char *new_os_statedir = sys_path_join(globals.path_prefix, "/var/lib/swupd");
 		bool tracking = init_tracking_dir(new_os_statedir, ".init");
 		if (tracking) {
 			for (iter = cmdline_option_bundles; iter; iter = iter->next) {
@@ -1197,7 +1197,7 @@ brick_the_system_and_clean_curl:
 			}
 			/* remove the temporary file created during
 			 * the initialization of the tracking directory */
-			char *init_file = mk_full_filename(new_os_statedir, "/bundles/.init");
+			char *init_file = sys_path_join(new_os_statedir, "/bundles/.init");
 			sys_rm(init_file);
 			free_string(&init_file);
 		}


### PR DESCRIPTION
mk_full_filename() and sys_path_join() does almost the same thing.
sys_path_join() was prefered because it works best with null strings and
there were problems when using mk_full_filename() for urls

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>