### PR TITLE
Function to print a header

### DIFF
--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -546,14 +546,9 @@ clean_and_exit:
 void third_party_repo_header(const char *repo_name)
 {
 	char *header = NULL;
-	int header_length;
 
 	string_or_die(&header, " 3rd-Party Repo: %s", repo_name);
-	header_length = strlen(header);
-	print_pattern("_", header_length + 1);
-	info("%s\n", header);
-	print_pattern("_", header_length + 1);
-	info("\n");
+	print_header(header);
 	free_string(&header);
 }
 

--- a/src/bundle_info.c
+++ b/src/bundle_info.c
@@ -383,14 +383,13 @@ enum swupd_code bundle_info(char *bundle)
 	mom->submanifests = recurse_manifest(mom, subs, NULL, false, NULL);
 
 	/* print header */
-	const int HEADER = 19;
-	int bundle_length = strlen(bundle);
-	print_pattern("_", HEADER + bundle_length);
-	info(" Info for bundle: %s\n", bundle);
-	print_pattern("_", HEADER + bundle_length);
+	char *header = NULL;
+	string_or_die(&header, " Info for bundle: %s", bundle);
+	print_header(header);
+	free_string(&header);
 
 	/* status info */
-	info("\nStatus: %s%s\n", installed ? "Installed" : "Not installed", file->is_experimental ? " (experimental)" : "");
+	info("Status: %s%s\n", installed ? "Installed" : "Not installed", file->is_experimental ? " (experimental)" : "");
 
 	/* version info */
 	if (installed) {

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -1133,6 +1133,17 @@ void print_pattern(const char *pattern, int times)
 	info("\n");
 }
 
+void print_header(const char *header)
+{
+	int header_length;
+
+	header_length = strlen(header);
+	print_pattern("_", header_length + 1);
+	info("%s\n", header);
+	print_pattern("_", header_length + 1);
+	info("\n");
+}
+
 void prettify_size(long size_in_bytes, char **pretty_size)
 {
 	double size;

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -311,6 +311,7 @@ extern int link_or_copy(const char *orig, const char *dest);
 extern int link_or_copy_all(const char *orig, const char *dest);
 extern int remove_files_from_fs(struct list *files);
 extern void print_pattern(const char *pattern, int times);
+extern void print_header(const char *header);
 extern void prettify_size(long size_in_bytes, char **pretty_size);
 extern int link_or_rename(const char *orig, const char *dest);
 extern int create_state_dirs(const char *state_dir_path);


### PR DESCRIPTION
This commit adds a function to print a header in a consistent manner
accross different swupd functions.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>