### PR TITLE
Implementing tree view for `bundle-list --deps`

### DIFF
--- a/src/3rd_party_bundle_list.c
+++ b/src/3rd_party_bundle_list.c
@@ -53,8 +53,8 @@ static void print_help(void)
 	print("Options:\n");
 	print("   -R, --repo              Specify the 3rd-party repository to use\n");
 	print("   -a, --all               List all available bundles for the current version of Clear Linux\n");
-	print("   -D, --has-dep=[BUNDLE]  List all bundles which have BUNDLE as a dependency\n");
-	print("   --deps=[BUNDLE]         List bundles included by BUNDLE\n");
+	print("   -D, --has-dep=[BUNDLE]  List all bundles which have BUNDLE as a dependency (use --verbose for tree view)\n");
+	print("   --deps=[BUNDLE]         List BUNDLE dependencies (use --verbose for tree view)\n");
 	print("\n");
 }
 

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -321,10 +321,12 @@ extern int link_or_rename(const char *orig, const char *dest);
 extern int create_state_dirs(const char *state_dir_path);
 
 /* subscription.c */
+typedef bool (*subs_fn_t)(struct list **subs, const char *component, int recursion, bool is_optional);
 struct list *free_list_file(struct list *item);
 extern void create_and_append_subscription(struct list **subs, const char *component);
 extern char *get_tracking_dir(void);
 extern int add_subscriptions(struct list *bundles, struct list **subs, struct manifest *mom, bool find_all, int recursion);
+extern int subscription_get_tree(struct list *bundles, struct list **subs, struct manifest *mom, bool find_all, int recursion);
 extern int subscription_bundlename_strcmp(const void *a, const void *b);
 extern int subscription_sort_component(const void *a, const void *b);
 

--- a/test/functional/bundlelist/list-deps-nested.bats
+++ b/test/functional/bundlelist/list-deps-nested.bats
@@ -17,13 +17,34 @@ test_setup() {
 @test "LST007: List bundle's dependencies when bundle has nested dependencies" {
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --deps test-bundle1"
-	assert_status_is 0
+
+	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 
 		Bundles included by test-bundle1:
 		 - test-bundle2
 		 - test-bundle3
+
+		Total: 2
+	EOM
+	)
+	assert_is_output --identical "$expected_output"
+
+}
+
+@test "LST023: List bundle's dependencies (with nested deps) in a tree view" {
+
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --deps test-bundle1 --verbose"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Loading required manifests...
+
+		Bundles included by test-bundle1:
+		  * test-bundle1
+		    |-- test-bundle2
+		        |-- test-bundle3
 
 		Total: 2
 	EOM


### PR DESCRIPTION
Sometimes is useful to see the list of dependencies in a tree view form, for example when trying to remove bundles from a system.

This commit adds the ability of listing the dependencies of a bundle in  a tree view when --verbose is used.

Example:
```
$ sudo ./swupd bundle-list --deps vim
Loading required manifests...

Bundles included by vim:
 - findutils
 - lib-openssl
 - libstdcpp
 - os-core
 - p11-kit
 - perl-basic
 - python3-basic

Total: 7

$ sudo ./swupd bundle-list --deps vim --verbose
Loading required manifests...

Bundles included by vim:
  * vim
    |-- perl-basic
        |-- lib-openssl
            |-- p11-kit
                |-- findutils
                    |-- os-core
                |-- os-core
            |-- os-core
        |-- os-core
    |-- python3-basic
        |-- libstdcpp
            |-- os-core
        |-- p11-kit
            |-- findutils
                |-- os-core
            |-- os-core
        |-- os-core
    |-- os-core

Total: 7
```

Closes #929