### PR TITLE
3rd party housekeeping

### DIFF
--- a/config
+++ b/config
@@ -198,6 +198,22 @@
 #has_dep=[BUNDLE]
 
 
+[bundle-info]
+
+#
+# Options for the "swupd bundle-info" command
+#
+
+# Show the bundle info for the specified version (integer value)
+#version=[VER]
+
+# Show the bundle dependencies as part of the information displayed (boolean value)
+#dependencies=<true/false>
+
+# Show the bundle files as part of the information displayed (boolean value)
+#files=<true/false>
+
+
 [search-file]
 
 #
@@ -237,6 +253,9 @@
 # Attempt to proceed even if non-critical errors found (boolean value)
 #force=<true/false>
 
+# Don't check for corrupt files, only find missing files (boolean value)
+#quick=<true/false>
+
 # List files which should not exist (boolean value)
 #picky=<true/false>
 
@@ -254,7 +273,7 @@
 # Example: --bundles=os-core,vi
 #bundles=[BUNDLES]
 
-# Like --picky, but it only searches for extra files
+# Like --picky, but it only searches for extra files (boolean value)
 #extra_files_only=<true/false>
 
 
@@ -291,7 +310,7 @@
 # Default: /usr/lib/modules|/usr/lib/kernel|/usr/local|/usr/src
 #picky_whitelist=[RE]
 
-# Like --picky, but it only removes extra files
+# Like --picky, but it only removes extra files (boolean value)
 #extra_files_only=<true/false>
 
 
@@ -349,6 +368,9 @@
 # Options for the "swupd 3rd-party bundle-add" command
 #
 
+# Specify the 3rd-party repository to use (string value)
+#repo=[REPOSITORY]
+
 # Do not check free disk space before adding bundle (boolean value)
 #skip_diskspace_check=<true/false>
 
@@ -356,11 +378,30 @@
 #skip_optional=<true/false>
 
 
+[3rd-party-bundle-remove]
+
+#
+# Options for the "swupd 3rd-party bundle-remove" command
+#
+
+# Specify the 3rd-party repository to use (string value)
+#repo=[REPOSITORY]
+
+# Removes a bundle along with all the bundles that depend on it (boolean value)
+#force=<true/false>
+
+# Removes a bundle and its dependencies recursively (boolean value)
+#recursive=<true/false>
+
+
 [3rd-party-bundle-list]
 
 #
 # Options for the "swupd 3rd-party bundle-list" command
 #
+
+# Specify the 3rd-party repository to use (string value)
+#repo=[REPOSITORY]
 
 # List all available bundles for the current version of Clear
 # Linux (boolean value)
@@ -372,3 +413,111 @@
 # List dependency tree of all bundles which have BUNDLE as a
 # dependency (string value)
 #has_dep=[BUNDLE]
+
+
+[3rd-party-bundle-info]
+
+#
+# Options for the "swupd 3rd-party bundle-info" command
+#
+
+# Specify the 3rd-party repository to use (string value)
+#repo=[REPOSITORY]
+
+# Show the bundle info for the specified version (integer value)
+#version=[VER]
+
+# Show the bundle dependencies as part of the information displayed (boolean value)
+#dependencies=<true/false>
+
+# Show the bundle files as part of the information displayed (boolean value)
+#files=<true/false>
+
+
+[3rd-party-diagnose]
+
+#
+# Options for the "swupd 3rd-party diagnose" command
+#
+
+# Specify the 3rd-party repository to use (string value)
+#repo=[REPOSITORY]
+
+# Diagnose the system against manifest version V (integer value)
+#version=[VER]
+
+# Attempt to proceed even if non-critical errors found (boolean value)
+#force=<true/false>
+
+# Don't check for corrupt files, only find missing files (boolean value)
+#quick=<true/false>
+
+# List files which should not exist (boolean value)
+#picky=<true/false>
+
+# Selects the sub-tree where --picky looks for extra files (string value)
+# Default: /usr (string value)
+#picky_tree=[PATH]
+
+# Any path completely matching the POSIX extended regular expression is ignored
+# by --picky, matched directories get skipped (string value)
+# Example: /var|/etc/machine-id
+# Default: /usr/lib/modules|/usr/lib/kernel|/usr/local|/usr/src
+#picky_whitelist=[RE]
+
+# Diagnose if BUNDLES are installed correctly (string value)
+# Example: --bundles=os-core,vi
+#bundles=[BUNDLES]
+
+# Like --picky, but it only searches for extra files (boolean value)
+#extra_files_only=<true/false>
+
+
+[3rd-party-repair]
+
+#
+# Options for the "swupd 3rd-party repair" command
+#
+
+# Specify the 3rd-party repository to use (string value)
+#repo=[REPOSITORY]
+
+# Compare against version V to determine what needs to be
+# repaired (integer value)
+#version=[VER]
+
+# Attempt to proceed even if non-critical errors found (boolean value)
+#force=<true/false>
+
+# Don't fix corrupt files, only fix missing files (boolean value)
+#quick=<true/false>
+
+# Repair BUNDLES that are not installed correctly (string value)
+# Example: --bundles=os-core,vi
+#bundles=[BUNDLES]
+
+# Remove files which should not exist (boolean value)
+#picky=<true/false>
+
+# Selects the sub-tree where --picky looks for extra files (string value)
+# Default: /usr
+#picky_tree=[PATH]
+
+# Any path completely matching the POSIX extended regular expression is ignored
+# by --picky, matched directories get skipped (string value)
+# Example: /var|/etc/machine-id
+# Default: /usr/lib/modules|/usr/lib/kernel|/usr/local|/usr/src
+#picky_whitelist=[RE]
+
+# Like --picky, but it only removes extra files (boolean value)
+#extra_files_only=<true/false>
+
+
+[3rd-party-check-update]
+
+#
+# Options for the "swupd 3rd-party check-update" command
+#
+
+# Specify the 3rd-party repository to use (string value)
+#repo=[REPOSITORY]

--- a/scripts/flag_validator.bash
+++ b/scripts/flag_validator.bash
@@ -5,7 +5,7 @@ SWUPD_DIR="$SCRIPTS_DIR"/..
 SWUPD="$SWUPD_DIR"/swupd
 
 swupd_commands=(info autoupdate check-update update bundle-add bundle-remove bundle-list bundle-info search-file diagnose repair os-install mirror clean hashdump 3rd-party)
-third_party_commands=(bundle-add bundle-remove bundle-list bundle-info update diagnose)
+third_party_commands=(add remove list bundle-add bundle-remove bundle-list bundle-info update diagnose repair check-update)
 conflict=0
 
 count_global_flags() {

--- a/src/3rd_party.c
+++ b/src/3rd_party.c
@@ -28,7 +28,7 @@ static struct subcmd third_party_commands[] = {
 	{ "add", "Add third party repository", third_party_add_main },
 	{ "remove", "Remove third party repository", third_party_remove_main },
 	{ "list", "List third party repository", third_party_list_main },
-	{ "update", "Update to latest version of a third party repository", thir_party_update_main },
+	{ "update", "Update to latest version of a third party repository", third_party_update_main },
 	{ "bundle-add", "Install a bundle from a third party repository", third_party_bundle_add_main },
 	{ "bundle-remove", "Remove a bundle from a third party repository", third_party_bundle_remove_main },
 	{ "bundle-list", "List bundles from a third party repository", third_party_bundle_list_main },

--- a/src/3rd_party_bundle_add.c
+++ b/src/3rd_party_bundle_add.c
@@ -38,7 +38,7 @@ static void print_help(void)
 	global_print_help();
 
 	print("Options:\n");
-	print("   -R, --repo              Specify the 3rd-party repo to use\n");
+	print("   -R, --repo              Specify the 3rd-party repository to use\n");
 	print("   --skip-optional         Do not install optional bundles (also-add flag in Manifests)\n");
 	print("   --skip-diskspace-check  Do not check free disk space before adding bundle\n");
 	print("\n");
@@ -133,7 +133,6 @@ enum swupd_code third_party_bundle_add_main(int argc, char **argv)
 		print_help();
 		return SWUPD_INVALID_OPTION;
 	}
-	progress_init_steps("3rd-party-bundle-add", steps_in_bundleadd);
 
 	/* initialize swupd */
 	ret_code = swupd_init(SWUPD_ALL);
@@ -141,6 +140,7 @@ enum swupd_code third_party_bundle_add_main(int argc, char **argv)
 		error("Failed swupd initialization, exiting now\n");
 		return ret_code;
 	}
+	progress_init_steps("3rd-party-bundle-add", steps_in_bundleadd);
 
 	/* move the bundles provided in the command line into a
 	 * list so it is easier to handle them */

--- a/src/3rd_party_bundle_info.c
+++ b/src/3rd_party_bundle_info.c
@@ -128,13 +128,13 @@ enum swupd_code third_party_bundle_info_main(int argc, char **argv)
 		print_help();
 		return SWUPD_INVALID_OPTION;
 	}
-	progress_init_steps("3rd-party-bundle-info", steps_in_bundleinfo);
 
 	ret_code = swupd_init(SWUPD_ALL);
 	if (ret_code != SWUPD_OK) {
 		error("Failed swupd initialization, exiting now\n");
-		goto exit;
+		return ret_code;
 	}
+	progress_init_steps("3rd-party-bundle-info", steps_in_bundleinfo);
 
 	/* set the command options */
 	bundle_info_set_option_version(cmdline_option_version);
@@ -146,8 +146,6 @@ enum swupd_code third_party_bundle_info_main(int argc, char **argv)
 
 	list_free_list(bundles);
 	swupd_deinit();
-
-exit:
 	progress_finish_steps(ret_code);
 
 	return ret_code;

--- a/src/3rd_party_bundle_list.c
+++ b/src/3rd_party_bundle_list.c
@@ -50,7 +50,7 @@ static void print_help(void)
 	global_print_help();
 
 	print("Options:\n");
-	print("   -R, --repo              Specify the 3rd-party repo to use\n");
+	print("   -R, --repo              Specify the 3rd-party repository to use\n");
 	print("   -a, --all               List all available bundles for the current version of Clear Linux\n");
 	print("   -D, --has-dep=[BUNDLE]  List all bundles which have BUNDLE as a dependency\n");
 	print("   --deps=[BUNDLE]         List bundles included by BUNDLE\n");

--- a/src/3rd_party_bundle_remove.c
+++ b/src/3rd_party_bundle_remove.c
@@ -37,7 +37,7 @@ static void print_help(void)
 	global_print_help();
 
 	print("Options:\n");
-	print("   -e, --repo             Specify the 3rd-party repo to use\n");
+	print("   -e, --repo             Specify the 3rd-party repository to use\n");
 	print("   -x, --force            Removes a bundle along with all the bundles that depend on it\n");
 	print("   -R, --recursive        Removes a bundle and its dependencies recursively\n");
 	print("\n");
@@ -92,7 +92,7 @@ static bool parse_options(int argc, char **argv)
 	return true;
 }
 
-enum swupd_code remove_bundle(char *bundle)
+static enum swupd_code remove_bundle(char *bundle)
 {
 	struct list *bundle_to_remove = NULL;
 	enum swupd_code ret = SWUPD_OK;
@@ -124,7 +124,6 @@ enum swupd_code third_party_bundle_remove_main(int argc, char **argv)
 		print_help();
 		return SWUPD_INVALID_OPTION;
 	}
-	progress_init_steps("3rd-party-bundle-remove", steps_in_bundle_remove);
 
 	/* initialize swupd */
 	ret_code = swupd_init(SWUPD_ALL);
@@ -132,6 +131,7 @@ enum swupd_code third_party_bundle_remove_main(int argc, char **argv)
 		error("Failed swupd initialization, exiting now\n");
 		return ret_code;
 	}
+	progress_init_steps("3rd-party-bundle-remove", steps_in_bundle_remove);
 
 	/* move the bundles provided in the command line into a
 	 * list so it is easier to handle them */

--- a/src/3rd_party_diagnose.c
+++ b/src/3rd_party_diagnose.c
@@ -50,7 +50,7 @@ static void print_help(void)
 	print("   -R, --repo              Specify the 3rd-party repository to use\n");
 	print("   -V, --version=[VER]     Diagnose against manifest version VER\n");
 	print("   -x, --force             Attempt to proceed even if non-critical errors found\n");
-	print("   -q, --quick             Don't check for corrupt files, only fix missing files\n");
+	print("   -q, --quick             Don't check for corrupt files, only find missing files\n");
 	print("   -B, --bundles=[BUNDLES] Forces swupd to only diagnose the specified BUNDLES. Example: --bundles=os-core,vi\n");
 	print("   -Y, --picky             Also list files which should not exist\n");
 	print("   -X, --picky-tree=[PATH] Selects the sub-tree where --picky and --extra-files-only look for extra files. Default: /usr\n");

--- a/src/3rd_party_update.c
+++ b/src/3rd_party_update.c
@@ -135,7 +135,7 @@ static enum swupd_code update_repos(UNUSED_PARAM char *unused)
 	}
 }
 
-enum swupd_code thir_party_update_main(int argc, char **argv)
+enum swupd_code third_party_update_main(int argc, char **argv)
 {
 	enum swupd_code ret_code = SWUPD_OK;
 

--- a/src/swupd_internal.h
+++ b/src/swupd_internal.h
@@ -30,7 +30,7 @@ enum swupd_code third_party_bundle_add_main(int argc, char **argv);
 enum swupd_code third_party_bundle_list_main(int argc, char **argv);
 enum swupd_code third_party_bundle_remove_main(int argc, char **argv);
 enum swupd_code third_party_bundle_info_main(int argc, char **argv);
-enum swupd_code thir_party_update_main(int argc, char **argv);
+enum swupd_code third_party_update_main(int argc, char **argv);
 enum swupd_code third_party_diagnose_main(int argc, char **argv);
 enum swupd_code third_party_repair_main(int argc, char **argv);
 enum swupd_code third_party_check_update_main(int argc, char **argv);

--- a/swupd.bash
+++ b/swupd.bash
@@ -29,7 +29,7 @@ _swupd()
 	do case "${COMP_WORDS[$i]}" in
 		("$1")
 		opts="--help --version autoupdate bundle-add bundle-remove
-		bundle-list hashdump update diagnose check-update search
+		bundle-list bundle-info hashdump update diagnose check-update search
 		search-file info clean mirror os-install repair verify 3rd-party"
 		break;;
 		("info")

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -167,6 +167,7 @@ if [[ -n "$state" ]]; then
         "bundle-add:Install a new bundle"
         "bundle-remove:Uninstall a bundle"
         "bundle-list:List installed bundles"
+        "bundle-info: Display information about a bundle"
         "search:Searches for the best bundle to install a binary or library"
         "search-file:Command to search files in Clear Linux bundles"
         "diagnose:Verify content for OS version"
@@ -191,6 +192,7 @@ if [[ -n "$state" ]]; then
           '(help)remove[Remove third party repo]'
           '(help)add[Add third party repo]'
           '(help)bundle-add[Install a bundle from a third party repository]'
+          '(help)bundle-remove[Uninstall a bundle from a third party repository]'
           '(help)bundle-list[List bundles from a third party repository]'
           '(help)bundle-info[Display information about a bundle in a third party repository]'
           '(help)update[Update to latest version of a third party repository]'

--- a/test/functional/3rd-party/3rd-party-bundle-add-config-file.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-config-file.bats
@@ -51,7 +51,7 @@ test_setup() {
 		1 bundle was installed as dependency
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 
 	# test-bundle1 is installed and tracked
 	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle1

--- a/test/functional/3rd-party/3rd-party-bundle-info-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-info-basic.bats
@@ -136,7 +136,7 @@ global_teardown() {
 		Please specify a repository using the --repo flag
 	EOM
 	)
-	assert_regex_is_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }
 


### PR DESCRIPTION
Housekeeping on 3rd-party commands
This commit does some housekeeping in the 3rd-party commands:
 - Initialize the function "progress" only after swupd has initialized successfully.
 - Make functions that are not used outside of a file static.
 - Avoid using regex or partial verifications on tests when possible.
 - Add 3rd-party command flags to the default config file.
 - Don't use "repo" in help menus, use the whole "repository" word.
 - Add 3rd-party sub-commands to the flag_validator script.
 - Add missing values from the autocompletion scripts.

This PR is built on top of #1232, #1233 and #1234 and have to be reviewed first.