### PR TITLE
Missing --repo flag to 3rd-party bundle-add help

### DIFF
--- a/src/3rd_party_bundle_add.c
+++ b/src/3rd_party_bundle_add.c
@@ -38,6 +38,7 @@ static void print_help(void)
 	global_print_help();
 
 	print("Options:\n");
+	print("   -R, --repo              Specify the 3rd-party repo to use\n");
 	print("   --skip-optional         Do not install optional bundles (also-add flag in Manifests)\n");
 	print("   --skip-diskspace-check  Do not check free disk space before adding bundle\n");
 	print("\n");


### PR DESCRIPTION
This commit adds a missing flag in the help menu of 3rd-party
bundle-add.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>