### PR TITLE
actions: Set a timeout of 1 hour to github jobs

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -7,6 +7,7 @@ env:
 jobs:
   unit_and_style:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v1
 
@@ -28,6 +29,7 @@ jobs:
 
   test_update1:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v1
 
@@ -48,6 +50,7 @@ jobs:
 
   test_update2:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v1
 
@@ -68,6 +71,7 @@ jobs:
 
   test_multiple:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v1
 
@@ -83,6 +87,7 @@ jobs:
 
   test_diagnose_search:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v1
 
@@ -98,6 +103,7 @@ jobs:
 
   test_os_install:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v1
 
@@ -113,6 +119,7 @@ jobs:
 
   test_repair:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v1
 
@@ -128,6 +135,7 @@ jobs:
 
   test_bundle_add:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v1
 
@@ -143,6 +151,7 @@ jobs:
 
   test_bundle_remove:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v1
 
@@ -158,6 +167,7 @@ jobs:
 
   test_bundle_list:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v1
 


### PR DESCRIPTION
Github job timeout is 6 hours, but we are sure that any job will take around
20~30 minutes to run. Set a one hour timeout to make sure that hung jobs aren't
going to be blocking us for a long time.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>