### PR TITLE
3rd party os core

### DIFF
--- a/src/3rd_party_add.c
+++ b/src/3rd_party_add.c
@@ -132,7 +132,7 @@ enum swupd_code third_party_add_main(int argc, char **argv)
 	globals.no_scripts = true;
 	struct list *bundle_to_install = NULL;
 	bundle_to_install = list_append_data(bundle_to_install, "os-core");
-	ret = execute_bundle_add(bundle_to_install, repo_version);
+	ret = bundle_add(bundle_to_install, repo_version);
 	list_free_list(bundle_to_install);
 
 finish:

--- a/src/3rd_party_bundle_list.c
+++ b/src/3rd_party_bundle_list.c
@@ -129,7 +129,6 @@ static void print_repo_header(const char *repo_name)
 
 static enum swupd_code list_repo_bundles(char *state_dir, char *path_prefix, struct repo *repo)
 {
-	int current_version;
 	enum swupd_code ret;
 
 	/* set the appropriate content_dir and state_dir for the selected 3rd-party repo */
@@ -138,17 +137,8 @@ static enum swupd_code list_repo_bundles(char *state_dir, char *path_prefix, str
 		return ret;
 	}
 
-	/* get the current version of the 3rd-party repo, if we cannot get the current_version,
-	 * the only list command we can still attempt is listing locally installed bundles
-	 * (with the limitation of not showing what bundles are experimental)*/
-	current_version = get_current_version(globals.path_prefix);
-	if (current_version < 0 && !cmdline_local) {
-		error("Unable to determine current OS version for repository %s\n\n", repo->name);
-		return SWUPD_CURRENT_VERSION_UNKNOWN;
-	}
-
 	print_repo_header(repo->name);
-	return list_bundles(current_version);
+	return list_bundles();
 }
 
 enum swupd_code third_party_bundle_list_main(int argc, char **argv)

--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -61,10 +61,6 @@ static bool parse_key_values(char *section, char *key, char *value, void *data)
 			free(repo->url);
 		}
 		repo->url = strdup_or_die(value);
-	} else if (strcasecmp(key, "version") == 0) {
-		if (strtoi_err(value, &repo->version) != 0) {
-			return false;
-		}
 	}
 
 	return true;
@@ -128,9 +124,8 @@ int third_party_add_repo(const char *repo_name, const char *repo_url)
 		goto exit;
 	}
 
-	// write url and version
+	// write url
 	ret = config_write_config(fp, "url", repo_url);
-	ret = config_write_config(fp, "version", "10");
 
 exit:
 	if (fp) {
@@ -145,7 +140,6 @@ exit:
 static int write_repo(FILE *fp, struct repo *repo)
 {
 	int ret;
-	char *version;
 
 	ret = config_write_section(fp, repo->name);
 	if (ret) {
@@ -159,9 +153,6 @@ static int write_repo(FILE *fp, struct repo *repo)
 		}
 	}
 
-	string_or_die(&version, "%d", repo->version);
-	ret = config_write_config(fp, "version", version);
-	free_string(&version);
 	if (ret) {
 		return ret;
 	}

--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -228,7 +228,7 @@ exit:
 	return ret;
 }
 
-int third_party_set_repo(const char *state_dir, const char *path_prefix, struct repo *repo)
+enum swupd_code third_party_set_repo(const char *state_dir, const char *path_prefix, struct repo *repo)
 {
 	char *repo_state_dir;
 	char *repo_path_prefix;
@@ -244,12 +244,13 @@ int third_party_set_repo(const char *state_dir, const char *path_prefix, struct 
 	string_or_die(&repo_state_dir, "%s/3rd_party/%s", state_dir, repo->name);
 	if (create_state_dirs(repo_state_dir)) {
 		free_string(&repo_state_dir);
-		return -1;
+		error("Unable to create the state directories for repository %s\n\n", repo->name);
+		return SWUPD_COULDNT_CREATE_DIR;
 	}
 	set_state_dir(repo_state_dir);
 	free_string(&repo_state_dir);
 
-	return 0;
+	return SWUPD_OK;
 }
 
 #endif

--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -18,7 +18,6 @@ extern "C" {
 struct repo {
 	char *name;
 	char *url;
-	int version;
 };
 
 /**

--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -69,9 +69,9 @@ int third_party_remove_repo(char *repo_name);
  * @param state_dir the original state directory of the system
  * @param path_prefix the original path prefix of the system
  *
- * @returns 0 on success, -1 on any failure
+ * @returns a swupd_code
  */
-int third_party_set_repo(const char *state_dir, const char *path_prefix, struct repo *repo);
+enum swupd_code third_party_set_repo(const char *state_dir, const char *path_prefix, struct repo *repo);
 
 /**
  * @brief strcmp like function to search for a repo based on its name

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -345,10 +345,10 @@ extern void verify_set_extra_files_only(bool opt);
 extern regex_t *compile_whitelist(const char *whitelist_pattern);
 
 /* bundle_list.c*/
-extern enum swupd_code list_local_bundles(int version);
-extern enum swupd_code list_installable_bundles(int version);
-extern enum swupd_code show_included_bundles(char *bundle_name, int version);
-extern enum swupd_code show_bundle_reqd_by(const char *bundle_name, bool server, int version);
+extern enum swupd_code list_bundles(int version);
+extern void bundle_list_set_option_all(bool opt);
+extern void bundle_list_set_option_has_dep(char *bundle);
+extern void bundle_list_set_option_deps(char *bundle);
 
 /* telemetry.c */
 typedef enum telem_prio_t {

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -322,8 +322,9 @@ extern char *get_tracking_dir(void);
 extern int add_subscriptions(struct list *bundles, struct list **subs, struct manifest *mom, bool find_all, int recursion);
 extern int subscription_bundlename_strcmp(const void *a, const void *b);
 
-/* bundle_add.c*/
-extern enum swupd_code execute_bundle_add(struct list *bundles_list, int version);
+/* bundle_add.c */
+extern enum swupd_code execute_bundle_add(struct list *bundles_list);
+extern enum swupd_code bundle_add(struct list *bundles_list, int version);
 
 /* verify.c */
 extern enum swupd_code execute_verify(void);
@@ -345,7 +346,7 @@ extern void verify_set_extra_files_only(bool opt);
 extern regex_t *compile_whitelist(const char *whitelist_pattern);
 
 /* bundle_list.c*/
-extern enum swupd_code list_bundles(int version);
+extern enum swupd_code list_bundles(void);
 extern void bundle_list_set_option_all(bool opt);
 extern void bundle_list_set_option_has_dep(char *bundle);
 extern void bundle_list_set_option_deps(char *bundle);

--- a/test/functional/3rd-party/3rd-party-allow-http.bats
+++ b/test/functional/3rd-party/3rd-party-allow-http.bats
@@ -5,9 +5,17 @@
 
 load "../testlib"
 
+test_path=$(realpath "$TEST_NAME")
+repo="$test_path"/3rd_party/my_repo
+
 global_setup() {
 
 	create_test_environment "$TEST_NAME"
+	create_third_party_repo "$TEST_NAME" 10 staging my_repo
+
+	# use a web server for serving the content, this is necessary
+	# since the code behaves differently if the content is local (e.g. file://)
+	start_web_server -r -D "$TPWEBDIR"
 
 }
 
@@ -32,7 +40,9 @@ global_teardown() {
 
 @test "TPR005: Trying to add a http repo" {
 
-	run sudo sh -c "$SWUPD 3rd-party add my_repo http://example.com/swupd-file $SWUPD_OPTS"
+	port=$(get_web_server_port "$TEST_NAME")
+
+	run sudo sh -c "$SWUPD 3rd-party add my_repo http://localhost:$port $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_INVALID_OPTION"
 	expected_output=$(cat <<-EOM
@@ -40,13 +50,15 @@ global_teardown() {
 		Use the --allow-insecure-http flag to proceed
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 
 @test "TPR006: Forcing a http repo add" {
 
-	run sudo sh -c "$SWUPD 3rd-party add my_repo http://example.com/swupd-file --allow-insecure-http $SWUPD_OPTS"
+	port=$(get_web_server_port "$TEST_NAME")
+
+	run sudo sh -c "$SWUPD 3rd-party add my_repo http://localhost:$port --allow-insecure-http $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -55,14 +67,16 @@ global_teardown() {
 		Repository my_repo added successfully
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_in_output "$expected_output"
 
 	run sudo sh -c "cat $STATEDIR/3rd_party/repo.ini"
-	assert_status_is "0"
+	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		[my_repo]
-		url=http://example.com/swupd-file
+		url=http://localhost:$port
 	EOM
 	)
 	assert_is_output --identical "$expected_output"
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/my_repo/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/my_repo/usr/lib/os-release
 }

--- a/test/functional/3rd-party/3rd-party-allow-http.bats
+++ b/test/functional/3rd-party/3rd-party-allow-http.bats
@@ -48,7 +48,7 @@ global_teardown() {
 
 	run sudo sh -c "$SWUPD 3rd-party add my_repo http://example.com/swupd-file --allow-insecure-http $SWUPD_OPTS"
 
-	assert_status_is 0
+	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Warning: This is an insecure connection
 		The --allow-insecure-http flag was used, be aware that this poses a threat to the system
@@ -62,7 +62,6 @@ global_teardown() {
 	expected_output=$(cat <<-EOM
 		[my_repo]
 		url=http://example.com/swupd-file
-		version=10
 	EOM
 	)
 	assert_is_output --identical "$expected_output"

--- a/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
@@ -12,7 +12,7 @@ test_setup() {
 
 	# create a 3rd-party repo within the test environment and add
 	# a bundle in the 3rd-party repo
-	create_third_party_repo "$TEST_NAME" 10
+	add_third_party_repo "$TEST_NAME" 10
 	create_bundle -n test-bundle2 -f /bar/file_2 -u test-repo "$TEST_NAME"
 
 }

--- a/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
@@ -8,12 +8,16 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment "$TEST_NAME"
-	create_bundle -n test-bundle1 -f /foo/file_1 "$TEST_NAME"
+	create_bundle -n upstream-bundle -f /upstream_file "$TEST_NAME"
 
-	# create a 3rd-party repo within the test environment and add
-	# a bundle in the 3rd-party repo
-	add_third_party_repo "$TEST_NAME" 10
-	create_bundle -n test-bundle2 -f /bar/file_2 -u test-repo "$TEST_NAME"
+	# create a couple 3rd-party repos within the test environment and add
+	# some bundles to them
+	add_third_party_repo "$TEST_NAME" 10 1 test-repo1
+	create_bundle -n test-bundle1 -f /foo/file_1 -u test-repo1 "$TEST_NAME"
+
+	add_third_party_repo "$TEST_NAME" 10 1 test-repo2
+	create_bundle -n test-bundle2 -f /foo/file_2 -u test-repo2 "$TEST_NAME"
+	create_bundle -n test-bundle3 -f /bar/file_3 -u test-repo2 "$TEST_NAME"
 
 }
 
@@ -26,7 +30,7 @@ test_setup() {
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Searching for bundle test-bundle2 in the 3rd-party repositories...
-		Bundle test-bundle2 found in 3rd-party repository test-repo
+		Bundle test-bundle2 found in 3rd-party repository test-repo2
 		Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Loading required manifests...
 		No packs need to be downloaded
@@ -38,8 +42,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/bar/file_2
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo2/foo/file_2
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo2/usr/share/clear/bundles/test-bundle2
 	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle2
 
 }
@@ -49,12 +53,12 @@ test_setup() {
 	# if the user tries to add an upstream bundle using the 3rd-party command
 	# the bundle should not be found/installed
 
-	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle1"
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS upstream-bundle"
 
 	assert_status_is "$SWUPD_INVALID_BUNDLE"
 	expected_output=$(cat <<-EOM
-		Searching for bundle test-bundle1 in the 3rd-party repositories...
-		Error: bundle test-bundle1 was not found in any 3rd-party repository
+		Searching for bundle upstream-bundle in the 3rd-party repositories...
+		Error: bundle upstream-bundle was not found in any 3rd-party repository
 	EOM
 	)
 	assert_is_output "$expected_output"
@@ -75,14 +79,14 @@ test_setup() {
 
 	# swupd should just ignore the invalid and should continue with the valid one
 
-	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle1 test-bundle2"
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS upstream-bundle test-bundle2"
 
 	assert_status_is "$SWUPD_INVALID_BUNDLE"
 	expected_output=$(cat <<-EOM
-		Searching for bundle test-bundle1 in the 3rd-party repositories...
-		Error: bundle test-bundle1 was not found in any 3rd-party repository
+		Searching for bundle upstream-bundle in the 3rd-party repositories...
+		Error: bundle upstream-bundle was not found in any 3rd-party repository
 		Searching for bundle test-bundle2 in the 3rd-party repositories...
-		Bundle test-bundle2 found in 3rd-party repository test-repo
+		Bundle test-bundle2 found in 3rd-party repository test-repo2
 		Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Loading required manifests...
 		No packs need to be downloaded
@@ -94,22 +98,22 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/bar/file_2
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo2/foo/file_2
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo2/usr/share/clear/bundles/test-bundle2
 	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle2
-	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo2/usr/share/clear/bundles/upstream-bundle
 
 	# same scenario with the arguments switched
 
-	remove_bundle -L "$TEST_NAME"/3rd_party/test-repo/10/Manifest.test-bundle2 test-repo
-	clean_state_dir "$TEST_NAME" test-repo
+	remove_bundle -L "$TEST_NAME"/3rd_party/test-repo2/10/Manifest.test-bundle2 test-repo2
+	clean_state_dir "$TEST_NAME" test-repo2
 
-	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle2 test-bundle1"
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle2 upstream-bundle"
 
 	assert_status_is "$SWUPD_INVALID_BUNDLE"
 	expected_output=$(cat <<-EOM
 		Searching for bundle test-bundle2 in the 3rd-party repositories...
-		Bundle test-bundle2 found in 3rd-party repository test-repo
+		Bundle test-bundle2 found in 3rd-party repository test-repo2
 		Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Loading required manifests...
 		No packs need to be downloaded
@@ -118,12 +122,12 @@ test_setup() {
 		Installing files...
 		Warning: post-update helper scripts skipped due to --no-scripts argument
 		Successfully installed 1 bundle
-		Searching for bundle test-bundle1 in the 3rd-party repositories...
-		Error: bundle test-bundle1 was not found in any 3rd-party repository
+		Searching for bundle upstream-bundle in the 3rd-party repositories...
+		Error: bundle upstream-bundle was not found in any 3rd-party repository
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/bar/file_2
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo2/foo/file_2
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo2/usr/share/clear/bundles/test-bundle2
 	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle2
 }

--- a/test/functional/3rd-party/3rd-party-bundle-add-config-file.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-config-file.bats
@@ -11,7 +11,7 @@ test_setup() {
 
 	# create a 3rd-party repo within the test environment and add
 	# a few bundles in the 3rd-party repo
-	create_third_party_repo "$TEST_NAME" 10
+	add_third_party_repo "$TEST_NAME" 10
 	create_bundle -n test-bundle1 -f /foo/file_1 -u test-repo "$TEST_NAME"
 	create_bundle -n test-bundle2 -f /bar/file_2 -u test-repo "$TEST_NAME"
 	create_bundle -n test-bundle3 -f /file_3     -u test-repo "$TEST_NAME"

--- a/test/functional/3rd-party/3rd-party-bundle-add-multi-repo.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-multi-repo.bats
@@ -10,11 +10,11 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 
 	# create a couple of 3rd-party repos with bundles
-	create_third_party_repo "$TEST_NAME" 10 staging repo1
+	add_third_party_repo "$TEST_NAME" 10 staging repo1
 	create_bundle -n test-bundle1 -f /foo/file_1A -u repo1 "$TEST_NAME"
 	create_bundle -n test-bundle2 -f /bar/file_2 -u repo1 "$TEST_NAME"
 
-	create_third_party_repo "$TEST_NAME" 10 staging repo2
+	add_third_party_repo "$TEST_NAME" 10 staging repo2
 	create_bundle -n test-bundle1 -f /baz/file_1B -u repo2 "$TEST_NAME"
 
 }

--- a/test/functional/3rd-party/3rd-party-bundle-list-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-list-basic.bats
@@ -52,18 +52,20 @@ global_teardown() {
 		_______________________
 
 		Installed bundles:
+		 - os-core
 		 - test-bundle2
 
-		Total: 1
+		Total: 2
 
 		_______________________
 		 3rd-Party Repo: repo2
 		_______________________
 
 		Installed bundles:
+		 - os-core
 		 - test-bundle3
 
-		Total: 1
+		Total: 2
 	EOM
 	)
 	assert_is_output --identical "$expected_output"
@@ -84,20 +86,22 @@ global_teardown() {
 		_______________________
 
 		All available bundles:
+		 - os-core
 		 - test-bundle1
 		 - test-bundle2
 
-		Total: 2
+		Total: 3
 
 		_______________________
 		 3rd-Party Repo: repo2
 		_______________________
 
 		All available bundles:
+		 - os-core
 		 - test-bundle1
 		 - test-bundle3
 
-		Total: 2
+		Total: 3
 	EOM
 	)
 	assert_is_output --identical "$expected_output"
@@ -117,9 +121,10 @@ global_teardown() {
 		_______________________
 
 		Installed bundles:
+		 - os-core
 		 - test-bundle3
 
-		Total: 1
+		Total: 2
 	EOM
 	)
 	assert_is_output --identical "$expected_output"
@@ -139,10 +144,11 @@ global_teardown() {
 		_______________________
 
 		All available bundles:
+		 - os-core
 		 - test-bundle1
 		 - test-bundle2
 
-		Total: 2
+		Total: 3
 	EOM
 	)
 	assert_is_output --identical "$expected_output"

--- a/test/functional/3rd-party/3rd-party-bundle-list-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-list-basic.bats
@@ -11,11 +11,11 @@ global_setup() {
 	create_bundle -n test-bundle-upstream -f /file_upstream "$TEST_NAME"
 
 	# create a couple of 3rd-party repos with bundles
-	create_third_party_repo "$TEST_NAME" 10 staging repo1
+	add_third_party_repo "$TEST_NAME" 10 staging repo1
 	create_bundle    -n test-bundle1 -f /foo/file_1A -u repo1 "$TEST_NAME"
 	create_bundle -L -n test-bundle2 -f /bar/file_2  -u repo1 "$TEST_NAME"
 
-	create_third_party_repo "$TEST_NAME" 10 staging repo2
+	add_third_party_repo "$TEST_NAME" 10 staging repo2
 	create_bundle    -n test-bundle1 -f /baz/file_1B -u repo2 "$TEST_NAME"
 	create_bundle -L -n test-bundle3 -f /baz/file_3  -u repo2 "$TEST_NAME"
 

--- a/test/functional/3rd-party/3rd-party-bundle-list-deps.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-list-deps.bats
@@ -10,7 +10,7 @@ global_setup() {
 	create_test_environment "$TEST_NAME"
 
 	# create a 3rd-party repo with bundles that have dependencies
-	create_third_party_repo "$TEST_NAME" 10 staging repo1
+	add_third_party_repo "$TEST_NAME" 10 staging repo1
 	create_bundle  -n test-bundle1 -f /foo/file_1 -u repo1 "$TEST_NAME"
 	create_bundle  -n test-bundle2 -f /bar/file_2 -u repo1 "$TEST_NAME"
 	create_bundle  -n test-bundle3 -f /baz/file_3 -u repo1 "$TEST_NAME"

--- a/test/functional/3rd-party/3rd-party-repo-add-negative.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add-negative.bats
@@ -5,6 +5,36 @@
 
 load "../testlib"
 
+test_path=$(realpath "$TEST_NAME")
+repo="$test_path"/3rd_party/test-repo1
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_third_party_repo "$TEST_NAME" 10 staging test-repo1
+
+}
+
+test_setup() {
+
+	# do nothing
+	return
+
+}
+
+test_teardown() {
+
+	# do nothing
+	return
+
+}
+
+global_teardown() {
+
+	destroy_test_environment "$TEST_NAME"
+
+}
+
 @test "TPR003: Negative test, repo add usage" {
 
 	run sudo sh -c "$SWUPD 3rd-party add $SWUPD_OPTS"
@@ -23,7 +53,7 @@ load "../testlib"
 	)
 	assert_in_output "$expected_output"
 
-	run sudo sh -c "$SWUPD 3rd-party add test-repo1 http://abc.com junk_positional $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD 3rd-party add test-repo1 file://$repo junk_positional $SWUPD_OPTS"
 	assert_status_is "$SWUPD_INVALID_OPTION"
 	expected_output=$(cat <<-EOM
 		Error: Unexpected arguments
@@ -35,19 +65,18 @@ load "../testlib"
 
 @test "TPR004: Negative test, Add an already added repo" {
 
-	run sudo sh -c "$SWUPD 3rd-party add test-repo1 https://www.xyz.com $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD 3rd-party add test-repo1 file://$repo $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Repository test-repo1 added successfully
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_in_output "$expected_output"
 
 	run sudo sh -c "$SWUPD 3rd-party add test-repo1 https://abc.com $SWUPD_OPTS"
 	assert_status_is "$SWUPD_COULDNT_WRITE_FILE"
 	expected_output=$(cat <<-EOM
 		Error: The repo: test-repo1 already exists
-		Error: Failed to add repo: test-repo1 to config
 	EOM
 	)
 	assert_is_output "$expected_output"

--- a/test/functional/3rd-party/3rd-party-repo-add-negative.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add-negative.bats
@@ -74,7 +74,7 @@ global_teardown() {
 	assert_in_output "$expected_output"
 
 	run sudo sh -c "$SWUPD 3rd-party add test-repo1 https://abc.com $SWUPD_OPTS"
-	assert_status_is "$SWUPD_COULDNT_WRITE_FILE"
+	assert_status_is "$SWUPD_INVALID_OPTION"
 	expected_output=$(cat <<-EOM
 		Error: The repo: test-repo1 already exists
 	EOM

--- a/test/functional/3rd-party/3rd-party-repo-add.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add.bats
@@ -19,7 +19,6 @@ load "../testlib"
 	expected_output=$(cat <<-EOM
 			[test-repo1]
 			url=https://xyz.com
-			version=10
 	EOM
 	)
 	assert_is_output "$expected_output"
@@ -74,23 +73,18 @@ load "../testlib"
 	expected_output=$(cat <<-EOM
 			[test-repo1]
 			url=https://xyz.com
-			version=10
 
 			[test-repo2]
 			url=file://abc.com
-			version=10
 
 			[test-repo3]
 			url=https://efg.com
-			version=10
 
 			[test-repo4]
 			url=https://hij.com
-			version=10
 
 			[test-repo5]
 			url=https://klm.com
-			version=10
 	EOM
 	)
 	assert_is_output --identical "$expected_output"

--- a/test/functional/3rd-party/3rd-party-repo-list.bats
+++ b/test/functional/3rd-party/3rd-party-repo-list.bats
@@ -12,23 +12,18 @@ test_setup(){
 	contents=$(cat <<- EOM
 		[test1]
 		url=https://www.abc.com
-		version=0
 
 		[test2]
 		url=https://www.efg.com
-		version=0
 
 		[test4]
 		url=https://www.pqr.com
-		version=0
 
 		[test5]
 		url=ERROR
-		version=0
 
 		[test5]
 		url=https://www.lmn.com
-		version=0
 		\n
 	EOM
 	)

--- a/test/functional/3rd-party/3rd-party-repo-remove.bats
+++ b/test/functional/3rd-party/3rd-party-repo-remove.bats
@@ -13,24 +13,19 @@ test_setup(){
 		\n
 		[test1]
 		url=www.abc.com
-		version=0
 
 		[test2]
 		url=www.efg.com
-		version=0
 
 		[test3]
 		url=www.xyz.com
-		version=0
 
 		[test4]
 		url=www.pqr.com
-		version=123
 		invalid=456
 
 		[test5]
 		url=www.lmn.com
-		version=0
 		\n
 	EOM
 	)
@@ -85,11 +80,9 @@ test_teardown(){
 	expected_contents=$(cat <<- EOM
 		[test2]
 		url=www.efg.com
-		version=0
 
 		[test4]
 		url=www.pqr.com
-		version=123
 	EOM
 	)
 

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1418,7 +1418,7 @@ create_third_party_repo() { #swupd_function
 	sudo mkdir -p "$repo_state_dir"/{staged,download,delta,telemetry,bundles}
 
 	# create the basic content for the 3rd-party repo
-	create_version "$env_name" "$version" 0 "$format" "$repo_name"
+	create_version -r "$env_name" "$version" 0 "$format" "$repo_name"
 	debug_msg "3rd-party repo $repo_name created successfully"
 
 	# add the new repo to the repo.ini file
@@ -1433,6 +1433,11 @@ create_third_party_repo() { #swupd_function
 	export TPWEBDIR="$env_name"/3rd_party/"$repo_name"
 	debug_msg "3rd-party repo state dir: $TPSTATEDIR"
 	debug_msg "3rd-party repo content dir: $TPWEBDIR"
+
+	# every 3rd-party repo needs to have at least the os-core bundle so this should be
+	# added by default
+	debug_msg "Adding bundle os-core to the 3rd-party repo"
+	create_bundle -L -n os-core -v "$version" -f /usr/lib/os-release:"$OS_RELEASE",/usr/share/defaults/swupd/format:"$FORMAT" -u "$repo_name" "$env_name"
 
 }
 

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1395,6 +1395,41 @@ create_third_party_repo() { #swupd_function
 	local version=$2
 	local format=${3:-staging}
 	local repo_name=${4:-test-repo}
+
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    create_third_party_repo <environment_name> <new_version> [format] [repo_name]
+			EOM
+		return
+	fi
+	validate_item "$env_name"
+	validate_param "$version"
+
+	debug_msg "Creating 3rd-party repo $repo_name..."
+	create_version -r "$env_name" "$version" 0 "$format" "$repo_name"
+	create_bundle -n os-core -v "$version" -f /usr/lib/os-release:"$OS_RELEASE",/usr/share/defaults/swupd/format:"$FORMAT" -u "$repo_name" "$env_name"
+	TPWEBDIR=$(realpath "$env_name/3rd_party/$repo_name")
+	export TPWEBDIR
+	debug_msg "3rd-party repo content dir: $TPWEBDIR"
+	debug_msg "3rd-party repo created successfully"
+
+}
+
+# Creates and adds a  new version of the server side content in the specified
+# location to serve as a 3rd-party repository
+# Parameters:
+# - ENVIRONMENT_NAME: the name of the test environment
+# - VERSION: the version of the server side content
+# - FORMAT: the format to use for the version
+# - REPO_NAME: the name of the 3rd-party repo, defaults to "test-repo"
+add_third_party_repo() { #swupd_function
+
+	local env_name=$1
+	local version=$2
+	local format=${3:-staging}
+	local repo_name=${4:-test-repo}
 	local repo_state_dir
 	local path
 
@@ -1402,7 +1437,7 @@ create_third_party_repo() { #swupd_function
 	if [ $# -eq 0 ]; then
 		cat <<-EOM
 			Usage:
-			    create_third_party_repo <environment_name> <new_version> [format] [repo_name]
+			    add_third_party_repo <environment_name> <new_version> [format] [repo_name]
 			EOM
 		return
 	fi


### PR DESCRIPTION
When using a 3rd-party repository we need to know the current version of the system related to the 3rd-party repository. This version may be different than the version related to the upstream content. The original idea of 3rd-party repositories was that this version would be tracked inside the repo.ini config file. This was not ideal cause it differ from the way swupd tracks version for upstream content. This PR makes a few updates so 3rd-party bundles are handled similarly to the way we handle upstream content.

The PR includes these updates:
 - Removes all the code related to handling the version key/value in the
    repo.ini file.
 - When doing 3rd-party operations, instead of getting the current version of a 3rd-party repo from the repo.ini file, it will now be gotten from the os-release file in the appropriate path_prefix for the repo.
 - Installs the os-core bundle when a 3rd-party repository is added so swupd can track the version of the 3rd-party repo.
 - Updates functions in testlib that facilitate the creation of tests.
 - Updates 3rd-party tests.

**Note**: This PR is built on top of #1216  and #1225, these need to be reviewed and merged first. 