### PR TITLE
Add ability to search files in specific version

### DIFF
--- a/config
+++ b/config
@@ -220,6 +220,9 @@
 # Options for the "swupd search-file" command
 #
 
+# Search for a match of the given file in the specified version VER
+#version=[VER]
+
 # Search paths where libraries are located for a match (boolean value)
 #library=<true/false>
 

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -512,6 +512,10 @@ SUBCOMMANDS
     download all manifests for bundles that are not installed, and may
     result in the download of several mega bytes of manifest data.
 
+    - `-V, --version=[VER]`
+
+        Search for a match of the given file in the specified version VER.
+
     - `-l, --library`
 
         Restrict search to designated dynamic shared library paths.

--- a/swupd.bash
+++ b/swupd.bash
@@ -60,7 +60,7 @@ _swupd()
 		opts="--help --all --quiet --verbose "
 		break;;
 		("search-file")
-		opts="$global --library --binary --top --csv --init --order "
+		opts="$global --version --library --binary --top --csv --init --order "
 		break;;
 		("diagnose")
 		opts="$global --version --picky --picky-tree --picky-whitelist --quick --force --extra-files-only --bundles "

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -299,6 +299,7 @@ if [[ -n "$state" ]]; then
         search-file)
           local -a searchfiles; searchfiles=(
             $global_opts
+            '(help -V --version)'{-V,--version=}'[Search for a match of the given file in the specified version VER]:version:()'
             '(help -l --library)'{-l,--library=}'[Search paths where libraries are located for a match]:library: _files -W "(/usr/lib/ /usr/lib64/)" -g \*.\(a\|so\)'
             '(help -B --binary)'{-B,--binary=}'[Search paths where binaries are located for a match]:binary: _files -W /usr/bin/'
             '(help -T --top)'{-T,--top=}'[Only display the top NUM results for each bundle]:top:()'

--- a/test/functional/search/search-version.bats
+++ b/test/functional/search/search-version.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n test-bundle1 -f /foo/file_1 "$TEST_NAME"
+	create_version -p "$TEST_NAME" 20 10
+	update_bundle "$TEST_NAME" test-bundle1 --add /bar/file_2
+	set_current_version "$TEST_NAME" 10
+
+}
+
+@test "SRH030: Search for a file specifying the version" {
+
+	# Users should be able to search for files in specific versions of Clear
+	# using the --version option
+
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS file_2"
+
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Downloading all Clear Linux manifests
+		Searching for 'file_2'
+		Search term not found
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS file_2 --version 20"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Downloading all Clear Linux manifests
+		Searching for 'file_2'
+		Bundle test-bundle1 \\(0 MB to install\\)
+		./bar/file_2
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}


### PR DESCRIPTION
The search-file command is restricted to looking for files in the
current version. This commit adds the --version option to the command
that can be used to seach for files in specific versions of Clear.

Closes #1155

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>