### PR TITLE
Show what indirect dependencies are optional

### DIFF
--- a/src/swupd.h
+++ b/src/swupd.h
@@ -82,6 +82,10 @@ struct sub {
 
 	/* oldversion: set to 0 by calloc(), possibly overridden by MoM read */
 	int oldversion;
+
+	/* is_optional: true if the subscription referred to by this struct is optional,
+	 * false otherwise */
+	bool is_optional;
 };
 
 enum swupd_init_config {
@@ -322,6 +326,7 @@ extern void create_and_append_subscription(struct list **subs, const char *compo
 extern char *get_tracking_dir(void);
 extern int add_subscriptions(struct list *bundles, struct list **subs, struct manifest *mom, bool find_all, int recursion);
 extern int subscription_bundlename_strcmp(const void *a, const void *b);
+extern int subscription_sort_component(const void *a, const void *b);
 
 /* bundle_add.c */
 extern enum swupd_code execute_bundle_add(struct list *bundles_list);

--- a/test/functional/bundleinfo/bundle-info-optional.bats
+++ b/test/functional/bundleinfo/bundle-info-optional.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n test-bundle1 -f /file_1 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /file_2 "$TEST_NAME"
+	create_bundle -n test-bundle3 -f /file_3 "$TEST_NAME"
+	create_bundle -n test-bundle4 -f /file_4 "$TEST_NAME"
+	create_bundle -n test-bundle5 -f /file_5 "$TEST_NAME"
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle1 test-bundle3
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle2 test-bundle4
+	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle2 test-bundle5
+}
+
+test_setup() {
+
+	# do nothing, just overwrite the lib test_setup
+	return
+
+}
+
+test_teardown() {
+
+	# do nothing, just overwrite the lib test_setup
+	return
+
+}
+
+global_teardown() {
+
+	destroy_test_environment "$TEST_NAME"
+
+}
+
+@test "BIN011: Show info about a bundle including its optional and non-optional dependencies" {
+
+	run sudo sh -c "$SWUPD bundle-info $SWUPD_OPTS test-bundle1 --dependencies"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		_______________________________
+		 Info for bundle: test-bundle1
+		_______________________________
+		Status: Not installed
+		Latest available version: 10
+		Bundle size:
+		 - Size of bundle: .* KB
+		 - Maximum amount of disk size the bundle will take if installed \(includes dependencies\): .* KB
+		Direct dependencies \(2\):
+		 - test-bundle2
+		 - test-bundle3 \(optional\)
+		Indirect dependencies \(2\):
+		 - test-bundle4
+		 - test-bundle5 \(optional\)
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}
+
+@test "BIN012: Show info about a bundle including its installed optional and non-optional dependencies" {
+
+	install_bundle "$WEBDIR"/10/Manifest.test-bundle1
+	install_bundle "$WEBDIR"/10/Manifest.test-bundle2
+	install_bundle "$WEBDIR"/10/Manifest.test-bundle5
+
+	run sudo sh -c "$SWUPD bundle-info $SWUPD_OPTS test-bundle1 --dependencies"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		_______________________________
+		 Info for bundle: test-bundle1
+		_______________________________
+		Status: Installed
+		Bundle test-bundle1 is up to date:
+		 - Installed bundle last updated in version: 10
+		 - Latest available version: 10
+		Bundle size:
+		 - Size of bundle: .* KB
+		 - Size bundle takes on disk \(includes dependencies\): .* KB
+		Direct dependencies \(2\):
+		 - test-bundle2
+		 - test-bundle3 \(optional, not installed\)
+		Indirect dependencies \(2\):
+		 - test-bundle4
+		 - test-bundle5 \(optional, installed\)
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}

--- a/test/functional/os-install/install-also-add.bats
+++ b/test/functional/os-install/install-also-add.bats
@@ -28,9 +28,9 @@ test_setup() {
 		Installing OS version 10 (latest)
 		Downloading missing manifests...
 		Downloading packs for:
+		 - test-bundle1
 		 - test-bundle3
 		 - test-bundle2
-		 - test-bundle1
 		 - os-core
 		Finishing packs extraction...
 		Checking for corrupt files


### PR DESCRIPTION
When using "bundle-info BUNDLE --dependencies", information regarding
BUNDLE is presented to the user, this information includes the list of
direct and indirect dependencies BUNDLE has. All direct includes that
are optional (also-add) are marked as such, while there is no way to
distiguish what indirect dependencies are optional with the provided
information.

This commit expands the information shown by the command so indirect
dependencies that are optional are shown as such along with info about
the status of that dependency.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>