### PR TITLE
Re-balancing functional tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,8 @@ stages:
 env:
         global:
                 - MAKEFLAGS="-j 2"
-                - UPDATE_TOTAL="$(find test/functional/update -name *.bats | wc -l)"
-                - UPDATE_SUBGROUP1_TOTAL=17
-                - UPDATE_SUBGROUP2_TOTAL="$((UPDATE_TOTAL - UPDATE_SUBGROUP1_TOTAL))"
-                - UPDATE_SUBGROUP1="$(find test/functional/update -name *.bats | head -n $UPDATE_SUBGROUP1_TOTAL | tr '\n' ' ')"
-                - UPDATE_SUBGROUP2="$(find test/functional/update -name *.bats | tail -n $UPDATE_SUBGROUP2_TOTAL | tr '\n' ' ')"
-                - GROUP1="$UPDATE_SUBGROUP1 $(find test/functional/{autoupdate,bundleinfo,verify-legacy} -name *.bats -printf '%p ')"
-                - GROUP2="$UPDATE_SUBGROUP2 $(find test/functional/{checkupdate,hashdump,mirror,usability} -name *.bats \( ! -name usa-config-file.bats \) -printf '%p ')"
+                - GROUP1="$(find test/functional/update -name *.bats -printf '%p ')"
+                - GROUP2="$(find test/functional/{autoupdate,bundleinfo,verify-legacy,checkupdate,hashdump,mirror,usability} -name *.bats \( ! -name usa-config-file.bats \) -printf '%p ')"
                 - GROUP3="$(find test/functional/{diagnose,search,os-install,repair} -name *.bats -printf '%p ')"
                 - GROUP4="$(find test/functional/{bundleadd,bundleremove,bundlelist,signature} -name *.bats -printf '%p ')"
                 # The config file cannot be isolated to a test environment, so tests related to it have to run separate
@@ -27,10 +22,10 @@ jobs:
                   name: "Static Analysis & Unit Tests"
                   script: make compliant && make shellcheck && sudo sh -c 'umask 0022 && make unit-check' && make docs-coverage
                 - stage: test
-                  name: "Functional Tests - update (group 1), autoupdate, bundle-info, verify-legacy"
+                  name: "Functional Tests - update"
                   script: env TESTS="$GROUP1" make -e check
                 - stage: test
-                  name: "Functional Tests - update (group 2), checkupdate, hashdump, mirror, usability"
+                  name: "Functional Tests - autoupdate, bundle-info, verify-legacy, checkupdate, hashdump, mirror, usability"
                   script: env TESTS="$GROUP2" make -e check && env TESTS="$CONFIG_FILE_TESTS" make -e check
                 - stage: test
                   name: "Functional Tests - diagnose, os-install, repair, search"


### PR DESCRIPTION
The number of functional tests that run in Travis have grown
considerably since the last time the jobs that run the tests were
balanced. This commit re-balances these jobs so tests take similar time
to run in each job.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>