### PR TITLE
Show spinner when loading manifests in bundle-list

### DIFF
--- a/src/3rd_party_bundle_list.c
+++ b/src/3rd_party_bundle_list.c
@@ -133,7 +133,7 @@ static enum swupd_code list_repo_bundles(UNUSED_PARAM char *unused)
 enum swupd_code third_party_bundle_list_main(int argc, char **argv)
 {
 	enum swupd_code ret_code = SWUPD_OK;
-	const int steps_in_bundlelist = 0;
+	const int steps_in_bundlelist = 2;
 
 	if (!parse_options(argc, argv)) {
 		print("\n");

--- a/test/functional/3rd-party/3rd-party-bundle-list-deps.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-list-deps.bats
@@ -49,6 +49,8 @@ global_teardown() {
 		 3rd-Party Repo: repo1
 		_______________________
 
+		Loading required manifests...
+
 		Bundles included by test-bundle2:
 		 - test-bundle3
 		 - test-bundle4
@@ -70,6 +72,8 @@ global_teardown() {
 		_______________________
 		 3rd-Party Repo: repo1
 		_______________________
+
+		Loading required manifests...
 
 		All bundles that have test-bundle4 as a dependency:
 		 - test-bundle2

--- a/test/functional/bundlelist/list-deps-flat.bats
+++ b/test/functional/bundlelist/list-deps-flat.bats
@@ -20,6 +20,8 @@ test_setup() {
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Loading required manifests...
+
 		Bundles included by test-bundle1:
 		 - test-bundle2
 		 - test-bundle3

--- a/test/functional/bundlelist/list-deps-invalid-bundle.bats
+++ b/test/functional/bundlelist/list-deps-invalid-bundle.bats
@@ -8,6 +8,7 @@ load "../testlib"
 
 	assert_status_is "$SWUPD_INVALID_BUNDLE"
 	expected_output=$(cat <<-EOM
+		Loading required manifests...
 		Warning: Bundle "not-a-bundle" is invalid, skipping it...
 	EOM
 	)

--- a/test/functional/bundlelist/list-deps-nested.bats
+++ b/test/functional/bundlelist/list-deps-nested.bats
@@ -19,6 +19,8 @@ test_setup() {
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --deps test-bundle1"
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Loading required manifests...
+
 		Bundles included by test-bundle1:
 		 - test-bundle2
 		 - test-bundle3

--- a/test/functional/bundlelist/list-has-dep-nested-server.bats
+++ b/test/functional/bundlelist/list-has-dep-nested-server.bats
@@ -20,6 +20,8 @@ test_setup() {
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Loading required manifests...
+
 		All bundles that have test-bundle1 as a dependency:
 		 - test-bundle2
 		 - test-bundle3

--- a/test/functional/bundlelist/list-has-dep-nested.bats
+++ b/test/functional/bundlelist/list-has-dep-nested.bats
@@ -20,6 +20,8 @@ test_setup() {
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Loading required manifests...
+
 		Installed bundles that have test-bundle1 as a dependency:
 		 - test-bundle2
 		 - test-bundle3
@@ -37,6 +39,8 @@ test_setup() {
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Loading required manifests...
+
 		Installed bundles that have test-bundle1 as a dependency:
 
 		format:

--- a/test/functional/bundlelist/list-json.bats
+++ b/test/functional/bundlelist/list-json.bats
@@ -24,16 +24,20 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		[
 		{ "type" : "start", "section" : "bundle-list" },
+		{ "type" : "progress", "currentStep" : 1, "totalSteps" : 2, "stepCompletion" : -1, "stepDescription" : "load_manifests" },
+		{ "type" : "progress", "currentStep" : 1, "totalSteps" : 2, "stepCompletion" : 100, "stepDescription" : "load_manifests" },
+		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 2, "stepCompletion" : -1, "stepDescription" : "list_bundles" },
 		{ "type" : "info", "msg" : "Installed bundles:" },
 		{ "type" : "info", "msg" : " -" },
 		{ "type" : "info", "msg" : "os-core" },
 		{ "type" : "info", "msg" : " -" },
 		{ "type" : "info", "msg" : "test-bundle" },
 		{ "type" : "info", "msg" : " Total: 2" },
+		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 2, "stepCompletion" : 100, "stepDescription" : "list_bundles" },
 		{ "type" : "end", "section" : "bundle-list", "status" : 0 }
 		]
 	EOM
 	)
-	assert_is_output --identical "$expected_output"
+	assert_is_output "$expected_output"
 
 }

--- a/test/functional/bundlelist/list-no-deps.bats
+++ b/test/functional/bundlelist/list-no-deps.bats
@@ -16,9 +16,11 @@ test_setup() {
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Loading required manifests...
+
 		No included bundles
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }

--- a/test/functional/bundlelist/list-none-has-deps.bats
+++ b/test/functional/bundlelist/list-none-has-deps.bats
@@ -16,9 +16,11 @@ test_setup() {
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Loading required manifests...
+
 		No bundles have test-bundle1 as a dependency
 	EOM
 	)
-	assert_is_output "$expected_output"
+	assert_is_output --identical "$expected_output"
 
 }


### PR DESCRIPTION
For some options of bundle-list, like --deps and --has-dep, we sometimes
need to download a considerable amount of manifests, if that happens
swupd just seems to hang for some time, this time could be considerably
in slow networks.

This commit enables the spinner while the manifests are baing downloaded
during a bundle-list operation so users know swupd is not hung and it is
doing some downloading.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>