### PR TITLE
Organizing compare-like functions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,6 +76,8 @@ swupd_SOURCES = \
 	src/info.c \
 	src/lib/archives.c \
 	src/lib/archives.h \
+	src/lib/comp_functions.c \
+	src/lib/comp_functions.h \
 	src/lib/config_file.c \
 	src/lib/config_file.h \
 	src/lib/formatter_json.c \
@@ -116,6 +118,8 @@ swupd_SOURCES = \
 	src/subscriptions.c \
 	src/swupd_build_opts.h \
 	src/swupd_build_variant.h \
+	src/swupd_comp_functions.c \
+	src/swupd_comp_functions.h \
 	src/swupd_curl.h \
 	src/swupd_curl_internal.h \
 	src/swupd_exit_codes.h \

--- a/src/bundle_info.c
+++ b/src/bundle_info.c
@@ -280,11 +280,11 @@ static enum swupd_code get_bundle_dependencies(struct manifest *manifest, struct
 	/* from the list of dependencies, remove those that were
 	 * directly pulled by the bundle so we are left only with the ones
 	 * indirectly pulled */
-	*indirect_includes = list_sort(*indirect_includes, subscription_sort_component);
+	*indirect_includes = list_sort(*indirect_includes, cmp_subscription_component);
 	manifest->includes = list_sort(manifest->includes, strcmp_wrapper);
 	manifest->optional = list_sort(manifest->optional, strcmp_wrapper);
-	*indirect_includes = list_sorted_filter_common_elements(*indirect_includes, manifest->includes, subscription_bundlename_strcmp, NULL);
-	*indirect_includes = list_sorted_filter_common_elements(*indirect_includes, manifest->optional, subscription_bundlename_strcmp, NULL);
+	*indirect_includes = list_sorted_filter_common_elements(*indirect_includes, manifest->includes, cmp_sub_component_string, NULL);
+	*indirect_includes = list_sorted_filter_common_elements(*indirect_includes, manifest->optional, cmp_sub_component_string, NULL);
 
 	return SWUPD_OK;
 }

--- a/src/bundle_list.c
+++ b/src/bundle_list.c
@@ -258,7 +258,7 @@ static enum swupd_code show_included_bundles(char *bundle_name, int version)
 	if (verbose) {
 		ret = subscription_get_tree(bundles, &subs, mom, true, 0);
 	} else {
-		subs = list_sort(subs, subscription_sort_component);
+		subs = list_sort(subs, cmp_subscription_component);
 		iter = list_head(subs);
 		while (iter) {
 			bundle_sub = iter->data;
@@ -306,7 +306,7 @@ static enum swupd_code list_installable_bundles(int version)
 
 	progress_next_step("list_bundles", PROGRESS_UNDEFINED);
 	info("All available bundles:\n");
-	list = MoM->manifests = list_sort(MoM->manifests, file_sort_filename);
+	list = MoM->manifests = list_sort(MoM->manifests, cmp_file_filename_is_deleted);
 	while (list) {
 		file = list->data;
 		list = list->next;

--- a/src/fullfile.c
+++ b/src/fullfile.c
@@ -30,21 +30,6 @@
 //FIXME #562
 #define MAX_XFER 15
 
-static int compare_fullfile(const void *a, const void *b)
-{
-	struct file *file1 = (struct file *)a;
-	struct file *file2 = (struct file *)b;
-	int comp;
-
-	comp = strcmp(file1->hash, file2->hash);
-	if (comp != 0) {
-		return comp;
-	}
-
-	/* they have the same hash, now let's check the version */
-	return file1->last_change - file2->last_change;
-}
-
 static int download_mix_file(struct file *file)
 {
 	int ret = -1;
@@ -226,12 +211,12 @@ int download_fullfiles(struct list *files, int *num_downloads)
 	complete = 0;
 	if (list_length < MAX_FILES) {
 		/* remove tar duplicates from the list first */
-		need_download = list_sort(need_download, file_sort_hash);
+		need_download = list_sort(need_download, cmp_file_hash);
 
 		/* different directories may need the same tar, in those cases it needs
 		 * to be downloaded only once, the tar for each file is downloaded from
 		 * <last_change>/files/<hash>.tar */
-		need_download = list_sorted_deduplicate(need_download, compare_fullfile, NULL);
+		need_download = list_sorted_deduplicate(need_download, cmp_file_hash_last_change, NULL);
 
 		download_progress.total_download_size = fullfile_query_total_download_size(need_download);
 		if (download_progress.total_download_size > 0) {

--- a/src/hash.c
+++ b/src/hash.c
@@ -256,14 +256,6 @@ bool verify_file_lazy(char *filename)
 	return !hash_is_zeros(local.hash);
 }
 
-static int file_name_cmp(const void *a, const void *b)
-{
-	const struct file *fa = a;
-	const struct file *fb = b;
-
-	return strcmp(fa->filename, fb->filename);
-}
-
 /* Compares the hash for BUNDLE with that listed in the Manifest.MoM.  If the
  * hash check fails, we should assume the bundle manifest is incorrect and
  * discard it. A retry should then force redownloading of the bundle manifest.
@@ -274,7 +266,7 @@ int verify_bundle_hash(struct manifest *mom, struct file *bundle)
 	char *local = NULL, *cached;
 	int ret = 0;
 
-	current = list_search(list_head(mom->manifests), bundle, file_name_cmp);
+	current = list_search(list_head(mom->manifests), bundle, cmp_file_filename);
 	if (!current) {
 		return -1;
 	}

--- a/src/lib/comp_functions.c
+++ b/src/lib/comp_functions.c
@@ -1,0 +1,39 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2012-2020 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define _GNU_SOURCE
+
+#include <string.h>
+
+#include "comp_functions.h"
+
+/**
+ * All comparison functions in this file should match this type definition:
+ * typedef int (*comparison_fn_t)(const void *a, const void *b);
+ *
+ * They should behave like this (similar to strcmp):
+ * - return 0 if a is equal to b
+ * - return any number "< 0" if a is lower than b
+ * - return any number "> 0" if a is bigger than b
+ */
+
+int strcmp_wrapper(const void *a, const void *b)
+{
+	return strcmp((const char *)a, (const char *)b);
+}

--- a/src/lib/comp_functions.h
+++ b/src/lib/comp_functions.h
@@ -1,0 +1,26 @@
+#ifndef __COMP_FUNCTIONS_H
+#define __COMP_FUNCTIONS_H
+
+/**
+ * @file
+ * @brief Compare like functions.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Definition of a funtion type to compare two elements
+ */
+typedef int (*comparison_fn_t)(const void *a, const void *b);
+
+/**
+ * @brief strcmp wrapper casting void * to char *.
+ */
+int strcmp_wrapper(const void *a, const void *b);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/lib/list.h
+++ b/src/lib/list.h
@@ -20,6 +20,8 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#include "comp_functions.h"
+
 /**
  * @brief List node.
  */
@@ -31,15 +33,6 @@ struct list {
 	/** @brief Next list node. */
 	struct list *next;
 };
-
-/**
- * @brief Callback to compare two datas in a list.
- * The comparison function should return 0 if a is equal to b,
- * any number "< 0" if a is lower than b and any number "> 0" if
- * a is bigger than b.
- * This behavior is similar to strcmp() and other standard compare functions.
- */
-typedef int (*comparison_fn_t)(const void *a, const void *b);
 
 /** @brief Callback to free data used in list. */
 typedef void (*list_free_data_fn_t)(void *data);

--- a/src/lib/strings.c
+++ b/src/lib/strings.c
@@ -204,8 +204,3 @@ char *str_subchar(const char *str, char c1, char c2)
 
 	return new;
 }
-
-int strcmp_wrapper(const void *a, const void *b)
-{
-	return strcmp((const char *)a, (const char *)b);
-}

--- a/src/lib/strings.h
+++ b/src/lib/strings.h
@@ -13,11 +13,6 @@ extern "C" {
 #endif
 
 /**
- * @brief strcmp wrapper casting void * to char *.
- */
-int strcmp_wrapper(const void *a, const void *b);
-
-/**
  * Save in strp a new allocated string with content printed from fmt and
  * parameters using vasprintf. Abort on memory allocation errors.
  */

--- a/src/manifest.h
+++ b/src/manifest.h
@@ -97,17 +97,6 @@ int mom_get_manifests_list(struct manifest *mom, struct list **manifest_list, fi
  */
 int recurse_dependencies(struct manifest *mom, const char *bundle, struct list **manifests, filter_fn_t filter_fn);
 
-/**
- * @brief Compares the "component" of a manifest "a" to a string "b"
- */
-int manifest_bundlename_strcmp(const void *a, const void *b);
-
-/**
- * @brief Compares the "component" of a manifest "a"
- *        to the "component" of string "b"
- */
-int manifest_component_strcmp(const void *a, const void *b);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/search_file.c
+++ b/src/search_file.c
@@ -84,14 +84,6 @@ static int bundle_cmp(const void *bundle, const void *bundle_name)
 	return strcmp(b->bundle_name, bundle_name);
 }
 
-static int manifest_name_cmp(const void *a, const void *b)
-{
-	const struct manifest *ma = a;
-	const struct manifest *mb = b;
-
-	return strcmp(ma->component, mb->component);
-}
-
 static int manifest_str_cmp(const void *manifest, const void *manifest_name)
 {
 	const struct manifest *m = manifest;
@@ -345,7 +337,7 @@ static int do_search(struct manifest *mom, const char *search_term)
 	int regexp_err;
 
 	if (sort == SORT_TYPE_ALPHA_BUNDLES_ONLY || sort == SORT_TYPE_ALPHA) {
-		manifest_list = list_sort(manifest_list, manifest_name_cmp);
+		manifest_list = list_sort(manifest_list, cmp_manifest_component);
 	} else if (sort == SORT_TYPE_SIZE) {
 		// pre process the bundle size of all bundles for sorting
 		for (l = manifest_list; l; l = l->next) {

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -53,23 +53,6 @@ struct list *free_list_file(struct list *item)
 	return list_free_item(item, free_file_data);
 }
 
-int subscription_bundlename_strcmp(const void *a, const void *b)
-{
-	return strcmp(((struct sub *)a)->component, (const char *)b);
-}
-
-int subscription_sort_component(const void *a, const void *b)
-{
-	struct sub *A, *B;
-	int ret;
-	A = (struct sub *)a;
-	B = (struct sub *)b;
-
-	ret = strcmp(A->component, B->component);
-
-	return ret;
-}
-
 /* Custom content comes from a different location and is not required to
  * have os-core added */
 void read_subscriptions(struct list **subs)
@@ -112,7 +95,7 @@ void read_subscriptions(struct list **subs)
 		create_and_append_subscription(subs, "os-core");
 	}
 
-	*subs = list_sort(*subs, subscription_sort_component);
+	*subs = list_sort(*subs, cmp_subscription_component);
 }
 
 static bool set_subscription_obligation(struct list *subs, char *component, bool is_optional)

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -15,6 +15,7 @@
 #include "config_loader.h"
 #include "globals.h"
 #include "lib/archives.h"
+#include "lib/comp_functions.h"
 #include "lib/config_file.h"
 #include "lib/formatter_json.h"
 #include "lib/list.h"
@@ -26,6 +27,7 @@
 #include "manifest.h"
 #include "progress.h"
 #include "scripts.h"
+#include "swupd_comp_functions.h"
 #include "swupd_curl.h"
 #include "swupd_exit_codes.h"
 #include "swupd_progress.h"
@@ -175,9 +177,6 @@ extern int get_server_format(int server_version);
 extern bool ignore(struct file *file);
 extern void apply_heuristics(struct file *file);
 
-extern int file_sort_filename(const void *a, const void *b);
-extern int file_sort_filename_reverse(const void *a, const void *b);
-extern int file_sort_hash(const void *a, const void *b);
 extern struct manifest *load_mom(int version, bool mix_exists, int *err);
 extern struct manifest *load_manifest(int version, struct file *file, struct manifest *mom, bool header_only, int *err);
 extern struct manifest *load_manifest_full(int version, bool mix);
@@ -327,8 +326,6 @@ extern void create_and_append_subscription(struct list **subs, const char *compo
 extern char *get_tracking_dir(void);
 extern int add_subscriptions(struct list *bundles, struct list **subs, struct manifest *mom, bool find_all, int recursion);
 extern int subscription_get_tree(struct list *bundles, struct list **subs, struct manifest *mom, bool find_all, int recursion);
-extern int subscription_bundlename_strcmp(const void *a, const void *b);
-extern int subscription_sort_component(const void *a, const void *b);
 
 /* bundle_add.c */
 extern enum swupd_code execute_bundle_add(struct list *bundles_list);

--- a/src/swupd_comp_functions.c
+++ b/src/swupd_comp_functions.c
@@ -1,0 +1,136 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2012-2020 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define _GNU_SOURCE
+
+#include <string.h>
+
+#include "swupd.h"
+
+/**
+ * All functions in this file should match this type definition:
+ * typedef int (*comparison_fn_t)(const void *a, const void *b);
+ *
+ * They should behave like this (similar to strcmp):
+ * - return 0 if a is equal to b
+ * - return any number "< 0" if a is lower than b
+ * - return any number "> 0" if a is bigger than b
+ *
+ * Naming convention:
+ *
+ * If both elements being compared are the same type and subtype:
+ *   cmp_<type>_<subtype>
+ *
+ * If both elements being compared are different type or subtype:
+ *   cmp_<type1>_<subtype1>_<type2>_<subtype2>
+ */
+
+int cmp_string_filerecord_filename(const void *a, const void *b)
+{
+	return strcmp(*(const char **)a, ((struct filerecord *)b)->filename);
+}
+
+int cmp_file_filename(const void *a, const void *b)
+{
+	return strcmp(((struct file *)a)->filename, ((struct file *)b)->filename);
+}
+
+int cmp_file_filename_ptr(const void *a, const void *b)
+{
+	return strcmp((*(struct file **)a)->filename, (*(struct file **)b)->filename);
+}
+
+int cmp_filerecord_filename(const void *a, const void *b)
+{
+	return strcmp(((struct filerecord *)a)->filename, ((struct filerecord *)b)->filename);
+}
+
+int cmp_file_hash(const void *a, const void *b)
+{
+	return strcmp(((struct file *)a)->hash, ((struct file *)b)->hash);
+}
+
+int cmp_manifest_component(const void *a, const void *b)
+{
+	return strcmp(((struct manifest *)a)->component, ((struct manifest *)b)->component);
+}
+
+int cmp_subscription_component(const void *a, const void *b)
+{
+	return strcmp(((struct sub *)a)->component, ((struct sub *)b)->component);
+}
+
+int cmp_manifest_component_string(const void *a, const void *b)
+{
+	return strcmp(((struct manifest *)a)->component, (const char *)b);
+}
+
+int cmp_file_filename_string(const void *a, const void *b)
+{
+	return strcmp(((struct file *)a)->filename, (const char *)b);
+}
+
+int cmp_sub_component_string(const void *a, const void *b)
+{
+	return strcmp(((struct sub *)a)->component, (const char *)b);
+}
+
+int cmp_file_filename_reverse(const void *a, const void *b)
+{
+	int ret;
+
+	ret = cmp_file_filename(a, b);
+	return -ret;
+}
+
+int cmp_file_hash_last_change(const void *a, const void *b)
+{
+	struct file *file1 = (struct file *)a;
+	struct file *file2 = (struct file *)b;
+	int comp;
+
+	comp = strcmp(file1->hash, file2->hash);
+	if (comp != 0) {
+		return comp;
+	}
+
+	/* they have the same hash, now let's check the version */
+	return file1->last_change - file2->last_change;
+}
+
+int cmp_file_filename_is_deleted(const void *a, const void *b)
+{
+	struct file *A, *B;
+	int ret;
+	A = (struct file *)a;
+	B = (struct file *)b;
+
+	ret = strcmp(A->filename, B->filename);
+	if (ret) {
+		return ret;
+	}
+	if (A->is_deleted > B->is_deleted) {
+		return 1;
+	}
+	if (A->is_deleted < B->is_deleted) {
+		return -1;
+	}
+
+	return 0;
+}

--- a/src/swupd_comp_functions.h
+++ b/src/swupd_comp_functions.h
@@ -1,0 +1,56 @@
+#ifndef __SWUPD_COMP_FUNCTIONS__
+#define __SWUPD_COMP_FUNCTIONS__
+
+/**
+ * @file
+ * @brief Compare-like functions used as arguments of other swupd functions
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* compare file->filename with file->filename */
+int cmp_file_filename(const void *a, const void *b);
+
+/* compare a pointer to file->filename with a pointer to file->filename */
+int cmp_file_filename_ptr(const void *a, const void *b);
+
+/* compare file->hash with file->hash */
+int cmp_file_hash(const void *a, const void *b);
+
+/* compare filerecord->filename with filerecord->filename */
+int cmp_filerecord_filename(const void *a, const void *b);
+
+/* compare manifest->component with manifest->component */
+int cmp_manifest_component(const void *a, const void *b);
+
+/* compare sub->component with sub->component */
+int cmp_subscription_component(const void *a, const void *b);
+
+/* compare manifest->component with a string */
+int cmp_manifest_component_string(const void *a, const void *b);
+
+/* compare file->filename with a string */
+int cmp_file_filename_string(const void *a, const void *b);
+
+/* compare sub->component with a string */
+int cmp_sub_component_string(const void *a, const void *b);
+
+/* compare a string with filerecord->filename */
+int cmp_string_filerecord_filename(const void *a, const void *b);
+
+/* compare file->filename with file->filename
+ * @returns an inverse result */
+int cmp_file_filename_reverse(const void *a, const void *b);
+
+/* compare file->hash, file->last_change with file->hash, file->last_change */
+int cmp_file_hash_last_change(const void *a, const void *b);
+
+/* compare file->filename, file->is_deleted with file->filename, file->is_deleted */
+int cmp_file_filename_is_deleted(const void *a, const void *b);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/update.c
+++ b/src/update.c
@@ -505,7 +505,7 @@ version_check:
 	/* need update list in filename order to insure directories are
 	 * created before their contents */
 	timelist_timer_start(globals.global_times, "Update loop");
-	updates = list_sort(updates, file_sort_filename);
+	updates = list_sort(updates, cmp_file_filename_is_deleted);
 
 	ret = update_loop(updates, server_manifest);
 	if (ret == 0 && !download_only) {

--- a/src/verify.c
+++ b/src/verify.c
@@ -485,7 +485,7 @@ static void remove_orphaned_files(struct manifest *official_manifest, bool repai
 
 	info("%s extraneous files\n", repair ? "Removing" : "Checking for");
 
-	official_manifest->files = list_sort(official_manifest->files, file_sort_filename_reverse);
+	official_manifest->files = list_sort(official_manifest->files, cmp_file_filename_reverse);
 
 	iter = list_head(official_manifest->files);
 	while (iter) {
@@ -775,7 +775,7 @@ static enum swupd_code deal_with_extra_files(struct manifest *manifest, bool fix
 	return ret;
 }
 
-static int find_unsafe_to_delete(const void *a, const void *b)
+static int filter_file_unsafe_to_delete(const void *a, const void *b)
 {
 	struct file *A, *B;
 	int ret;
@@ -1056,7 +1056,7 @@ enum swupd_code execute_verify(void)
 		 * are compared against the full list of consolidated files
 		 * from all bundles so we don't end up deleting a file that
 		 * is needed by another bundle */
-		bundles_files = list_sorted_filter_common_elements(bundles_files, all_files, find_unsafe_to_delete, NULL);
+		bundles_files = list_sorted_filter_common_elements(bundles_files, all_files, filter_file_unsafe_to_delete, NULL);
 		official_manifest->files = bundles_files;
 
 		/* at this point we no longer need the data regarding bundles
@@ -1171,7 +1171,7 @@ brick_the_system_and_clean_curl:
 			char *bundle = iter->data;
 			/* make sure the bundle was in fact valid and will
 			 * be installed before creating the tracking file */
-			if (list_search(bundles_subs, bundle, subscription_bundlename_strcmp)) {
+			if (list_search(bundles_subs, bundle, cmp_sub_component_string)) {
 				track_bundle_in_statedir(bundle, new_os_statedir);
 			}
 		}


### PR DESCRIPTION
We used compare-like functions as arguments to other functions that
filter, sort, compare data. These functions are scattered accros the
code and they are sometimes difficult to identify so there is a lot of
code duplication.

This commit organizes all the compare like functions throughout the code
in the same place and with standard naming so it is easier to find them
and reuse them.

Closes #1167

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>