### PR TITLE
Implement --file option for diagnose and repair

### DIFF
--- a/config
+++ b/config
@@ -282,6 +282,9 @@
 # Like --picky, but it only searches for extra files (boolean value)
 #extra_files_only=<true/false>
 
+# Forces swupd to only diagnose the specified file or directory (recursively)
+#file=[PATH]
+
 
 [repair]
 
@@ -318,6 +321,9 @@
 
 # Like --picky, but it only removes extra files (boolean value)
 #extra_files_only=<true/false>
+
+# Forces swupd to only repair the specified file or directory (recursively)
+#file=[PATH]
 
 
 [os-install]

--- a/docs/RELEASE_NOTES_DRAFT
+++ b/docs/RELEASE_NOTES_DRAFT
@@ -5,7 +5,7 @@ Release vX.XX.XX
 Bug Fixes:
 
 Features:
- - Add a bundle-remove --recursive flag to remove a bundle and all its dependencies from
- the system (with some exceptions, e.g. dependencies required by other installed bundles).
+ - Add the --file flag to diagnose and repair to allow users to diagnose/repair a specific
+   file or directory (recursively).
 
 Tests:

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -483,6 +483,11 @@ SUBCOMMANDS
        Like ``--picky``, but it only looks for extra files. It omits checking
        hash values, and for missing files, directories and/or symlinks.
 
+    -  ``--file``
+
+       Forces swupd to only diagnose the specified file or directory
+       (recursively).
+
 ``repair``
 
     Correct any issues found. This will overwrite incorrect file content,
@@ -557,6 +562,11 @@ SUBCOMMANDS
 
        Like ``--picky``, but it only removes extra files. It omits repairing
        corrupt files, and adding missing files, directories and/or symlinks.
+
+    -  ``--file``
+
+       Forces swupd to only repair the specified file or directory
+       (recursively).
 
 ``os-install``
 

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -672,9 +672,9 @@ enum swupd_code verify_fix_path(char *targetpath, struct manifest *target_MoM)
 				/* this subpart of the path does exist, nothing to be done */
 				continue;
 			}
-			info("Hash did not match for path : %s ... fixing\n", path);
+			warn_unlabeled(" -> Corrupt directory: %s", target);
 		} else if (ret == -1 && errno == ENOENT) {
-			info("Path %s is missing on the file system ... fixing\n", path);
+			warn_unlabeled(" -> Missing directory: %s", target);
 		} else {
 			goto end;
 		}
@@ -692,6 +692,7 @@ enum swupd_code verify_fix_path(char *targetpath, struct manifest *target_MoM)
 		string_or_die(&url, "%s/%i/files/%s.tar", globals.content_url, file->last_change, file->hash);
 		ret = swupd_curl_get_file(url, tar_dotfile);
 		if (ret != 0) {
+			warn_unlabeled(" -> not fixed\n");
 			error("Failed to download file %s in verify_fix_path\n", file->filename);
 			ret = SWUPD_COULDNT_DOWNLOAD_FILE;
 			unlink(tar_dotfile);
@@ -699,6 +700,7 @@ enum swupd_code verify_fix_path(char *targetpath, struct manifest *target_MoM)
 		}
 
 		if (untar_full_download(file) != 0) {
+			warn_unlabeled(" -> not fixed\n");
 			error("Failed to untar file %s\n", file->filename);
 			ret = SWUPD_COULDNT_UNTAR_FILE;
 			goto end;
@@ -708,9 +710,11 @@ enum swupd_code verify_fix_path(char *targetpath, struct manifest *target_MoM)
 		if (ret != 0) {
 			/* do_staging returns a swupd_code on error,
 			* just propagate the error */
+			warn_unlabeled(" -> not fixed\n");
 			error("Path %s failed to stage in verify_fix_path\n", path);
 			goto end;
 		}
+		warn_unlabeled(" -> fixed\n");
 	}
 end:
 	free_string(&target);

--- a/src/lib/log.h
+++ b/src/lib/log.h
@@ -56,8 +56,12 @@ void log_full(int log_level, FILE *out, const char *file, int line, const char *
 #define print(_fmt, ...) log_full(LOG_ALWAYS, stdout, __FILE__, __LINE__, NULL, _fmt, ##__VA_ARGS__);
 /** @brief Print messages using LOG_ERROR level. */
 #define error(_fmt, ...) log_full(LOG_ERROR, stderr, __FILE__, __LINE__, "Error", _fmt, ##__VA_ARGS__);
+/** @brief Print messages using LOG_ERROR level with no label. */
+#define error_unlabeled(_fmt, ...) log_full(LOG_ERROR, stderr, __FILE__, __LINE__, NULL, _fmt, ##__VA_ARGS__);
 /** @brief Print messages using LOG_WARN level. */
 #define warn(_fmt, ...) log_full(LOG_WARN, stderr, __FILE__, __LINE__, "Warning", _fmt, ##__VA_ARGS__);
+/** @brief Print messages using LOG_WARN level with no label. */
+#define warn_unlabeled(_fmt, ...) log_full(LOG_WARN, stderr, __FILE__, __LINE__, NULL, _fmt, ##__VA_ARGS__);
 /** @brief Print messages using LOG_INFO level. */
 #define info(_fmt, ...) log_full(LOG_INFO, stdout, __FILE__, __LINE__, NULL, _fmt, ##__VA_ARGS__);
 /** @brief Print messages using LOG_INFO_VERBOSE level. */

--- a/src/lib/sys.h
+++ b/src/lib/sys.h
@@ -191,6 +191,11 @@ char *sys_path_join(const char *prefix, const char *path);
 bool is_root(void);
 
 /**
+ * @brief Check if the provided path is a directory
+ */
+bool is_dir(const char *path);
+
+/**
  * @brief Remove file or directory.
  *
  * If filename is a directory, removes all files and directories recursively.

--- a/src/staging.c
+++ b/src/staging.c
@@ -97,13 +97,12 @@ enum swupd_code do_staging(struct file *file, struct manifest *MoM)
 	ret = stat(targetpath, &s);
 	if ((ret == -1) && (errno == ENOENT)) {
 		if (MoM) {
-			warn("Update target directory does not exist: %s. Trying to fix it\n", targetpath);
 			verify_fix_path(dir, MoM);
 		} else {
-			debug("Update target directory does not exist: %s. Auto-fix disabled\n", targetpath);
+			debug("Target directory does not exist: %s. Auto-fix disabled\n", targetpath);
 		}
 	} else if (!S_ISDIR(s.st_mode)) {
-		error("Update target exists but is NOT a directory: %s\n", targetpath);
+		error("Target exists but is NOT a directory: %s\n", targetpath);
 	}
 
 	if (!realpath(targetpath, real_path)) {

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -363,6 +363,7 @@ extern void verify_set_option_picky(bool opt);
 extern void verify_set_picky_whitelist(regex_t *whitelist);
 extern void verify_set_picky_tree(char *picky_tree);
 extern void verify_set_extra_files_only(bool opt);
+extern void verify_set_option_file(char *path);
 
 /* repair.c */
 extern regex_t *compile_whitelist(const char *whitelist_pattern);

--- a/swupd.bash
+++ b/swupd.bash
@@ -63,10 +63,10 @@ _swupd()
 		opts="$global --version --library --binary --top --csv --init --order "
 		break;;
 		("diagnose")
-		opts="$global --version --picky --picky-tree --picky-whitelist --quick --force --extra-files-only --bundles "
+		opts="$global --version --picky --picky-tree --picky-whitelist --quick --force --extra-files-only --bundles --file "
 		break;;
 		("repair")
-		opts="$global --version --picky --picky-tree --picky-whitelist --quick --force --extra-files-only --bundles "
+		opts="$global --version --picky --picky-tree --picky-whitelist --quick --force --extra-files-only --bundles --file "
 		break;;
 		("os-install")
 		opts="$global --version --force --bundles --statedir-cache --download --skip-optional"

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -324,6 +324,7 @@ if [[ -n "$state" ]]; then
             '(help -w --picky-whitelist)'{-w,--picky-whitelist=}'[Directories that match the regex get skipped. Example\: /var|/etc/machine-id. Default\: /usr/lib/modules|/usr/lib/kernel|/usr/local|/usr/src]:picky-whitelist:()'
             '(help)--extra-files-only[Only list files which should not exist]'
             '(help -B --bundles)'{-B,--bundles=}'[Forces swupd to only diagnose the specified BUNDLES. Example: --bundles=os-core,vi]:bundles:()'
+            '(help)--file[Forces swupd to only diagnose the specified file or directory (recursively)]'
           )
           _arguments $diagnoses && ret=0
           ;;
@@ -338,6 +339,7 @@ if [[ -n "$state" ]]; then
             '(help -X --picky-tree)'{-X,--picky-tree=}'[Selects the sub-tree where --picky and --extra-files-only looks for extra files. Default\: /usr]:picky-tree: _path_files -/'
             '(help)--extra-files-only[Only remove files which should not exist]'
             '(help -B --bundles)'{-B,--bundles=}'[Forces swupd to only repair the specified BUNDLES. Example: --bundles=os-core,vi]:bundles:()'
+            '(help)--file[Forces swupd to only repair the specified file or directory (recursively)]'
           )
           _arguments $repair && ret=0
           ;;

--- a/test/functional/bundleadd/add-verify-fix-path.bats
+++ b/test/functional/bundleadd/add-verify-fix-path.bats
@@ -22,15 +22,14 @@ test_setup() {
 @test "ADD022: When adding a bundle and a path is missing on the fs, bundle-add fixes it" {
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1"
-	assert_status_is 0
+	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		No packs need to be downloaded
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Installing files...
-		Warning: Update target directory does not exist: $TEST_DIRNAME/testfs/target-dir/foo/bar. Trying to fix it
-		Path /foo/bar is missing on the file system ... fixing
+		 -> Missing directory: $PATH_PREFIX/foo/bar -> fixed
 		Calling post-update helper scripts
 		Successfully installed 1 bundle
 	EOM

--- a/test/functional/diagnose/diagnose-path.bats
+++ b/test/functional/diagnose/diagnose-path.bats
@@ -1,0 +1,208 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment -r "$TEST_NAME" 10 1
+	create_bundle -L -n test-bundle1 -f /foo/file_1,/bar/file_2 "$TEST_NAME"
+	create_version "$TEST_NAME" 20 10 1
+	update_bundle -p "$TEST_NAME" test-bundle1 --update /foo/file_1
+	update_bundle -p "$TEST_NAME" test-bundle1 --delete /bar/file_2
+	update_bundle "$TEST_NAME" test-bundle1 --add /baz/file_3
+	update_bundle "$TEST_NAME" test-bundle1 --add /bar/file_4
+	update_bundle "$TEST_NAME" test-bundle1 --add /bar/bat/file_5
+	set_current_version "$TEST_NAME" 20
+	# adding an untracked files into an untracked directory (/bat)
+	sudo mkdir "$TARGETDIR"/bat
+	sudo touch "$TARGETDIR"/bat/untracked_file1
+	# adding an untracked file into tracked directory (/bar)
+	sudo touch "$TARGETDIR"/bar/untracked_file2
+	# adding an untracked file into /usr
+	sudo touch "$TARGETDIR"/usr/untracked_file3
+
+}
+
+@test "DIA022: Diagnose can be limited to a specific file" {
+
+	# if the user uses the --file option, the diagnose is limited to the
+	# file/directory specified by the user
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --file /baz/file_3"
+
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 20
+		Downloading missing manifests...
+		Limiting diagnose to the following file:
+		 - /baz/file_3
+		Checking for missing files
+		 -> Missing file: $PATH_PREFIX/baz/file_3
+		Checking for corrupt files
+		Checking for extraneous files
+		Inspected 1 file
+		  1 file was missing
+		Use "swupd repair" to correct the problems in the system
+		Diagnose successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "DIA023: Diagnose picky can be limited to a specific file" {
+
+	# if the user uses the --file + --picky options, the diagnose is limited to the
+	# file/directory specified by the user and looks for extra files in the
+	# same path only
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --file /baz/file_3 --picky"
+
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 20
+		Downloading missing manifests...
+		Limiting diagnose to the following file:
+		 - /baz/file_3
+		Checking for missing files
+		 -> Missing file: $PATH_PREFIX/baz/file_3
+		Checking for corrupt files
+		Checking for extraneous files
+		Checking for extra files under $PATH_PREFIX/baz/file_3
+		Inspected 1 file
+		  1 file was missing
+		Use "swupd repair" to correct the problems in the system
+		Diagnose successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "DIA024: Diagnose can be limited to a specific path" {
+
+	# if the user uses the --file option, the diagnose is limited to the
+	# file/directory specified by the user
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --file /bar"
+
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 20
+		Downloading missing manifests...
+		Limiting diagnose to the following directory (recursively):
+		 - /bar
+		Checking for missing files
+		 -> Missing file: $PATH_PREFIX/bar/bat
+		 -> Missing file: $PATH_PREFIX/bar/bat/file_5
+		 -> Missing file: $PATH_PREFIX/bar/file_4
+		Checking for corrupt files
+		Checking for extraneous files
+		 -> File that should be deleted: $PATH_PREFIX/bar/file_2
+		Inspected 5 files
+		  3 files were missing
+		  1 file found which should be deleted
+		Use "swupd repair" to correct the problems in the system
+		Diagnose successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "DIA025: Diagnose can be limited to a specific path to look for extra files only" {
+
+	# if the user uses the --file + --extra-files-only option, swupd should only look for
+	# extra files in the path specified by the user
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --file /bar --extra-files-only"
+
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 20
+		Downloading missing manifests...
+		Limiting diagnose to the following directory (recursively):
+		 - /bar
+		Checking for extra files under $PATH_PREFIX/bar
+		 -> Extra file: $PATH_PREFIX/bar/untracked_file2
+		 -> Extra file: $PATH_PREFIX/bar/file_2
+		Inspected 2 files
+		  2 files found which should be deleted
+		Use "swupd repair --picky" to correct the problems in the system
+		Diagnose successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "DIA026: Diagnose can be limited to a specific path and can look for extra files in another path" {
+
+	# if the user uses the --file option with --picky-tree,
+	# the latter should take precedence
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --file /bar --picky --picky-tree /usr"
+
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 20
+		Downloading missing manifests...
+		Limiting diagnose to the following directory (recursively):
+		 - /bar
+		Checking for missing files
+		 -> Missing file: $PATH_PREFIX/bar/bat
+		 -> Missing file: $PATH_PREFIX/bar/bat/file_5
+		 -> Missing file: $PATH_PREFIX/bar/file_4
+		Checking for corrupt files
+		Checking for extraneous files
+		 -> File that should be deleted: $PATH_PREFIX/bar/file_2
+		Checking for extra files under $PATH_PREFIX/usr
+		 -> Extra file: $PATH_PREFIX/usr/untracked_file3
+		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/versionurl
+		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/contenturl
+		Inspected 8 files
+		  3 files were missing
+		  4 files found which should be deleted
+		Use "swupd repair --picky" to correct the problems in the system
+		Diagnose successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "DIA027: Diagnose can be limited to a specific path for a specific bundle" {
+
+	# if the --bundles and --file options are used together, swupd should only
+	# look in the specified path and only for files that are part of the specified
+	# bundle
+
+	write_to_protected_file -a "$PATH_PREFIX"/usr/share/clear/bundles/os-core "corrupting the file"
+	write_to_protected_file -a "$PATH_PREFIX"/usr/share/clear/bundles/test-bundle1 "corrupting the file"
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --bundle test-bundle1 --file /usr/share/clear/bundles"
+
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 20
+		Limiting diagnose to the following bundles:
+		 - test-bundle1
+		Downloading missing manifests...
+		Limiting diagnose to the following directory (recursively):
+		 - /usr/share/clear/bundles
+		Checking for missing files
+		Checking for corrupt files
+		 -> Hash mismatch for file: $PATH_PREFIX/usr/share/clear/bundles/test-bundle1
+		Checking for extraneous files
+		Inspected 1 file
+		  1 file did not match
+		Use "swupd repair" to correct the problems in the system
+		Diagnose successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/repair/repair-path.bats
+++ b/test/functional/repair/repair-path.bats
@@ -1,0 +1,279 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment -r "$TEST_NAME" 10 1
+	create_bundle -L -n test-bundle1 -f /foo/file_1,/bar/file_2 -d /baz/testdir "$TEST_NAME"
+	create_version "$TEST_NAME" 20 10 1
+	update_bundle -p "$TEST_NAME" test-bundle1 --update /foo/file_1
+	update_bundle -p "$TEST_NAME" test-bundle1 --delete /bar/file_2
+	update_bundle "$TEST_NAME" test-bundle1 --add /baz/testdir/file_3
+	update_bundle "$TEST_NAME" test-bundle1 --add /bar/file_4
+	update_bundle "$TEST_NAME" test-bundle1 --add /bar/bat/file_5
+	set_current_version "$TEST_NAME" 20
+	# adding an untracked files into an untracked directory (/bat)
+	sudo mkdir "$TARGETDIR"/bat
+	sudo touch "$TARGETDIR"/bat/untracked_file1
+	# adding an untracked file into tracked directory (/bar)
+	sudo touch "$TARGETDIR"/bar/untracked_file2
+	# adding an untracked file into /usr
+	sudo touch "$TARGETDIR"/usr/untracked_file3
+
+}
+
+@test "REP038: Repair can be limited to a specific file" {
+
+	# if the user uses the --file option, the repair is limited to the
+	# file/directory specified by the user
+
+	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --file /baz/testdir/file_3"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 20
+		Downloading missing manifests...
+		Limiting diagnose to the following file:
+		 - /baz/testdir/file_3
+		Checking for corrupt files
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Adding any missing files
+		 -> Missing file: $PATH_PREFIX/baz/testdir/file_3 -> fixed
+		Repairing corrupt files
+		Removing extraneous files
+		Inspected 1 file
+		  1 file was missing
+		    1 of 1 missing files were replaced
+		    0 of 1 missing files were not replaced
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "REP039: Repair extra files only can be limited to a specific file" {
+
+	# if the user uses the --file + --picky options, the repair is limited to the
+	# file/directory specified by the user and looks for extra files in the
+	# same path only
+
+	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --file /foo/file_1 --extra-files-only"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 20
+		Downloading missing manifests...
+		Limiting diagnose to the following file:
+		 - /foo/file_1
+		Removing extra files under $PATH_PREFIX/foo/file_1
+		Inspected 0 files
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "REP040: Repair can fix a specific file even if its parent directory is missing" {
+
+	# if the user uses the --file option, the repair is limited to the
+	# file/directory specified by the user. If a file was specified to be
+	# verified, but part of its path is missing or corrput, fix it anyway
+
+	sudo rm -rf "$PATH_PREFIX"/baz
+
+	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --file /baz/testdir/file_3"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 20
+		Downloading missing manifests...
+		Limiting diagnose to the following file:
+		 - /baz/testdir/file_3
+		Checking for corrupt files
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Adding any missing files
+		 -> Missing directory: $PATH_PREFIX/baz -> fixed
+		 -> Missing directory: $PATH_PREFIX/baz/testdir -> fixed
+		 -> Missing file: $PATH_PREFIX/baz/testdir/file_3 -> fixed
+		Repairing corrupt files
+		Removing extraneous files
+		Inspected 1 file
+		  1 file was missing
+		    1 of 1 missing files were replaced
+		    0 of 1 missing files were not replaced
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "REP041: Repair can be limited to a specific path" {
+
+	# if the user uses the --file option, the repair is limited to the
+	# file/directory specified by the user
+
+	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --file /bar"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 20
+		Downloading missing manifests...
+		Limiting diagnose to the following directory (recursively):
+		 - /bar
+		Checking for corrupt files
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Adding any missing files
+		 -> Missing file: $PATH_PREFIX/bar/bat -> fixed
+		 -> Missing file: $PATH_PREFIX/bar/bat/file_5 -> fixed
+		 -> Missing file: $PATH_PREFIX/bar/file_4 -> fixed
+		Repairing corrupt files
+		Removing extraneous files
+		 -> File that should be deleted: $PATH_PREFIX/bar/file_2 -> deleted
+		Inspected 5 files
+		  3 files were missing
+		    3 of 3 missing files were replaced
+		    0 of 3 missing files were not replaced
+		  1 file found which should be deleted
+		    1 of 1 files were deleted
+		    0 of 1 files were not deleted
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "REP042: Repair picky can be limited to a specific path" {
+
+	# if the user uses the --file + --picky option, the repair is limited to the
+	# file/directory specified by the user and swupd will only look for extra files
+	# in the provided path
+
+	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --file /bar --picky"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 20
+		Downloading missing manifests...
+		Limiting diagnose to the following directory (recursively):
+		 - /bar
+		Checking for corrupt files
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Adding any missing files
+		 -> Missing file: $PATH_PREFIX/bar/bat -> fixed
+		 -> Missing file: $PATH_PREFIX/bar/bat/file_5 -> fixed
+		 -> Missing file: $PATH_PREFIX/bar/file_4 -> fixed
+		Repairing corrupt files
+		Removing extraneous files
+		 -> File that should be deleted: $PATH_PREFIX/bar/file_2 -> deleted
+		Removing extra files under $PATH_PREFIX/bar
+		 -> Extra file: $PATH_PREFIX/bar/untracked_file2 -> deleted
+		Inspected 6 files
+		  3 files were missing
+		    3 of 3 missing files were replaced
+		    0 of 3 missing files were not replaced
+		  2 files found which should be deleted
+		    2 of 2 files were deleted
+		    0 of 2 files were not deleted
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "REP043: Repair can be limited to a specific path and can look for extra files in another path" {
+
+	# if the user uses the --file option with --picky-tree,
+	# the latter should take precedence
+
+	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --file /bar --picky --picky-tree /usr"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 20
+		Downloading missing manifests...
+		Limiting diagnose to the following directory (recursively):
+		 - /bar
+		Checking for corrupt files
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Adding any missing files
+		 -> Missing file: $PATH_PREFIX/bar/bat -> fixed
+		 -> Missing file: $PATH_PREFIX/bar/bat/file_5 -> fixed
+		 -> Missing file: $PATH_PREFIX/bar/file_4 -> fixed
+		Repairing corrupt files
+		Removing extraneous files
+		 -> File that should be deleted: $PATH_PREFIX/bar/file_2 -> deleted
+		Removing extra files under $PATH_PREFIX/usr
+		 -> Extra file: $PATH_PREFIX/usr/untracked_file3 -> deleted
+		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/versionurl -> deleted
+		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/contenturl -> deleted
+		Inspected 8 files
+		  3 files were missing
+		    3 of 3 missing files were replaced
+		    0 of 3 missing files were not replaced
+		  4 files found which should be deleted
+		    4 of 4 files were deleted
+		    0 of 4 files were not deleted
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "REP044: Repair can be limited to a specific path for a specific bundle" {
+
+	# if the --bundles and --file options are used together, swupd should only
+	# look in the specified path and only for files that are part of the specified
+	# bundle
+
+	write_to_protected_file -a "$PATH_PREFIX"/usr/share/clear/bundles/os-core "corrupting the file"
+	write_to_protected_file -a "$PATH_PREFIX"/usr/share/clear/bundles/test-bundle1 "corrupting the file"
+
+	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --bundle test-bundle1 --file /usr/share/clear/bundles"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 20
+		Limiting diagnose to the following bundles:
+		 - test-bundle1
+		Downloading missing manifests...
+		Limiting diagnose to the following directory (recursively):
+		 - /usr/share/clear/bundles
+		Checking for corrupt files
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Adding any missing files
+		Repairing corrupt files
+		 -> Hash mismatch for file: $PATH_PREFIX/usr/share/clear/bundles/test-bundle1 -> fixed
+		Removing extraneous files
+		Inspected 1 file
+		  1 file did not match
+		    1 of 1 files were repaired
+		    0 of 1 files were not repaired
+		Calling post-update helper scripts
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/update/update-verify-fix-path-hash-mismatch.bats
+++ b/test/functional/update/update-verify-fix-path-hash-mismatch.bats
@@ -38,9 +38,8 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Installing files...
-		Warning: Update target directory does not exist: .*/target-dir/usr/foo. Trying to fix it
-		Hash did not match for path : /usr ... fixing
-		Path /usr/foo is missing on the file system ... fixing
+		 -> Corrupt directory: $PATH_PREFIX/usr -> fixed
+		 -> Missing directory: $PATH_PREFIX/usr/foo -> fixed
 		Update was applied
 		Calling post-update helper scripts
 		1 files were not in a pack

--- a/test/functional/update/update-verify-fix-path-missing-dir.bats
+++ b/test/functional/update/update-verify-fix-path-missing-dir.bats
@@ -5,11 +5,11 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment "$TEST_NAME"
-	create_bundle -L -n test-bundle -f /usr/foo/test-file "$TEST_NAME"
+	create_bundle -L -n test-bundle -f /foo/bar/baz/test-file "$TEST_NAME"
 	# remove the foo dir
-	sudo rm -rf "$TARGETDIR"/usr/foo
+	sudo rm -rf "$TARGETDIR"/foo
 	create_version "$TEST_NAME" 100 10
-	update_bundle "$TEST_NAME" test-bundle --update /usr/foo/test-file
+	update_bundle "$TEST_NAME" test-bundle --update /foo/bar/baz/test-file
 
 }
 
@@ -35,8 +35,9 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Installing files...
-		Warning: Update target directory does not exist: .*/target-dir/usr/foo. Trying to fix it
-		Path /usr/foo is missing on the file system ... fixing
+		 -> Missing directory: $PATH_PREFIX/foo -> fixed
+		 -> Missing directory: $PATH_PREFIX/foo/bar -> fixed
+		 -> Missing directory: $PATH_PREFIX/foo/bar/baz -> fixed
 		Update was applied
 		Calling post-update helper scripts
 		1 files were not in a pack
@@ -44,8 +45,8 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_dir_exists "$TARGETDIR"/usr/foo
-	assert_file_exists "$TARGETDIR"/usr/foo/test-file
+	assert_dir_exists "$TARGETDIR"/foo/bar/baz
+	assert_file_exists "$TARGETDIR"/foo/bar/baz/test-file
 
 }
 


### PR DESCRIPTION
When diagnosing/repairing a system, sometimes is useful to only diagnose/repair a
specific file or path.

This commit implements the --file option for diagnose/repair so a file or path
can be diagnosed/repaired only instead of doing it to the whole OS or a whole
bundle.

Closes #1150

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>