### PR TITLE
Implement --repo flag for 3rd-party bundle-list

### DIFF
--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -774,6 +774,7 @@ The non-zero return codes for other operations are listed here:
   - **34**: swupd ran out of memory
   - **35**: Unable to fix/replace/delete one or more files
   - **36**: Unable to execute binary, is either missing or invalid
+  - **37**: Invalid 3rd-party repository (not found)
 
 
 SEE ALSO

--- a/src/3rd_party_bundle_add.c
+++ b/src/3rd_party_bundle_add.c
@@ -206,7 +206,7 @@ enum swupd_code third_party_bundle_add_main(int argc, char **argv)
 
 		if (!selected_repo) {
 			error("3rd-party repository %s was not found\n\n", cmdline_repo);
-			ret_code = SWUPD_INVALID_OPTION;
+			ret_code = SWUPD_INVALID_REPOSITORY;
 			goto clean_and_exit;
 		}
 

--- a/src/swupd_exit_codes.h
+++ b/src/swupd_exit_codes.h
@@ -47,6 +47,7 @@ enum swupd_code {
 	SWUPD_OUT_OF_MEMORY_ERROR,	     /* 34 swupd ran out of memory */
 	SWUPD_VERIFY_FAILED,		     /* 35 verify could not fix/replace/delete one or more files */
 	SWUPD_INVALID_BINARY,		     /* 36 binary to be executed is missing or invalid */
+	SWUPD_INVALID_REPOSITORY,	     /* 37 the specified 3rd-party repository is invalid */
 
 };
 

--- a/swupd.bash
+++ b/swupd.bash
@@ -122,6 +122,11 @@ _swupd()
 		opts+=" $(unset CDPATH; test -d /usr/share/clear/bundles && \
 			find /usr/share/clear/bundles/ -maxdepth 1 -type f ! -name os-core -printf '%f ')"
 		;;
+		("bundle-list")
+		if [ "${COMP_WORDS[$i - 1]}" = "3rd-party" ]; then
+			opts+="--repo"
+		fi
+		;;
 		("hashdump")
 		# Add in filenames. TODO add in directory completion
 		opts+=" $( compgen -f -- "$2" )"

--- a/test/functional/3rd-party/3rd-party-bundle-list-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-list-basic.bats
@@ -103,3 +103,48 @@ global_teardown() {
 	assert_is_output --identical "$expected_output"
 
 }
+
+@test "TPR022: List installed 3rd-party bundles from a specific repo" {
+
+	# users should be able to list installed 3rd-party bundles from a specific repo
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list --repo repo2 $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		_______________________
+		 3rd-Party Repo: repo2
+		_______________________
+
+		Installed bundles:
+		 - test-bundle3
+
+		Total: 1
+	EOM
+	)
+	assert_is_output --identical "$expected_output"
+
+}
+
+@test "TPR023: List all available 3rd-party bundles from a specific repo" {
+
+	# users should be able to list all 3rd-party bundles from a specific repo
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list --all --repo repo1 $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		_______________________
+		 3rd-Party Repo: repo1
+		_______________________
+
+		All available bundles:
+		 - test-bundle1
+		 - test-bundle2
+
+		Total: 2
+	EOM
+	)
+	assert_is_output --identical "$expected_output"
+
+}

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -61,6 +61,8 @@ export SWUPD_COULDNT_WRITE_FILE=32  # couldn't write to a file
 export SWUPD_MIX_COLLISIONS=33  # collisions were found between mix and upstream
 export SWUPD_OUT_OF_MEMORY_ERROR=34  # swupd ran out of memory
 export SWUPD_VERIFY_FAILED=35  # verify could not fix/replace/delete one or more files
+export SWUPD_INVALID_BINARY=36  # binary to be executed is missing or invalid
+export SWUPD_INVALID_REPOSITORY=37  # the specified 3rd-party repository is invalid
 
 # global constant
 export zero_hash="0000000000000000000000000000000000000000000000000000000000000000"


### PR DESCRIPTION
This commit adds the --repo flag for the 3rd-party bundle-list command
which can be used to specify the repository from which the bundles are
going to be listed.

This PR is built on top of #1216 

Closes #1179 