### PR TITLE
test: Don't conflict config tests with other tests

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -75,10 +75,7 @@ jobs:
       run:  scripts/build_ci.bash
 
     - name: run check
-      run: env TESTS="$(find test/functional/{autoupdate,bundleinfo,verify-legacy,checkupdate,hashdump,mirror,usability,signature} -name *.bats \( ! -name usa-config-file.bats \) -printf '%p ')" make -e -j2 check
-
-    - name: run check - config file
-      run: env TESTS="$(find test/functional/usability -name usa-config-file.bats -printf '%p ')" make -e -j2 check
+      run: env TESTS="$(find test/functional/{autoupdate,bundleinfo,verify-legacy,checkupdate,hashdump,mirror,usability,signature} -name *.bats -printf '%p ')" make -e -j2 check
 
     - name: print status
       if: failure()

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -11,7 +11,7 @@ export TEST_NAME_SHORT="$TEST_NAME"
 export THEME_DIRNAME
 export FUNC_DIR
 export SWUPD_DIR="$FUNC_DIR/../.."
-export SWUPD_CONFIG_DIR="$SWUPD_DIR"/testconfig
+export SWUPD_CONFIG_DIR="$TEST_NAME"/testconfig
 export SWUPD_CONFIG_FILE="$SWUPD_CONFIG_DIR"/config
 
 # detect where the swupd binary is
@@ -1784,14 +1784,14 @@ create_config_file() { # swupd_function
 		destroy_config_file
 	fi
 
-	mkdir -p "$SWUPD_CONFIG_DIR"
-	touch "$SWUPD_CONFIG_FILE"
+	sudo mkdir -p "$SWUPD_CONFIG_DIR"
+	sudo touch "$SWUPD_CONFIG_FILE"
 
 }
 
 destroy_config_file() { # swupd_function
 
-	rm -rf "$SWUPD_CONFIG_DIR"
+	sudo rm -rf "$SWUPD_CONFIG_DIR"
 	# we need to make sure the config file is deleted before
 	# another test is run so it does not interfere with it since
 	# the config file is common and shared by all commands
@@ -1818,9 +1818,9 @@ add_option_to_config_file() { # swupd_function
 	validate_param "$value"
 
 	if [ -n "$section" ]; then
-		echo "[$section]" >> "$SWUPD_CONFIG_FILE"
+		write_to_protected_file -a "$SWUPD_CONFIG_FILE" "[$section]\n"
 	fi
-	echo "$option"="$value" >> "$SWUPD_CONFIG_FILE"
+	write_to_protected_file -a "$SWUPD_CONFIG_FILE" "$option=$value\n"
 
 }
 

--- a/test/functional/usability/usa-config-file.bats
+++ b/test/functional/usability/usa-config-file.bats
@@ -7,13 +7,6 @@ load "../testlib"
 
 global_setup() {
 
-	# Skip this test for local development because it needs an special config
-	# flag. To run this test locally, configure swupd with
-	# --with-config-file-path=./testconfig and run: TRAVIS=true make check
-	if [ -z "${TRAVIS}" ]; then
-		return
-	fi
-
 	create_test_environment "$TEST_NAME"
 	create_bundle -n test-bundle -f /file_1 "$TEST_NAME"
 
@@ -21,9 +14,6 @@ global_setup() {
 
 test_setup() {
 
-	if [ -z "$TRAVIS" ]; then
-		skip "This test is intended to run only in Travis (use TRAVIS=true to run it anyway)..."
-	fi
 	create_config_file
 
 }
@@ -46,6 +36,7 @@ global_teardown() {
 
 	add_option_to_config_file json_output true
 
+	cd "$TEST_NAME" || exit 1
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
 	assert_status_is "$SWUPD_OK"
@@ -71,6 +62,7 @@ global_teardown() {
 
 	add_option_to_config_file json_output true GLOBAL
 
+	cd "$TEST_NAME" || exit 1
 	run sudo sh -c "$SWUPD info $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_OK"
@@ -96,6 +88,7 @@ global_teardown() {
 
 	add_option_to_config_file json_output true info
 
+	cd "$TEST_NAME" || exit 1
 	run sudo sh -c "$SWUPD info $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_OK"
@@ -124,6 +117,7 @@ global_teardown() {
 	add_option_to_config_file json_output true global
 	add_option_to_config_file json_output false check-update
 
+	cd "$TEST_NAME" || exit 1
 	run sudo sh -c "$SWUPD info $SWUPD_OPTS"
 
 	assert_status_is 0
@@ -151,6 +145,7 @@ global_teardown() {
 
 	add_option_to_config_file picky true diagnose
 
+	cd "$TEST_NAME" || exit 1
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
@@ -167,6 +162,7 @@ global_teardown() {
 
 	add_option_to_config_file url https://someurl.com global
 
+	cd "$TEST_NAME" || exit 1
 	run sudo sh -c "$SWUPD info $SWUPD_OPTS -v https://anotherurl.com"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -187,6 +183,7 @@ global_teardown() {
 	add_option_to_config_file picky true diagnose
 	add_option_to_config_file picky_tree /fake/path
 
+	cd "$TEST_NAME" || exit 1
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --picky-tree /usr/lib"
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
@@ -203,6 +200,7 @@ global_teardown() {
 
 	add_option_to_config_file json_output true invalid_section
 
+	cd "$TEST_NAME" || exit 1
 	run sudo sh -c "$SWUPD info $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -223,6 +221,7 @@ global_teardown() {
 
 	add_option_to_config_file invalid_option true global
 
+	cd "$TEST_NAME" || exit 1
 	run sudo sh -c "$SWUPD info $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -243,8 +242,9 @@ global_teardown() {
 	# a warning should be generated and the option should be ignored
 
 	add_option_to_config_file picky true diagnose
-	{ echo "picky-tree="; echo "=true"; echo "picky-tree=/some/path=/usr"; } >> "$SWUPD_CONFIG_FILE"
+	sudo sh -c "{ echo 'picky-tree='; echo '=true'; echo 'picky-tree=/some/path=/usr'; } >> $SWUPD_CONFIG_FILE"
 
+	cd "$TEST_NAME" || exit 1
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM


### PR DESCRIPTION
Always save the config file in another directory so we won't have
problems on running the config tests in parallel. Before this patch
if you run the config tests in parallel with any other tests you could
end up having false-negatives.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>