### PR TITLE
Show optional includes with bundle-list --has-dep

### DIFF
--- a/src/bundle.h
+++ b/src/bundle.h
@@ -32,8 +32,15 @@ bool is_tracked_bundle(const char *bundle_name);
  * @brief Create a list of bundles required by bundle_name.
  * TODO: Make this function more generic. Right now it's too specific for
  * bundle-list and bundle-remove use cases.
+ * @param reqd_by A list where the bundles found will be stored
+ * @param bundle_name The bundle we are looking for
+ * @param mom The MoM
+ * @param recursion A control variable used to sense what level of recursion the function is
+ * @param exlusions A list of bundles that should not be considered when finding dependencies
+ * @param msg The message to be printed if dependencies are found
+ * @param include_optional A flag to indicate if we want to include optional dependencies in the list
  */
-int required_by(struct list **reqd_by, const char *bundle_name, struct manifest *mom, int recursion, struct list *exclusions, char *msg);
+int required_by(struct list **reqd_by, const char *bundle_name, struct manifest *mom, int recursion, struct list *exclusions, char *msg, bool include_optional);
 
 /**
  * @brief Creates a tracking file in the tracking directory within the

--- a/src/bundle_list.c
+++ b/src/bundle_list.c
@@ -345,6 +345,7 @@ static enum swupd_code show_bundle_reqd_by(const char *bundle_name, bool server,
 	struct list *subs = NULL;
 	struct list *reqd_by = NULL;
 	int number_of_reqd = 0;
+	const bool INCLUDE_OPTIONAL_DEPS = true;
 
 	if (!server && !is_installed_bundle(bundle_name)) {
 		info("Bundle \"%s\" does not seem to be installed\n", bundle_name);
@@ -393,7 +394,7 @@ static enum swupd_code show_bundle_reqd_by(const char *bundle_name, bool server,
 
 	char *msg;
 	string_or_die(&msg, "\n%s bundles that have %s as a dependency:\n", server ? "All" : "Installed", bundle_name);
-	number_of_reqd = required_by(&reqd_by, bundle_name, current_manifest, 0, NULL, msg);
+	number_of_reqd = required_by(&reqd_by, bundle_name, current_manifest, 0, NULL, msg, INCLUDE_OPTIONAL_DEPS);
 	free_string(&msg);
 	if (reqd_by == NULL) {
 		info("\nNo bundles have %s as a dependency\n", bundle_name);

--- a/src/bundle_remove.c
+++ b/src/bundle_remove.c
@@ -195,6 +195,7 @@ static enum swupd_code validate_bundle(const char *bundle, struct manifest *mom,
 	enum swupd_code ret = SWUPD_OK;
 	char *msg;
 	int number_of_reqd;
+	const bool DONT_INCLUDE_OPTIONAL_DEPS = false;
 
 	/* os-core bundle not allowed to be removed */
 	if (strcmp(bundle, "os-core") == 0) {
@@ -214,7 +215,7 @@ static enum swupd_code validate_bundle(const char *bundle, struct manifest *mom,
 
 	/* check if bundle is required by another installed bundle */
 	string_or_die(&msg, "\nBundle \"%s\" is required by the following bundles:\n", bundle);
-	number_of_reqd = required_by(reqd_by, bundle, mom, 0, bundles, msg);
+	number_of_reqd = required_by(reqd_by, bundle, mom, 0, bundles, msg, DONT_INCLUDE_OPTIONAL_DEPS);
 	free_string(&msg);
 	if (number_of_reqd > 0) {
 		/* the bundle is required by other bundles */


### PR DESCRIPTION
Using the "bundle-list --has-dep BUNDLE" command shows a list of bundles
that have BUNDLE as a dependency. However this list is not considering
the bundles that have BUNDLE as an optional dependency.

This commit completes the list by including these bundles.

Closes #1159 

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>