### PR TITLE
Remove the state dir when removing 3rd-party repo

### DIFF
--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -235,19 +235,26 @@ int third_party_remove_repo_directory(const char *repo_name)
 {
 	char *repo_dir;
 	int ret = 0;
+	int ret_code = 0;
 
 	//TODO: use a global function to get this value
-	repo_dir = str_or_die("%s/%s/%s", globals.path_prefix, "opt/3rd_party", repo_name);
+	repo_dir = str_or_die("%s/opt/3rd_party/%s", globals.path_prefix, repo_name);
 	ret = sys_rm_recursive(repo_dir);
-	if (ret == -ENOENT) {
-		ret = 0;
-	}
-	if (ret < 0) {
+	if (ret < 0 && ret != -ENOENT) {
 		error("Failed to delete repository directory\n");
+		ret_code = ret;
 	}
-
 	free(repo_dir);
-	return ret;
+
+	repo_dir = str_or_die("%s/3rd_party/%s", globals.state_dir, repo_name);
+	ret = sys_rm_recursive(repo_dir);
+	if (ret < 0 && ret != -ENOENT) {
+		error("Failed to delete repository state directory\n");
+		ret_code = ret;
+	}
+	free(repo_dir);
+
+	return ret_code;
 }
 
 enum swupd_code third_party_set_repo(const char *state_dir, const char *path_prefix, struct repo *repo, bool sigcheck)

--- a/test/functional/3rd-party/3rd-party-repo-remove.bats
+++ b/test/functional/3rd-party/3rd-party-repo-remove.bats
@@ -31,9 +31,10 @@ test_setup(){
 	)
 
 	repo_config_file="$STATEDIR"/3rd_party/repo.ini
-	run sudo sh -c "mkdir -p $STATEDIR/3rd_party/"
-	run sudo sh -c "mkdir -p $PATH_PREFIX/opt/3rd_party/{test1,test2,test3,test4,test5}"
+	sudo mkdir -p "$STATEDIR"/3rd_party
+	sudo mkdir -p "$PATH_PREFIX"/opt/3rd_party/{test1,test2,test3,test4,test5}
 	write_to_protected_file -a "$repo_config_file" "$contents"
+	sudo mkdir "$STATEDIR"/3rd_party/{test1,test2,test3,test4,test5}
 
 }
 
@@ -48,6 +49,8 @@ test_teardown(){
 	repo_config_file="$STATEDIR"/3rd_party/repo.ini
 
 	#remove at start of file
+	assert_dir_exists "$PATH_PREFIX"/opt/3rd_party/test1
+	assert_dir_exists "$STATEDIR"/3rd_party/test1
 	run sudo sh -c "$SWUPD 3rd-party remove test1 $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -55,9 +58,12 @@ test_teardown(){
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_dir_not_exists "$PATH_PREFIX/opt/3rd-party/test1"
+	assert_dir_not_exists "$PATH_PREFIX"/opt/3rd_party/test1
+	assert_dir_not_exists "$STATEDIR"/3rd_party/test1
 
 	#remove at middle of file
+	assert_dir_exists "$PATH_PREFIX"/opt/3rd_party/test3
+	assert_dir_exists "$STATEDIR"/3rd_party/test3
 	run sudo sh -c "$SWUPD 3rd-party remove test3 $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -65,9 +71,12 @@ test_teardown(){
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_dir_not_exists "$PATH_PREFIX/opt/3rd-party/test1"
+	assert_dir_not_exists "$PATH_PREFIX"/opt/3rd_party/test3
+	assert_dir_not_exists "$STATEDIR"/3rd_party/test3
 
 	#remove at end of file
+	assert_dir_exists "$PATH_PREFIX"/opt/3rd_party/test5
+	assert_dir_exists "$STATEDIR"/3rd_party/test5
 	run sudo sh -c "$SWUPD 3rd-party remove test5 $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -75,7 +84,8 @@ test_teardown(){
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_dir_not_exists "$PATH_PREFIX/opt/3rd-party/test1"
+	assert_dir_not_exists "$PATH_PREFIX"/opt/3rd_party/test5
+	assert_dir_not_exists "$STATEDIR"/3rd_party/test5
 
 	expected_contents=$(cat <<- EOM
 		[test2]


### PR DESCRIPTION
When we remove a 3rd-party repo from the system, we remove the directory
where all its contents got installed, but we don't remove its state
directory.

This commit removes it since we no longer need that state directory.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>