### PR TITLE
Implementing the "3rd-party check-update" command

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,6 +38,7 @@ swupd_SOURCES = \
 	src/3rd_party_bundle_list.c \
 	src/3rd_party_bundle_remove.c \
 	src/3rd_party.c \
+	src/3rd_party_check_update.c \
 	src/3rd_party_diagnose.c \
 	src/3rd_party_list.c \
 	src/3rd_party_remove.c \

--- a/src/3rd_party.c
+++ b/src/3rd_party.c
@@ -35,6 +35,7 @@ static struct subcmd third_party_commands[] = {
 	{ "bundle-info", "Display information about a bundle in a third party repository", third_party_bundle_info_main },
 	{ "diagnose", "Verify content from a third party repository", third_party_diagnose_main },
 	{ "repair", "Repair local issues relative to a third party repository", third_party_repair_main },
+	{ "check-update", "Check if a new version of a third party repository is available", third_party_check_update_main },
 	{ 0 }
 };
 

--- a/src/3rd_party_check_update.c
+++ b/src/3rd_party_check_update.c
@@ -1,0 +1,111 @@
+/*/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2019 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define _GNU_SOURCE
+
+#include "3rd_party_repos.h"
+#include "swupd.h"
+
+#ifdef THIRDPARTY
+
+static char *cmdline_option_repo = NULL;
+
+static void print_help(void)
+{
+	print("Usage:\n");
+	print("   swupd 3rd-party check-update [OPTION...]\n\n");
+
+	global_print_help();
+
+	print("Options:\n");
+	print("   -R, --repo       Specify the 3rd-party repository to use\n");
+}
+
+static const struct option prog_opts[] = {
+	{ "repo", required_argument, 0, 'R' },
+};
+
+static bool parse_opt(int opt, char *optarg)
+{
+	switch (opt) {
+	case 'R':
+		cmdline_option_repo = strdup_or_die(optarg);
+		return true;
+	default:
+		return false;
+	}
+	return false;
+}
+
+static const struct global_options opts = {
+	prog_opts,
+	sizeof(prog_opts) / sizeof(struct option),
+	parse_opt,
+	print_help,
+};
+
+static bool parse_options(int argc, char **argv)
+{
+	int optind = global_parse_options(argc, argv, &opts);
+
+	if (optind < 0) {
+		return false;
+	}
+
+	if (argc > optind) {
+		error("unexpected arguments\n\n");
+		return false;
+	}
+
+	return true;
+}
+
+static enum swupd_code check_update_repo(UNUSED_PARAM char *unused)
+{
+	return check_update();
+}
+
+enum swupd_code third_party_check_update_main(int argc, char **argv)
+{
+	enum swupd_code ret_code = SWUPD_OK;
+	const int steps_in_checkupdate = 1;
+
+	/* there is no need to report in progress for check-update at this time */
+
+	if (!parse_options(argc, argv)) {
+		print_help();
+		return SWUPD_INVALID_OPTION;
+	}
+
+	ret_code = swupd_init(SWUPD_NO_ROOT);
+	if (ret_code != SWUPD_OK) {
+		return ret_code;
+	}
+	progress_init_steps("3rd-party-check-update", steps_in_checkupdate);
+
+	/* run check-update */
+	ret_code = third_party_run_operation_multirepo(cmdline_option_repo, check_update_repo, SWUPD_NO);
+
+	swupd_deinit();
+	progress_finish_steps(ret_code);
+
+	return ret_code;
+}
+
+#endif

--- a/src/swupd_internal.h
+++ b/src/swupd_internal.h
@@ -33,6 +33,7 @@ enum swupd_code third_party_bundle_info_main(int argc, char **argv);
 enum swupd_code thir_party_update_main(int argc, char **argv);
 enum swupd_code third_party_diagnose_main(int argc, char **argv);
 enum swupd_code third_party_repair_main(int argc, char **argv);
+enum swupd_code third_party_check_update_main(int argc, char **argv);
 
 /**
  * @brief Creates a new third-party repo under THIRDPARTY_REPO_PREFIX

--- a/swupd.bash
+++ b/swupd.bash
@@ -84,7 +84,7 @@ _swupd()
 		opts="$global --version --manifest --fix --picky --picky-tree --picky-whitelist --install --quick --force --install "
 		break;;
 		("3rd-party")
-		opts="$global add remove list bundle-add bundle-list bundle-remove bundle-info update diagnose repair "
+		opts="$global add remove list bundle-add bundle-list bundle-remove bundle-info update diagnose repair check-update "
 		break;;
 		("add")
 		opts="$global --repo"
@@ -148,6 +148,11 @@ _swupd()
 		fi
 		;;
 		("repair")
+		if [ "${COMP_WORDS[$i - 1]}" = "3rd-party" ]; then
+			opts+="--repo"
+		fi
+		;;
+		("check-update")
 		if [ "${COMP_WORDS[$i - 1]}" = "3rd-party" ]; then
 			opts+="--repo"
 		fi

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -196,6 +196,7 @@ if [[ -n "$state" ]]; then
           '(help)update[Update to latest version of a third party repository]'
           '(help)diagnose[Verify content from a third party repository]'
           '(help)repair[Repair local issues relative to a third party repository]'
+          '(help)check-update[Check if a new version of a third party repository is available]'
           _arguments $thirdparty && ret=0
           ;;
           add)

--- a/test/functional/3rd-party/3rd-party-check_update_basic.bats
+++ b/test/functional/3rd-party/3rd-party-check_update_basic.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+
+	# create a couple of 3rd-party repos with bundles
+	add_third_party_repo "$TEST_NAME" 10 staging test-repo1
+	create_bundle -L -t -n test-bundle1 -f /foo/file_1 -u test-repo1 "$TEST_NAME"
+	create_version -p "$TEST_NAME" 20 10 staging test-repo1
+	update_bundle "$TEST_NAME" test-bundle1 --update /foo/file_1 test-repo1
+
+	add_third_party_repo "$TEST_NAME" 10 staging test-repo2
+	create_bundle -L -t -n test-bundle2 -f /bar/file_2 -u test-repo2 "$TEST_NAME"
+
+}
+
+test_setup() {
+
+	return
+
+}
+
+test_teardown() {
+
+	return
+}
+
+global_teardown() {
+
+	destroy_test_environment "$TEST_NAME"
+
+}
+
+@test "TPR053: Check for available updates on third party repos" {
+
+	run sudo sh -c "$SWUPD 3rd-party check-update $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		____________________________
+		 3rd-Party Repo: test-repo1
+		____________________________
+
+		Current OS version: 10
+		Latest server version: 20
+		There is a new OS version available: 20
+
+
+		____________________________
+		 3rd-Party Repo: test-repo2
+		____________________________
+
+		Current OS version: 10
+		Latest server version: 10
+		There are no updates available
+	EOM
+	)
+	assert_is_output --identical "$expected_output"
+
+}
+
+@test "TPR054: Check for available updates on a specific third party repo that has updates" {
+
+	run sudo sh -c "$SWUPD 3rd-party check-update $SWUPD_OPTS --repo test-repo1"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Current OS version: 10
+		Latest server version: 20
+		There is a new OS version available: 20
+	EOM
+	)
+	assert_is_output --identical "$expected_output"
+
+}
+
+@test "TPR055: Check for available updates on a specific third party repo that doesn't have updates" {
+
+	run sudo sh -c "$SWUPD 3rd-party check-update $SWUPD_OPTS --repo test-repo2"
+
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Current OS version: 10
+		Latest server version: 10
+		There are no updates available
+	EOM
+	)
+	assert_is_output --identical "$expected_output"
+
+}


### PR DESCRIPTION
This PR adds the ability to check for updates on 3rd-party repos.

This PR is built on top of #1232 and #1233 and have to be reviewed first.