### PR TITLE
Use the user specified path for 3rd-party cert

### DIFF
--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -276,9 +276,14 @@ enum swupd_code third_party_set_repo(struct repo *repo, bool sigcheck)
 	set_content_url(repo->url);
 	set_version_url(repo->url);
 
-	/* set up swupd to use the certificate from the 3rd-party repository */
+	/* set up swupd to use the certificate from the 3rd-party repository,
+	 * unless the user is specifying a path for the certificate to use */
 	string_or_die(&repo_cert_path, "%s%s/%s%s", globals_bkp.path_prefix, SWUPD_3RD_PARTY_BUNDLES_DIR, repo->name, CERT_PATH);
-	set_cert_path(repo_cert_path);
+	if (!globals.user_defined_cert_path) {
+		/* the user did not specify a cert, use repo's default */
+		set_cert_path(repo_cert_path);
+	}
+
 	/* if --nosigcheck was used, we do not attempt any signature checking */
 	if (sigcheck) {
 		signature_deinit();

--- a/src/globals.c
+++ b/src/globals.c
@@ -587,6 +587,7 @@ static bool global_parse_opt(int opt, char *optarg)
 		return true;
 	case 'C':
 		set_cert_path(optarg);
+		globals.user_defined_cert_path = true;
 		return true;
 	case 'W':
 		err = strtoi_err(optarg, &max_parallel_downloads);

--- a/src/globals.h
+++ b/src/globals.h
@@ -33,6 +33,7 @@ extern struct globals {
 	bool sigcheck;
 	bool timecheck;
 	bool wait_for_scripts;
+	bool user_defined_cert_path;
 	char **swupd_argv;
 	char *cert_path;
 	char *content_url;


### PR DESCRIPTION
When using 3rd-party repos, swupd looks for the certificate to use
inside the repository directory, if the user specifies another location
it is just ignored.

If the user specifies a different path for the certificate, it should be
used. This commit fixes that.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>