### PR TITLE
More sane usage of dirname() and basename() in clear

### DIFF
--- a/src/alias.c
+++ b/src/alias.c
@@ -173,7 +173,7 @@ struct list *get_alias_definitions(void)
 	iters = system_alias_files;
 	iteru = user_alias_files;
 	while (iters && iteru) {
-		int pivot = strcmp(basename(iteru->data), basename(iters->data));
+		int pivot = strcmp(sys_basename(iteru->data), sys_basename(iters->data));
 		if (pivot == 0) {
 			if (iters == system_alias_files) {
 				system_alias_files = iters->next;

--- a/src/autoupdate.c
+++ b/src/autoupdate.c
@@ -22,7 +22,6 @@
 #define _GNU_SOURCE
 #include <fcntl.h>
 #include <getopt.h>
-#include <libgen.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -23,7 +23,6 @@
 
 #define _GNU_SOURCE
 #include <fcntl.h>
-#include <libgen.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/bundle_add.c
+++ b/src/bundle_add.c
@@ -26,7 +26,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
-#include <libgen.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/src/bundle_list.c
+++ b/src/bundle_list.c
@@ -23,7 +23,6 @@
 #define _GNU_SOURCE
 #include <errno.h>
 #include <getopt.h>
-#include <libgen.h>
 #include <string.h>
 
 #include "config.h"
@@ -156,20 +155,19 @@ skip_mom:
 
 	while (item) {
 		if (MoM) {
-			bundle_manifest = mom_search_bundle(MoM, basename((char *)item->data));
+			bundle_manifest = mom_search_bundle(MoM, sys_basename((char *)item->data));
 		}
 		if (bundle_manifest) {
 			name = get_printable_bundle_name(bundle_manifest->filename, bundle_manifest->is_experimental);
+			print("%s\n", name);
+			free(name);
 		} else {
-			string_or_die(&name, basename((char *)item->data));
+			print("%s\n", sys_basename((char *)item->data));
 		}
-		print("%s\n", name);
-		free_string(&name);
-		free(item->data);
 		item = item->next;
 	}
 
-	list_free_list(bundles);
+	list_free_list_and_data(bundles, free);
 
 	free_string(&path);
 	manifest_free(MoM);

--- a/src/bundle_remove.c
+++ b/src/bundle_remove.c
@@ -25,7 +25,6 @@
 #define _GNU_SOURCE
 #include <fcntl.h>
 #include <getopt.h>
-#include <libgen.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/src/delta.c
+++ b/src/delta.c
@@ -25,7 +25,6 @@
 #include <bsdiff.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <libgen.h>
 #include <linux/fs.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/hashdump.c
+++ b/src/hashdump.c
@@ -47,7 +47,7 @@ static struct option opts[] = {
 static void usage(const char *name)
 {
 	print("Usage:\n");
-	print("   swupd %s [OPTION...] filename\n\n", basename((char *)name));
+	print("   swupd %s [OPTION...] filename\n\n", sys_basename(name));
 	print("Help Options:\n");
 	print("   -h, --help              Show help options\n\n");
 	print("Application Options:\n");

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -25,7 +25,6 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <libgen.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -474,12 +473,10 @@ int get_dirfd_path(const char *fullname)
 {
 	int ret = -1;
 	int fd;
-	char *tmp = NULL;
-	char *dir;
+	char *dir = NULL;
 	char *real_path = NULL;
 
-	string_or_die(&tmp, "%s", fullname);
-	dir = dirname(tmp);
+	dir = sys_dirname(fullname);
 
 	fd = open(dir, O_RDONLY);
 	if (fd < 0) {
@@ -505,7 +502,7 @@ int get_dirfd_path(const char *fullname)
 
 	free_string(&real_path);
 out:
-	free_string(&tmp);
+	free_string(&dir);
 	return ret;
 }
 
@@ -542,7 +539,7 @@ enum swupd_code verify_fix_path(char *targetpath, struct manifest *target_MoM)
 	 */
 	while (strcmp(path, "/") != 0) {
 		path_list = list_prepend_data(path_list, strdup_or_die(path));
-		tmp = strdup_or_die(dirname(path));
+		tmp = sys_dirname(path);
 		free_string(&path);
 		path = tmp;
 	}

--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -17,22 +17,25 @@
  *
  */
 
+// Make sure we are getting the gnu version of basename
 #define _GNU_SOURCE
-#include "sys.h"
+#include <libgen.h>
+#undef basename
+#include <string.h>
+
 #include "list.h"
 #include "log.h"
 #include "macros.h"
 #include "memory.h"
 #include "strings.h"
+#include "sys.h"
 
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <libgen.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
 #include <sys/wait.h>
@@ -352,6 +355,15 @@ char *sys_dirname(const char *path)
 	dir = strdup_or_die(dir);
 	free(tmp);
 	return dir;
+}
+
+char *sys_basename(const char *path)
+{
+	if (!path) {
+		return NULL;
+	}
+
+	return basename(path);
 }
 
 char *sys_path_join(const char *prefix, const char *path)

--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -338,9 +338,18 @@ char *sys_dirname(const char *path)
 {
 	char *tmp, *dir;
 
-	tmp = strdup_or_die(path);
-	dir = strdup_or_die(dirname(tmp));
+	if (!path) {
+		return NULL;
+	}
 
+	tmp = strdup_or_die(path);
+	dir = dirname(tmp);
+
+	if (dir == tmp) {
+		return tmp;
+	}
+
+	dir = strdup_or_die(dir);
 	free(tmp);
 	return dir;
 }

--- a/src/lib/sys.h
+++ b/src/lib/sys.h
@@ -164,6 +164,18 @@ bool systemd_in_container(void);
 char *sys_dirname(const char *path);
 
 /**
+ * @brief Safe GNU implementation of basename
+ *
+ * Make sure the GNU implementation of basename will be used and not the
+ * posix one. The GNU implementation is read-only and won't change the value
+ * of path. For more information consult GNU basename manual.
+ *
+ * A pointer for a portion of the path string will be returned and shoudn't be
+ * freed. If you need to keep it you need to strdup it.
+ */
+char *sys_basename(const char *path);
+
+/**
  * @brief Join 2 paths using the default path separator.
  *
  * Can be used to prepend a prefix to an path (eg: the global path_prefix to a

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@
  *
  */
 
-#define _GNU_SOURCE // for basename()
+#define _GNU_SOURCE
 #include <getopt.h>
 #include <locale.h>
 #include <stdio.h>
@@ -81,8 +81,8 @@ static const struct option prog_opts[] = {
 static void print_help(const char *name)
 {
 	print("Usage:\n");
-	print("    %s [OPTION...]\n", basename((char *)name));
-	print(" or %s [OPTION...] SUBCOMMAND [OPTION...]\n\n", basename((char *)name));
+	print("    %s [OPTION...]\n", sys_basename(name));
+	print(" or %s [OPTION...] SUBCOMMAND [OPTION...]\n\n", sys_basename(name));
 	print("Help Options:\n");
 	print("   -h, --help              Show help options\n");
 	print("   -v, --version           Output version information and exit\n\n");
@@ -95,7 +95,7 @@ static void print_help(const char *name)
 		entry++;
 	}
 	print("\n");
-	print("To view subcommand options, run `%s SUBCOMMAND --help'\n", basename((char *)name));
+	print("To view subcommand options, run `%s SUBCOMMAND --help'\n", sys_basename(name));
 }
 
 /* this function prints the copyright message for the --version command */

--- a/src/mirror.c
+++ b/src/mirror.c
@@ -21,7 +21,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <getopt.h>
-#include <libgen.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -141,10 +140,9 @@ static int unset_mirror_url()
 
 static enum swupd_code write_to_path(const char *content, const char *path)
 {
-	char *dir, *tmp = NULL;
+	char *dir = NULL;
 	struct stat dirstat;
-	string_or_die(&tmp, "%s", path);
-	dir = dirname(tmp);
+	dir = sys_dirname(path);
 
 	/* attempt to make the directory, ok if already exists */
 	int ret = mkdir(dir, S_IRWXU | S_IRWXG | S_IRWXO);
@@ -187,7 +185,7 @@ static enum swupd_code write_to_path(const char *content, const char *path)
 	}
 
 out:
-	free_string(&tmp);
+	free_string(&dir);
 	return ret;
 }
 

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -23,7 +23,6 @@
 
 #define _GNU_SOURCE
 #include <fcntl.h>
-#include <libgen.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -59,8 +58,8 @@ void telemetry(telem_prio_t level, const char *class, const char *fmt, ...)
 
 	close(fd);
 
-	filename_n = basename(filename);
-	if (!filename_n) {
+	filename_n = sys_basename(filename);
+	if (!filename_n || !filename_n[0]) {
 		free_string(&filename);
 		goto error;
 	}

--- a/src/update.c
+++ b/src/update.c
@@ -25,7 +25,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
-#include <libgen.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Dirname is tricky to be used. And basename() has 2 different implementations that are conflicting.
Make a wrapper to reduce the problems on misusing them