### PR TITLE
Do not run scripts after updating from 3rd-party

### DIFF
--- a/src/3rd_party_update.c
+++ b/src/3rd_party_update.c
@@ -127,10 +127,12 @@ static enum swupd_code update_repos(UNUSED_PARAM char *unused)
 {
 	/* Update should always ignore optional bundles */
 	globals.skip_optional_bundles = true;
+	globals.no_scripts = true;
 
 	if (cmdline_option_status) {
 		return check_update();
 	} else {
+		info("Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons\n\n");
 		return execute_update();
 	}
 }

--- a/test/functional/3rd-party/3rd-party-update-basic.bats
+++ b/test/functional/3rd-party/3rd-party-update-basic.bats
@@ -31,6 +31,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
+		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Preparing to update from 10 to 20
 		Downloading packs for:
@@ -47,7 +48,7 @@ test_setup() {
 		No extra files need to be downloaded
 		Installing files...
 		Update was applied
-		Calling post-update helper scripts
+		Warning: post-update helper scripts skipped due to --no-scripts argument
 		Update successful - System updated from version 10 to version 20
 	EOM
 	)
@@ -82,6 +83,7 @@ test_setup() {
 		____________________________
 		 3rd-Party Repo: test-repo1
 		____________________________
+		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Preparing to update from 10 to 20
 		Downloading packs for:
@@ -98,11 +100,12 @@ test_setup() {
 		No extra files need to be downloaded
 		Installing files...
 		Update was applied
-		Calling post-update helper scripts
+		Warning: post-update helper scripts skipped due to --no-scripts argument
 		Update successful - System updated from version 10 to version 20
 		____________________________
 		 3rd-Party Repo: test-repo2
 		____________________________
+		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Version on server (10) is not newer than system version (10)
 		Update complete - System already up-to-date at version 10

--- a/test/functional/3rd-party/3rd-party-update-specific-version.bats
+++ b/test/functional/3rd-party/3rd-party-update-specific-version.bats
@@ -26,6 +26,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
+		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Preparing to update from 10 to 20
 		Downloading packs for:
@@ -42,7 +43,7 @@ test_setup() {
 		No extra files need to be downloaded
 		Installing files...
 		Update was applied
-		Calling post-update helper scripts
+		Warning: post-update helper scripts skipped due to --no-scripts argument
 		Update successful - System updated from version 10 to version 20
 	EOM
 	)


### PR DESCRIPTION
Swupd should not run post-update scripts after updating content from a
3rd-party repo since it may threaten the security of the system.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>