### PR TITLE
Add ability to install bundles from 3rd-party repositories

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,7 @@ AM_CPPFLAGS = $(AM_CFLAGS) $(libarchive_CFLAGS)
 
 swupd_SOURCES = \
 	src/3rd_party_add.c \
+	src/3rd_party_bundle_add.c \
 	src/3rd_party.c \
 	src/3rd_party_list.c \
 	src/3rd_party_remove.c \

--- a/config
+++ b/config
@@ -343,3 +343,16 @@
 #
 
 
+[3rd-party-bundle-add]
+
+#
+# Options for the "swupd 3rd-party bundle-add" command
+#
+
+# Do not check free disk space before adding bundle (boolean value)
+#skip_diskspace_check=<true/false>
+
+# Do not install optional bundles, also-add flag in Manifests (boolean value)
+#skip_optional=<true/false>
+
+

--- a/src/3rd_party.c
+++ b/src/3rd_party.c
@@ -28,6 +28,7 @@ static struct subcmd third_party_commands[] = {
 	{ "add", "Add third party repository", third_party_add_main },
 	{ "remove", "Remove third party repository", third_party_remove_main },
 	{ "list", "List third party repository", third_party_list_main },
+	{ "bundle-add", "Install a bundle from a third party repository", third_party_bundle_add_main },
 	{ 0 }
 };
 

--- a/src/3rd_party_bundle_add.c
+++ b/src/3rd_party_bundle_add.c
@@ -19,6 +19,7 @@
 
 #define _GNU_SOURCE
 
+#include "3rd_party_repos.h"
 #include "swupd.h"
 
 #ifdef THIRDPARTY
@@ -89,7 +90,16 @@ static bool parse_options(int argc, char **argv)
 enum swupd_code third_party_bundle_add_main(int argc, char **argv)
 {
 	struct list *bundles = NULL;
+	struct list *iter1 = NULL;
+	struct list *iter2 = NULL;
+	struct list *repos = NULL;
+	char *state_dir;
+	char *path_prefix;
 	int ret_code = SWUPD_OK;
+	int ret = SWUPD_OK;
+
+	// TODO(s):
+	// 1) if the bundle is in multiple repos we need to ask the user to choose one
 
 	const int steps_in_bundleadd = 8;
 
@@ -106,6 +116,9 @@ enum swupd_code third_party_bundle_add_main(int argc, char **argv)
 		return ret_code;
 	}
 
+	/* load the existing 3rd-party repos from the repo.ini config file */
+	repos = third_party_get_repos();
+
 	/* move the bundles provided in the command line into a
 	 * list so it is easier to handle them */
 	for (; *cmdline_bundles; ++cmdline_bundles) {
@@ -114,10 +127,86 @@ enum swupd_code third_party_bundle_add_main(int argc, char **argv)
 	}
 	bundles = list_head(bundles);
 
-	//ret_code = execute_bundle_add(bundles);
+	/* backup the original state_dir and path_prefix values */
+	state_dir = strdup_or_die(globals.state_dir);
+	path_prefix = strdup_or_die(globals.path_prefix);
+
+	/* try installing bundles one by one */
+	for (iter1 = bundles; iter1; iter1 = iter1->next) {
+		char *bundle = iter1->data;
+		struct repo *selected_repo = NULL;
+		int count = 0;
+
+		/* search for the bundle in all the 3rd-party repos */
+		info("Searching for bundle %s in the 3rd-party repositories...\n", bundle);
+		for (iter2 = repos; iter2; iter2 = iter2->next) {
+			struct repo *repo = iter2->data;
+			struct manifest *mom = NULL;
+			struct file *file = NULL;
+
+			/* set the appropriate content_dir and state_dir for the selected 3rd-party repo */
+			if (third_party_set_repo(state_dir, path_prefix, repo)) {
+				ret_code = SWUPD_COULDNT_CREATE_DIR;
+				goto clean_and_exit;
+			}
+
+			/* load the repo's MoM*/
+			mom = load_mom(repo->version, false, NULL);
+			if (!mom) {
+				error("Cannot load manifest MoM for 3rd-party repository %s version %i\n", repo->name, repo->version);
+				ret_code = SWUPD_COULDNT_LOAD_MOM;
+				goto clean_and_exit;
+			}
+
+			/* search for the bundle in the MoM */
+			file = mom_search_bundle(mom, bundle);
+			if (file) {
+				/* the bundle was found in this repo, keep a pointer to the repo */
+				info("Bundle %s found in 3rd-party repository %s\n", bundle, repo->name);
+				count++;
+				selected_repo = repo;
+			}
+			manifest_free(mom);
+		}
+
+		/* if the bundle exists in only one repo, we can continue */
+		if (count == 0) {
+			error("bundle %s was not found in any 3rd-party repository\n\n", bundle);
+			ret_code = SWUPD_INVALID_BUNDLE;
+			continue;
+		} else if (count > 1) {
+			error("bundle %s was found in more than one 3rd-party repository, please specify a repository\n\n", bundle);
+			ret_code = SWUPD_INVALID_OPTION;
+			continue;
+		}
+
+		/* set the content_url and state_dir to those from the 3rd-party repo
+		 * where the requested bundle was found */
+		if (third_party_set_repo(state_dir, path_prefix, selected_repo)) {
+			ret_code = SWUPD_COULDNT_CREATE_DIR;
+			goto clean_and_exit;
+		}
+
+		/* execute_bundle_add expects a list so we can send a new list with only
+		 * the one bundle we want to install in this iteration */
+		struct list *bundle_to_install = NULL;
+		bundle_to_install = list_append_data(bundle_to_install, bundle);
+
+		ret = execute_bundle_add(bundle_to_install, selected_repo->version);
+
+		if (ret != SWUPD_OK) {
+			ret_code = ret;
+		}
+		list_free_list(bundle_to_install);
+		info("\n");
+	}
 
 clean_and_exit:
+	free_string(&state_dir);
+	free_string(&path_prefix);
 	list_free_list(bundles);
+	list_free_list_and_data(repos, repo_free_data);
+
 	swupd_deinit();
 	progress_finish_steps(ret_code);
 	return ret_code;

--- a/src/3rd_party_bundle_add.c
+++ b/src/3rd_party_bundle_add.c
@@ -98,10 +98,22 @@ enum swupd_code third_party_bundle_add_main(int argc, char **argv)
 	int ret_code = SWUPD_OK;
 	int ret = SWUPD_OK;
 
+	/*
+	 * Steps for 3rd-party bundle-add:
+	 *
+	 *  1) load_manifests
+	 *  2) download_packs
+	 *  3) extract_packs
+	 *  4) validate_fullfiles
+	 *  5) download_fullfiles
+	 *  6) extract_fullfiles
+	 *  7) install_files
+	 */
+
 	// TODO(s):
 	// 1) if the bundle is in multiple repos we need to ask the user to choose one
 
-	const int steps_in_bundleadd = 8;
+	const int steps_in_bundleadd = 7;
 
 	if (!parse_options(argc, argv)) {
 		print_help();
@@ -191,6 +203,9 @@ enum swupd_code third_party_bundle_add_main(int argc, char **argv)
 		 * the one bundle we want to install in this iteration */
 		struct list *bundle_to_install = NULL;
 		bundle_to_install = list_append_data(bundle_to_install, bundle);
+
+		info("\nBundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons\n\n");
+		globals.no_scripts = true;
 
 		ret = execute_bundle_add(bundle_to_install, selected_repo->version);
 

--- a/src/3rd_party_bundle_add.c
+++ b/src/3rd_party_bundle_add.c
@@ -1,0 +1,126 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2019 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define _GNU_SOURCE
+
+#include "swupd.h"
+
+#ifdef THIRDPARTY
+
+#define FLAG_SKIP_OPTIONAL 2000
+#define FLAG_SKIP_DISKSPACE_CHECK 2001
+
+static char **cmdline_bundles;
+
+static void print_help(void)
+{
+	print("Usage:\n");
+	print("   swupd 3rd-party bundle-add [OPTION...] [bundle1 bundle2 (...)]\n\n");
+
+	global_print_help();
+
+	print("Options:\n");
+	print("   --skip-optional         Do not install optional bundles (also-add flag in Manifests)\n");
+	print("   --skip-diskspace-check  Do not check free disk space before adding bundle\n");
+	print("\n");
+}
+
+static const struct option prog_opts[] = {
+	{ "skip-optional", no_argument, 0, FLAG_SKIP_OPTIONAL },
+	{ "skip-diskspace-check", no_argument, 0, FLAG_SKIP_DISKSPACE_CHECK },
+};
+
+static bool parse_opt(int opt, UNUSED_PARAM char *optarg)
+{
+	switch (opt) {
+	case FLAG_SKIP_OPTIONAL:
+		globals.skip_optional_bundles = optarg_to_bool(optarg);
+		return true;
+	case FLAG_SKIP_DISKSPACE_CHECK:
+		globals.skip_diskspace_check = optarg_to_bool(optarg);
+		return true;
+	default:
+		return false;
+	}
+	return false;
+}
+
+static const struct global_options opts = {
+	prog_opts,
+	sizeof(prog_opts) / sizeof(struct option),
+	parse_opt,
+	print_help,
+};
+
+static bool parse_options(int argc, char **argv)
+{
+	int optind = global_parse_options(argc, argv, &opts);
+
+	if (optind < 0) {
+		return false;
+	}
+
+	if (argc <= optind) {
+		error("missing bundle(s) to be installed\n\n");
+		return false;
+	}
+
+	cmdline_bundles = argv + optind;
+
+	return true;
+}
+
+enum swupd_code third_party_bundle_add_main(int argc, char **argv)
+{
+	struct list *bundles = NULL;
+	int ret_code = SWUPD_OK;
+
+	const int steps_in_bundleadd = 8;
+
+	if (!parse_options(argc, argv)) {
+		print_help();
+		return SWUPD_INVALID_OPTION;
+	}
+	progress_init_steps("3rd-party-bundle-add", steps_in_bundleadd);
+
+	/* initialize swupd */
+	ret_code = swupd_init(SWUPD_ALL);
+	if (ret_code != SWUPD_OK) {
+		error("Failed swupd initialization, exiting now\n");
+		return ret_code;
+	}
+
+	/* move the bundles provided in the command line into a
+	 * list so it is easier to handle them */
+	for (; *cmdline_bundles; ++cmdline_bundles) {
+		char *bundle = *cmdline_bundles;
+		bundles = list_append_data(bundles, bundle);
+	}
+	bundles = list_head(bundles);
+
+	//ret_code = execute_bundle_add(bundles);
+
+clean_and_exit:
+	list_free_list(bundles);
+	swupd_deinit();
+	progress_finish_steps(ret_code);
+	return ret_code;
+}
+
+#endif

--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -227,4 +227,29 @@ exit:
 	list_free_list_and_data(repos, repo_free_data);
 	return ret;
 }
+
+int third_party_set_repo(const char *state_dir, const char *path_prefix, struct repo *repo)
+{
+	char *repo_state_dir;
+	char *repo_path_prefix;
+
+	set_content_url(repo->url);
+
+	string_or_die(&repo_path_prefix, "%s/opt/3rd_party/%s", path_prefix, repo->name);
+	set_path_prefix(repo_path_prefix);
+	free_string(&repo_path_prefix);
+
+	/* make sure there are state directories for the 3rd-party
+	 * repo if not there already */
+	string_or_die(&repo_state_dir, "%s/3rd_party/%s", state_dir, repo->name);
+	if (create_state_dirs(repo_state_dir)) {
+		free_string(&repo_state_dir);
+		return -1;
+	}
+	set_state_dir(repo_state_dir);
+	free_string(&repo_state_dir);
+
+	return 0;
+}
+
 #endif

--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -29,7 +29,7 @@ static char *get_repo_config_path(void)
 	return str_or_die("%s/%s/%s", globals.state_dir, "3rd_party", "repo.ini");
 }
 
-static int repo_name_cmp(const void *repo, const void *name)
+int repo_name_cmp(const void *repo, const void *name)
 {
 	return strcmp(((struct repo *)repo)->name, name);
 }

--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -63,6 +63,16 @@ int third_party_add_repo(const char *repo_name, const char *repo_url);
  */
 int third_party_remove_repo(char *repo_name);
 
+/**
+ * @brief This function sets up swupd to use a specific 3rd-party repo.
+ *
+ * @param state_dir the original state directory of the system
+ * @param path_prefix the original path prefix of the system
+ *
+ * @returns 0 on success, -1 on any failure
+ */
+int third_party_set_repo(const char *state_dir, const char *path_prefix, struct repo *repo);
+
 #endif
 
 #ifdef __cplusplus

--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -18,7 +18,7 @@ extern "C" {
 struct repo {
 	char *name;
 	char *url;
-	char *version;
+	int version;
 };
 
 /**

--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -73,6 +73,11 @@ int third_party_remove_repo(char *repo_name);
  */
 int third_party_set_repo(const char *state_dir, const char *path_prefix, struct repo *repo);
 
+/**
+ * @brief strcmp like function to search for a repo based on its name
+ */
+int repo_name_cmp(const void *repo, const void *name);
+
 #endif
 
 #ifdef __cplusplus

--- a/src/globals.c
+++ b/src/globals.c
@@ -682,11 +682,21 @@ static bool load_flags_in_config(char *command, struct option *opts_array, const
 	bool config_found = false;
 #ifdef CONFIG_FILE_PATH
 	// load configuration values from the config file
-	struct config_loader_data loader_data = { command, opts_array, global_parse_opt, opts->parse_opt };
 	struct stat st;
 	char *ctx = NULL;
 	char *config_file = NULL;
 	char *str = strdup_or_die(CONFIG_FILE_PATH);
+	char *full_command = NULL;
+
+	/* the command we get here can actually be a subcommand, if that
+	 * is the case we need to build the section name as "command-subcommand",
+	 * so we can distinguish it the config file */
+	if (strcmp(globals.swupd_argv[1], "3rd-party") == 0) {
+		string_or_die(&full_command, "%s-%s", "3rd-party", command);
+	} else {
+		full_command = strdup_or_die(command);
+	}
+	struct config_loader_data loader_data = { full_command, opts_array, global_parse_opt, opts->parse_opt };
 
 	for (char *tok = strtok_r(str, ":", &ctx); tok; tok = strtok_r(NULL, ":", &ctx)) {
 		/* load values from all configuration files found, starting from
@@ -705,6 +715,7 @@ static bool load_flags_in_config(char *command, struct option *opts_array, const
 		free_string(&config_file);
 	}
 
+	free_string(&full_command);
 	free_string(&str);
 #endif
 	return config_found;

--- a/src/globals.c
+++ b/src/globals.c
@@ -76,7 +76,7 @@ static void set_json_format(bool on)
 }
 
 /* Sets the content_url global variable */
-static void set_content_url(char *url)
+void set_content_url(char *url)
 {
 	if (globals.content_url) {
 		free_string(&globals.content_url);
@@ -193,7 +193,7 @@ static bool is_valid_integer_format(char *str)
  * NULL, state_dir will be set to its value. Otherwise, the value is the
  * build-time default (STATE_DIR).
  */
-static bool set_state_dir(char *path)
+bool set_state_dir(char *path)
 {
 	if (!path) {
 		error("Statedir shouldn't be NULL\n");

--- a/src/globals.h
+++ b/src/globals.h
@@ -81,6 +81,8 @@ bool set_path_prefix(char *path);
 bool set_default_urls(void);
 bool set_state_dir_cache(char *path);
 void set_default_path_prefix(void);
+void set_content_url(char *url);
+bool set_state_dir(char *path);
 
 #ifdef __cplusplus
 }

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -188,12 +188,20 @@ static bool validate_tracking_dir(const char *state_dir)
 	 * user installed themselves just copy the entire system tracking directory
 	 * into the state tracking directory. */
 	if (!is_populated_dir(tracking_dir)) {
+		src = sys_path_join(globals.path_prefix, "/usr/share/clear/bundles");
+
+		if (!sys_file_exists(src)) {
+			/* there is no bundles directory to copy from */
+			free_string(&src);
+			free_string(&tracking_dir);
+			return false;
+		}
+
 		ret = rm_rf(tracking_dir);
 		if (ret) {
 			goto out;
 		}
 
-		src = sys_path_join(globals.path_prefix, "/usr/share/clear/bundles");
 		/* at the point this function is called <bundle_name> is already
 		 * installed on the system and therefore has a tracking file under
 		 * /usr/share/clear/bundles. A simple cp -a of that directory will
@@ -233,7 +241,7 @@ int create_state_dirs(const char *state_dir_path)
 
 	// check for existence
 	if (ensure_root_owned_dir(state_dir_path)) {
-		//state dir doesn't exist
+		// state dir doesn't exist
 		if (mkdir_p(state_dir_path) != 0 || chmod(state_dir_path, S_IRWXU) != 0) {
 			error("failed to create %s\n", state_dir_path);
 			return -1;
@@ -247,6 +255,7 @@ int create_state_dirs(const char *state_dir_path)
 			ret = mkdir(dir, S_IRWXU);
 			if (ret) {
 				error("failed to create %s\n", dir);
+				free_string(&dir);
 				return -1;
 			}
 		}

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -322,6 +322,9 @@ extern char *get_tracking_dir(void);
 extern int add_subscriptions(struct list *bundles, struct list **subs, struct manifest *mom, bool find_all, int recursion);
 extern int subscription_bundlename_strcmp(const void *a, const void *b);
 
+/* bundle_add.c*/
+extern enum swupd_code execute_bundle_add(struct list *bundles_list);
+
 /* verify.c */
 extern enum swupd_code execute_verify(void);
 extern void verify_set_option_download(bool opt);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -323,7 +323,7 @@ extern int add_subscriptions(struct list *bundles, struct list **subs, struct ma
 extern int subscription_bundlename_strcmp(const void *a, const void *b);
 
 /* bundle_add.c*/
-extern enum swupd_code execute_bundle_add(struct list *bundles_list);
+extern enum swupd_code execute_bundle_add(struct list *bundles_list, int version);
 
 /* verify.c */
 extern enum swupd_code execute_verify(void);

--- a/src/swupd_internal.h
+++ b/src/swupd_internal.h
@@ -26,6 +26,7 @@ enum swupd_code diagnose_main(int argc, char **argv);
 enum swupd_code bundle_info_main(int argc, char **argv);
 enum swupd_code verify_main(int argc, char **argv);
 enum swupd_code third_party_main(int argc, char **argv);
+enum swupd_code third_party_bundle_add_main(int argc, char **argv);
 
 /**
  * @brief Creates a new third-party repo under THIRDPARTY_REPO_PREFIX

--- a/swupd.bash
+++ b/swupd.bash
@@ -45,7 +45,7 @@ _swupd()
 		opts="$global --download --status --force --migrate --allow-mix-collisions --keepcache --update-search-file-index "
 		break;;
 		("bundle-add")
-		opts="$global --skip-diskspace-check "
+		opts="$global --skip-diskspace-check --skip-optional "
 		break;;
 		("bundle-remove")
 		opts="$global --force --recursive "
@@ -84,7 +84,7 @@ _swupd()
 		opts="$global --version --manifest --fix --picky --picky-tree --picky-whitelist --install --quick --force --install "
 		break;;
 		("3rd-party")
-		opts="$global add remove list"
+		opts="$global add remove list bundle-add"
 		break;;
 		("add")
 		opts="$global --repo"
@@ -99,19 +99,23 @@ _swupd()
 	then
 	case "${COMP_WORDS[$i]}" in
 		("bundle-add")
-		MoM=""
-		if [ -r /var/tmp/swupd/Manifest.MoM ]
-		then MoM=/var/tmp/swupd/Manifest.MoM
-		elif [ -r /var/lib/swupd/version ] &&
-			   installed=$(</var/lib/swupd/version) &&
-			   [ -r "/var/lib/swupd/$installed/Manifest.MoM" ]
-		then
-			MoM=/var/lib/swupd/$installed/Manifest.MoM
+		# only show the list of upstream bundles if not using "3rd-party bundle-add"
+		if [ "${COMP_WORDS[$i - 1]}" != "3rd-party" ]; then
+			MoM=""
+			if [ -r /var/tmp/swupd/Manifest.MoM ]
+			then MoM=/var/tmp/swupd/Manifest.MoM
+			elif [ -r /var/lib/swupd/version ] &&
+				   installed=$(</var/lib/swupd/version) &&
+				   [ -r "/var/lib/swupd/$installed/Manifest.MoM" ]
+			then
+				MoM=/var/lib/swupd/$installed/Manifest.MoM
+			fi
+			if [ -n "$MoM" ]
+			then
+				opts+="$( sed '/^[^M]/d' "$MoM" | cut -f4 | LC_ALL=C sort )"
+			fi
 		fi
-		if [ -n "$MoM" ]
-		then
-			opts+="$( sed '/^[^M]/d' "$MoM" | cut -f4 | LC_ALL=C sort )"
-		fi ;;
+		;;
 		("bundle-remove")
 		opts+=" $(unset CDPATH; test -d /usr/share/clear/bundles && \
 			find /usr/share/clear/bundles/ -maxdepth 1 -type f ! -name os-core -printf '%f ')"

--- a/swupd.bash
+++ b/swupd.bash
@@ -114,6 +114,8 @@ _swupd()
 			then
 				opts+="$( sed '/^[^M]/d' "$MoM" | cut -f4 | LC_ALL=C sort )"
 			fi
+		else
+			opts+="--repo"
 		fi
 		;;
 		("bundle-remove")

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -190,6 +190,7 @@ if [[ -n "$state" ]]; then
           '(help)list[List third party repo(s)]'
           '(help)remove[Remove third party repo]'
           '(help)add[Add third party repo]'
+          '(help)bundle-add[Install a bundle from a third party repository]'
           _arguments $thirdparty && ret=0
           ;;
           add)

--- a/test/functional/3rd-party/3rd-party-allow-http.bats
+++ b/test/functional/3rd-party/3rd-party-allow-http.bats
@@ -62,7 +62,7 @@ global_teardown() {
 	expected_output=$(cat <<-EOM
 		[my_repo]
 		url=http://example.com/swupd-file
-		version=0
+		version=10
 	EOM
 	)
 	assert_is_output --identical "$expected_output"

--- a/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n test-bundle1 -f /foo/file_1 "$TEST_NAME"
+
+	# create a 3rd-party repo within the test environment and add
+	# a bundle in the 3rd-party repo
+	create_third_party_repo "$TEST_NAME" 10
+	create_bundle -n test-bundle2 -f /bar/file_2 -u test-repo "$TEST_NAME"
+
+}
+
+@test "TPR012: Adding one bundle from a third party repo" {
+
+	# users should be able to install bundles from 3rd-party repos
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle2"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle2 in the 3rd-party repositories...
+		Bundle test-bundle2 found in 3rd-party repository test-repo
+		Loading required manifests...
+		No packs need to be downloaded
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Installing files...
+		Calling post-update helper scripts
+		Successfully installed 1 bundle
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/bar/file_2
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$REPO_STATEDIR"/bundles/test-bundle2
+
+}
+
+@test "TPR013: Try adding one invalid bundle from a third party repo" {
+
+	# if the user tries to add an upstream bundle using the 3rd-party command
+	# the bundle should not be found/installed
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle1"
+
+	assert_status_is "$SWUPD_INVALID_BUNDLE"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle1 in the 3rd-party repositories...
+		Error: bundle test-bundle1 was not found in any 3rd-party repository
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	# the same should happen with an invalid bundle
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS fake-bundle"
+
+	assert_status_is "$SWUPD_INVALID_BUNDLE"
+	expected_output=$(cat <<-EOM
+		Searching for bundle fake-bundle in the 3rd-party repositories...
+		Error: bundle fake-bundle was not found in any 3rd-party repository
+	EOM
+	)
+	assert_is_output "$expected_output"
+}
+
+@test "TPR014: Try adding one valid bundle from a third party repo and one invalid" {
+
+	# swupd should just ignore the invalid and should continue with the valid one
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle1 test-bundle2"
+
+	assert_status_is "$SWUPD_INVALID_BUNDLE"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle1 in the 3rd-party repositories...
+		Error: bundle test-bundle1 was not found in any 3rd-party repository
+		Searching for bundle test-bundle2 in the 3rd-party repositories...
+		Bundle test-bundle2 found in 3rd-party repository test-repo
+		Loading required manifests...
+		No packs need to be downloaded
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Installing files...
+		Calling post-update helper scripts
+		Successfully installed 1 bundle
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/bar/file_2
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$REPO_STATEDIR"/bundles/test-bundle2
+	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle1
+
+	# same scenario with the arguments switched
+
+	remove_bundle -L "$TEST_NAME"/3rd_party/test-repo/10/Manifest.test-bundle2 test-repo
+	clean_state_dir "$TEST_NAME" test-repo
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle2 test-bundle1"
+
+	assert_status_is "$SWUPD_INVALID_BUNDLE"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle2 in the 3rd-party repositories...
+		Bundle test-bundle2 found in 3rd-party repository test-repo
+		Loading required manifests...
+		No packs need to be downloaded
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Installing files...
+		Calling post-update helper scripts
+		Successfully installed 1 bundle
+		Searching for bundle test-bundle1 in the 3rd-party repositories...
+		Error: bundle test-bundle1 was not found in any 3rd-party repository
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/bar/file_2
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$REPO_STATEDIR"/bundles/test-bundle2
+}

--- a/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
@@ -40,7 +40,7 @@ test_setup() {
 	assert_is_output "$expected_output"
 	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/bar/file_2
 	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$REPO_STATEDIR"/bundles/test-bundle2
+	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle2
 
 }
 
@@ -96,7 +96,7 @@ test_setup() {
 	assert_is_output "$expected_output"
 	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/bar/file_2
 	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$REPO_STATEDIR"/bundles/test-bundle2
+	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle2
 	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle1
 
 	# same scenario with the arguments switched
@@ -125,5 +125,5 @@ test_setup() {
 	assert_is_output "$expected_output"
 	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/bar/file_2
 	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$REPO_STATEDIR"/bundles/test-bundle2
+	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle2
 }

--- a/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
@@ -27,12 +27,13 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Searching for bundle test-bundle2 in the 3rd-party repositories...
 		Bundle test-bundle2 found in 3rd-party repository test-repo
+		Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Loading required manifests...
 		No packs need to be downloaded
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Installing files...
-		Calling post-update helper scripts
+		Warning: post-update helper scripts skipped due to --no-scripts argument
 		Successfully installed 1 bundle
 	EOM
 	)
@@ -82,12 +83,13 @@ test_setup() {
 		Error: bundle test-bundle1 was not found in any 3rd-party repository
 		Searching for bundle test-bundle2 in the 3rd-party repositories...
 		Bundle test-bundle2 found in 3rd-party repository test-repo
+		Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Loading required manifests...
 		No packs need to be downloaded
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Installing files...
-		Calling post-update helper scripts
+		Warning: post-update helper scripts skipped due to --no-scripts argument
 		Successfully installed 1 bundle
 	EOM
 	)
@@ -108,12 +110,13 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Searching for bundle test-bundle2 in the 3rd-party repositories...
 		Bundle test-bundle2 found in 3rd-party repository test-repo
+		Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Loading required manifests...
 		No packs need to be downloaded
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Installing files...
-		Calling post-update helper scripts
+		Warning: post-update helper scripts skipped due to --no-scripts argument
 		Successfully installed 1 bundle
 		Searching for bundle test-bundle1 in the 3rd-party repositories...
 		Error: bundle test-bundle1 was not found in any 3rd-party repository

--- a/test/functional/3rd-party/3rd-party-bundle-add-config-file.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-config-file.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+
+	# create a 3rd-party repo within the test environment and add
+	# a few bundles in the 3rd-party repo
+	create_third_party_repo "$TEST_NAME" 10
+	create_bundle -n test-bundle1 -f /foo/file_1 -u test-repo "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /bar/file_2 -u test-repo "$TEST_NAME"
+	create_bundle -n test-bundle3 -f /file_3     -u test-repo "$TEST_NAME"
+
+	# add test-bundle2 as a dependency of test-bundle1 and test-bundle3 as optional
+	add_dependency_to_manifest "$TPWEBDIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest -o "$TPWEBDIR"/10/Manifest.test-bundle1 test-bundle3
+
+	create_config_file
+
+}
+
+@test "TPR015: Set a local option in a command that uses a subcommand in the configuration file" {
+
+	# some commands can include subcommands, in those cases the command and
+	# subcommand are represented by a section like [command-subcommand] in the
+	# config file
+
+	add_option_to_config_file skip_optional true 3rd-party-bundle-add
+
+	cd "$TEST_NAME" || exit 1
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle1"
+	cd - || exit 1
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle1 in the 3rd-party repositories...
+		Bundle test-bundle1 found in 3rd-party repository test-repo
+		Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Loading required manifests...
+		No packs need to be downloaded
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Installing files...
+		Warning: post-update helper scripts skipped due to --no-scripts argument
+		Successfully installed 1 bundle
+		1 bundle was installed as dependency
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+	# test-bundle1 is installed and tracked
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle1
+
+	# test-bundle2 is installed but not tracked
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TPSTATEDIR"/bundles/test-bundle2
+
+	# test-bundle3 is not installed at all
+	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle3
+	assert_file_not_exists "$TPSTATEDIR"/bundles/test-bundle3
+
+}

--- a/test/functional/3rd-party/3rd-party-bundle-add-multi-repo.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-multi-repo.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+
+	# create a couple of 3rd-party repos with bundles
+	create_third_party_repo "$TEST_NAME" 10 staging repo1
+	create_bundle -n test-bundle1 -f /foo/file_1A -u repo1 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /bar/file_2 -u repo1 "$TEST_NAME"
+
+	create_third_party_repo "$TEST_NAME" 10 staging repo2
+	create_bundle -n test-bundle1 -f /baz/file_1B -u repo2 "$TEST_NAME"
+
+}
+
+@test "TPR016: Try adding a bundle that exists in many third party repos" {
+
+	# when a bundle is in many 3rd-party repos the user needs to specify
+	# the repo using the --repo flag or the installation won't continue
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle1"
+
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle1 in the 3rd-party repositories...
+		Bundle test-bundle1 found in 3rd-party repository repo1
+		Bundle test-bundle1 found in 3rd-party repository repo2
+		Error: bundle test-bundle1 was found in more than one 3rd-party repository
+		Please specify a repository using the --repo flag
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/repo1/foo/file_1A
+	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/repo2/baz/file_1B
+	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/repo2/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$STATEDIR"/3rd_party/repo1/bundles/test-bundle1
+	assert_file_not_exists "$STATEDIR"/3rd_party/repo2/bundles/test-bundle1
+
+}
+
+@test "TPR017: Adding a bundle that exists in many third party repos specifying the repo" {
+
+	# when a bundle is in many 3rd-party repos the user needs to specify
+	# the repo using the --repo flag or the installation won't continue
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle1 --repo repo2"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Loading required manifests...
+		No packs need to be downloaded
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Installing files...
+		Warning: post-update helper scripts skipped due to --no-scripts argument
+		Successfully installed 1 bundle
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/repo1/foo/file_1A
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/repo2/baz/file_1B
+	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/repo2/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$STATEDIR"/3rd_party/repo1/bundles/test-bundle1
+	assert_file_exists "$STATEDIR"/3rd_party/repo2/bundles/test-bundle1
+
+}

--- a/test/functional/3rd-party/3rd-party-repo-add.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add.bats
@@ -19,7 +19,7 @@ load "../testlib"
 	expected_output=$(cat <<-EOM
 			[test-repo1]
 			url=https://xyz.com
-			version=0
+			version=10
 	EOM
 	)
 	assert_is_output "$expected_output"
@@ -74,23 +74,23 @@ load "../testlib"
 	expected_output=$(cat <<-EOM
 			[test-repo1]
 			url=https://xyz.com
-			version=0
+			version=10
 
 			[test-repo2]
 			url=file://abc.com
-			version=0
+			version=10
 
 			[test-repo3]
 			url=https://efg.com
-			version=0
+			version=10
 
 			[test-repo4]
 			url=https://hij.com
-			version=0
+			version=10
 
 			[test-repo5]
 			url=https://klm.com
-			version=0
+			version=10
 	EOM
 	)
 	assert_is_output --identical "$expected_output"

--- a/test/functional/bundleadd/add-no-disk-space.bats
+++ b/test/functional/bundleadd/add-no-disk-space.bats
@@ -37,6 +37,7 @@ test_setup() {
 		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
 		Error: Failed to retrieve 10 MoM manifest
 		Error: Cannot load official manifest MoM for version 10
+		Failed to install 1 of 1 bundles
 	EOM
 	)
 	assert_is_output "$expected_output"

--- a/test/functional/bundleadd/add-no-signature.bats
+++ b/test/functional/bundleadd/add-no-signature.bats
@@ -19,6 +19,7 @@ test_setup() {
 		Warning: Removing corrupt Manifest.MoM artifacts and re-downloading...
 		Error: FAILED TO VERIFY SIGNATURE OF Manifest.MoM version 10!!!
 		Error: Cannot load official manifest MoM for version 10
+		Failed to install 1 of 1 bundles
 	EOM
 	)
 	assert_is_output "$expected_output"

--- a/test/functional/signature/no-signature.bats
+++ b/test/functional/signature/no-signature.bats
@@ -22,6 +22,7 @@ test_setup() {
 		Warning: Removing corrupt Manifest.MoM artifacts and re-downloading...
 		Error: FAILED TO VERIFY SIGNATURE OF Manifest.MoM version 10!!!
 		Error: Cannot load official manifest MoM for version 10
+		Failed to install 1 of 1 bundles
 	EOM
 	)
 	assert_is_output "$expected_output"

--- a/test/functional/usability/usa-download-retries.bats
+++ b/test/functional/usability/usa-download-retries.bats
@@ -40,6 +40,7 @@ test_setup() {
 		Warning: Maximum number of retries reached
 		Error: Failed to retrieve 10 MoM manifest
 		Error: Cannot load official manifest MoM for version 10
+		Failed to install 1 of 1 bundles
 	EOM
 	)
 	assert_is_output "$expected_output"
@@ -61,6 +62,7 @@ test_setup() {
 		Download retries is disabled
 		Error: Failed to retrieve 10 MoM manifest
 		Error: Cannot load official manifest MoM for version 10
+		Failed to install 1 of 1 bundles
 	EOM
 	)
 	assert_is_output "$expected_output"
@@ -90,6 +92,7 @@ test_setup() {
 		Warning: Maximum number of retries reached
 		Error: Failed to retrieve 10 MoM manifest
 		Error: Cannot load official manifest MoM for version 10
+		Failed to install 1 of 1 bundles
 	EOM
 	)
 	assert_is_output "$expected_output"


### PR DESCRIPTION
Implement a command swupd 3rd-party bundle-add that can install bundles from a 3rd party repository.

Tasks:
- [x] Add support for `3rd-party bundle-add` to the `testlib`
- [x] Add functional tests for adding bundles from a 3rd-party repo
- [x] Add new test group to Travis/github actions
- [x] Add the `3rd-party bundle-add` command to swupd (without functionality)
- [ ] Add documentation to man pages.
- [x] Add command to autocompletion script swupd.bash
- [ ] Add command to autocompletion script swupd.zsh
- [x] Add command to the config file
- [x] Search for 3rd-party bundles in a hardcoded 3rd-party repo URL, and install it (as POC)
- [x] Search for the bundle in 3rd-party repos registered in repo.ini
- [x] When getting the URL of the 3rd-party repo, if there are multiple repos, we need to search for the bundle in all of them
- [x] If the bundle is in multiple bundles we need to ask the user to specify a repo
- [x] When using a 3rd-party repo, we need to get the current version of the system from the appropriate section of the repo.ini config file
- [x] When tracking the installed bundle, we need to track it in the state dir that is specific to the 3rd-party repo.
- [x] Check output correctness and consistency with other commands (including output using `--quiet`, `--verbose`, `--debug`)
- [ ] Update release notes draft

Closes #1177 

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>