### PR TITLE
Implementing a command to remove 3rd-party bundles

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,7 @@ swupd_SOURCES = \
 	src/3rd_party_add.c \
 	src/3rd_party_bundle_add.c \
 	src/3rd_party_bundle_list.c \
+	src/3rd_party_bundle_remove.c \
 	src/3rd_party.c \
 	src/3rd_party_list.c \
 	src/3rd_party_remove.c \

--- a/src/3rd_party.c
+++ b/src/3rd_party.c
@@ -29,6 +29,7 @@ static struct subcmd third_party_commands[] = {
 	{ "remove", "Remove third party repository", third_party_remove_main },
 	{ "list", "List third party repository", third_party_list_main },
 	{ "bundle-add", "Install a bundle from a third party repository", third_party_bundle_add_main },
+	{ "bundle-remove", "Remove a bundle from a third party repository", third_party_bundle_remove_main },
 	{ "bundle-list", "List bundles from a third party repository", third_party_bundle_list_main },
 	{ 0 }
 };

--- a/src/3rd_party_bundle_add.c
+++ b/src/3rd_party_bundle_add.c
@@ -93,16 +93,27 @@ static bool parse_options(int argc, char **argv)
 	return true;
 }
 
+static enum swupd_code add_bundle(char *bundle)
+{
+
+	struct list *bundle_to_install = NULL;
+	enum swupd_code ret = SWUPD_OK;
+
+	/* execute_bundle_add expects a list */
+	bundle_to_install = list_append_data(bundle_to_install, bundle);
+
+	info("\nBundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons\n\n");
+	globals.no_scripts = true;
+
+	ret = execute_bundle_add(bundle_to_install);
+
+	list_free_list(bundle_to_install);
+	return ret;
+}
+
 enum swupd_code third_party_bundle_add_main(int argc, char **argv)
 {
 	struct list *bundles = NULL;
-	struct list *iter1 = NULL;
-	struct list *iter2 = NULL;
-	struct list *repos = NULL;
-	char *state_dir;
-	char *path_prefix;
-	int repo_version;
-	int ret;
 	enum swupd_code ret_code = SWUPD_OK;
 
 	/*
@@ -132,9 +143,6 @@ enum swupd_code third_party_bundle_add_main(int argc, char **argv)
 		return ret_code;
 	}
 
-	/* load the existing 3rd-party repos from the repo.ini config file */
-	repos = third_party_get_repos();
-
 	/* move the bundles provided in the command line into a
 	 * list so it is easier to handle them */
 	for (; *cmdline_bundles; ++cmdline_bundles) {
@@ -143,115 +151,13 @@ enum swupd_code third_party_bundle_add_main(int argc, char **argv)
 	}
 	bundles = list_head(bundles);
 
-	/* backup the original state_dir and path_prefix values */
-	state_dir = strdup_or_die(globals.state_dir);
-	path_prefix = strdup_or_die(globals.path_prefix);
-
 	/* try installing bundles one by one */
-	for (iter1 = bundles; iter1; iter1 = iter1->next) {
-		char *bundle = iter1->data;
-		struct repo *selected_repo = NULL;
-		int count = 0;
+	ret_code = third_party_run_operation(bundles, cmdline_repo, add_bundle);
 
-		/* if the repo to be used was specified, use it, otherwise
-		* search for the bundle in all the 3rd-party repos */
-		if (cmdline_repo) {
-
-			selected_repo = list_search(repos, cmdline_repo, repo_name_cmp);
-
-		} else {
-
-			info("Searching for bundle %s in the 3rd-party repositories...\n", bundle);
-			for (iter2 = repos; iter2; iter2 = iter2->next) {
-				struct repo *repo = iter2->data;
-				struct manifest *mom = NULL;
-				struct file *file = NULL;
-
-				/* set the appropriate content_dir and state_dir for the selected 3rd-party repo */
-				ret = third_party_set_repo(state_dir, path_prefix, repo);
-				if (ret) {
-					ret_code = ret;
-					goto clean_and_exit;
-				}
-
-				/* get repo's version */
-				repo_version = get_current_version(globals.path_prefix);
-				if (repo_version < 0) {
-					error("Unable to determine current version for repository %s\n\n", repo->name);
-					ret_code = SWUPD_CURRENT_VERSION_UNKNOWN;
-					goto clean_and_exit;
-				}
-
-				/* load the repo's MoM*/
-				mom = load_mom(repo_version, false, NULL);
-				if (!mom) {
-					error("Cannot load manifest MoM for 3rd-party repository %s version %i\n", repo->name, repo_version);
-					ret_code = SWUPD_COULDNT_LOAD_MOM;
-					goto clean_and_exit;
-				}
-
-				/* search for the bundle in the MoM */
-				file = mom_search_bundle(mom, bundle);
-				if (file) {
-					/* the bundle was found in this repo, keep a pointer to the repo */
-					info("Bundle %s found in 3rd-party repository %s\n", bundle, repo->name);
-					count++;
-					selected_repo = repo;
-				}
-				manifest_free(mom);
-			}
-
-			/* if the bundle exists in only one repo, we can continue */
-			if (count == 0) {
-				error("bundle %s was not found in any 3rd-party repository\n\n", bundle);
-				ret_code = SWUPD_INVALID_BUNDLE;
-				continue;
-			} else if (count > 1) {
-				error("bundle %s was found in more than one 3rd-party repository\n", bundle);
-				info("Please specify a repository using the --repo flag\n\n");
-				ret_code = SWUPD_INVALID_OPTION;
-				continue;
-			}
-		}
-
-		if (!selected_repo) {
-			error("3rd-party repository %s was not found\n\n", cmdline_repo);
-			ret_code = SWUPD_INVALID_REPOSITORY;
-			goto clean_and_exit;
-		}
-
-		/* set the appropriate content_dir and state_dir for the selected 3rd-party repo */
-		ret = third_party_set_repo(state_dir, path_prefix, selected_repo);
-		if (ret) {
-			ret_code = ret;
-			goto clean_and_exit;
-		}
-
-		/* execute_bundle_add expects a list so we can send a new list with only
-		 * the one bundle we want to install in this iteration */
-		struct list *bundle_to_install = NULL;
-		bundle_to_install = list_append_data(bundle_to_install, bundle);
-
-		info("\nBundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons\n\n");
-		globals.no_scripts = true;
-
-		ret = execute_bundle_add(bundle_to_install);
-
-		if (ret != SWUPD_OK) {
-			ret_code = ret;
-		}
-		list_free_list(bundle_to_install);
-		info("\n");
-	}
-
-clean_and_exit:
-	free_string(&state_dir);
-	free_string(&path_prefix);
 	list_free_list(bundles);
-	list_free_list_and_data(repos, repo_free_data);
-
 	swupd_deinit();
 	progress_finish_steps(ret_code);
+
 	return ret_code;
 }
 

--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -20,6 +20,9 @@ struct repo {
 	char *url;
 };
 
+/* @brief Definition of a function that performs an action on a given bundle */
+typedef enum swupd_code (*run_operation_fn_t)(char *bundle);
+
 /**
  * @brief Free repo pointed by @c repo.
  */
@@ -76,6 +79,18 @@ enum swupd_code third_party_set_repo(const char *state_dir, const char *path_pre
  * @brief strcmp like function to search for a repo based on its name
  */
 int repo_name_cmp(const void *repo, const void *name);
+
+/**
+ * @brief Performs an operation on every bundle from the list.
+ *
+ * @param repo the name of the 3rd-party repository where the bundles
+ * should be looked for. If no repo is specified the bundles are searched for
+ * in all existing repos.
+ * @param run_operation_fn the function to be performed on the bundles
+ *
+ * @returns a swupd_code
+ */
+enum swupd_code third_party_run_operation(struct list *bundles, const char *repo, run_operation_fn_t run_operation_fn);
 
 #endif
 

--- a/src/bundle_add.c
+++ b/src/bundle_add.c
@@ -516,7 +516,8 @@ enum swupd_code bundle_add_main(int argc, char **argv)
 	ret = execute_bundle_add(bundles_list);
 
 	list_free_list(bundles_list);
-	swupd_deinit();
 	progress_finish_steps(ret);
+	swupd_deinit();
+
 	return ret;
 }

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -326,6 +326,11 @@ extern int subscription_bundlename_strcmp(const void *a, const void *b);
 extern enum swupd_code execute_bundle_add(struct list *bundles_list);
 extern enum swupd_code bundle_add(struct list *bundles_list, int version);
 
+/* bundle_remove.c */
+extern enum swupd_code execute_remove_bundles(struct list *bundles);
+extern void bundle_remove_set_option_force(bool opt);
+extern void bundle_remove_set_option_recursive(bool opt);
+
 /* verify.c */
 extern enum swupd_code execute_verify(void);
 extern void verify_set_option_download(bool opt);

--- a/src/swupd_internal.h
+++ b/src/swupd_internal.h
@@ -28,6 +28,7 @@ enum swupd_code verify_main(int argc, char **argv);
 enum swupd_code third_party_main(int argc, char **argv);
 enum swupd_code third_party_bundle_add_main(int argc, char **argv);
 enum swupd_code third_party_bundle_list_main(int argc, char **argv);
+enum swupd_code third_party_bundle_remove_main(int argc, char **argv);
 
 /**
  * @brief Creates a new third-party repo under THIRDPARTY_REPO_PREFIX

--- a/swupd.bash
+++ b/swupd.bash
@@ -84,7 +84,7 @@ _swupd()
 		opts="$global --version --manifest --fix --picky --picky-tree --picky-whitelist --install --quick --force --install "
 		break;;
 		("3rd-party")
-		opts="$global add remove list bundle-add bundle-list "
+		opts="$global add remove list bundle-add bundle-list bundle-remove "
 		break;;
 		("add")
 		opts="$global --repo"
@@ -119,8 +119,13 @@ _swupd()
 		fi
 		;;
 		("bundle-remove")
-		opts+=" $(unset CDPATH; test -d /usr/share/clear/bundles && \
-			find /usr/share/clear/bundles/ -maxdepth 1 -type f ! -name os-core -printf '%f ')"
+		#
+		if [ "${COMP_WORDS[$i - 1]}" != "3rd-party" ]; then
+			opts+=" $(unset CDPATH; test -d /usr/share/clear/bundles && \
+				find /usr/share/clear/bundles/ -maxdepth 1 -type f ! -name os-core -printf '%f ')"
+		else
+			opts+="--repo"
+		fi
 		;;
 		("bundle-list")
 		if [ "${COMP_WORDS[$i - 1]}" = "3rd-party" ]; then

--- a/test/functional/3rd-party/3rd-party-bundle-remove-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-basic.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n upstream-bundle -f /upstream_file "$TEST_NAME"
+
+	# create a couple 3rd-party repos within the test environment and add
+	# some bundles to them
+	add_third_party_repo "$TEST_NAME" 10 1 test-repo1
+	create_bundle -L -t -n test-bundle1 -f /foo/file_1 -u test-repo1 "$TEST_NAME"
+
+	add_third_party_repo "$TEST_NAME" 10 1 test-repo2
+	create_bundle -L -t -n test-bundle2 -f /foo/file_2 -u test-repo2 "$TEST_NAME"
+	create_bundle -L -t -n test-bundle3 -f /bar/file_3 -u test-repo2 "$TEST_NAME"
+
+}
+
+@test "TPR024: Removing one bundle from a third party repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS test-bundle2"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle2 in the 3rd-party repositories...
+		Bundle test-bundle2 found in 3rd-party repository test-repo2
+		The following bundles are being removed:
+		 - test-bundle2
+		Deleting bundle files...
+		Total deleted files: 3
+		Successfully removed 1 bundle
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo2/foo/file_2
+	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo2/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TPSTATEDIR"/bundles/test-bundle2
+
+}
+
+@test "TPR025: Try removing one invalid bundle from a third party repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS upstream-bundle"
+
+	assert_status_is "$SWUPD_INVALID_BUNDLE"
+	expected_output=$(cat <<-EOM
+		Searching for bundle upstream-bundle in the 3rd-party repositories...
+		Error: bundle upstream-bundle was not found in any 3rd-party repository
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	# the same should happen with an invalid bundle
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS fake-bundle"
+
+	assert_status_is "$SWUPD_INVALID_BUNDLE"
+	expected_output=$(cat <<-EOM
+		Searching for bundle fake-bundle in the 3rd-party repositories...
+		Error: bundle fake-bundle was not found in any 3rd-party repository
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "TPR026: Try removing one valid bundle from a third party repo and one invalid" {
+
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo1/foo/file_1
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$STATEDIR"/3rd_party/test-repo1/bundles/test-bundle1
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS test-bundle1 upstream-bundle"
+
+	assert_status_is "$SWUPD_INVALID_BUNDLE"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle1 in the 3rd-party repositories...
+		Bundle test-bundle1 found in 3rd-party repository test-repo1
+		The following bundles are being removed:
+		 - test-bundle1
+		Deleting bundle files...
+		Total deleted files: 3
+		Successfully removed 1 bundle
+		Searching for bundle upstream-bundle in the 3rd-party repositories...
+		Error: bundle upstream-bundle was not found in any 3rd-party repository
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo1/foo/file_1
+	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$STATEDIR"/3rd_party/test-repo1/bundles/test-bundle1
+
+	# run the same scenario with the arguments switched
+	install_bundle "$TEST_NAME"/3rd_party/test-repo1/10/Manifest.test-bundle1 test-repo1
+	clean_state_dir "$TEST_NAME" test-repo1
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo1/foo/file_1
+	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo1/usr/share/clear/bundles/test-bundle1
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS upstream-bundle test-bundle1"
+
+	assert_status_is "$SWUPD_INVALID_BUNDLE"
+	expected_output=$(cat <<-EOM
+		Searching for bundle upstream-bundle in the 3rd-party repositories...
+		Error: bundle upstream-bundle was not found in any 3rd-party repository
+		Searching for bundle test-bundle1 in the 3rd-party repositories...
+		Bundle test-bundle1 found in 3rd-party repository test-repo1
+		The following bundles are being removed:
+		 - test-bundle1
+		Deleting bundle files...
+		Total deleted files: 3
+		Successfully removed 1 bundle
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo1/foo/file_1
+	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo1/usr/share/clear/bundles/test-bundle1
+
+}

--- a/test/functional/3rd-party/3rd-party-bundle-remove-multi-repo.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-multi-repo.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -n upstream-bundle -f /upstream_file "$TEST_NAME"
+
+	# create a couple 3rd-party repos within the test environment and add
+	# some bundles to them
+	add_third_party_repo "$TEST_NAME" 10 1 test-repo1
+	create_bundle -L -n test-bundle1 -f /foo/file_1 -u test-repo1 "$TEST_NAME"
+
+	add_third_party_repo "$TEST_NAME" 10 1 test-repo2
+	create_bundle -L -t -n test-bundle1 -f /foo/file_2 -u test-repo2 "$TEST_NAME"
+	create_bundle -L    -n test-bundle2 -f /bar/file_3 -u test-repo2 "$TEST_NAME"
+	add_dependency_to_manifest "$TEST_NAME"/3rd_party/test-repo2/10/Manifest.test-bundle1 test-bundle2
+
+}
+
+@test "TPR027: Try removing a bundle that exists in many third party repos" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS test-bundle1"
+
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle1 in the 3rd-party repositories...
+		Bundle test-bundle1 found in 3rd-party repository test-repo1
+		Bundle test-bundle1 found in 3rd-party repository test-repo2
+		Error: bundle test-bundle1 was found in more than one 3rd-party repository
+		Please specify a repository using the --repo flag
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "TPR028: Removing a bundle that exists in many third party repos specifying the repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS test-bundle1 --repo test-repo2"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		The following bundles are being removed:
+		 - test-bundle1
+		Deleting bundle files...
+		Total deleted files: 3
+		Successfully removed 1 bundle
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "TPR029: Removing a bundle and its dependencies specifying the repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS test-bundle1 --repo test-repo2 --recursive"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Warning: The --recursive option was used, the specified bundle and its dependencies will be removed from the system
+		The following bundles are being removed:
+		 - test-bundle1
+		 - test-bundle2
+		Deleting bundle files...
+		Total deleted files: 6
+		Successfully removed 1 bundle
+		1 bundle that was installed as a dependency was removed
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "TPR030: Removing a bundle and all bundles that depend on it specifying the repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS test-bundle2 --repo test-repo2 --force"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Warning: The --force option was used, the specified bundle and all bundles that require it will be removed from the system
+		Bundle "test-bundle2" is required by the following bundles:
+		 - test-bundle1
+		The following bundles are being removed:
+		 - test-bundle2
+		 - test-bundle1
+		Deleting bundle files...
+		Total deleted files: 6
+		Successfully removed 1 bundle
+		1 bundle that depended on the specified bundle(s) was removed
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}


### PR DESCRIPTION
Implementing the 3rd-party bundle-remove command

This PR adds the ability to remove 3rd-party bundles. If a repo is not specified the bundle will be searched for in all repositories. All options from the normal bundle-remove command are supported with 3rd-party bundles.

**Note:** This PR is built on top of these PRs: #1216, #1225, #1226 and #1227, so they need to be reviewed first (in that order).