### PR TITLE
Fix an error showing the size during bundle-info

### DIFF
--- a/src/bundle_info.c
+++ b/src/bundle_info.c
@@ -208,7 +208,7 @@ static void print_bundle_size(struct manifest *manifest, long size, bool bundle_
 
 static long get_bundle_size(struct manifest *mom, bool bundle_installed)
 {
-	int bundle_size;
+	long bundle_size;
 	struct list *bundles_not_installed = NULL;
 	struct list *iter;
 	struct manifest *manifest;


### PR DESCRIPTION
When showing the information of a large bundle, there was a variable
that was incorrectly declared so it was overflowing, turning the size of
the bundle into a negative number.

This commit fixes the issue.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>