### PR TITLE
3rd-party: Ignoring invalid bundle error if exist in one repo

### DIFF
--- a/src/3rd_party_bundle_list.c
+++ b/src/3rd_party_bundle_list.c
@@ -115,7 +115,19 @@ static bool parse_options(int argc, char **argv)
 
 static enum swupd_code list_repo_bundles(UNUSED_PARAM char *unused)
 {
-	return list_bundles();
+	static enum swupd_code ret_code = SWUPD_NO;
+	int ret;
+
+	ret = list_bundles();
+
+	/* When using the --deps or --has-dep flags which take a BUNDLE as argument,
+	 * one or more repositories may not have BUNDLE, but we should not propagate
+	 * the SWUPD_INVALID_BUNDLE error unless the bundle is not found in any repository. */
+	if (ret != SWUPD_INVALID_BUNDLE || ret_code == SWUPD_NO) {
+		ret_code = ret;
+	}
+
+	return ret_code;
 }
 
 enum swupd_code third_party_bundle_list_main(int argc, char **argv)

--- a/src/bundle_list.c
+++ b/src/bundle_list.c
@@ -229,14 +229,15 @@ static enum swupd_code show_included_bundles(char *bundle_name, int version)
 			string_or_die(&m, "Processing error");
 			ret = SWUPD_COULDNT_LOAD_MANIFEST;
 		} else if (ret & add_sub_BADNAME) {
-			string_or_die(&m, "Bad bundle name detected");
 			ret = SWUPD_INVALID_BUNDLE;
 		} else {
 			string_or_die(&m, "Unknown error");
 			ret = SWUPD_UNEXPECTED_CONDITION;
 		}
 
-		error("%s - Aborting\n", m);
+		if (m) {
+			error("%s - Aborting\n", m);
+		}
 		free_string(&m);
 		goto out;
 	}
@@ -351,7 +352,7 @@ static enum swupd_code show_bundle_reqd_by(const char *bundle_name, bool server,
 	}
 
 	if (!mom_search_bundle(current_manifest, bundle_name)) {
-		error("Bundle name %s is invalid, aborting dependency list\n", bundle_name);
+		warn("Bundle \"%s\" is invalid, skipping it...\n", bundle_name);
 		ret = SWUPD_INVALID_BUNDLE;
 		goto out;
 	}
@@ -394,10 +395,6 @@ static enum swupd_code show_bundle_reqd_by(const char *bundle_name, bool server,
 out:
 	if (current_manifest) {
 		manifest_free(current_manifest);
-	}
-
-	if (ret) {
-		print("Bundle list failed\n");
 	}
 
 	if (subs) {

--- a/test/functional/bundlelist/list-deps-invalid-bundle.bats
+++ b/test/functional/bundlelist/list-deps-invalid-bundle.bats
@@ -9,7 +9,6 @@ load "../testlib"
 	assert_status_is "$SWUPD_INVALID_BUNDLE"
 	expected_output=$(cat <<-EOM
 		Warning: Bundle "not-a-bundle" is invalid, skipping it...
-		Error: Bad bundle name detected - Aborting
 	EOM
 	)
 	assert_is_output "$expected_output"

--- a/test/functional/bundlelist/list-has-dep-nested-not-installed.bats
+++ b/test/functional/bundlelist/list-has-dep-nested-not-installed.bats
@@ -22,7 +22,6 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Bundle "test-bundle1" does not seem to be installed
 		       try passing --all to check uninstalled bundles
-		Bundle list failed
 	EOM
 	)
 	assert_is_output "$expected_output"


### PR DESCRIPTION
When listing bundles using the --deps or --has-dep flags which take a BUNDLE as argument, one or more repositories may not have the specified BUNDLE, but we should not return a SWUPD_INVALID_BUNDLE error unless the bundle is not found in any repository.

This PR enforces that behavior and also modify the output of the different list options to make them more consistent with one another.

This PR is built on top of #1232, #1233, #1234 and #1235 and have to be reviewed first.