### PR TITLE
Consistency with signature verification messages

### DIFF
--- a/src/manifest.c
+++ b/src/manifest.c
@@ -437,9 +437,9 @@ retry_load:
 	string_or_die(&url, "%s/%i/Manifest.MoM", globals.content_url, version);
 
 	if (!globals.sigcheck) {
-		warn("FAILED TO VERIFY SIGNATURE OF Manifest.MoM. Operation proceeding due to\n"
-		     "  --nosigcheck, but system security may be compromised\n");
-		journal_log_error("swupd security notice: --nosigcheck used to bypass MoM signature verification failure");
+		warn("The --nosigcheck flag was used, THE MANIFEST SIGNATURE WILL NOT BE VERIFIED\n");
+		info("Be aware that this compromises the system security\n\n");
+		journal_log_error("swupd security notice: --nosigcheck used to bypass MoM signature verification");
 	} else {
 		/* Only when migrating , ignore the locally made signature check which is guaranteed to have been signed
 		 * by the user and does not come from any network source */
@@ -453,7 +453,7 @@ retry_load:
 				retried = true;
 				goto retry_load;
 			}
-			error("FAILED TO VERIFY SIGNATURE OF Manifest.MoM version %d!!!\n", version);
+			error("Signature verification failed for manifest version %d\n", version);
 			free_string(&filename);
 			free_string(&url);
 			manifest_free(manifest);

--- a/src/version.c
+++ b/src/version.c
@@ -176,10 +176,9 @@ static int get_version_from_url(char *url)
 	if (globals.sigcheck) {
 		sig_verified = verify_signature(url, &tmp_version);
 	} else {
-		error("FAILED TO VERIFY SIGNATURE OF %s. Operation proceeding due to \n"
-		      " --nosigcheck, but system security may be compromised\n",
-		      url);
-		journal_log_error("swupd security notice:  --nosigcheck used to bypass version signature");
+		warn("The --nosigcheck flag was used, THE SIGNATURE OF %s WILL NOT BE VERIFIED\n", url);
+		info("Be aware that this compromises the system security\n\n");
+		journal_log_error("swupd security notice: --nosigcheck used to bypass version signature");
 		sig_verified = 0;
 	}
 
@@ -188,7 +187,7 @@ static int get_version_from_url(char *url)
 		warn("Signature for latest file (%s) is missing\n", url);
 		warn("Support for unsigned latest file will be deprecated soon\n");
 	} else if (sig_verified != 0) {
-		error("Signature Verification failed for URL: %s\n", url);
+		error("Signature verification failed for URL: %s\n", url);
 		return -SWUPD_ERROR_SIGNATURE_VERIFICATION;
 	}
 

--- a/test/functional/bundleadd/add-no-signature.bats
+++ b/test/functional/bundleadd/add-no-signature.bats
@@ -17,7 +17,7 @@ test_setup() {
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
 		Warning: Removing corrupt Manifest.MoM artifacts and re-downloading...
-		Error: FAILED TO VERIFY SIGNATURE OF Manifest.MoM version 10!!!
+		Error: Signature verification failed for manifest version 10
 		Error: Cannot load official manifest MoM for version 10
 		Failed to install 1 of 1 bundles
 	EOM
@@ -33,8 +33,8 @@ test_setup() {
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
-		FAILED TO VERIFY SIGNATURE OF Manifest.MoM. Operation proceeding due to
-		  --nosigcheck, but system security may be compromised
+		Warning: The --nosigcheck flag was used, THE MANIFEST SIGNATURE WILL NOT BE VERIFIED
+		Be aware that this compromises the system security
 		Loading required manifests...
 		No packs need to be downloaded
 		Validate downloaded files

--- a/test/functional/signature/cert-chain.bats
+++ b/test/functional/signature/cert-chain.bats
@@ -38,7 +38,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
-		Error: FAILED TO VERIFY SIGNATURE OF Manifest.MoM version 10!!!
+		Error: Signature verification failed for manifest version 10
 		Error: Cannot load official manifest MoM for version 10
 	EOM
 	)
@@ -75,7 +75,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
-		Error: FAILED TO VERIFY SIGNATURE OF Manifest.MoM version 10!!!
+		Error: Signature verification failed for manifest version 10
 		Error: Cannot load official manifest MoM for version 10
 	EOM
 	)
@@ -112,7 +112,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
-		Error: FAILED TO VERIFY SIGNATURE OF Manifest.MoM version 10!!!
+		Error: Signature verification failed for manifest version 10
 		Error: Cannot load official manifest MoM for version 10
 	EOM
 	)

--- a/test/functional/signature/cert-chain.bats
+++ b/test/functional/signature/cert-chain.bats
@@ -38,11 +38,15 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
+		Warning: Signature check failed
+		Warning: Removing corrupt Manifest.MoM artifacts and re-downloading...
+		Warning: Signature check failed
 		Error: Signature verification failed for manifest version 10
 		Error: Cannot load official manifest MoM for version 10
+		Failed to install 1 of 1 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_file_not_exists "$TARGETDIR"/test-file
 
 }
@@ -62,7 +66,7 @@ test_setup() {
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_file_exists "$TARGETDIR"/test-file
 
 }
@@ -75,11 +79,15 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
+		Warning: Signature check failed
+		Warning: Removing corrupt Manifest.MoM artifacts and re-downloading...
+		Warning: Signature check failed
 		Error: Signature verification failed for manifest version 10
 		Error: Cannot load official manifest MoM for version 10
+		Failed to install 1 of 1 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_file_not_exists "$TARGETDIR"/test-file
 
 }
@@ -101,7 +109,7 @@ test_setup() {
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_file_exists "$TARGETDIR"/test-file
 
 }
@@ -112,11 +120,15 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
+		Warning: Signature check failed
+		Warning: Removing corrupt Manifest.MoM artifacts and re-downloading...
+		Warning: Signature check failed
 		Error: Signature verification failed for manifest version 10
 		Error: Cannot load official manifest MoM for version 10
+		Failed to install 1 of 1 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_file_not_exists "$TARGETDIR"/test-file
 
 }
@@ -136,7 +148,7 @@ test_setup() {
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_file_exists "$TARGETDIR"/test-file
 
 }
@@ -158,7 +170,7 @@ test_setup() {
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_file_exists "$TARGETDIR"/test-file
 
 }

--- a/test/functional/signature/corrupted-certificate.bats
+++ b/test/functional/signature/corrupted-certificate.bats
@@ -33,8 +33,8 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		FAILED TO VERIFY SIGNATURE OF Manifest.MoM. Operation proceeding due to
-		  --nosigcheck, but system security may be compromised
+		Warning: The --nosigcheck flag was used, THE MANIFEST SIGNATURE WILL NOT BE VERIFIED
+		Be aware that this compromises the system security
 		Loading required manifests...
 		No packs need to be downloaded
 		Validate downloaded files

--- a/test/functional/signature/corrupted-certificate.bats
+++ b/test/functional/signature/corrupted-certificate.bats
@@ -19,10 +19,11 @@ test_setup() {
 
 	assert_status_is "$SWUPD_SIGNATURE_VERIFICATION_FAILED"
 	expected_output=$(cat <<-EOM
-		Error: Failed to verify certificate: .*
+		Error: Failed to verify certificate: unknown certificate verification error
+		Error: Failed swupd initialization, exiting now
 	EOM
 	)
-	assert_regex_in_output "$expected_output"
+	assert_regex_is_output "$expected_output"
 	assert_file_not_exists "$TARGETDIR"/test-file
 
 }
@@ -44,7 +45,7 @@ test_setup() {
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_file_exists "$TARGETDIR"/test-file
 
 }

--- a/test/functional/signature/corrupted-signature.bats
+++ b/test/functional/signature/corrupted-signature.bats
@@ -20,11 +20,15 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
+		Warning: Signature check failed
+		Warning: Removing corrupt Manifest.MoM artifacts and re-downloading...
+		Warning: Signature check failed
 		Error: Signature verification failed for manifest version 10
 		Error: Cannot load official manifest MoM for version 10
+		Failed to install 1 of 1 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_file_not_exists "$TARGETDIR"/test-file
 
 }
@@ -46,7 +50,7 @@ test_setup() {
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_file_exists "$TARGETDIR"/test-file
 
 }

--- a/test/functional/signature/corrupted-signature.bats
+++ b/test/functional/signature/corrupted-signature.bats
@@ -20,7 +20,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
-		Error: FAILED TO VERIFY SIGNATURE OF Manifest.MoM version 10!!!
+		Error: Signature verification failed for manifest version 10
 		Error: Cannot load official manifest MoM for version 10
 	EOM
 	)
@@ -35,8 +35,8 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		FAILED TO VERIFY SIGNATURE OF Manifest.MoM. Operation proceeding due to
-		  --nosigcheck, but system security may be compromised
+		Warning: The --nosigcheck flag was used, THE MANIFEST SIGNATURE WILL NOT BE VERIFIED
+		Be aware that this compromises the system security
 		Loading required manifests...
 		No packs need to be downloaded
 		Validate downloaded files

--- a/test/functional/signature/invalid-certificate.bats
+++ b/test/functional/signature/invalid-certificate.bats
@@ -19,11 +19,15 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
+		Warning: Signature check failed
+		Warning: Removing corrupt Manifest.MoM artifacts and re-downloading...
+		Warning: Signature check failed
 		Error: Signature verification failed for manifest version 10
 		Error: Cannot load official manifest MoM for version 10
+		Failed to install 1 of 1 bundles
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_file_not_exists "$TARGETDIR"/test-file
 
 }
@@ -45,7 +49,7 @@ test_setup() {
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_file_exists "$TARGETDIR"/test-file
 
 }

--- a/test/functional/signature/invalid-certificate.bats
+++ b/test/functional/signature/invalid-certificate.bats
@@ -19,7 +19,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
-		Error: FAILED TO VERIFY SIGNATURE OF Manifest.MoM version 10!!!
+		Error: Signature verification failed for manifest version 10
 		Error: Cannot load official manifest MoM for version 10
 	EOM
 	)
@@ -34,8 +34,8 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		FAILED TO VERIFY SIGNATURE OF Manifest.MoM. Operation proceeding due to
-		  --nosigcheck, but system security may be compromised
+		Warning: The --nosigcheck flag was used, THE MANIFEST SIGNATURE WILL NOT BE VERIFIED
+		Be aware that this compromises the system security
 		Loading required manifests...
 		No packs need to be downloaded
 		Validate downloaded files

--- a/test/functional/signature/key-rotation.bats
+++ b/test/functional/signature/key-rotation.bats
@@ -145,12 +145,14 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Update started
 		Preparing to update from 40 to 50
-		Error: Certificate verification error - self signed certificate
-		Error: Signature check error
-		Signature check failed!
+		Warning: Signature check failed
+		Warning: Removing corrupt Manifest.MoM artifacts and re-downloading...
+		Warning: Signature check failed
+		Error: Signature verification failed for manifest version 40
+		Update failed
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_file_exists "$TARGETDIR"/core
 
 }

--- a/test/functional/signature/no-signature.bats
+++ b/test/functional/signature/no-signature.bats
@@ -47,7 +47,7 @@ test_setup() {
 		Successfully installed 1 bundle
 	EOM
 	)
-	assert_in_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_file_exists "$TARGETDIR"/test-file
 
 }

--- a/test/functional/signature/no-signature.bats
+++ b/test/functional/signature/no-signature.bats
@@ -20,7 +20,7 @@ test_setup() {
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
 		Warning: Removing corrupt Manifest.MoM artifacts and re-downloading...
-		Error: FAILED TO VERIFY SIGNATURE OF Manifest.MoM version 10!!!
+		Error: Signature verification failed for manifest version 10
 		Error: Cannot load official manifest MoM for version 10
 		Failed to install 1 of 1 bundles
 	EOM
@@ -36,8 +36,8 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		FAILED TO VERIFY SIGNATURE OF Manifest.MoM. Operation proceeding due to
-		  --nosigcheck, but system security may be compromised
+		Warning: The --nosigcheck flag was used, THE MANIFEST SIGNATURE WILL NOT BE VERIFIED
+		Be aware that this compromises the system security
 		Loading required manifests...
 		No packs need to be downloaded
 		Validate downloaded files

--- a/test/functional/signature/version-sig-check.bats
+++ b/test/functional/signature/version-sig-check.bats
@@ -24,13 +24,13 @@ test_setup() {
 	assert_status_is "$SWUPD_SIGNATURE_VERIFICATION_FAILED"
 
 	expected_output=$(cat <<-EOM
-		Error: Failed to retrieve size for signature file: .*latest_version.sig
-		Error: Signature Verification failed for URL: .*latest_version
+		Error: Failed to retrieve size for signature file: file://$TEST_DIRNAME/web-dir/version/latest_version.sig
+		Error: Signature Verification failed for URL: file://$TEST_DIRNAME/web-dir/version/latest_version
 		Error: Unable to determine the server version as signature verification failed
 		Current OS version: 10
 	EOM
 	)
-	assert_regex_is_output "$expected_output"
+	assert_is_output "$expected_output"
 
 	sudo sh -c "mv $WEBDIR/version/latest_version_bad_name.sig $WEBDIR/version/latest_version.sig"
 	# check-update succeeds as verification is successful
@@ -57,12 +57,11 @@ test_setup() {
 
 	expected_output=$(cat <<-EOM
 		Update started
-		Error: Signature check error
-		.*:not enough data.*
+		Error: Signature verification failed for URL: file://$TEST_DIRNAME/web-dir/version/formatstaging/latest
 		Error: Unable to determine the server version as signature verification failed
 		Update failed
 	EOM
 	)
-	assert_regex_is_output "$expected_output"
+	assert_is_output "$expected_output"
 
 }


### PR DESCRIPTION
This commit enhance the consistency and readability, of the messages
shown when the signature verification is skipped or fails.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>