### PR TITLE
Fix name of 3rd-party directory

### DIFF
--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -28,7 +28,7 @@
 
 static char *get_repo_config_path(void)
 {
-	return str_or_die("%s/%s/%s", globals.state_dir, "3rd_party", "repo.ini");
+	return str_or_die("%s/%s/%s", globals.state_dir, SWUPD_3RD_PARTY_DIRNAME, "repo.ini");
 }
 
 int repo_name_cmp(const void *repo, const void *name)
@@ -238,7 +238,7 @@ int third_party_remove_repo_directory(const char *repo_name)
 	int ret_code = 0;
 
 	//TODO: use a global function to get this value
-	repo_dir = str_or_die("%s/opt/3rd_party/%s", globals.path_prefix, repo_name);
+	repo_dir = str_or_die("%s/opt/%s/%s", globals.path_prefix, SWUPD_3RD_PARTY_DIRNAME, repo_name);
 	ret = sys_rm_recursive(repo_dir);
 	if (ret < 0 && ret != -ENOENT) {
 		error("Failed to delete repository directory\n");
@@ -246,7 +246,7 @@ int third_party_remove_repo_directory(const char *repo_name)
 	}
 	free(repo_dir);
 
-	repo_dir = str_or_die("%s/3rd_party/%s", globals.state_dir, repo_name);
+	repo_dir = str_or_die("%s/%s/%s", globals.state_dir, SWUPD_3RD_PARTY_DIRNAME, repo_name);
 	ret = sys_rm_recursive(repo_dir);
 	if (ret < 0 && ret != -ENOENT) {
 		error("Failed to delete repository state directory\n");
@@ -267,7 +267,7 @@ enum swupd_code third_party_set_repo(const char *state_dir, const char *path_pre
 	set_version_url(repo->url);
 
 	/* set up swupd to use the certificate from the 3rd-party repository */
-	string_or_die(&repo_cert_path, "%s/opt/3rd_party/%s/%s", path_prefix, repo->name, CERT_PATH);
+	string_or_die(&repo_cert_path, "%s/opt/%s/%s/%s", path_prefix, SWUPD_3RD_PARTY_DIRNAME, repo->name, CERT_PATH);
 	set_cert_path(repo_cert_path);
 	/* if --nosigcheck was used, we do not attempt any signature checking */
 	if (sigcheck) {
@@ -281,13 +281,13 @@ enum swupd_code third_party_set_repo(const char *state_dir, const char *path_pre
 	}
 	free_string(&repo_cert_path);
 
-	string_or_die(&repo_path_prefix, "%s/opt/3rd_party/%s", path_prefix, repo->name);
+	string_or_die(&repo_path_prefix, "%s/opt/%s/%s", path_prefix, SWUPD_3RD_PARTY_DIRNAME, repo->name);
 	set_path_prefix(repo_path_prefix);
 	free_string(&repo_path_prefix);
 
 	/* make sure there are state directories for the 3rd-party
 	 * repo if not there already */
-	string_or_die(&repo_state_dir, "%s/3rd_party/%s", state_dir, repo->name);
+	string_or_die(&repo_state_dir, "%s/%s/%s", state_dir, SWUPD_3RD_PARTY_DIRNAME, repo->name);
 	if (create_state_dirs(repo_state_dir)) {
 		free_string(&repo_state_dir);
 		error("Unable to create the state directories for repository %s\n\n", repo->name);

--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -14,6 +14,8 @@ extern "C" {
 
 #ifdef THIRDPARTY
 
+#define SWUPD_3RD_PARTY_DIRNAME "3rd-party"
+
 /** @brief Store information of a repository.  */
 struct repo {
 	char *name;

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -237,7 +237,7 @@ int create_state_dirs(const char *state_dir_path)
 	unsigned int i;
 	char *dir;
 #define STATE_DIR_COUNT (sizeof(state_dirs) / sizeof(state_dirs[0]))
-	const char *state_dirs[] = { "delta", "staged", "download", "telemetry", "bundles", "3rd_party" };
+	const char *state_dirs[] = { "delta", "staged", "download", "telemetry", "bundles", "3rd-party" };
 
 	// check for existence
 	if (ensure_root_owned_dir(state_dir_path)) {

--- a/test/functional/3rd-party/3rd-party-allow-http.bats
+++ b/test/functional/3rd-party/3rd-party-allow-http.bats
@@ -6,7 +6,7 @@
 load "../testlib"
 
 test_path=$(realpath "$TEST_NAME")
-repo="$test_path"/3rd_party/my_repo
+repo="$test_path"/3rd-party/my_repo
 
 global_setup() {
 
@@ -71,7 +71,7 @@ global_teardown() {
 	assert_in_output "$expected_output"
 	assert_in_output "Repository added successfully"
 
-	run sudo sh -c "cat $STATEDIR/3rd_party/repo.ini"
+	run sudo sh -c "cat $STATEDIR/3rd-party/repo.ini"
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		[my_repo]
@@ -79,6 +79,6 @@ global_teardown() {
 	EOM
 	)
 	assert_is_output --identical "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/my_repo/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/my_repo/usr/lib/os-release
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/my_repo/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/my_repo/usr/lib/os-release
 }

--- a/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
@@ -42,8 +42,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo2/foo/file_2
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo2/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo2/foo/file_2
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo2/usr/share/clear/bundles/test-bundle2
 	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle2
 
 }
@@ -98,14 +98,14 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo2/foo/file_2
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo2/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo2/foo/file_2
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo2/usr/share/clear/bundles/test-bundle2
 	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle2
-	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo2/usr/share/clear/bundles/upstream-bundle
+	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo2/usr/share/clear/bundles/upstream-bundle
 
 	# same scenario with the arguments switched
 
-	remove_bundle -L "$TEST_NAME"/3rd_party/test-repo2/10/Manifest.test-bundle2 test-repo2
+	remove_bundle -L "$TEST_NAME"/3rd-party/test-repo2/10/Manifest.test-bundle2 test-repo2
 	clean_state_dir "$TEST_NAME" test-repo2
 
 	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle2 upstream-bundle"
@@ -127,7 +127,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo2/foo/file_2
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo2/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo2/foo/file_2
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo2/usr/share/clear/bundles/test-bundle2
 	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle2
 }

--- a/test/functional/3rd-party/3rd-party-bundle-add-config-file.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-config-file.bats
@@ -54,15 +54,15 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# test-bundle1 is installed and tracked
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo/usr/share/clear/bundles/test-bundle1
 	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle1
 
 	# test-bundle2 is installed but not tracked
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo/usr/share/clear/bundles/test-bundle2
 	assert_file_not_exists "$TPSTATEDIR"/bundles/test-bundle2
 
 	# test-bundle3 is not installed at all
-	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo/usr/share/clear/bundles/test-bundle3
+	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo/usr/share/clear/bundles/test-bundle3
 	assert_file_not_exists "$TPSTATEDIR"/bundles/test-bundle3
 
 }

--- a/test/functional/3rd-party/3rd-party-bundle-add-multi-repo.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-multi-repo.bats
@@ -36,12 +36,12 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/repo1/foo/file_1A
-	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/repo2/baz/file_1B
-	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/repo1/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/repo2/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$STATEDIR"/3rd_party/repo1/bundles/test-bundle1
-	assert_file_not_exists "$STATEDIR"/3rd_party/repo2/bundles/test-bundle1
+	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/repo1/foo/file_1A
+	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/repo2/baz/file_1B
+	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/repo2/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$STATEDIR"/3rd-party/repo1/bundles/test-bundle1
+	assert_file_not_exists "$STATEDIR"/3rd-party/repo2/bundles/test-bundle1
 
 }
 
@@ -65,11 +65,11 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/repo1/foo/file_1A
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/repo2/baz/file_1B
-	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/repo1/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/repo2/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$STATEDIR"/3rd_party/repo1/bundles/test-bundle1
-	assert_file_exists "$STATEDIR"/3rd_party/repo2/bundles/test-bundle1
+	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/repo1/foo/file_1A
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/repo2/baz/file_1B
+	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/repo2/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$STATEDIR"/3rd-party/repo1/bundles/test-bundle1
+	assert_file_exists "$STATEDIR"/3rd-party/repo2/bundles/test-bundle1
 
 }

--- a/test/functional/3rd-party/3rd-party-bundle-info-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-info-basic.bats
@@ -14,7 +14,7 @@ global_setup() {
 	add_third_party_repo "$TEST_NAME" 10 staging repo1
 	create_bundle    -n test-bundle1 -f /foo/file_1A -u repo1 "$TEST_NAME"
 	create_bundle -L -n test-bundle2 -f /bar/file_2  -u repo1 "$TEST_NAME"
-	add_dependency_to_manifest "$TEST_NAME"/3rd_party/repo1/10/Manifest.test-bundle2 test-bundle1
+	add_dependency_to_manifest "$TEST_NAME"/3rd-party/repo1/10/Manifest.test-bundle2 test-bundle1
 
 	add_third_party_repo "$TEST_NAME" 10 staging repo2
 	create_bundle    -n test-bundle1 -f /baz/file_1B -u repo2 "$TEST_NAME"

--- a/test/functional/3rd-party/3rd-party-bundle-remove-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-basic.bats
@@ -37,8 +37,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo2/foo/file_2
-	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo2/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo2/foo/file_2
+	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo2/usr/share/clear/bundles/test-bundle2
 	assert_file_not_exists "$TPSTATEDIR"/bundles/test-bundle2
 
 }
@@ -70,9 +70,9 @@ test_setup() {
 
 @test "TPR026: Try removing one valid bundle from a third party repo and one invalid" {
 
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo1/foo/file_1
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo1/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$STATEDIR"/3rd_party/test-repo1/bundles/test-bundle1
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/foo/file_1
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$STATEDIR"/3rd-party/test-repo1/bundles/test-bundle1
 
 	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS test-bundle1 upstream-bundle"
 
@@ -90,15 +90,15 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo1/foo/file_1
-	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo1/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$STATEDIR"/3rd_party/test-repo1/bundles/test-bundle1
+	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo1/foo/file_1
+	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$STATEDIR"/3rd-party/test-repo1/bundles/test-bundle1
 
 	# run the same scenario with the arguments switched
-	install_bundle "$TEST_NAME"/3rd_party/test-repo1/10/Manifest.test-bundle1 test-repo1
+	install_bundle "$TEST_NAME"/3rd-party/test-repo1/10/Manifest.test-bundle1 test-repo1
 	clean_state_dir "$TEST_NAME" test-repo1
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo1/foo/file_1
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/foo/file_1
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/usr/share/clear/bundles/test-bundle1
 
 	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS upstream-bundle test-bundle1"
 
@@ -116,7 +116,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo1/foo/file_1
-	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo1/foo/file_1
+	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo1/usr/share/clear/bundles/test-bundle1
 
 }

--- a/test/functional/3rd-party/3rd-party-bundle-remove-multi-repo.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-multi-repo.bats
@@ -18,7 +18,7 @@ test_setup() {
 	add_third_party_repo "$TEST_NAME" 10 1 test-repo2
 	create_bundle -L -t -n test-bundle1 -f /foo/file_2 -u test-repo2 "$TEST_NAME"
 	create_bundle -L    -n test-bundle2 -f /bar/file_3 -u test-repo2 "$TEST_NAME"
-	add_dependency_to_manifest "$TEST_NAME"/3rd_party/test-repo2/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest "$TEST_NAME"/3rd-party/test-repo2/10/Manifest.test-bundle1 test-bundle2
 
 }
 

--- a/test/functional/3rd-party/3rd-party-diagnose-basic.bats
+++ b/test/functional/3rd-party/3rd-party-diagnose-basic.bats
@@ -23,12 +23,12 @@ global_setup() {
 	create_bundle -L -t -n test-bundle2 -f /baz/file_3 -u test-repo2 "$TEST_NAME"
 
 	# adding an untracked files into an untracked directory (/bat)
-	sudo mkdir "$TARGETDIR"/opt/3rd_party/test-repo1/bat
-	sudo touch "$TARGETDIR"/opt/3rd_party/test-repo1/bat/untracked_file1
+	sudo mkdir "$TARGETDIR"/opt/3rd-party/test-repo1/bat
+	sudo touch "$TARGETDIR"/opt/3rd-party/test-repo1/bat/untracked_file1
 	# adding an untracked file into tracked directory (/bar)
-	sudo touch "$TARGETDIR"/opt/3rd_party/test-repo1/bar/untracked_file2
+	sudo touch "$TARGETDIR"/opt/3rd-party/test-repo1/bar/untracked_file2
 	# adding an untracked file into /usr
-	sudo touch "$TARGETDIR"/opt/3rd_party/test-repo2/usr/untracked_file3
+	sudo touch "$TARGETDIR"/opt/3rd-party/test-repo2/usr/untracked_file3
 
 }
 
@@ -62,13 +62,13 @@ global_teardown() {
 		Diagnosing version 20
 		Downloading missing manifests...
 		Checking for missing files
-		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz
-		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz/file_3
+		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz
+		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz/file_3
 		Checking for corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/foo/file_1
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/usr/lib/os-release
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/foo/file_1
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/usr/lib/os-release
 		Checking for extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/opt/3rd_party/test-repo1/bar/file_2
+		 -> File that should be deleted: $PATH_PREFIX/opt/3rd-party/test-repo1/bar/file_2
 		Inspected 19 files
 		  2 files were missing
 		  2 files did not match
@@ -133,7 +133,7 @@ global_teardown() {
 		Downloading missing manifests...
 		Checking for missing files
 		Checking for corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/usr/lib/os-release
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/usr/lib/os-release
 		Checking for extraneous files
 		Inspected 17 files
 		  1 file did not match
@@ -157,14 +157,14 @@ global_teardown() {
 		Diagnosing version 20
 		Downloading missing manifests...
 		Checking for missing files
-		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz
-		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz/file_3
+		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz
+		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz/file_3
 		Checking for corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/foo/file_1
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/usr/lib/os-release
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/foo/file_1
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/usr/lib/os-release
 		Checking for extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/opt/3rd_party/test-repo1/bar/file_2
-		Checking for extra files under $PATH_PREFIX/opt/3rd_party/test-repo1/usr
+		 -> File that should be deleted: $PATH_PREFIX/opt/3rd-party/test-repo1/bar/file_2
+		Checking for extra files under $PATH_PREFIX/opt/3rd-party/test-repo1/usr
 		Inspected 19 files
 		  2 files were missing
 		  2 files did not match
@@ -179,8 +179,8 @@ global_teardown() {
 		Checking for missing files
 		Checking for corrupt files
 		Checking for extraneous files
-		Checking for extra files under $PATH_PREFIX/opt/3rd_party/test-repo2/usr
-		 -> Extra file: $PATH_PREFIX/opt/3rd_party/test-repo2/usr/untracked_file3
+		Checking for extra files under $PATH_PREFIX/opt/3rd-party/test-repo2/usr
+		 -> Extra file: $PATH_PREFIX/opt/3rd-party/test-repo2/usr/untracked_file3
 		Inspected 16 files
 		  1 file found which should be deleted
 		Use "swupd repair --picky" to correct the problems in the system
@@ -203,16 +203,16 @@ global_teardown() {
 		Diagnosing version 20
 		Downloading missing manifests...
 		Checking for missing files
-		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz
-		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz/file_3
+		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz
+		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz/file_3
 		Checking for corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/foo/file_1
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/usr/lib/os-release
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/foo/file_1
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/usr/lib/os-release
 		Checking for extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/opt/3rd_party/test-repo1/bar/file_2
-		Checking for extra files under $PATH_PREFIX/opt/3rd_party/test-repo1/bat
-		 -> Extra file: $PATH_PREFIX/opt/3rd_party/test-repo1/bat/untracked_file1
-		 -> Extra file: $PATH_PREFIX/opt/3rd_party/test-repo1/bat/
+		 -> File that should be deleted: $PATH_PREFIX/opt/3rd-party/test-repo1/bar/file_2
+		Checking for extra files under $PATH_PREFIX/opt/3rd-party/test-repo1/bat
+		 -> Extra file: $PATH_PREFIX/opt/3rd-party/test-repo1/bat/untracked_file1
+		 -> Extra file: $PATH_PREFIX/opt/3rd-party/test-repo1/bat/
 		Inspected 21 files
 		  2 files were missing
 		  2 files did not match
@@ -227,7 +227,7 @@ global_teardown() {
 		Checking for missing files
 		Checking for corrupt files
 		Checking for extraneous files
-		Checking for extra files under $PATH_PREFIX/opt/3rd_party/test-repo2/bat
+		Checking for extra files under $PATH_PREFIX/opt/3rd-party/test-repo2/bat
 		Inspected 15 files
 		Diagnose successful
 	EOM

--- a/test/functional/3rd-party/3rd-party-repair-basic.bats
+++ b/test/functional/3rd-party/3rd-party-repair-basic.bats
@@ -23,12 +23,12 @@ test_setup() {
 	create_bundle -L -t -n test-bundle2 -f /baz/file_3 -u test-repo2 "$TEST_NAME"
 
 	# adding an untracked files into an untracked directory (/bat)
-	sudo mkdir "$TARGETDIR"/opt/3rd_party/test-repo1/bat
-	sudo touch "$TARGETDIR"/opt/3rd_party/test-repo1/bat/untracked_file1
+	sudo mkdir "$TARGETDIR"/opt/3rd-party/test-repo1/bat
+	sudo touch "$TARGETDIR"/opt/3rd-party/test-repo1/bat/untracked_file1
 	# adding an untracked file into tracked directory (/bar)
-	sudo touch "$TARGETDIR"/opt/3rd_party/test-repo1/bar/untracked_file2
+	sudo touch "$TARGETDIR"/opt/3rd-party/test-repo1/bar/untracked_file2
 	# adding an untracked file into /usr
-	sudo touch "$TARGETDIR"/opt/3rd_party/test-repo2/usr/untracked_file3
+	sudo touch "$TARGETDIR"/opt/3rd-party/test-repo2/usr/untracked_file3
 
 }
 
@@ -47,13 +47,13 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz -> fixed
-		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz/file_3 -> fixed
+		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz -> fixed
+		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz/file_3 -> fixed
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/foo/file_1 -> fixed
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/usr/lib/os-release -> fixed
 		Removing extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/opt/3rd_party/test-repo1/bar/file_2 -> deleted
+		 -> File that should be deleted: $PATH_PREFIX/opt/3rd-party/test-repo1/bar/file_2 -> deleted
 		Inspected 19 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
@@ -119,7 +119,7 @@ test_setup() {
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/usr/lib/os-release -> fixed
 		Removing extraneous files
 		Inspected 17 files
 		  1 file did not match
@@ -148,14 +148,14 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz -> fixed
-		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz/file_3 -> fixed
+		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz -> fixed
+		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz/file_3 -> fixed
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/foo/file_1 -> fixed
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/usr/lib/os-release -> fixed
 		Removing extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/opt/3rd_party/test-repo1/bar/file_2 -> deleted
-		Removing extra files under $PATH_PREFIX/opt/3rd_party/test-repo1/usr
+		 -> File that should be deleted: $PATH_PREFIX/opt/3rd-party/test-repo1/bar/file_2 -> deleted
+		Removing extra files under $PATH_PREFIX/opt/3rd-party/test-repo1/usr
 		Inspected 19 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
@@ -177,8 +177,8 @@ test_setup() {
 		Adding any missing files
 		Repairing corrupt files
 		Removing extraneous files
-		Removing extra files under $PATH_PREFIX/opt/3rd_party/test-repo2/usr
-		 -> Extra file: $PATH_PREFIX/opt/3rd_party/test-repo2/usr/untracked_file3 -> deleted
+		Removing extra files under $PATH_PREFIX/opt/3rd-party/test-repo2/usr
+		 -> Extra file: $PATH_PREFIX/opt/3rd-party/test-repo2/usr/untracked_file3 -> deleted
 		Inspected 16 files
 		  1 file found which should be deleted
 		    1 of 1 files were deleted
@@ -206,16 +206,16 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz -> fixed
-		 -> Missing file: $PATH_PREFIX/opt/3rd_party/test-repo1/baz/file_3 -> fixed
+		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz -> fixed
+		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz/file_3 -> fixed
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/foo/file_1 -> fixed
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd_party/test-repo1/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/usr/lib/os-release -> fixed
 		Removing extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/opt/3rd_party/test-repo1/bar/file_2 -> deleted
-		Removing extra files under $PATH_PREFIX/opt/3rd_party/test-repo1/bat
-		 -> Extra file: $PATH_PREFIX/opt/3rd_party/test-repo1/bat/untracked_file1 -> deleted
-		 -> Extra file: $PATH_PREFIX/opt/3rd_party/test-repo1/bat/ -> deleted
+		 -> File that should be deleted: $PATH_PREFIX/opt/3rd-party/test-repo1/bar/file_2 -> deleted
+		Removing extra files under $PATH_PREFIX/opt/3rd-party/test-repo1/bat
+		 -> Extra file: $PATH_PREFIX/opt/3rd-party/test-repo1/bat/untracked_file1 -> deleted
+		 -> Extra file: $PATH_PREFIX/opt/3rd-party/test-repo1/bat/ -> deleted
 		Inspected 21 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
@@ -237,7 +237,7 @@ test_setup() {
 		Adding any missing files
 		Repairing corrupt files
 		Removing extraneous files
-		Removing extra files under $PATH_PREFIX/opt/3rd_party/test-repo2/bat
+		Removing extra files under $PATH_PREFIX/opt/3rd-party/test-repo2/bat
 		Inspected 15 files
 		Calling post-update helper scripts
 		Repair successful

--- a/test/functional/3rd-party/3rd-party-repo-add-negative.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add-negative.bats
@@ -6,7 +6,7 @@
 load "../testlib"
 
 test_path=$(realpath "$TEST_NAME")
-repo="$test_path"/3rd_party/test-repo1
+repo="$test_path"/3rd-party/test-repo1
 
 global_setup() {
 

--- a/test/functional/3rd-party/3rd-party-repo-add.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add.bats
@@ -40,7 +40,7 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 
-	run sudo sh -c "cat $STATEDIR/3rd_party/repo.ini"
+	run sudo sh -c "cat $STATEDIR/3rd-party/repo.ini"
 	expected_output=$(cat <<-EOM
 			[test-repo1]
 			url=file://$repo1
@@ -49,8 +49,8 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# make sure the os-core bundle of the repo is installed in the appropriate place
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo1/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo1/usr/lib/os-release
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/usr/lib/os-release
 
 }
 
@@ -64,8 +64,8 @@ test_setup() {
 	EOM
 	)
 	assert_in_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo1/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo1/usr/lib/os-release
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/usr/lib/os-release
 
 	run sudo sh -c "$SWUPD 3rd-party add test-repo2 file://$repo2 $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
@@ -74,10 +74,10 @@ test_setup() {
 	EOM
 	)
 	assert_in_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo2/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo2/usr/lib/os-release
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo2/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo2/usr/lib/os-release
 
-	run sudo sh -c "cat $STATEDIR/3rd_party/repo.ini"
+	run sudo sh -c "cat $STATEDIR/3rd-party/repo.ini"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 			[test-repo1]

--- a/test/functional/3rd-party/3rd-party-repo-list.bats
+++ b/test/functional/3rd-party/3rd-party-repo-list.bats
@@ -28,8 +28,8 @@ test_setup(){
 	EOM
 	)
 
-	repo_config_file="$STATEDIR"/3rd_party/repo.ini
-	run sudo sh -c "mkdir -p $STATEDIR/3rd_party/"
+	repo_config_file="$STATEDIR"/3rd-party/repo.ini
+	run sudo sh -c "mkdir -p $STATEDIR/3rd-party/"
 	run sudo sh -c "mkdir -p $PATH_PREFIX/opt/3rd-party/{test1,test2,test3,test4,test5}"
 	write_to_protected_file -a "$repo_config_file" "$contents"
 

--- a/test/functional/3rd-party/3rd-party-repo-remove-negative.bats
+++ b/test/functional/3rd-party/3rd-party-repo-remove-negative.bats
@@ -25,7 +25,7 @@ test_setup(){
 	EOM
 	)
 
-	repo_config_file="$STATEDIR"/3rd_party/repo.ini
+	repo_config_file="$STATEDIR"/3rd-party/repo.ini
 	write_to_protected_file -a "$repo_config_file" "$contents"
 
 }
@@ -73,7 +73,7 @@ test_teardown(){
 @test "TPR011: Negative test, Remove a repo on a new system" {
 
 	run sudo sh -c "rm -r $PATH_PREFIX/opt/3rd-party"
-	run sudo sh -c "rm -r $STATEDIR/3rd_party"
+	run sudo sh -c "rm -r $STATEDIR/3rd-party"
 
 	run sudo sh -c "$SWUPD 3rd-party remove test3 $SWUPD_OPTS"
 	assert_status_is "$SWUPD_INVALID_OPTION"

--- a/test/functional/3rd-party/3rd-party-repo-remove.bats
+++ b/test/functional/3rd-party/3rd-party-repo-remove.bats
@@ -30,11 +30,11 @@ test_setup(){
 	EOM
 	)
 
-	repo_config_file="$STATEDIR"/3rd_party/repo.ini
-	sudo mkdir -p "$STATEDIR"/3rd_party
-	sudo mkdir -p "$PATH_PREFIX"/opt/3rd_party/{test1,test2,test3,test4,test5}
+	repo_config_file="$STATEDIR"/3rd-party/repo.ini
+	sudo mkdir -p "$STATEDIR"/3rd-party
+	sudo mkdir -p "$PATH_PREFIX"/opt/3rd-party/{test1,test2,test3,test4,test5}
 	write_to_protected_file -a "$repo_config_file" "$contents"
-	sudo mkdir "$STATEDIR"/3rd_party/{test1,test2,test3,test4,test5}
+	sudo mkdir "$STATEDIR"/3rd-party/{test1,test2,test3,test4,test5}
 
 }
 
@@ -46,11 +46,11 @@ test_teardown(){
 
 @test "TPR008: Remove multiple repos" {
 
-	repo_config_file="$STATEDIR"/3rd_party/repo.ini
+	repo_config_file="$STATEDIR"/3rd-party/repo.ini
 
 	#remove at start of file
-	assert_dir_exists "$PATH_PREFIX"/opt/3rd_party/test1
-	assert_dir_exists "$STATEDIR"/3rd_party/test1
+	assert_dir_exists "$PATH_PREFIX"/opt/3rd-party/test1
+	assert_dir_exists "$STATEDIR"/3rd-party/test1
 	run sudo sh -c "$SWUPD 3rd-party remove test1 $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -59,12 +59,12 @@ test_teardown(){
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_dir_not_exists "$PATH_PREFIX"/opt/3rd_party/test1
-	assert_dir_not_exists "$STATEDIR"/3rd_party/test1
+	assert_dir_not_exists "$PATH_PREFIX"/opt/3rd-party/test1
+	assert_dir_not_exists "$STATEDIR"/3rd-party/test1
 
 	#remove at middle of file
-	assert_dir_exists "$PATH_PREFIX"/opt/3rd_party/test3
-	assert_dir_exists "$STATEDIR"/3rd_party/test3
+	assert_dir_exists "$PATH_PREFIX"/opt/3rd-party/test3
+	assert_dir_exists "$STATEDIR"/3rd-party/test3
 	run sudo sh -c "$SWUPD 3rd-party remove test3 $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -73,12 +73,12 @@ test_teardown(){
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_dir_not_exists "$PATH_PREFIX"/opt/3rd_party/test3
-	assert_dir_not_exists "$STATEDIR"/3rd_party/test3
+	assert_dir_not_exists "$PATH_PREFIX"/opt/3rd-party/test3
+	assert_dir_not_exists "$STATEDIR"/3rd-party/test3
 
 	#remove at end of file
-	assert_dir_exists "$PATH_PREFIX"/opt/3rd_party/test5
-	assert_dir_exists "$STATEDIR"/3rd_party/test5
+	assert_dir_exists "$PATH_PREFIX"/opt/3rd-party/test5
+	assert_dir_exists "$STATEDIR"/3rd-party/test5
 	run sudo sh -c "$SWUPD 3rd-party remove test5 $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -87,8 +87,8 @@ test_teardown(){
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_dir_not_exists "$PATH_PREFIX"/opt/3rd_party/test5
-	assert_dir_not_exists "$STATEDIR"/3rd_party/test5
+	assert_dir_not_exists "$PATH_PREFIX"/opt/3rd-party/test5
+	assert_dir_not_exists "$STATEDIR"/3rd-party/test5
 
 	expected_contents=$(cat <<- EOM
 		[test2]

--- a/test/functional/3rd-party/3rd-party-update-basic.bats
+++ b/test/functional/3rd-party/3rd-party-update-basic.bats
@@ -52,7 +52,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo1/new_file
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/new_file
 
 }
 
@@ -109,7 +109,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd_party/test-repo1/new_file
+	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/new_file
 
 }
 

--- a/test/functional/3rd-party/3rd-party-update-specific-version.bats
+++ b/test/functional/3rd-party/3rd-party-update-specific-version.bats
@@ -47,7 +47,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/opt/3rd_party/test-repo1/new_file
+	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo1/new_file
 
 }
 

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1358,7 +1358,7 @@ set_current_version() { # swupd_function
 	validate_path "$env_name"
 
 	if [ -n "$repo_name" ]; then
-		os_release="$env_name"/testfs/target-dir/opt/3rd_party/"$repo_name"/usr/lib/os-release
+		os_release="$env_name"/testfs/target-dir/opt/3rd-party/"$repo_name"/usr/lib/os-release
 	else
 		os_release="$env_name"/testfs/target-dir/usr/lib/os-release
 	fi
@@ -1424,12 +1424,12 @@ create_third_party_repo() { #swupd_function
 	# we need to create os-core which should include the os-release and Swupd_Root.pem
 	debug_msg "Creating os-core with Swupd_Root.pem and os-release..."
 	hashed_name=$(sudo "$SWUPD" hashdump --quiet "$TEST_ROOT_DIR"/Swupd_Root.pem)
-	sudo cp -p "$TEST_ROOT_DIR"/Swupd_Root.pem "$env_name"/3rd_party/"$repo_name"/"$version"/files/"$hashed_name"
-	create_tar "$env_name"/3rd_party/"$repo_name"/"$version"/files/"$hashed_name"
-	CERT="$env_name"/3rd_party/"$repo_name"/"$version"/files/"$hashed_name"
+	sudo cp -p "$TEST_ROOT_DIR"/Swupd_Root.pem "$env_name"/3rd-party/"$repo_name"/"$version"/files/"$hashed_name"
+	create_tar "$env_name"/3rd-party/"$repo_name"/"$version"/files/"$hashed_name"
+	CERT="$env_name"/3rd-party/"$repo_name"/"$version"/files/"$hashed_name"
 	create_bundle -n os-core -v "$version" -f /usr/lib/os-release:"$OS_RELEASE",/usr/share/clear/update-ca/Swupd_Root.pem:"$CERT",/usr/share/defaults/swupd/format:"$FORMAT" -u "$repo_name" "$env_name"
 
-	TPWEBDIR=$(realpath "$env_name/3rd_party/$repo_name")
+	TPWEBDIR=$(realpath "$env_name/3rd-party/$repo_name")
 	export TPWEBDIR
 	debug_msg "3rd-party repo content dir: $TPWEBDIR"
 	debug_msg "3rd-party repo created successfully"
@@ -1467,7 +1467,7 @@ add_third_party_repo() { #swupd_function
 	path=$(dirname "$(realpath "$env_name")")
 
 	# create the state dir for the 3rd-party repo
-	repo_state_dir="$STATEDIR"/3rd_party/"$repo_name"
+	repo_state_dir="$STATEDIR"/3rd-party/"$repo_name"
 	debug_msg "Creating a state directory for repo $repo_name at $repo_state_dir"
 	sudo mkdir -p "$repo_state_dir"/{staged,download,delta,telemetry,bundles}
 
@@ -1478,13 +1478,13 @@ add_third_party_repo() { #swupd_function
 	# add the new repo to the repo.ini file
 	{
 		printf '[%s]\n\n' "$repo_name"
-		printf 'URL=%s\n\n' "file://$path/$env_name/3rd_party/$repo_name"
+		printf 'URL=%s\n\n' "file://$path/$env_name/3rd-party/$repo_name"
 		printf 'VERSION=%s\n\n' "$version"
-	} | sudo tee -a "$STATEDIR"/3rd_party/repo.ini > /dev/null
+	} | sudo tee -a "$STATEDIR"/3rd-party/repo.ini > /dev/null
 
 	sudo chmod -R 0700 "$STATEDIR"
 	export TPSTATEDIR="$repo_state_dir"
-	export TPWEBDIR="$env_name"/3rd_party/"$repo_name"
+	export TPWEBDIR="$env_name"/3rd-party/"$repo_name"
 	debug_msg "3rd-party repo state dir: $TPSTATEDIR"
 	debug_msg "3rd-party repo content dir: $TPWEBDIR"
 
@@ -1492,9 +1492,9 @@ add_third_party_repo() { #swupd_function
 	# added by default which should include the os-release and Swupd_Root.pem
 	debug_msg "Adding bundle os-core to the 3rd-party repo"
 	hashed_name=$(sudo "$SWUPD" hashdump --quiet "$TEST_ROOT_DIR"/Swupd_Root.pem)
-	sudo cp -p "$TEST_ROOT_DIR"/Swupd_Root.pem "$env_name"/3rd_party/"$repo_name"/"$version"/files/"$hashed_name"
-	create_tar "$env_name"/3rd_party/"$repo_name"/"$version"/files/"$hashed_name"
-	CERT="$env_name"/3rd_party/"$repo_name"/"$version"/files/"$hashed_name"
+	sudo cp -p "$TEST_ROOT_DIR"/Swupd_Root.pem "$env_name"/3rd-party/"$repo_name"/"$version"/files/"$hashed_name"
+	create_tar "$env_name"/3rd-party/"$repo_name"/"$version"/files/"$hashed_name"
+	CERT="$env_name"/3rd-party/"$repo_name"/"$version"/files/"$hashed_name"
 	create_bundle -L -n os-core -v "$version" -f /usr/lib/os-release:"$OS_RELEASE",/usr/share/clear/update-ca/Swupd_Root.pem:"$CERT",/usr/share/defaults/swupd/format:"$FORMAT" -u "$repo_name" "$env_name"
 
 }
@@ -1550,7 +1550,7 @@ create_version() { # swupd_function
 
 	# if a content_dir is specified it means we are using a 3rd-party repo
 	if [ "$content_dir" != web-dir ]; then
-		content_dir=3rd_party/"$content_dir"
+		content_dir=3rd-party/"$content_dir"
 	fi
 
 	debug_msg "Creating content for version $version at $content_dir..."
@@ -1757,7 +1757,7 @@ create_test_environment() { # swupd_function
 
 	# state files & dirs
 	debug_msg "Creating a state dir"
-	sudo mkdir -p "$statedir"/{staged,download,delta,telemetry,bundles,3rd_party}
+	sudo mkdir -p "$statedir"/{staged,download,delta,telemetry,bundles,3rd-party}
 	sudo chmod -R 0700 "$statedir"
 
 	# export environment variables that are dependent of the test env
@@ -2375,9 +2375,9 @@ create_bundle() { # swupd_function
 
 	# if a 3rd-party repo was specified, the bundle should be created in there
 	if [ "$third_party" = true ]; then
-		state_path="$env_name"/testfs/state/3rd_party/"$repo_name"
-		target_path="$env_name"/testfs/target-dir/opt/3rd_party/"$repo_name"
-		content_dir=3rd_party/"$repo_name"
+		state_path="$env_name"/testfs/state/3rd-party/"$repo_name"
+		target_path="$env_name"/testfs/target-dir/opt/3rd-party/"$repo_name"
+		content_dir=3rd-party/"$repo_name"
 	else
 		target_path="$env_name"/testfs/target-dir
 		content_dir=web-dir
@@ -2643,7 +2643,7 @@ remove_bundle() { # swupd_function
 	if [ -z "$repo_name" ]; then
 		target_path=$(dirname "$bundle_manifest" | cut -d "/" -f1)/testfs/target-dir
 	else
-		target_path=$(dirname "$bundle_manifest" | cut -d "/" -f1)/testfs/target-dir/opt/3rd_party/"$repo_name"
+		target_path=$(dirname "$bundle_manifest" | cut -d "/" -f1)/testfs/target-dir/opt/3rd-party/"$repo_name"
 	fi
 	version_path=$(dirname "$bundle_manifest")
 	manifest_file=$(basename "$bundle_manifest")
@@ -2705,7 +2705,7 @@ install_bundle() { # swupd_function
 	if [ -z "$repo_name" ]; then
 		target_path=$(dirname "$bundle_manifest" | cut -d "/" -f1)/testfs/target-dir
 	else
-		target_path=$(dirname "$bundle_manifest" | cut -d "/" -f1)/testfs/target-dir/opt/3rd_party/"$repo_name"
+		target_path=$(dirname "$bundle_manifest" | cut -d "/" -f1)/testfs/target-dir/opt/3rd-party/"$repo_name"
 	fi
 	files_path=$(dirname "$bundle_manifest")/files
 	manifest_file=$(basename "$bundle_manifest")
@@ -2843,7 +2843,7 @@ update_bundle() { # swupd_function
 
 	# if a 3rd-party repo was specified, set it up
 	if [ -n "$repo_name" ]; then
-		content_dir="$env_name"/3rd_party/"$repo_name"
+		content_dir="$env_name"/3rd-party/"$repo_name"
 	else
 		content_dir="$env_name"/web-dir
 	fi
@@ -3262,8 +3262,8 @@ clean_state_dir() { # swupd_function
 		sudo rm -rf "$env_name"/testfs/state
 		sudo mkdir -p "$env_name"/testfs/state/{staged,download,delta,telemetry}
 	else
-		sudo rm -rf "$env_name"/testfs/state/3rd_party/"$repo_name"
-		sudo mkdir -p "$env_name"/testfs/state/3rd_party/"$repo_name"/{staged,download,delta,telemetry,bundles}
+		sudo rm -rf "$env_name"/testfs/state/3rd-party/"$repo_name"
+		sudo mkdir -p "$env_name"/testfs/state/3rd-party/"$repo_name"/{staged,download,delta,telemetry,bundles}
 	fi
 	sudo chmod -R 0700 "$env_name"/testfs/state
 


### PR DESCRIPTION
The name of the 3rd-party repository directory is currently `3rd_party`, this name is incorrect and needs to be changed to `3rd-party`. This PR fixes that.