### PR TITLE
Verifying the URL of a repo doesn't exist already

### DIFF
--- a/src/3rd_party_add.c
+++ b/src/3rd_party_add.c
@@ -127,7 +127,7 @@ enum swupd_code third_party_add_main(int argc, char **argv)
 	ret = third_party_add_repo(name, url);
 	if (ret) {
 		if (ret != -EEXIST) {
-			error("Failed to add repo: %s to config\n", name);
+			error("Failed to add repository: %s to config\n", name);
 			ret_code = SWUPD_COULDNT_WRITE_FILE;
 		} else {
 			ret_code = SWUPD_INVALID_OPTION;

--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -34,6 +34,11 @@ int repo_name_cmp(const void *repo, const void *name)
 	return strcmp(((struct repo *)repo)->name, name);
 }
 
+int repo_url_cmp(const void *repo, const void *url)
+{
+	return strcmp(((struct repo *)repo)->url, url);
+}
+
 /**
  * @brief This function is called by the repo ini parse.
  *
@@ -106,7 +111,12 @@ int third_party_add_repo(const char *repo_name, const char *repo_url)
 
 	repos = third_party_get_repos();
 	if (list_search(repos, repo_name, repo_name_cmp)) {
-		error("The repo: %s already exists\n", repo_name);
+		error("The repository: %s already exists\n", repo_name);
+		ret = -EEXIST;
+		goto exit;
+	}
+	if (list_search(repos, repo_url, repo_url_cmp)) {
+		error("The specified URL %s is already assigned to another repository\n", repo_url);
 		ret = -EEXIST;
 		goto exit;
 	}

--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -90,7 +90,12 @@ enum swupd_code third_party_set_repo(const char *state_dir, const char *path_pre
 int repo_name_cmp(const void *repo, const void *name);
 
 /**
- * @brief Performs an operation on every 3rd-party bundle from the list.
+ * @brief strcmp like function to search for a repo based on its URL
+ */
+int repo_url_cmp(const void *repo, const void *url);
+
+/**
+ * @brief Performs an operation on every bundle from the list.
  *
  * @param bundles the list of bundles to which the operation will be performed
  * @param repo the name of the 3rd-party repository where the bundles

--- a/test/functional/3rd-party/3rd-party-repo-add-negative.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add-negative.bats
@@ -76,7 +76,7 @@ global_teardown() {
 	run sudo sh -c "$SWUPD 3rd-party add test-repo1 https://abc.com $SWUPD_OPTS"
 	assert_status_is "$SWUPD_INVALID_OPTION"
 	expected_output=$(cat <<-EOM
-		Error: The repo: test-repo1 already exists
+		Error: The repository: test-repo1 already exists
 	EOM
 	)
 	assert_is_output "$expected_output"


### PR DESCRIPTION
When adding a 3rd-party repository we need to make sure that the URL
provided by the user is not already assigned to another 3rd-arty
repository, otherwise we can end up having the same repository multiple
times, just with different names.

This commit checks the URL doesn't already exists.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>