### PR TITLE
Implementation of 3rd-party bundle-info command

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,6 +34,7 @@ AM_CPPFLAGS = $(AM_CFLAGS) $(libarchive_CFLAGS)
 swupd_SOURCES = \
 	src/3rd_party_add.c \
 	src/3rd_party_bundle_add.c \
+	src/3rd_party_bundle_info.c \
 	src/3rd_party_bundle_list.c \
 	src/3rd_party_bundle_remove.c \
 	src/3rd_party.c \

--- a/scripts/flag_validator.bash
+++ b/scripts/flag_validator.bash
@@ -5,7 +5,7 @@ SWUPD_DIR="$SCRIPTS_DIR"/..
 SWUPD="$SWUPD_DIR"/swupd
 
 swupd_commands=(info autoupdate check-update update bundle-add bundle-remove bundle-list bundle-info search-file diagnose repair os-install mirror clean hashdump 3rd-party)
-third_party_commands=(bundle-add bundle-remove bundle-list)
+third_party_commands=(bundle-add bundle-remove bundle-list bundle-info)
 conflict=0
 
 count_global_flags() {

--- a/src/3rd_party.c
+++ b/src/3rd_party.c
@@ -31,6 +31,7 @@ static struct subcmd third_party_commands[] = {
 	{ "bundle-add", "Install a bundle from a third party repository", third_party_bundle_add_main },
 	{ "bundle-remove", "Remove a bundle from a third party repository", third_party_bundle_remove_main },
 	{ "bundle-list", "List bundles from a third party repository", third_party_bundle_list_main },
+	{ "bundle-info", "Display information about a bundle in a third party repository", third_party_bundle_info_main },
 	{ 0 }
 };
 

--- a/src/3rd_party_bundle_info.c
+++ b/src/3rd_party_bundle_info.c
@@ -1,0 +1,156 @@
+/*/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2019 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define _GNU_SOURCE
+
+#include "3rd_party_repos.h"
+#include "swupd.h"
+
+#ifdef THIRDPARTY
+
+#define FLAG_DEPENDENCIES 2000
+#define FLAG_FILES 2001
+
+static bool cmdline_option_dependencies = false;
+static bool cmdline_option_files = false;
+static int cmdline_option_version = 0;
+static char *cmdline_option_repo = NULL;
+static char *cmdline_option_bundle = NULL;
+
+static void print_help(void)
+{
+	print("Usage:\n");
+	print("   swupd 3rd-party bundle-info [OPTIONS...] BUNDLE\n\n");
+
+	global_print_help();
+
+	print("Options:\n");
+	print("   -R, --repo       Specify the 3rd-party repository to use\n");
+	print("   -V, --version=V  Show the bundle info for the specified version V (current by default), also accepts 'latest'\n");
+	print("   --dependencies   Show the bundle dependencies\n");
+	print("   --files          Show the files installed by this bundle\n");
+	print("\n");
+}
+
+static const struct option prog_opts[] = {
+	{ "version", required_argument, 0, 'V' },
+	{ "dependencies", no_argument, 0, FLAG_DEPENDENCIES },
+	{ "files", no_argument, 0, FLAG_FILES },
+	{ "repo", required_argument, 0, 'R' },
+};
+
+static bool parse_opt(int opt, UNUSED_PARAM char *optarg)
+{
+	int err;
+
+	switch (opt) {
+	case 'V':
+		if (strcmp("latest", optarg) == 0) {
+			cmdline_option_version = -1;
+			return true;
+		}
+		err = strtoi_err(optarg, &cmdline_option_version);
+		if (err < 0 || cmdline_option_version < 0) {
+			error("Invalid --version argument: %s\n\n", optarg);
+			return false;
+		}
+		return true;
+	case FLAG_DEPENDENCIES:
+		cmdline_option_dependencies = optarg_to_bool(optarg);
+		return true;
+	case FLAG_FILES:
+		cmdline_option_files = optarg_to_bool(optarg);
+		return true;
+	case 'R':
+		cmdline_option_repo = strdup_or_die(optarg);
+		return true;
+	default:
+		return false;
+	}
+	return false;
+}
+
+static const struct global_options opts = {
+	prog_opts,
+	sizeof(prog_opts) / sizeof(struct option),
+	parse_opt,
+	print_help,
+};
+
+static bool parse_options(int argc, char **argv)
+{
+	int ind = global_parse_options(argc, argv, &opts);
+
+	if (ind < 0) {
+		return false;
+	}
+
+	if (argc <= optind) {
+		error("Please specify the bundle you wish to display information from\n\n");
+		return false;
+	}
+
+	if (optind + 1 < argc) {
+		error("Please specify only one bundle at a time\n\n");
+		return false;
+	}
+
+	cmdline_option_bundle = *(argv + optind);
+
+	return true;
+}
+
+enum swupd_code third_party_bundle_info_main(int argc, char **argv)
+{
+	struct list *bundles = NULL;
+	enum swupd_code ret_code = SWUPD_OK;
+	const int steps_in_bundleinfo = 1;
+
+	/* there is no need to report in progress for bundle-info at this time */
+
+	if (!parse_options(argc, argv)) {
+		print_help();
+		return SWUPD_INVALID_OPTION;
+	}
+	progress_init_steps("3rd-party-bundle-info", steps_in_bundleinfo);
+
+	ret_code = swupd_init(SWUPD_ALL);
+	if (ret_code != SWUPD_OK) {
+		error("Failed swupd initialization, exiting now\n");
+		goto exit;
+	}
+
+	/* set the command options */
+	bundle_info_set_option_version(cmdline_option_version);
+	bundle_info_set_option_dependencies(cmdline_option_dependencies);
+	bundle_info_set_option_files(cmdline_option_files);
+
+	bundles = list_append_data(bundles, cmdline_option_bundle);
+	ret_code = third_party_run_operation(bundles, cmdline_option_repo, bundle_info);
+
+	list_free_list(bundles);
+	swupd_deinit();
+
+exit:
+	progress_finish_steps(ret_code);
+
+	return ret_code;
+}
+
+#endif

--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -282,7 +282,7 @@ static enum swupd_code third_party_find_bundle(const char *bundle, struct list *
 		/* load the repo's MoM*/
 		mom = load_mom(version, false, NULL);
 		if (!mom) {
-			error("Cannot load manifest MoM for 3rd-party repository %s version %i\n", repo->name, version);
+			error("Cannot load manifest MoM for 3rd-party repository %s version %i\n\n", repo->name, version);
 			ret_code = SWUPD_COULDNT_LOAD_MOM;
 			goto clean_and_exit;
 		}

--- a/src/bundle_info.c
+++ b/src/bundle_info.c
@@ -31,8 +31,22 @@
 static bool cmdline_option_dependencies = false;
 static bool cmdline_option_files = false;
 static int cmdline_option_version = 0;
-
 static char *bundle;
+
+void bundle_info_set_option_version(int opt)
+{
+	cmdline_option_version = opt;
+}
+
+void bundle_info_set_option_dependencies(bool opt)
+{
+	cmdline_option_dependencies = opt;
+}
+
+void bundle_info_set_option_files(bool opt)
+{
+	cmdline_option_files = opt;
+}
 
 static void print_help(void)
 {
@@ -236,7 +250,7 @@ static enum swupd_code get_bundle_files(struct manifest *manifest, struct manife
 	return SWUPD_OK;
 }
 
-static enum swupd_code get_bundle_dependencies(struct manifest *manifest, struct list *subs, struct list **indirect_includes)
+static enum swupd_code get_bundle_dependencies(struct manifest *manifest, struct list *subs, struct list **indirect_includes, const char *bundle)
 {
 	struct list *iter;
 	struct sub *sub;
@@ -265,7 +279,7 @@ static enum swupd_code get_bundle_dependencies(struct manifest *manifest, struct
 	return SWUPD_OK;
 }
 
-static enum swupd_code bundle_info(char *bundle)
+enum swupd_code bundle_info(char *bundle)
 {
 	enum swupd_code ret = SWUPD_OK;
 	int requested_version, latest_version;
@@ -400,7 +414,7 @@ static enum swupd_code bundle_info(char *bundle)
 	if (cmdline_option_dependencies) {
 
 		struct list *indirect_includes = NULL;
-		ret = get_bundle_dependencies(manifest, subs, &indirect_includes);
+		ret = get_bundle_dependencies(manifest, subs, &indirect_includes, bundle);
 		if (ret) {
 			error("Could not get all bundles included by %s\n", bundle);
 			goto clean;
@@ -445,18 +459,18 @@ enum swupd_code bundle_info_main(int argc, char **argv)
 		print_help();
 		return SWUPD_INVALID_OPTION;
 	}
-
 	progress_init_steps("bundle-info", steps_in_bundleinfo);
+
 	ret = swupd_init(SWUPD_ALL);
 	if (ret != 0) {
-		error("Failed swupd initialization. Exiting now\n");
-		ret = SWUPD_CURL_INIT_FAILED;
+		error("Failed swupd initialization, exiting now\n");
 		goto exit;
 	}
 
 	ret = bundle_info(bundle);
 
 	swupd_deinit();
+
 exit:
 	progress_finish_steps(ret);
 

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -331,6 +331,12 @@ extern enum swupd_code execute_remove_bundles(struct list *bundles);
 extern void bundle_remove_set_option_force(bool opt);
 extern void bundle_remove_set_option_recursive(bool opt);
 
+/* bundle_info.c */
+extern enum swupd_code bundle_info(char *bundle);
+extern void bundle_info_set_option_version(int opt);
+extern void bundle_info_set_option_dependencies(bool opt);
+extern void bundle_info_set_option_files(bool opt);
+
 /* verify.c */
 extern enum swupd_code execute_verify(void);
 extern void verify_set_option_download(bool opt);

--- a/src/swupd_internal.h
+++ b/src/swupd_internal.h
@@ -29,6 +29,7 @@ enum swupd_code third_party_main(int argc, char **argv);
 enum swupd_code third_party_bundle_add_main(int argc, char **argv);
 enum swupd_code third_party_bundle_list_main(int argc, char **argv);
 enum swupd_code third_party_bundle_remove_main(int argc, char **argv);
+enum swupd_code third_party_bundle_info_main(int argc, char **argv);
 
 /**
  * @brief Creates a new third-party repo under THIRDPARTY_REPO_PREFIX

--- a/swupd.bash
+++ b/swupd.bash
@@ -84,7 +84,7 @@ _swupd()
 		opts="$global --version --manifest --fix --picky --picky-tree --picky-whitelist --install --quick --force --install "
 		break;;
 		("3rd-party")
-		opts="$global add remove list bundle-add bundle-list bundle-remove "
+		opts="$global add remove list bundle-add bundle-list bundle-remove bundle-info "
 		break;;
 		("add")
 		opts="$global --repo"
@@ -128,6 +128,11 @@ _swupd()
 		fi
 		;;
 		("bundle-list")
+		if [ "${COMP_WORDS[$i - 1]}" = "3rd-party" ]; then
+			opts+="--repo"
+		fi
+		;;
+		("bundle-info")
 		if [ "${COMP_WORDS[$i - 1]}" = "3rd-party" ]; then
 			opts+="--repo"
 		fi

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -192,6 +192,7 @@ if [[ -n "$state" ]]; then
           '(help)add[Add third party repo]'
           '(help)bundle-add[Install a bundle from a third party repository]'
           '(help)bundle-list[List bundles from a third party repository]'
+          '(help)bundle-info[Display information about a bundle in a third party repository]'
           _arguments $thirdparty && ret=0
           ;;
           add)

--- a/test/functional/3rd-party/3rd-party-bundle-info-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-info-basic.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n test-bundle-upstream -f /file_upstream "$TEST_NAME"
+
+	# create a couple of 3rd-party repos with bundles
+	add_third_party_repo "$TEST_NAME" 10 staging repo1
+	create_bundle    -n test-bundle1 -f /foo/file_1A -u repo1 "$TEST_NAME"
+	create_bundle -L -n test-bundle2 -f /bar/file_2  -u repo1 "$TEST_NAME"
+	add_dependency_to_manifest "$TEST_NAME"/3rd_party/repo1/10/Manifest.test-bundle2 test-bundle1
+
+	add_third_party_repo "$TEST_NAME" 10 staging repo2
+	create_bundle    -n test-bundle1 -f /baz/file_1B -u repo2 "$TEST_NAME"
+	create_bundle    -n test-bundle3 -f /baz/file_3  -u repo2 "$TEST_NAME"
+
+}
+
+test_setup() {
+
+	return
+
+}
+
+test_teardown() {
+
+	return
+}
+
+global_teardown() {
+
+	destroy_test_environment "$TEST_NAME"
+
+}
+
+@test "TPR031: Show info about a 3rd-party bundle installed in the system" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-info $SWUPD_OPTS test-bundle2"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle2 in the 3rd-party repositories...
+		Bundle test-bundle2 found in 3rd-party repository repo1
+		_______________________________
+		 Info for bundle: test-bundle2
+		_______________________________
+		Status: Installed
+		Bundle test-bundle2 is up to date:
+		 - Installed bundle last updated in version: 10
+		 - Latest available version: 10
+		Bundle size:
+		 - Size of bundle: .* KB
+		 - Size bundle takes on disk \(includes dependencies\): .* KB
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}
+
+@test "TPR032: Show info about a 3rd-party bundle not installed in the system" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-info $SWUPD_OPTS test-bundle3"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle3 in the 3rd-party repositories...
+		Bundle test-bundle3 found in 3rd-party repository repo2
+		_______________________________
+		 Info for bundle: test-bundle3
+		_______________________________
+		Status: Not installed
+		Latest available version: 10
+		Bundle size:
+		 - Size of bundle: .* KB
+		 - Maximum amount of disk size the bundle will take if installed \(includes dependencies\): .* KB
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}
+
+@test "TPR033: Show info about a 3rd-party bundle displaying its dependencies and files" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-info $SWUPD_OPTS test-bundle2 --files --dependencies"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle2 in the 3rd-party repositories...
+		Bundle test-bundle2 found in 3rd-party repository repo1
+		_______________________________
+		 Info for bundle: test-bundle2
+		_______________________________
+		Status: Installed
+		Bundle test-bundle2 is up to date:
+		 - Installed bundle last updated in version: 10
+		 - Latest available version: 10
+		Bundle size:
+		 - Size of bundle: .* KB
+		 - Size bundle takes on disk \(includes dependencies\): .* KB
+		Direct dependencies \(1\):
+		 - test-bundle1
+		Files in bundle \(includes dependencies\):
+		 - /bar
+		 - /bar/file_2
+		 - /foo
+		 - /foo/file_1A
+		 - /usr
+		 - /usr/share
+		 - /usr/share/clear
+		 - /usr/share/clear/bundles
+		 - /usr/share/clear/bundles/test-bundle1
+		 - /usr/share/clear/bundles/test-bundle2
+		Total files: 10
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}
+
+@test "TPR034: Try showing info about a 3rd-party bundle that exists in many third party repos" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-info $SWUPD_OPTS test-bundle1"
+
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle1 in the 3rd-party repositories...
+		Bundle test-bundle1 found in 3rd-party repository repo1
+		Bundle test-bundle1 found in 3rd-party repository repo2
+		Error: bundle test-bundle1 was found in more than one 3rd-party repository
+		Please specify a repository using the --repo flag
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}
+
+@test "TPR035: Show info about a 3rd-party bundle from a specific repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-info $SWUPD_OPTS test-bundle1 --repo repo2"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		_______________________________
+		 Info for bundle: test-bundle1
+		_______________________________
+		Status: Not installed
+		Latest available version: 10
+		Bundle size:
+		 - Size of bundle: .* KB
+		 - Maximum amount of disk size the bundle will take if installed \(includes dependencies\): .* KB
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}

--- a/test/functional/bundleinfo/bundle-info-basic.bats
+++ b/test/functional/bundleinfo/bundle-info-basic.bats
@@ -136,7 +136,7 @@ global_teardown() {
 
 }
 
-@test "BIN005: Try fo show nfo about an invalid bundle" {
+@test "BIN005: Try to show info about an invalid bundle" {
 
 	run sudo sh -c "$SWUPD bundle-info $SWUPD_OPTS bad-bundle"
 


### PR DESCRIPTION
This commit adds a new "3rd-party bundle-info" command which can be used to show information about a bundle from a 3rd-party repository. If no 3rd-party repository is specified, the bundle is searched for in all available repositories.

This PR is built on top of #1227 and has to be reviewed first.