### PR TITLE
swupd documentation improvements

### DIFF
--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -292,12 +292,19 @@ SUBCOMMANDS
     - `-Y, --picky`
 
         Also list files which should not exist. Only files listed in the
-        manifests should exist.
+        manifests should exist. By default swupd only looks for these
+        files at `/usr`, this path can be changed using --picky-tree.
+        Some paths at '`\usr` are skipped by default:
+        ``/usr/lib/modules``, ``/usr/lib/kernel``, ``/usr/local``
+        and ``/usr/src``. These paths can be changed using
+        --picky-whitelist.
 
     - `-X, --picky-tree=[PATH]`
 
-        Selects the sub-tree where --picky and --extra-files-only looks for extra files.
-        To be specified as absolute path. The default is `/usr`.
+        Changes the path where --picky and --extra-files-only looks for
+        extra files. To be specified as absolute path.
+
+        The default path is `/usr`.
 
     - `-w, --picky-whitelist=[RE]`
 
@@ -433,13 +440,19 @@ SUBCOMMANDS
 
     - `-Y, --picky`
 
-        Also remove files which should not exist. Only files listed in the
-        manifests should exist.
+        Also removes files which should not exist. Only files listed in the
+        manifests should exist. By default swupd only looks for these
+        files at `/usr`, this path can be changed using --picky-tree.
+        Some paths at '`\usr` are skipped by default:
+        ``/usr/lib/modules``, ``/usr/lib/kernel``, ``/usr/local``
+        and ``/usr/src``. These paths can be changed using
+        --picky-whitelist.
 
     - `-X, --picky-tree=[PATH]`
 
-        Selects the sub-tree where --picky and --extra-files-only looks for extra files.
-        To be specified as absolute path. The default is `/usr`.
+        Changes the path where --picky and --extra-files-only looks for
+        extra files. To be specified as absolute path.
+        The default path is `/usr`.
 
     - `-w, --picky-whitelist=[RE]`
 

--- a/src/3rd_party.c
+++ b/src/3rd_party.c
@@ -42,6 +42,7 @@ static struct subcmd third_party_commands[] = {
 
 static void print_help(const char *name)
 {
+	print("Gives users the ability for handling custom content not provided upstream\n\n");
 	print("Usage:\n");
 	print("    swupd %s SUBCOMMAND [OPTION...]\n\n", sys_basename(name));
 	print("Help Options:\n");

--- a/src/3rd_party_add.c
+++ b/src/3rd_party_add.c
@@ -28,6 +28,9 @@
 
 static void print_help(void)
 {
+	/* TODO(castulo): we need to change this description to match that of the
+	 * documentation once the documentation for this content is added */
+	print("Adds a repository from which 3rd-party content can be installed\n\n");
 	print("Usage:\n");
 	print("   swupd 3rd-party add [repo-name] [repo-URL]\n\n");
 

--- a/src/3rd_party_bundle_add.c
+++ b/src/3rd_party_bundle_add.c
@@ -32,6 +32,7 @@ static char *cmdline_repo = NULL;
 
 static void print_help(void)
 {
+	print("Installs new software bundles from 3rd-party repositories\n\n");
 	print("Usage:\n");
 	print("   swupd 3rd-party bundle-add [OPTION...] [bundle1 bundle2 (...)]\n\n");
 

--- a/src/3rd_party_bundle_info.c
+++ b/src/3rd_party_bundle_info.c
@@ -35,6 +35,7 @@ static char *cmdline_option_bundle = NULL;
 
 static void print_help(void)
 {
+	print("Displays detailed information about a bundle from a 3rd-party repository\n\n");
 	print("Usage:\n");
 	print("   swupd 3rd-party bundle-info [OPTIONS...] BUNDLE\n\n");
 

--- a/src/3rd_party_bundle_list.c
+++ b/src/3rd_party_bundle_list.c
@@ -44,6 +44,7 @@ static void free_deps(void)
 
 static void print_help(void)
 {
+	print("Lists all installed and installable software bundles from 3rd-party repositories\n\n");
 	print("Usage:\n");
 	print("   swupd 3rd-party bundle-list [OPTIONS...]\n\n");
 

--- a/src/3rd_party_bundle_remove.c
+++ b/src/3rd_party_bundle_remove.c
@@ -31,6 +31,7 @@ static bool cmdline_option_recursive = false;
 
 static void print_help(void)
 {
+	print("Removes software bundles installed from 3rd-party repositories\n\n");
 	print("Usage:\n");
 	print("   swupd 3rd-party bundle-remove [OPTION...] [bundle1 bundle2 (...)]\n\n");
 

--- a/src/3rd_party_check_update.c
+++ b/src/3rd_party_check_update.c
@@ -28,6 +28,7 @@ static char *cmdline_option_repo = NULL;
 
 static void print_help(void)
 {
+	print("Checks whether an update is available for the 3rd-party repositories and prints out the information if so\n\n");
 	print("Usage:\n");
 	print("   swupd 3rd-party check-update [OPTION...]\n\n");
 

--- a/src/3rd_party_diagnose.c
+++ b/src/3rd_party_diagnose.c
@@ -41,6 +41,7 @@ static regex_t *picky_whitelist;
 
 static void print_help(void)
 {
+	print("Performs a system software installation verification for content installed from 3rd-party repositories\n\n");
 	print("Usage:\n");
 	print("   swupd 3rd-party diagnose [OPTION...]\n\n");
 

--- a/src/3rd_party_diagnose.c
+++ b/src/3rd_party_diagnose.c
@@ -53,10 +53,10 @@ static void print_help(void)
 	print("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	print("   -q, --quick             Don't check for corrupt files, only find missing files\n");
 	print("   -B, --bundles=[BUNDLES] Forces swupd to only diagnose the specified BUNDLES. Example: --bundles=os-core,vi\n");
-	print("   -Y, --picky             Also list files which should not exist\n");
-	print("   -X, --picky-tree=[PATH] Selects the sub-tree where --picky and --extra-files-only look for extra files. Default: /usr\n");
-	print("   -w, --picky-whitelist=[RE] Directories that match the regex get skipped. Example: /var|/etc/machine-id\n");
-	print("                           Default: %s\n", picky_whitelist_default);
+	print("   -Y, --picky             Also list files which should not exist. By default swupd only looks for them at /usr\n");
+	print("                           skipping /usr/lib/modules, /usr/lib/kernel, /usr/local, and /usr/src\n");
+	print("   -X, --picky-tree=[PATH] Changes the path where --picky and --extra-files-only look for extra files\n");
+	print("   -w, --picky-whitelist=[RE] Directories that match the regex get skipped during --picky. Example: /usr/man|/usr/doc\n");
 	print("   --extra-files-only      Like --picky, but it only performs this task\n");
 	print("\n");
 }

--- a/src/3rd_party_list.c
+++ b/src/3rd_party_list.c
@@ -25,6 +25,9 @@
 
 static void print_help(void)
 {
+	/* TODO(castulo): we need to change this description to match that of the
+	 * documentation once the documentation for this content is added */
+	print("Lists the 3rd-party repositories defined in the system\n\n");
 	print("Usage:\n");
 	print("   swupd 3rd-party list\n\n");
 

--- a/src/3rd_party_remove.c
+++ b/src/3rd_party_remove.c
@@ -27,6 +27,9 @@
 
 static void print_help(void)
 {
+	/* TODO(castulo): we need to change this description to match that of the
+	 * documentation once the documentation for this content is added */
+	print("Removes a 3rd-party repository from the list of available repositories in the system\n\n");
 	print("Usage:\n");
 	print("   swupd 3rd-party remove [repo-name]\n\n");
 

--- a/src/3rd_party_repair.c
+++ b/src/3rd_party_repair.c
@@ -42,6 +42,7 @@ static regex_t *picky_whitelist;
 
 static void print_help(void)
 {
+	print("Corrects any issues found with the current content installed from 3rd-party repositories\n\n");
 	print("Usage:\n");
 	print("   swupd 3rd-party repair [OPTION...]\n\n");
 

--- a/src/3rd_party_repair.c
+++ b/src/3rd_party_repair.c
@@ -54,10 +54,10 @@ static void print_help(void)
 	print("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	print("   -q, --quick             Don't compare hashes, only fix missing files\n");
 	print("   -B, --bundles=[BUNDLES] Forces swupd to only repair the specified BUNDLES. Example: --bundles=os-core,vi\n");
-	print("   -Y, --picky             Also remove files which should not exist\n");
-	print("   -X, --picky-tree=[PATH] Selects the sub-tree where --picky and --extra-files-only  looks for extra files. Default: /usr\n");
-	print("   -w, --picky-whitelist=[RE] Directories that match the regex get skipped. Example: /var|/etc/machine-id\n");
-	print("                           Default: %s\n", picky_whitelist_default);
+	print("   -Y, --picky             Also remove files which should not exist. By default swupd only looks for them at /usr\n");
+	print("                           skipping /usr/lib/modules, /usr/lib/kernel, /usr/local, and /usr/src\n");
+	print("   -X, --picky-tree=[PATH] Changes the path where --picky and --extra-files-only look for extra files\n");
+	print("   -w, --picky-whitelist=[RE] Directories that match the regex get skipped during --picky. Example: /usr/man|/usr/doc\n");
 	print("   --extra-files-only      Like --picky, but it only performs this task\n");
 	print("\n");
 }

--- a/src/3rd_party_update.c
+++ b/src/3rd_party_update.c
@@ -34,6 +34,7 @@ static char *cmdline_option_repo = NULL;
 
 static void print_help(void)
 {
+	print("Performs a system software update for content installed from 3rd-party repositories\n\n");
 	print("Usage:\n");
 	print("   swupd 3rd-party update [OPTION...]\n\n");
 

--- a/src/autoupdate.c
+++ b/src/autoupdate.c
@@ -30,6 +30,7 @@
 
 static void print_help(void)
 {
+	print("Enables or disables automatic updates, or reports current status\n\n");
 	print("Usage:\n");
 	print("   swupd autoupdate [OPTION...]\n\n");
 

--- a/src/bundle_add.c
+++ b/src/bundle_add.c
@@ -44,6 +44,7 @@ static char **cmdline_bundles;
 
 static void print_help(void)
 {
+	print("Installs new software bundles\n\n");
 	print("Usage:\n");
 	print("   swupd bundle-add [OPTION...] [bundle1 bundle2 (...)]\n\n");
 

--- a/src/bundle_info.c
+++ b/src/bundle_info.c
@@ -50,6 +50,7 @@ void bundle_info_set_option_files(bool opt)
 
 static void print_help(void)
 {
+	print("Displays detailed information about a bundle\n\n");
 	print("Usage:\n");
 	print("   swupd bundle-info [OPTIONS...] BUNDLE\n\n");
 

--- a/src/bundle_list.c
+++ b/src/bundle_list.c
@@ -73,6 +73,7 @@ static void free_deps(void)
 
 static void print_help(void)
 {
+	print("Lists all installed and installable software bundles\n\n");
 	print("Usage:\n");
 	print("   swupd bundle-list [OPTIONS...]\n\n");
 

--- a/src/bundle_remove.c
+++ b/src/bundle_remove.c
@@ -51,6 +51,7 @@ void bundle_remove_set_option_recursive(bool opt)
 
 static void print_help(void)
 {
+	print("Removes software bundles\n\n");
 	print("Usage:\n");
 	print("   swupd bundle-remove [OPTION...] [bundle1 bundle2 (...)]\n\n");
 

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -34,6 +34,7 @@
 
 static void print_help(void)
 {
+	print("Checks whether an update is available and prints out the information if so\n\n");
 	print("Usage:\n");
 	print("   swupd check-update [OPTION...]\n\n");
 	//TODO: Add documentation explaining this command

--- a/src/hashdump.c
+++ b/src/hashdump.c
@@ -46,6 +46,7 @@ static struct option opts[] = {
 
 static void usage(const char *name)
 {
+	print("Calculates and print the Manifest hash for a specific file on disk\n\n");
 	print("Usage:\n");
 	print("   swupd %s [OPTION...] filename\n\n", sys_basename(name));
 	print("Help Options:\n");

--- a/src/mirror.c
+++ b/src/mirror.c
@@ -35,10 +35,9 @@ const char *set_url = NULL;
 
 static void print_help(void)
 {
+	print("Configures a mirror URL for swupd to use instead of the defaults on the system\n\n");
 	print("Usage:\n");
 	print("   swupd mirror [OPTION...]\n\n");
-
-	//TODO: Add documentation explaining this command
 
 	global_print_help();
 

--- a/src/os_install.c
+++ b/src/os_install.c
@@ -44,6 +44,7 @@ static const struct option prog_opts[] = {
 
 static void print_help(void)
 {
+	print("Performs a system software installation in the specified location\n\n");
 	print("Usage:\n");
 	print("   swupd os-install [OPTION...] PATH\n\n");
 

--- a/src/repair.c
+++ b/src/repair.c
@@ -66,10 +66,10 @@ static void print_help(void)
 	print("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	print("   -q, --quick             Don't compare hashes, only fix missing files\n");
 	print("   -B, --bundles=[BUNDLES] Forces swupd to only repair the specified BUNDLES. Example: --bundles=os-core,vi\n");
-	print("   -Y, --picky             Also remove files which should not exist\n");
-	print("   -X, --picky-tree=[PATH] Selects the sub-tree where --picky and --extra-files-only  looks for extra files. Default: /usr\n");
-	print("   -w, --picky-whitelist=[RE] Directories that match the regex get skipped. Example: /var|/etc/machine-id\n");
-	print("                           Default: %s\n", picky_whitelist_default);
+	print("   -Y, --picky             Also remove files which should not exist. By default swupd only looks for them at /usr\n");
+	print("                           skipping /usr/lib/modules, /usr/lib/kernel, /usr/local, and /usr/src\n");
+	print("   -X, --picky-tree=[PATH] Changes the path where --picky and --extra-files-only look for extra files\n");
+	print("   -w, --picky-whitelist=[RE] Directories that match the regex get skipped during --picky. Example: /usr/man|/usr/doc\n");
 	print("   --extra-files-only      Like --picky, but it only performs this task\n");
 	print("\n");
 }

--- a/src/repair.c
+++ b/src/repair.c
@@ -55,6 +55,7 @@ static const struct option prog_opts[] = {
 
 static void print_help(void)
 {
+	print("Corrects any issues found with the current system\n\n");
 	print("Usage:\n");
 	print("   swupd repair [OPTION...]\n\n");
 

--- a/src/search_file.c
+++ b/src/search_file.c
@@ -389,8 +389,9 @@ error:
 
 static void print_help(void)
 {
+	print("Searches for matching paths in manifest data\n\n");
 	print("Usage:\n");
-	print("   swupd search [OPTION...] 'search_term'\n\n");
+	print("   swupd search-file [OPTION...] 'search_term'\n\n");
 	print("		'search_term': A substring of a binary, library or filename (default)\n");
 	print("		Return: Bundle name : filename matching search term\n\n");
 

--- a/src/update.c
+++ b/src/update.c
@@ -648,6 +648,7 @@ static const struct option prog_opts[] = {
 
 static void print_help(void)
 {
+	print("Performs a system software update\n\n");
 	print("Usage:\n");
 	print("   swupd update [OPTION...]\n\n");
 

--- a/src/verify.c
+++ b/src/verify.c
@@ -177,11 +177,11 @@ static void print_help(void)
 		print("   -i, --install           This option has been superseded, please consider using \"swupd os-install\" instead\n");
 		print("   -Y, --picky             Also list (without --fix) or remove (with --fix) files which should not exist\n");
 	} else {
-		print("   -Y, --picky             Also list files which should not exist\n");
+		print("   -Y, --picky             Also list files which should not exist. By default swupd only looks for them at /usr\n");
+		print("                           skipping /usr/lib/modules, /usr/lib/kernel, /usr/local, and /usr/src\n");
 	}
-	print("   -X, --picky-tree=[PATH] Selects the sub-tree where --picky and --extra-files-only look for extra files. Default: /usr\n");
-	print("   -w, --picky-whitelist=[RE] Directories that match the regex get skipped. Example: /var|/etc/machine-id\n");
-	print("                           Default: %s\n", picky_whitelist_default);
+	print("   -X, --picky-tree=[PATH] Changes the path where --picky and --extra-files-only look for extra files\n");
+	print("   -w, --picky-whitelist=[RE] Directories that match the regex get skipped during --picky. Example: /usr/bin|/usr/doc\n");
 	print("   --extra-files-only      Like --picky, but it only performs this task\n");
 	print("\n");
 }

--- a/src/verify.c
+++ b/src/verify.c
@@ -154,9 +154,12 @@ void verify_set_extra_files_only(bool opt)
 
 static void print_help(void)
 {
+	print("Performs a system software installation verification\n\n");
 	print("Usage:\n");
 	if (cmdline_command_verify) {
 		print("   swupd verify [OPTION...]\n\n");
+		print("Warning: The \"swupd verify\" command has been superseded\n");
+		print("Please consider using \"swupd diagnose\", \"swupd repair\" or \"swupd os-install\" instead\n\n");
 	} else {
 		print("   swupd diagnose [OPTION...]\n\n");
 	}


### PR DESCRIPTION
This PR makes a couple of improvements in the swupd documentation:
 - Adds a short description to all swupd commands.
 - Rephrases the `--picky` related documentation to make it clearer to the user.

Closes #1205 
Closes #1108