### PR TITLE
Prevent memory leak

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -537,6 +537,11 @@ out_close_lock:
 out_fds:
 	dump_file_descriptor_leaks();
 
+	/* This means there was a problem after global_init earlier.
+	 * This is needed to prevent memory leak
+	 */
+	globals_deinit();
+
 	return ret;
 }
 


### PR DESCRIPTION
This makes sure we always deallocate memory if there was an
error after the initial global_init

Signed-off-by: Karthik Prabhu Vinod <karthik.prabhu.vinod@intel.com>