### PR TITLE
Implementing the "3rd-party repair" command

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,7 @@ swupd_SOURCES = \
 	src/3rd_party_diagnose.c \
 	src/3rd_party_list.c \
 	src/3rd_party_remove.c \
+	src/3rd_party_repair.c \
 	src/3rd_party_repos.c \
 	src/3rd_party_repos.h \
 	src/3rd_party_update.c \

--- a/src/3rd_party.c
+++ b/src/3rd_party.c
@@ -34,6 +34,7 @@ static struct subcmd third_party_commands[] = {
 	{ "bundle-list", "List bundles from a third party repository", third_party_bundle_list_main },
 	{ "bundle-info", "Display information about a bundle in a third party repository", third_party_bundle_info_main },
 	{ "diagnose", "Verify content from a third party repository", third_party_diagnose_main },
+	{ "repair", "Repair local issues relative to a third party repository", third_party_repair_main },
 	{ 0 }
 };
 

--- a/src/3rd_party_repair.c
+++ b/src/3rd_party_repair.c
@@ -1,0 +1,262 @@
+/*/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2019 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define _GNU_SOURCE
+
+#include "3rd_party_repos.h"
+#include "swupd.h"
+
+#ifdef THIRDPARTY
+
+#define FLAG_EXTRA_FILES_ONLY 2000
+
+static const char picky_tree_default[] = "/usr";
+static const char picky_whitelist_default[] = "/usr/lib/modules|/usr/lib/kernel|/usr/local|/usr/src";
+
+static int cmdline_option_version = 0;
+static bool cmdline_option_force = false;
+static bool cmdline_option_quick = false;
+static bool cmdline_option_picky = false;
+static bool cmdline_option_extra_files_only = false;
+static char *cmdline_option_picky_tree = NULL;
+static char *cmdline_option_repo = NULL;
+static const char *cmdline_option_picky_whitelist = picky_whitelist_default;
+static struct list *cmdline_option_bundles = NULL;
+static regex_t *picky_whitelist;
+
+static void print_help(void)
+{
+	print("Usage:\n");
+	print("   swupd 3rd-party repair [OPTION...]\n\n");
+
+	global_print_help();
+
+	print("Options:\n");
+	print("   -R, --repo              Specify the 3rd-party repository to use\n");
+	print("   -V, --version=[VER]     Compare against version VER to repair\n");
+	print("   -x, --force             Attempt to proceed even if non-critical errors found\n");
+	print("   -q, --quick             Don't compare hashes, only fix missing files\n");
+	print("   -B, --bundles=[BUNDLES] Forces swupd to only repair the specified BUNDLES. Example: --bundles=os-core,vi\n");
+	print("   -Y, --picky             Also remove files which should not exist\n");
+	print("   -X, --picky-tree=[PATH] Selects the sub-tree where --picky and --extra-files-only  looks for extra files. Default: /usr\n");
+	print("   -w, --picky-whitelist=[RE] Directories that match the regex get skipped. Example: /var|/etc/machine-id\n");
+	print("                           Default: %s\n", picky_whitelist_default);
+	print("   --extra-files-only      Like --picky, but it only performs this task\n");
+	print("\n");
+}
+
+static const struct option prog_opts[] = {
+	{ "force", no_argument, 0, 'x' },
+	{ "version", required_argument, 0, 'V' },
+	{ "picky", no_argument, 0, 'Y' },
+	{ "picky-tree", required_argument, 0, 'X' },
+	{ "picky-whitelist", required_argument, 0, 'w' },
+	{ "quick", no_argument, 0, 'q' },
+	{ "extra-files-only", no_argument, 0, FLAG_EXTRA_FILES_ONLY },
+	{ "bundles", required_argument, 0, 'B' },
+	{ "repo", required_argument, 0, 'R' },
+};
+
+static bool parse_opt(int opt, char *optarg)
+{
+	int err;
+
+	switch (opt) {
+	case 'x':
+		cmdline_option_force = optarg_to_bool(optarg);
+		return true;
+	case 'q':
+		cmdline_option_quick = optarg_to_bool(optarg);
+		return true;
+	case 'Y':
+		cmdline_option_picky = optarg_to_bool(optarg);
+		return true;
+	case FLAG_EXTRA_FILES_ONLY:
+		cmdline_option_extra_files_only = optarg_to_bool(optarg);
+		return true;
+	case 'R':
+		cmdline_option_repo = strdup_or_die(optarg);
+		return true;
+	case 'V':
+		err = strtoi_err(optarg, &cmdline_option_version);
+		if (err < 0 || cmdline_option_version < 0) {
+			error("Invalid --version argument: %s\n\n", optarg);
+			return false;
+		}
+		return true;
+	case 'X':
+		if (optarg[0] != '/') {
+			error("--picky-tree must be an absolute path, for example /usr\n\n");
+			return false;
+		}
+		free_string(&cmdline_option_picky_tree);
+		cmdline_option_picky_tree = strdup_or_die(optarg);
+		return true;
+	case 'w':
+		cmdline_option_picky_whitelist = strdup_or_die(optarg);
+		return true;
+	case 'B':
+		/* if we are parsing a list from the command line we don't want to append it to
+		 * a possible existing list parsed from a config file, we want to replace it, so
+		 * we need to delete the existing list first */
+		list_free_list(cmdline_option_bundles);
+		cmdline_option_bundles = NULL;
+		cmdline_option_bundles = string_split(",", optarg);
+		if (!cmdline_option_bundles) {
+			error("Missing required --bundles argument\n\n");
+			return false;
+		}
+		return true;
+	default:
+		return false;
+	}
+	return false;
+}
+
+static const struct global_options opts = {
+	prog_opts,
+	sizeof(prog_opts) / sizeof(struct option),
+	parse_opt,
+	print_help,
+};
+
+static bool parse_options(int argc, char **argv)
+{
+	int ind = global_parse_options(argc, argv, &opts);
+
+	if (ind < 0) {
+		return false;
+	}
+
+	if (argc > ind) {
+		error("unexpected arguments\n\n");
+		return false;
+	}
+
+	/* flag restrictions */
+	if (cmdline_option_quick) {
+		if (cmdline_option_picky) {
+			error("--quick and --picky options are mutually exclusive\n");
+			return false;
+		}
+		if (cmdline_option_extra_files_only) {
+			error("--quick and --extra-files-only options are mutually exclusive\n");
+			return false;
+		}
+	}
+	if (cmdline_option_extra_files_only) {
+		if (cmdline_option_picky) {
+			error("--extra-files-only and --picky options are mutually exclusive\n");
+			return false;
+		}
+	}
+	if (cmdline_option_bundles) {
+		if (cmdline_option_picky) {
+			error("--bundles and --picky options are mutually exclusive\n");
+			return false;
+		}
+		if (cmdline_option_extra_files_only) {
+			error("--bundles and --extra-files-only options are mutually exclusive\n");
+			return false;
+		}
+		if (!cmdline_option_repo) {
+			error("a repository needs to be specified to use the --bundles flag\n\n");
+			return false;
+		}
+	}
+	if (cmdline_option_version > 0) {
+		if (!cmdline_option_repo) {
+			error("a repository needs to be specified to use the --version flag\n\n");
+			return false;
+		}
+	}
+
+	picky_whitelist = compile_whitelist(cmdline_option_picky_whitelist);
+	if (!picky_whitelist) {
+		return false;
+	}
+
+	return true;
+}
+
+static enum swupd_code repair_repos(UNUSED_PARAM char *unused)
+{
+	verify_set_option_version(cmdline_option_version);
+	return execute_verify();
+}
+
+enum swupd_code third_party_repair_main(int argc, char **argv)
+{
+	enum swupd_code ret_code = SWUPD_OK;
+
+	/*
+	 * Steps for repair:
+	 *
+	 *  1) load_manifests
+	 *  2) check_files_hash
+	 *  3) validate_fullfiles
+	 *  4) download_fullfiles
+	 *  5) extract_fullfiles
+	 *  6) add_missing_files
+	 *  7) fix_files
+	 *  8) remove_extraneous_files
+	 *  9) remove_extra_files
+	 */
+	const int steps_in_repair = 9;
+
+	string_or_die(&cmdline_option_picky_tree, "%s", picky_tree_default);
+
+	if (!parse_options(argc, argv)) {
+		print_help();
+		return SWUPD_INVALID_OPTION;
+	}
+
+	ret_code = swupd_init(SWUPD_ALL);
+	if (ret_code != SWUPD_OK) {
+		error("Failed swupd initialization, exiting now\n");
+		free_string(&cmdline_option_picky_tree);
+		return ret_code;
+	}
+	progress_init_steps("3rd-party-repair", steps_in_repair);
+
+	/* set the command options */
+	verify_set_option_fix(true);
+	verify_set_option_force(cmdline_option_force);
+	verify_set_option_quick(cmdline_option_quick);
+	verify_set_option_picky(cmdline_option_picky);
+	verify_set_extra_files_only(cmdline_option_extra_files_only);
+	verify_set_picky_whitelist(picky_whitelist);
+	verify_set_picky_tree(cmdline_option_picky_tree);
+	verify_set_option_bundles(cmdline_option_bundles);
+
+	/* run repair (verify --fix) */
+	ret_code = third_party_run_operation_multirepo(cmdline_option_repo, repair_repos, SWUPD_OK);
+
+	free_string(&cmdline_option_picky_tree);
+	if (picky_whitelist) {
+		regfree(picky_whitelist);
+		picky_whitelist = NULL;
+	}
+	swupd_deinit();
+	progress_finish_steps(ret_code);
+
+	return ret_code;
+}
+
+#endif

--- a/src/swupd_internal.h
+++ b/src/swupd_internal.h
@@ -32,6 +32,7 @@ enum swupd_code third_party_bundle_remove_main(int argc, char **argv);
 enum swupd_code third_party_bundle_info_main(int argc, char **argv);
 enum swupd_code thir_party_update_main(int argc, char **argv);
 enum swupd_code third_party_diagnose_main(int argc, char **argv);
+enum swupd_code third_party_repair_main(int argc, char **argv);
 
 /**
  * @brief Creates a new third-party repo under THIRDPARTY_REPO_PREFIX

--- a/swupd.bash
+++ b/swupd.bash
@@ -84,7 +84,7 @@ _swupd()
 		opts="$global --version --manifest --fix --picky --picky-tree --picky-whitelist --install --quick --force --install "
 		break;;
 		("3rd-party")
-		opts="$global add remove list bundle-add bundle-list bundle-remove bundle-info update diagnose "
+		opts="$global add remove list bundle-add bundle-list bundle-remove bundle-info update diagnose repair "
 		break;;
 		("add")
 		opts="$global --repo"
@@ -143,6 +143,11 @@ _swupd()
 		fi
 		;;
 		("diagnose")
+		if [ "${COMP_WORDS[$i - 1]}" = "3rd-party" ]; then
+			opts+="--repo"
+		fi
+		;;
+		("repair")
 		if [ "${COMP_WORDS[$i - 1]}" = "3rd-party" ]; then
 			opts+="--repo"
 		fi

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -195,6 +195,7 @@ if [[ -n "$state" ]]; then
           '(help)bundle-info[Display information about a bundle in a third party repository]'
           '(help)update[Update to latest version of a third party repository]'
           '(help)diagnose[Verify content from a third party repository]'
+          '(help)repair[Repair local issues relative to a third party repository]'
           _arguments $thirdparty && ret=0
           ;;
           add)

--- a/test/functional/3rd-party/3rd-party-repair-basic.bats
+++ b/test/functional/3rd-party/3rd-party-repair-basic.bats
@@ -1,0 +1,248 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME" 10 1
+
+	# add a 3rd-party repo with some "findings" for diagnose
+	add_third_party_repo "$TEST_NAME" 10 1 test-repo1
+	create_bundle -L -t -n test-bundle1 -f /foo/file_1,/bar/file_2 -u test-repo1 "$TEST_NAME"
+	create_version -p "$TEST_NAME" 20 10 1 test-repo1
+	update_bundle -p "$TEST_NAME" test-bundle1 --update /foo/file_1 test-repo1
+	update_bundle -p "$TEST_NAME" test-bundle1 --delete /bar/file_2 test-repo1
+	update_bundle    "$TEST_NAME" test-bundle1 --add    /baz/file_3 test-repo1
+	set_current_version "$TEST_NAME" 20 test-repo1
+
+	# add another 3rd-party repo that has nothing to get fixed
+	add_third_party_repo "$TEST_NAME" 10 1 test-repo2
+	create_bundle -L -t -n test-bundle2 -f /baz/file_3 -u test-repo2 "$TEST_NAME"
+
+	# adding an untracked files into an untracked directory (/bat)
+	sudo mkdir "$TARGETDIR"/opt/3rd_party/test-repo1/bat
+	sudo touch "$TARGETDIR"/opt/3rd_party/test-repo1/bat/untracked_file1
+	# adding an untracked file into tracked directory (/bar)
+	sudo touch "$TARGETDIR"/opt/3rd_party/test-repo1/bar/untracked_file2
+	# adding an untracked file into /usr
+	sudo touch "$TARGETDIR"/opt/3rd_party/test-repo2/usr/untracked_file3
+
+}
+
+@test "TPR048: Repair a system that has a corrupt bundles from a 3rd-party repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party repair $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		____________________________
+		 3rd-Party Repo: test-repo1
+		____________________________
+		Diagnosing version 20
+		Downloading missing manifests...
+		Checking for corrupt files
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Adding any missing files
+		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz -> fixed
+		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz/file_3 -> fixed
+		Repairing corrupt files
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/usr/lib/os-release -> fixed
+		Removing extraneous files
+		 -> File that should be deleted: $PATH_PREFIX/opt/3rd_party/test-repo1/bar/file_2 -> deleted
+		Inspected 17 files
+		  2 files were missing
+		    2 of 2 missing files were replaced
+		    0 of 2 missing files were not replaced
+		  2 files did not match
+		    2 of 2 files were repaired
+		    0 of 2 files were not repaired
+		  1 file found which should be deleted
+		    1 of 1 files were deleted
+		    0 of 1 files were not deleted
+		Calling post-update helper scripts
+		Repair successful
+		____________________________
+		 3rd-Party Repo: test-repo2
+		____________________________
+		Diagnosing version 10
+		Downloading missing manifests...
+		Checking for corrupt files
+		Adding any missing files
+		Repairing corrupt files
+		Removing extraneous files
+		Inspected 13 files
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "TPR049: Repair 3rd-party bundles from a specific repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party repair $SWUPD_OPTS --repo test-repo2"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Downloading missing manifests...
+		Checking for corrupt files
+		Adding any missing files
+		Repairing corrupt files
+		Removing extraneous files
+		Inspected 13 files
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "TPR050: Repair 3rd-party bundles to a specific version" {
+
+	run sudo sh -c "$SWUPD 3rd-party repair $SWUPD_OPTS --version 10 --force --repo test-repo1"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 10
+		Warning: The --force option is specified; ignoring version mismatch for repair
+		Downloading missing manifests...
+		Checking for corrupt files
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Adding any missing files
+		Repairing corrupt files
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/usr/lib/os-release -> fixed
+		Removing extraneous files
+		Inspected 15 files
+		  1 file did not match
+		    1 of 1 files were repaired
+		    0 of 1 files were not repaired
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "TPR051: Repair 3rd-party bundles using the picky option" {
+
+	run sudo sh -c "$SWUPD 3rd-party repair $SWUPD_OPTS --picky"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		____________________________
+		 3rd-Party Repo: test-repo1
+		____________________________
+		Diagnosing version 20
+		Downloading missing manifests...
+		Checking for corrupt files
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Adding any missing files
+		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz -> fixed
+		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz/file_3 -> fixed
+		Repairing corrupt files
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/usr/lib/os-release -> fixed
+		Removing extraneous files
+		 -> File that should be deleted: $PATH_PREFIX/opt/3rd_party/test-repo1/bar/file_2 -> deleted
+		Removing extra files under $PATH_PREFIX/opt/3rd_party/test-repo1/usr
+		Inspected 17 files
+		  2 files were missing
+		    2 of 2 missing files were replaced
+		    0 of 2 missing files were not replaced
+		  2 files did not match
+		    2 of 2 files were repaired
+		    0 of 2 files were not repaired
+		  1 file found which should be deleted
+		    1 of 1 files were deleted
+		    0 of 1 files were not deleted
+		Calling post-update helper scripts
+		Repair successful
+		____________________________
+		 3rd-Party Repo: test-repo2
+		____________________________
+		Diagnosing version 10
+		Downloading missing manifests...
+		Checking for corrupt files
+		Adding any missing files
+		Repairing corrupt files
+		Removing extraneous files
+		Removing extra files under $PATH_PREFIX/opt/3rd_party/test-repo2/usr
+		 -> Extra file: $PATH_PREFIX/opt/3rd_party/test-repo2/usr/untracked_file3 -> deleted
+		Inspected 14 files
+		  1 file found which should be deleted
+		    1 of 1 files were deleted
+		    0 of 1 files were not deleted
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "TPR052: Repair 3rd-party bundles using the picky option specifying the tree" {
+
+	run sudo sh -c "$SWUPD 3rd-party repair $SWUPD_OPTS --picky --picky-tree /bat"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		____________________________
+		 3rd-Party Repo: test-repo1
+		____________________________
+		Diagnosing version 20
+		Downloading missing manifests...
+		Checking for corrupt files
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Adding any missing files
+		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz -> fixed
+		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz/file_3 -> fixed
+		Repairing corrupt files
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/usr/lib/os-release -> fixed
+		Removing extraneous files
+		 -> File that should be deleted: $PATH_PREFIX/opt/3rd_party/test-repo1/bar/file_2 -> deleted
+		Removing extra files under $PATH_PREFIX/opt/3rd_party/test-repo1/bat
+		 -> Extra file: $PATH_PREFIX/opt/3rd_party/test-repo1/bat/untracked_file1 -> deleted
+		 -> Extra file: $PATH_PREFIX/opt/3rd_party/test-repo1/bat/ -> deleted
+		Inspected 19 files
+		  2 files were missing
+		    2 of 2 missing files were replaced
+		    0 of 2 missing files were not replaced
+		  2 files did not match
+		    2 of 2 files were repaired
+		    0 of 2 files were not repaired
+		  3 files found which should be deleted
+		    3 of 3 files were deleted
+		    0 of 3 files were not deleted
+		Calling post-update helper scripts
+		Repair successful
+		____________________________
+		 3rd-Party Repo: test-repo2
+		____________________________
+		Diagnosing version 10
+		Downloading missing manifests...
+		Checking for corrupt files
+		Adding any missing files
+		Repairing corrupt files
+		Removing extraneous files
+		Removing extra files under $PATH_PREFIX/opt/3rd_party/test-repo2/bat
+		Inspected 13 files
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}


### PR DESCRIPTION
This PR adds the ability to repair bundles from 3rd-party repos.

This PR is built on top of #1232  and has to be reviewed first.