### PR TITLE
Moving the content from 3rd-party bundles

### DIFF
--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -238,7 +238,7 @@ int third_party_remove_repo_directory(const char *repo_name)
 	int ret_code = 0;
 
 	//TODO: use a global function to get this value
-	repo_dir = str_or_die("%s/opt/%s/%s", globals.path_prefix, SWUPD_3RD_PARTY_DIRNAME, repo_name);
+	repo_dir = str_or_die("%s/%s/%s", globals.path_prefix, SWUPD_3RD_PARTY_BUNDLES_DIR, repo_name);
 	ret = sys_rm_recursive(repo_dir);
 	if (ret < 0 && ret != -ENOENT) {
 		error("Failed to delete repository directory\n");
@@ -267,7 +267,7 @@ enum swupd_code third_party_set_repo(const char *state_dir, const char *path_pre
 	set_version_url(repo->url);
 
 	/* set up swupd to use the certificate from the 3rd-party repository */
-	string_or_die(&repo_cert_path, "%s/opt/%s/%s/%s", path_prefix, SWUPD_3RD_PARTY_DIRNAME, repo->name, CERT_PATH);
+	string_or_die(&repo_cert_path, "%s/%s/%s/%s", path_prefix, SWUPD_3RD_PARTY_BUNDLES_DIR, repo->name, CERT_PATH);
 	set_cert_path(repo_cert_path);
 	/* if --nosigcheck was used, we do not attempt any signature checking */
 	if (sigcheck) {
@@ -281,7 +281,7 @@ enum swupd_code third_party_set_repo(const char *state_dir, const char *path_pre
 	}
 	free_string(&repo_cert_path);
 
-	string_or_die(&repo_path_prefix, "%s/opt/%s/%s", path_prefix, SWUPD_3RD_PARTY_DIRNAME, repo->name);
+	string_or_die(&repo_path_prefix, "%s/%s/%s", path_prefix, SWUPD_3RD_PARTY_BUNDLES_DIR, repo->name);
 	set_path_prefix(repo_path_prefix);
 	free_string(&repo_path_prefix);
 

--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -15,6 +15,7 @@ extern "C" {
 #ifdef THIRDPARTY
 
 #define SWUPD_3RD_PARTY_DIRNAME "3rd-party"
+#define SWUPD_3RD_PARTY_BUNDLES_DIR "/opt/" SWUPD_3RD_PARTY_DIRNAME "/bundles"
 
 /** @brief Store information of a repository.  */
 struct repo {

--- a/test/functional/3rd-party/3rd-party-allow-http.bats
+++ b/test/functional/3rd-party/3rd-party-allow-http.bats
@@ -79,6 +79,6 @@ global_teardown() {
 	EOM
 	)
 	assert_is_output --identical "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/my_repo/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/my_repo/usr/lib/os-release
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/my_repo/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/my_repo/usr/lib/os-release
 }

--- a/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
@@ -42,8 +42,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo2/foo/file_2
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo2/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/foo/file_2
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/test-bundle2
 	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle2
 
 }
@@ -98,10 +98,10 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo2/foo/file_2
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo2/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/foo/file_2
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/test-bundle2
 	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle2
-	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo2/usr/share/clear/bundles/upstream-bundle
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/upstream-bundle
 
 	# same scenario with the arguments switched
 
@@ -127,7 +127,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo2/foo/file_2
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo2/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/foo/file_2
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/test-bundle2
 	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle2
 }

--- a/test/functional/3rd-party/3rd-party-bundle-add-config-file.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-config-file.bats
@@ -54,15 +54,15 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# test-bundle1 is installed and tracked
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo/usr/share/clear/bundles/test-bundle1
 	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle1
 
 	# test-bundle2 is installed but not tracked
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo/usr/share/clear/bundles/test-bundle2
 	assert_file_not_exists "$TPSTATEDIR"/bundles/test-bundle2
 
 	# test-bundle3 is not installed at all
-	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo/usr/share/clear/bundles/test-bundle3
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo/usr/share/clear/bundles/test-bundle3
 	assert_file_not_exists "$TPSTATEDIR"/bundles/test-bundle3
 
 }

--- a/test/functional/3rd-party/3rd-party-bundle-add-multi-repo.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-multi-repo.bats
@@ -36,10 +36,10 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/repo1/foo/file_1A
-	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/repo2/baz/file_1B
-	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/repo1/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/repo2/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/foo/file_1A
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo2/baz/file_1B
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo2/usr/share/clear/bundles/test-bundle1
 	assert_file_not_exists "$STATEDIR"/3rd-party/repo1/bundles/test-bundle1
 	assert_file_not_exists "$STATEDIR"/3rd-party/repo2/bundles/test-bundle1
 
@@ -65,10 +65,10 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/repo1/foo/file_1A
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/repo2/baz/file_1B
-	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/repo1/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/repo2/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/foo/file_1A
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo2/baz/file_1B
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo2/usr/share/clear/bundles/test-bundle1
 	assert_file_not_exists "$STATEDIR"/3rd-party/repo1/bundles/test-bundle1
 	assert_file_exists "$STATEDIR"/3rd-party/repo2/bundles/test-bundle1
 

--- a/test/functional/3rd-party/3rd-party-bundle-remove-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-basic.bats
@@ -37,8 +37,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo2/foo/file_2
-	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo2/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/foo/file_2
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/test-bundle2
 	assert_file_not_exists "$TPSTATEDIR"/bundles/test-bundle2
 
 }
@@ -70,8 +70,8 @@ test_setup() {
 
 @test "TPR026: Try removing one valid bundle from a third party repo and one invalid" {
 
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/foo/file_1
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/foo/file_1
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/test-bundle1
 	assert_file_exists "$STATEDIR"/3rd-party/test-repo1/bundles/test-bundle1
 
 	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS test-bundle1 upstream-bundle"
@@ -90,15 +90,15 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo1/foo/file_1
-	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/foo/file_1
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/test-bundle1
 	assert_file_not_exists "$STATEDIR"/3rd-party/test-repo1/bundles/test-bundle1
 
 	# run the same scenario with the arguments switched
 	install_bundle "$TEST_NAME"/3rd-party/test-repo1/10/Manifest.test-bundle1 test-repo1
 	clean_state_dir "$TEST_NAME" test-repo1
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/foo/file_1
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/foo/file_1
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/test-bundle1
 
 	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS upstream-bundle test-bundle1"
 
@@ -116,7 +116,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo1/foo/file_1
-	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/foo/file_1
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/test-bundle1
 
 }

--- a/test/functional/3rd-party/3rd-party-diagnose-basic.bats
+++ b/test/functional/3rd-party/3rd-party-diagnose-basic.bats
@@ -23,12 +23,12 @@ global_setup() {
 	create_bundle -L -t -n test-bundle2 -f /baz/file_3 -u test-repo2 "$TEST_NAME"
 
 	# adding an untracked files into an untracked directory (/bat)
-	sudo mkdir "$TARGETDIR"/opt/3rd-party/test-repo1/bat
-	sudo touch "$TARGETDIR"/opt/3rd-party/test-repo1/bat/untracked_file1
+	sudo mkdir "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/bat
+	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/bat/untracked_file1
 	# adding an untracked file into tracked directory (/bar)
-	sudo touch "$TARGETDIR"/opt/3rd-party/test-repo1/bar/untracked_file2
+	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/bar/untracked_file2
 	# adding an untracked file into /usr
-	sudo touch "$TARGETDIR"/opt/3rd-party/test-repo2/usr/untracked_file3
+	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/untracked_file3
 
 }
 
@@ -62,13 +62,13 @@ global_teardown() {
 		Diagnosing version 20
 		Downloading missing manifests...
 		Checking for missing files
-		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz
-		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz/file_3
+		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz
+		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz/file_3
 		Checking for corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/foo/file_1
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/usr/lib/os-release
+		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/foo/file_1
+		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/lib/os-release
 		Checking for extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/opt/3rd-party/test-repo1/bar/file_2
+		 -> File that should be deleted: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bar/file_2
 		Inspected 19 files
 		  2 files were missing
 		  2 files did not match
@@ -133,7 +133,7 @@ global_teardown() {
 		Downloading missing manifests...
 		Checking for missing files
 		Checking for corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/usr/lib/os-release
+		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/lib/os-release
 		Checking for extraneous files
 		Inspected 17 files
 		  1 file did not match
@@ -157,14 +157,14 @@ global_teardown() {
 		Diagnosing version 20
 		Downloading missing manifests...
 		Checking for missing files
-		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz
-		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz/file_3
+		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz
+		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz/file_3
 		Checking for corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/foo/file_1
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/usr/lib/os-release
+		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/foo/file_1
+		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/lib/os-release
 		Checking for extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/opt/3rd-party/test-repo1/bar/file_2
-		Checking for extra files under $PATH_PREFIX/opt/3rd-party/test-repo1/usr
+		 -> File that should be deleted: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bar/file_2
+		Checking for extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr
 		Inspected 19 files
 		  2 files were missing
 		  2 files did not match
@@ -179,8 +179,8 @@ global_teardown() {
 		Checking for missing files
 		Checking for corrupt files
 		Checking for extraneous files
-		Checking for extra files under $PATH_PREFIX/opt/3rd-party/test-repo2/usr
-		 -> Extra file: $PATH_PREFIX/opt/3rd-party/test-repo2/usr/untracked_file3
+		Checking for extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo2/usr
+		 -> Extra file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo2/usr/untracked_file3
 		Inspected 16 files
 		  1 file found which should be deleted
 		Use "swupd repair --picky" to correct the problems in the system
@@ -203,16 +203,16 @@ global_teardown() {
 		Diagnosing version 20
 		Downloading missing manifests...
 		Checking for missing files
-		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz
-		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz/file_3
+		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz
+		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz/file_3
 		Checking for corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/foo/file_1
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/usr/lib/os-release
+		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/foo/file_1
+		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/lib/os-release
 		Checking for extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/opt/3rd-party/test-repo1/bar/file_2
-		Checking for extra files under $PATH_PREFIX/opt/3rd-party/test-repo1/bat
-		 -> Extra file: $PATH_PREFIX/opt/3rd-party/test-repo1/bat/untracked_file1
-		 -> Extra file: $PATH_PREFIX/opt/3rd-party/test-repo1/bat/
+		 -> File that should be deleted: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bar/file_2
+		Checking for extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bat
+		 -> Extra file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bat/untracked_file1
+		 -> Extra file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bat/
 		Inspected 21 files
 		  2 files were missing
 		  2 files did not match
@@ -227,7 +227,7 @@ global_teardown() {
 		Checking for missing files
 		Checking for corrupt files
 		Checking for extraneous files
-		Checking for extra files under $PATH_PREFIX/opt/3rd-party/test-repo2/bat
+		Checking for extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo2/bat
 		Inspected 15 files
 		Diagnose successful
 	EOM

--- a/test/functional/3rd-party/3rd-party-repair-basic.bats
+++ b/test/functional/3rd-party/3rd-party-repair-basic.bats
@@ -23,12 +23,12 @@ test_setup() {
 	create_bundle -L -t -n test-bundle2 -f /baz/file_3 -u test-repo2 "$TEST_NAME"
 
 	# adding an untracked files into an untracked directory (/bat)
-	sudo mkdir "$TARGETDIR"/opt/3rd-party/test-repo1/bat
-	sudo touch "$TARGETDIR"/opt/3rd-party/test-repo1/bat/untracked_file1
+	sudo mkdir "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/bat
+	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/bat/untracked_file1
 	# adding an untracked file into tracked directory (/bar)
-	sudo touch "$TARGETDIR"/opt/3rd-party/test-repo1/bar/untracked_file2
+	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/bar/untracked_file2
 	# adding an untracked file into /usr
-	sudo touch "$TARGETDIR"/opt/3rd-party/test-repo2/usr/untracked_file3
+	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/untracked_file3
 
 }
 
@@ -47,13 +47,13 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz -> fixed
-		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz/file_3 -> fixed
+		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz -> fixed
+		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz/file_3 -> fixed
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/foo/file_1 -> fixed
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/lib/os-release -> fixed
 		Removing extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/opt/3rd-party/test-repo1/bar/file_2 -> deleted
+		 -> File that should be deleted: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bar/file_2 -> deleted
 		Inspected 19 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
@@ -119,7 +119,7 @@ test_setup() {
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/lib/os-release -> fixed
 		Removing extraneous files
 		Inspected 17 files
 		  1 file did not match
@@ -148,14 +148,14 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz -> fixed
-		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz/file_3 -> fixed
+		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz -> fixed
+		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz/file_3 -> fixed
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/foo/file_1 -> fixed
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/lib/os-release -> fixed
 		Removing extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/opt/3rd-party/test-repo1/bar/file_2 -> deleted
-		Removing extra files under $PATH_PREFIX/opt/3rd-party/test-repo1/usr
+		 -> File that should be deleted: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bar/file_2 -> deleted
+		Removing extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr
 		Inspected 19 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
@@ -177,8 +177,8 @@ test_setup() {
 		Adding any missing files
 		Repairing corrupt files
 		Removing extraneous files
-		Removing extra files under $PATH_PREFIX/opt/3rd-party/test-repo2/usr
-		 -> Extra file: $PATH_PREFIX/opt/3rd-party/test-repo2/usr/untracked_file3 -> deleted
+		Removing extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo2/usr
+		 -> Extra file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo2/usr/untracked_file3 -> deleted
 		Inspected 16 files
 		  1 file found which should be deleted
 		    1 of 1 files were deleted
@@ -206,16 +206,16 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz -> fixed
-		 -> Missing file: $PATH_PREFIX/opt/3rd-party/test-repo1/baz/file_3 -> fixed
+		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz -> fixed
+		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz/file_3 -> fixed
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/foo/file_1 -> fixed
-		 -> Hash mismatch for file: $PATH_PREFIX/opt/3rd-party/test-repo1/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/lib/os-release -> fixed
 		Removing extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/opt/3rd-party/test-repo1/bar/file_2 -> deleted
-		Removing extra files under $PATH_PREFIX/opt/3rd-party/test-repo1/bat
-		 -> Extra file: $PATH_PREFIX/opt/3rd-party/test-repo1/bat/untracked_file1 -> deleted
-		 -> Extra file: $PATH_PREFIX/opt/3rd-party/test-repo1/bat/ -> deleted
+		 -> File that should be deleted: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bar/file_2 -> deleted
+		Removing extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bat
+		 -> Extra file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bat/untracked_file1 -> deleted
+		 -> Extra file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bat/ -> deleted
 		Inspected 21 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
@@ -237,7 +237,7 @@ test_setup() {
 		Adding any missing files
 		Repairing corrupt files
 		Removing extraneous files
-		Removing extra files under $PATH_PREFIX/opt/3rd-party/test-repo2/bat
+		Removing extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo2/bat
 		Inspected 15 files
 		Calling post-update helper scripts
 		Repair successful

--- a/test/functional/3rd-party/3rd-party-repo-add.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add.bats
@@ -49,8 +49,8 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# make sure the os-core bundle of the repo is installed in the appropriate place
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/usr/lib/os-release
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/lib/os-release
 
 }
 
@@ -64,8 +64,8 @@ test_setup() {
 	EOM
 	)
 	assert_in_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/usr/lib/os-release
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/lib/os-release
 
 	run sudo sh -c "$SWUPD 3rd-party add test-repo2 file://$repo2 $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
@@ -74,8 +74,8 @@ test_setup() {
 	EOM
 	)
 	assert_in_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo2/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo2/usr/lib/os-release
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/lib/os-release
 
 	run sudo sh -c "cat $STATEDIR/3rd-party/repo.ini"
 	assert_status_is "$SWUPD_OK"

--- a/test/functional/3rd-party/3rd-party-repo-list.bats
+++ b/test/functional/3rd-party/3rd-party-repo-list.bats
@@ -30,7 +30,7 @@ test_setup(){
 
 	repo_config_file="$STATEDIR"/3rd-party/repo.ini
 	run sudo sh -c "mkdir -p $STATEDIR/3rd-party/"
-	run sudo sh -c "mkdir -p $PATH_PREFIX/opt/3rd-party/{test1,test2,test3,test4,test5}"
+	run sudo sh -c "mkdir -p $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/{test1,test2,test3,test4,test5}"
 	write_to_protected_file -a "$repo_config_file" "$contents"
 
 }

--- a/test/functional/3rd-party/3rd-party-repo-remove-negative.bats
+++ b/test/functional/3rd-party/3rd-party-repo-remove-negative.bats
@@ -72,7 +72,7 @@ test_teardown(){
 
 @test "TPR011: Negative test, Remove a repo on a new system" {
 
-	run sudo sh -c "rm -r $PATH_PREFIX/opt/3rd-party"
+	run sudo sh -c "rm -r $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR"
 	run sudo sh -c "rm -r $STATEDIR/3rd-party"
 
 	run sudo sh -c "$SWUPD 3rd-party remove test3 $SWUPD_OPTS"

--- a/test/functional/3rd-party/3rd-party-repo-remove.bats
+++ b/test/functional/3rd-party/3rd-party-repo-remove.bats
@@ -32,7 +32,7 @@ test_setup(){
 
 	repo_config_file="$STATEDIR"/3rd-party/repo.ini
 	sudo mkdir -p "$STATEDIR"/3rd-party
-	sudo mkdir -p "$PATH_PREFIX"/opt/3rd-party/{test1,test2,test3,test4,test5}
+	sudo mkdir -p "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/{test1,test2,test3,test4,test5}
 	write_to_protected_file -a "$repo_config_file" "$contents"
 	sudo mkdir "$STATEDIR"/3rd-party/{test1,test2,test3,test4,test5}
 
@@ -49,7 +49,7 @@ test_teardown(){
 	repo_config_file="$STATEDIR"/3rd-party/repo.ini
 
 	#remove at start of file
-	assert_dir_exists "$PATH_PREFIX"/opt/3rd-party/test1
+	assert_dir_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/test1
 	assert_dir_exists "$STATEDIR"/3rd-party/test1
 	run sudo sh -c "$SWUPD 3rd-party remove test1 $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
@@ -59,11 +59,11 @@ test_teardown(){
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_dir_not_exists "$PATH_PREFIX"/opt/3rd-party/test1
+	assert_dir_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/test1
 	assert_dir_not_exists "$STATEDIR"/3rd-party/test1
 
 	#remove at middle of file
-	assert_dir_exists "$PATH_PREFIX"/opt/3rd-party/test3
+	assert_dir_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/test3
 	assert_dir_exists "$STATEDIR"/3rd-party/test3
 	run sudo sh -c "$SWUPD 3rd-party remove test3 $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
@@ -73,11 +73,11 @@ test_teardown(){
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_dir_not_exists "$PATH_PREFIX"/opt/3rd-party/test3
+	assert_dir_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/test3
 	assert_dir_not_exists "$STATEDIR"/3rd-party/test3
 
 	#remove at end of file
-	assert_dir_exists "$PATH_PREFIX"/opt/3rd-party/test5
+	assert_dir_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/test5
 	assert_dir_exists "$STATEDIR"/3rd-party/test5
 	run sudo sh -c "$SWUPD 3rd-party remove test5 $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
@@ -87,7 +87,7 @@ test_teardown(){
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_dir_not_exists "$PATH_PREFIX"/opt/3rd-party/test5
+	assert_dir_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/test5
 	assert_dir_not_exists "$STATEDIR"/3rd-party/test5
 
 	expected_contents=$(cat <<- EOM

--- a/test/functional/3rd-party/3rd-party-update-basic.bats
+++ b/test/functional/3rd-party/3rd-party-update-basic.bats
@@ -52,7 +52,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/new_file
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/new_file
 
 }
 
@@ -109,7 +109,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/opt/3rd-party/test-repo1/new_file
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/new_file
 
 }
 

--- a/test/functional/3rd-party/3rd-party-update-specific-version.bats
+++ b/test/functional/3rd-party/3rd-party-update-specific-version.bats
@@ -47,7 +47,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/opt/3rd-party/test-repo1/new_file
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/new_file
 
 }
 

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -5,6 +5,7 @@ TEST_ROOT_DIR="$(pwd)"
 TEST_FILENAME=$(basename "$BATS_TEST_FILENAME")
 TEST_NAME=${TEST_FILENAME%.bats}
 THEME_DIRNAME="$BATS_TEST_DIRNAME"
+THIRD_PARTY_BUNDLES_DIR="opt/3rd-party/bundles"
 
 export TEST_NAME
 export TEST_NAME_SHORT="$TEST_NAME"
@@ -1358,7 +1359,7 @@ set_current_version() { # swupd_function
 	validate_path "$env_name"
 
 	if [ -n "$repo_name" ]; then
-		os_release="$env_name"/testfs/target-dir/opt/3rd-party/"$repo_name"/usr/lib/os-release
+		os_release="$env_name"/testfs/target-dir/"$THIRD_PARTY_BUNDLES_DIR"/"$repo_name"/usr/lib/os-release
 	else
 		os_release="$env_name"/testfs/target-dir/usr/lib/os-release
 	fi
@@ -2376,7 +2377,7 @@ create_bundle() { # swupd_function
 	# if a 3rd-party repo was specified, the bundle should be created in there
 	if [ "$third_party" = true ]; then
 		state_path="$env_name"/testfs/state/3rd-party/"$repo_name"
-		target_path="$env_name"/testfs/target-dir/opt/3rd-party/"$repo_name"
+		target_path="$env_name"/testfs/target-dir/"$THIRD_PARTY_BUNDLES_DIR"/"$repo_name"
 		content_dir=3rd-party/"$repo_name"
 	else
 		target_path="$env_name"/testfs/target-dir
@@ -2643,7 +2644,7 @@ remove_bundle() { # swupd_function
 	if [ -z "$repo_name" ]; then
 		target_path=$(dirname "$bundle_manifest" | cut -d "/" -f1)/testfs/target-dir
 	else
-		target_path=$(dirname "$bundle_manifest" | cut -d "/" -f1)/testfs/target-dir/opt/3rd-party/"$repo_name"
+		target_path=$(dirname "$bundle_manifest" | cut -d "/" -f1)/testfs/target-dir/"$THIRD_PARTY_BUNDLES_DIR"/"$repo_name"
 	fi
 	version_path=$(dirname "$bundle_manifest")
 	manifest_file=$(basename "$bundle_manifest")
@@ -2705,7 +2706,7 @@ install_bundle() { # swupd_function
 	if [ -z "$repo_name" ]; then
 		target_path=$(dirname "$bundle_manifest" | cut -d "/" -f1)/testfs/target-dir
 	else
-		target_path=$(dirname "$bundle_manifest" | cut -d "/" -f1)/testfs/target-dir/opt/3rd-party/"$repo_name"
+		target_path=$(dirname "$bundle_manifest" | cut -d "/" -f1)/testfs/target-dir/"$THIRD_PARTY_BUNDLES_DIR"/"$repo_name"
 	fi
 	files_path=$(dirname "$bundle_manifest")/files
 	manifest_file=$(basename "$bundle_manifest")


### PR DESCRIPTION
This commit moves the path where the content from 3rd-party bundles is
going to be installed from opt/3rd-party/<bundle_name> to
/opt/3rd-party/bundles/<bundle_name> so bundle directories are separated
from other top level directories like bin.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>