### PR TITLE
actions: Test make distcheck on github actions

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -23,6 +23,9 @@ jobs:
     - name: run unit tests
       run:  make check
 
+    - name: run distcheck
+      run:  make distcheck
+
     - name: print status
       if: failure()
       run: cat test-suite.log


### PR DESCRIPTION
Distcheck is light now, so adding it to github actions to make sure
we aren't breaking the build on a dist package

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>