### PR TITLE
Revert operation when theres an error adding repos

### DIFF
--- a/src/3rd_party_remove.c
+++ b/src/3rd_party_remove.c
@@ -25,25 +25,6 @@
 
 #ifdef THIRDPARTY
 
-static int remove_repo_directory(char *repo_name)
-{
-	char *repo_dir;
-	int ret = 0;
-
-	//TODO: use a global function to get this value
-	repo_dir = str_or_die("%s/%s/%s", globals.path_prefix, "opt/3rd_party", repo_name);
-	ret = sys_rm_recursive(repo_dir);
-	if (ret == -ENOENT) {
-		ret = 0;
-	}
-	if (ret < 0) {
-		error("Failed to delete repository directory\n");
-	}
-
-	free(repo_dir);
-	return ret;
-}
-
 static void print_help(void)
 {
 	print("Usage:\n");
@@ -112,7 +93,7 @@ enum swupd_code third_party_remove_main(int argc, char **argv)
 		goto exit;
 	}
 
-	if (remove_repo_directory(argv[argc - 1]) < 0) {
+	if (third_party_remove_repo_directory(argv[argc - 1]) < 0) {
 		ret = SWUPD_COULDNT_REMOVE_FILE;
 		goto exit;
 	}

--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -193,14 +193,14 @@ exit:
 	return ret;
 }
 
-int third_party_remove_repo(char *repo_name)
+int third_party_remove_repo(const char *repo_name)
 {
 	struct repo *repo;
 	struct list *repos;
 	int ret = 0;
 
 	repos = third_party_get_repos();
-	repo = list_remove(repo_name, &repos, repo_name_cmp);
+	repo = list_remove((void *)repo_name, &repos, repo_name_cmp);
 
 	if (!repo) {
 		error("Repository not found\n");
@@ -216,6 +216,25 @@ int third_party_remove_repo(char *repo_name)
 
 exit:
 	list_free_list_and_data(repos, repo_free_data);
+	return ret;
+}
+
+int third_party_remove_repo_directory(const char *repo_name)
+{
+	char *repo_dir;
+	int ret = 0;
+
+	//TODO: use a global function to get this value
+	repo_dir = str_or_die("%s/%s/%s", globals.path_prefix, "opt/3rd_party", repo_name);
+	ret = sys_rm_recursive(repo_dir);
+	if (ret == -ENOENT) {
+		ret = 0;
+	}
+	if (ret < 0) {
+		error("Failed to delete repository directory\n");
+	}
+
+	free(repo_dir);
 	return ret;
 }
 

--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -63,7 +63,16 @@ int third_party_add_repo(const char *repo_name, const char *repo_url);
  * @returns 0 on success ie: a repo is found, removed & repo config is adjusted
  * otherwise a -1 on any failure
  */
-int third_party_remove_repo(char *repo_name);
+int third_party_remove_repo(const char *repo_name);
+
+/**
+ * @brief This function removes the directory where the content of a repo is installed.
+ *
+ * @param repo_name A string containing repo_name
+ *
+ * @returns 0 on success, otherwise a negative errno on any failure
+ */
+int third_party_remove_repo_directory(const char *repo_name);
 
 /**
  * @brief This function sets up swupd to use a specific 3rd-party repo.


### PR DESCRIPTION
When adding 3rd-party repositories, errors may occur, in these cases the
operation has to be reverted completely because we don't want to be left
with an invalid repo.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>