### PR TITLE
Removing superseded commands from the help menu

### DIFF
--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -561,10 +561,6 @@ SUBCOMMANDS
 
         Update to a specific version, also accepts 'latest' (default).
 
-    - `-m, --manifest`
-
-        Update to a specific version. This flag has been superseded. Please use -V instead.
-
     - `-s, --status`
 
         Do not perform an update, instead display whether an update is
@@ -595,102 +591,6 @@ SUBCOMMANDS
 
         Update the index used by search-file to speed up searches. Don't
         enable this if you have download or space restrictions.
-
-``verify``
-
-    Perform system software installation verification. The program will
-    obtain all the manifests needed from version url and content url to
-    establish whether the system software is correctly installed and not
-    overwritten, modified, missing or otherwise incorrect (permissions, etc.).
-
-    After obtaining the proper resources, all files that are under
-    control of the software update program are verified according to the
-    manifest data.
-
-    NOTE: This command has been superseded, please consider using "swupd diagnose"
-    instead.
-
-    - `-V, --version`
-
-        Verify against a specific version.
-
-    - `-m, --manifest`
-
-        Verify against a specific version. This flag has been superseded. Please use -V instead.
-
-    - `-f, --fix`
-
-        Correct any issues found. This will overwrite incorrect file
-        content, add missing files and do additional corrections, permissions
-        etc.  This option has been superseded, please consider using
-        "swupd repair" instead.
-
-    - `-Y, --picky`
-
-        Also List files which should not exist. Only files listed in the
-        manifests should exist. If the flag is used along with --fix, it
-        removes these files.
-
-    - `-X, --picky-tree=[PATH]`
-
-        Selects the sub-tree where --picky looks for extra files. To be
-        specified as absolute path. The default is `/usr`.
-
-    - `-w, --picky-whitelist=[RE]`
-
-        Any path matching the POSIX extended regular expression is
-        ignored by --picky. The given expression is always wrapped
-        in ``^(`` and ``)$`` and thus has to match the entire path.
-        Matched directories get skipped completely.
-
-        The default is to ignore ``/usr/lib/kernel``,
-        ``/usr/lib/modules``, ``/usr/src`` and ``/usr/local``.
-
-        Examples:
-
-        - ``/var|/etc/machine-id``
-
-            Ignores ``/var`` or ``/etc/machine-id``, regardless of
-            whether they are directories or something else. In the
-            usual case that ``/var`` is a directory, also everything
-            inside it is ignored because the directory gets skipped
-            while scanning the directory tree.
-
-        - empty string or ``^$``
-
-            Matches nothing, because paths are never empty.
-
-    - `-i, --install`
-
-        Install all files into {path} as specified by the `--path={path}`
-        option. Useful to generate a new system root, or verify side
-        by side. This option has been superseded, please consider using
-        "swupd os-install" instead.
-
-    - `-q, --quick`
-
-        Omit checking hash values. Instead only looks for missing files
-        and directories and/or symlinks.
-
-    - `-x, --force`
-
-        Attempt to proceed even if non-critical errors found.
-
-    - `-B, --bundles=[BUNDLES]`
-
-        Forces swupd to only consider the (comma separated) list of BUNDLES for
-        verify.
-
-        Examples:
-
-        - ``--bundles os-core,vi``
-
-            Only runs the verify operation on the os-core and vi bundles.
-
-    - `--extra-files-only`
-
-        Like --picky, but it only removes extra files. It omits checking
-        hash values, and for missing files, directories and/or symlinks.
 
 
 FILES

--- a/src/main.c
+++ b/src/main.c
@@ -41,8 +41,6 @@ static enum swupd_code external_search_main(int argc, char **argv)
 	return ret;
 }
 
-// TODO(castulo): remove the superseded command from the help menu by end of November 2019,
-// so it is not visible but the command must remain available in the back so we don't break users
 static struct subcmd main_commands[] = {
 	{ "info", "Show the version and the update URLs", info_main },
 	{ "autoupdate", "Enable/disable automatic system updates", autoupdate_main },
@@ -88,7 +86,11 @@ static void print_help(const char *name)
 	struct subcmd *entry = main_commands;
 
 	while (entry->name != NULL) {
-		print("   %-20s    %-30s\n", entry->name, entry->doc);
+		if (strcmp(entry->name, "verify") != 0) {
+			/* this command was superseded so it won't be shown in the help menu
+			 * anymore, but it needs to continue to work due to backwards compatibility */
+			print("   %-20s    %-30s\n", entry->name, entry->doc);
+		}
 		entry++;
 	}
 	print("\n");

--- a/src/update.c
+++ b/src/update.c
@@ -652,15 +652,12 @@ static void print_help(void)
 
 	global_print_help();
 
-	// TODO(castulo): remove the superseded -m option from the help menu by end of November 2019,
-	// so it is not visible but the option must remain available in the back so we don't break users
 	print("Options:\n");
 	print("   -V, --version=V         Update to version V, also accepts 'latest' (default)\n");
 	print("   -s, --status            Show current OS version and latest version available on server. Equivalent to \"swupd check-update\"\n");
 	print("   -k, --keepcache         Do not delete the swupd state directory content after updating the system\n");
 	print("   -T, --migrate           Migrate to augmented upstream/mix content\n");
 	print("   -a, --allow-mix-collisions	Ignore and continue if custom user content conflicts with upstream provided content\n");
-	print("   -m, --manifest=V        NOTE: this flag has been superseded. Please use -V instead\n");
 	print("   --download              Download all content, but do not actually install the update\n");
 	print("   --update-search-file-index Update the index used by search-file to speed up searches (Don't enable this if you have download or space restrictions)\n");
 	print("\n");


### PR DESCRIPTION
After a grace time period, superseded or deprecated commands should be
removed from the help menu so people is not encouraged to use them. They
should continue to work though for backward compatibility.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>