### PR TITLE
os_install: Skip optional bundles when flag set

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -251,6 +251,7 @@ BATS = \
 	test/functional/os-install/install-json.bats \
 	test/functional/os-install/install-latest-missing.bats \
 	test/functional/os-install/install-multiple.bats \
+	test/functional/os-install/install-no-also-add.bats \
 	test/functional/os-install/install-no-fullfile-fallback.bats \
 	test/functional/os-install/install-no-packs.bats \
 	test/functional/os-install/install-statedir-cache.bats \

--- a/config
+++ b/config
@@ -319,6 +319,8 @@
 # Download all content, but do not actually install it (boolean value)
 #download=<true/false>
 
+# Do not install optional bundles, also-add flag in Manifests (boolean value)
+#skip_optional=<true/false>
 
 [mirror]
 

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -414,6 +414,14 @@ SUBCOMMANDS
         Do not perform an os-install, instead download all resources needed
         to perform the os-install, and exit.
 
+    - `--skip-optional`
+
+        Do not install optional bundles (also-add flag in Manifests).
+        A bundle may include other bundles that will also get installed
+        when installing the bundle that includes them. This included bundles
+        can be either optional, or mandatory. Optional bundles can be skipped
+        at install time by using this option.
+
 ``repair``
 
     Correct any issues found. This will overwrite incorrect file content,

--- a/src/os_install.c
+++ b/src/os_install.c
@@ -22,9 +22,11 @@
 #include "swupd.h"
 
 #define FLAG_DOWNLOAD_ONLY 2000
+#define FLAG_SKIP_OPTIONAL 2001
 
 static bool cmdline_option_download = false;
 static bool cmdline_option_force = false;
+static bool cmdline_option_skip_optional = false;
 static struct list *cmdline_bundles = NULL;
 static char *path;
 static int cmdline_option_version = -1;
@@ -37,6 +39,7 @@ static const struct option prog_opts[] = {
 	{ "manifest", required_argument, 0, 'm' },
 	{ "statedir-cache", required_argument, 0, 's' },
 	{ "download", no_argument, 0, FLAG_DOWNLOAD_ONLY },
+	{ "skip-optional", no_argument, 0, FLAG_SKIP_OPTIONAL },
 };
 
 static void print_help(void)
@@ -52,6 +55,7 @@ static void print_help(void)
 	print("   -V, --version=[VER]         If the version to install is not the latest, it can be specified with this option\n");
 	print("   -s, --statedir-cache=[PATH] After checking for content in the statedir, check the statedir-cache before downloading it over the network\n");
 	print("   --download                  Download all content, but do not actually install it\n");
+	print("   --skip-optional             Do not install optional bundles (also-add flag in Manifests)\n");
 	print("\n");
 }
 
@@ -97,6 +101,9 @@ static bool parse_opt(int opt, char *optarg)
 	}
 	case FLAG_DOWNLOAD_ONLY:
 		cmdline_option_download = optarg_to_bool(optarg);
+		return true;
+	case FLAG_SKIP_OPTIONAL:
+		cmdline_option_skip_optional = optarg_to_bool(optarg);
 		return true;
 	default:
 		return false;
@@ -187,6 +194,7 @@ enum swupd_code install_main(int argc, char **argv)
 	verify_set_option_install(true);
 	verify_set_option_statedir_cache(cmdline_option_statedir_cache);
 	verify_set_option_download(cmdline_option_download);
+	verify_set_option_skip_optional(cmdline_option_skip_optional);
 	verify_set_option_force(cmdline_option_force);
 	verify_set_option_bundles(cmdline_bundles);
 	verify_set_option_version(cmdline_option_version);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -329,6 +329,7 @@ extern enum swupd_code remove_bundles(struct list *bundles);
 /* verify.c */
 extern enum swupd_code execute_verify(void);
 extern void verify_set_option_download(bool opt);
+extern void verify_set_option_skip_optional(bool opt);
 extern void verify_set_command_verify(bool opt);
 extern void verify_set_option_force(bool opt);
 extern void verify_set_option_install(bool opt);

--- a/src/verify.c
+++ b/src/verify.c
@@ -43,6 +43,7 @@ static const char picky_whitelist_default[] = "/usr/lib/modules|/usr/lib/kernel|
 
 static bool warning_printed = false;
 static bool cmdline_option_download = false;
+static bool cmdline_option_skip_optional = false;
 static bool cmdline_command_verify = false;
 static bool cmdline_option_force = false;
 static bool cmdline_option_fix = false;
@@ -87,6 +88,11 @@ void verify_set_command_verify(bool opt)
 void verify_set_option_download(bool opt)
 {
 	cmdline_option_download = opt;
+}
+
+void verify_set_option_skip_optional(bool opt)
+{
+	cmdline_option_skip_optional = opt;
 }
 
 void verify_set_option_force(bool opt)
@@ -815,9 +821,9 @@ enum swupd_code execute_verify(void)
 		}
 	}
 
-	/* Unless we are installing a new bundle we shoudn't include optional
-	* bundles to the bundle list */
-	if (!cmdline_option_install) {
+	/* Unless we are installing a new bundle and the --skip-optional flag is not
+	* set we shoudn't include optional bundles to the bundle list */
+	if (!cmdline_option_install || cmdline_option_skip_optional) {
 		globals.skip_optional_bundles = true;
 	}
 

--- a/swupd.bash
+++ b/swupd.bash
@@ -67,7 +67,7 @@ _swupd()
 		opts="$global --version --picky --picky-tree --picky-whitelist --quick --force --extra-files-only --bundles "
 		break;;
 		("os-install")
-		opts="$global --version --force --bundles --statedir-cache --download "
+		opts="$global --version --force --bundles --statedir-cache --download --skip-optional"
 		break;;
 		("mirror")
 		opts="$global --set --unset "

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -310,6 +310,7 @@ if [[ -n "$state" ]]; then
             '(help -V --version)'{-V,--version=}'[If the version to install is not the latest, it can be specified with this option]:version:()'
             '(help -s --statedir-cache)'{-s,--statedir-cache=}'[After checking for content in the statedir, check the statedir-cache before downloading it over the network]'
             '(help status)--download[Download all content, but do not actually install it]'
+            '(help status)--skip-optional[Do not install optional bundles (also-add flag in Manifests)]'
           )
           _arguments $osinstall && ret=0
           ;;

--- a/test/functional/os-install/install-no-also-add.bats
+++ b/test/functional/os-install/install-no-also-add.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+# Author: John Akre
+# Email: john.w.akre@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n test-bundle1 -f /foo/test-file1 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /bar/test-file2 "$TEST_NAME"
+	create_bundle -n test-bundle3 -f /bar/test-file3 "$TEST_NAME"
+
+	# Create bundle dependencies
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.os-core test-bundle1
+	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.os-core test-bundle2
+	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle1 test-bundle3
+
+}
+
+@test "INS026: Install without also-add bundles" {
+
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH --path $TARGETDIR --skip-optional"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Installing OS version 10 (latest)
+		Downloading missing manifests...
+		Downloading packs for:
+		 - test-bundle1
+		 - os-core
+		Finishing packs extraction...
+		Checking for corrupt files
+		Validate downloaded files
+		No extra files need to be downloaded
+		Installing base OS and selected bundles
+		Inspected 5 files
+		  3 files were missing
+		    3 of 3 missing files were installed
+		    0 of 3 missing files were not installed
+		Calling post-update helper scripts
+		Installation successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGETDIR"/foo/test-file1
+	assert_file_not_exists "$TARGETDIR"/bar/test-file2
+	assert_file_not_exists "$TARGETDIR"/bar/test-file3
+
+}


### PR DESCRIPTION
When the --skip-optional flag is set, optional (also-add) bundles will
be skipped.

Fixes: #1182