### PR TITLE
Show what bundles are explicitly installed vs implicitly installed with bundle-list

### DIFF
--- a/config
+++ b/config
@@ -197,6 +197,9 @@
 # dependency (string value)
 #has_dep=[BUNDLE]
 
+# Show the installation status of the listed bundles (boolean value)
+#status=<true/false>
+
 
 [bundle-info]
 
@@ -416,6 +419,9 @@
 # List dependency tree of all bundles which have BUNDLE as a
 # dependency (string value)
 #has_dep=[BUNDLE]
+
+# Show the installation status of the listed bundles (boolean value)
+#status=<true/false>
 
 
 [3rd-party-bundle-info]

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -252,6 +252,14 @@ SUBCOMMANDS
         not installed on the system. Combine with `--verbose` to show a tree of
         these bundles.
 
+    - `--status`
+
+        Show the installation status of the listed bundles. Bundles installation
+        status can be; "explicitly installed", meaning that they were specifically
+        requested to be installed by the user, or they can be "implicitly installed",
+        meaning they were installed as a dependency of another explicitly installed
+        bundle.
+
 ``bundle-info``
 
     Display detailed information about a bundle.

--- a/src/3rd_party_bundle_list.c
+++ b/src/3rd_party_bundle_list.c
@@ -25,12 +25,14 @@
 #ifdef THIRDPARTY
 
 #define FLAG_DEPS 2000
+#define FLAG_STATUS 2001
 
 static bool cmdline_local = true;
 static bool cmdline_option_all = false;
 static char *cmdline_option_has_dep = NULL;
 static char *cmdline_option_deps = NULL;
 static char *cmdline_repo = NULL;
+static bool cmdline_option_status = false;
 
 static void free_has_dep(void)
 {
@@ -55,6 +57,7 @@ static void print_help(void)
 	print("   -a, --all               List all available bundles for the current version of Clear Linux\n");
 	print("   -D, --has-dep=[BUNDLE]  List all bundles which have BUNDLE as a dependency (use --verbose for tree view)\n");
 	print("   --deps=[BUNDLE]         List BUNDLE dependencies (use --verbose for tree view)\n");
+	print("   --status                Show the installation status of the listed bundles\n");
 	print("\n");
 }
 
@@ -62,6 +65,7 @@ static const struct option prog_opts[] = {
 	{ "all", no_argument, 0, 'a' },
 	{ "deps", required_argument, 0, FLAG_DEPS },
 	{ "has-dep", required_argument, 0, 'D' },
+	{ "status", no_argument, 0, FLAG_STATUS },
 	{ "repo", required_argument, 0, 'R' },
 };
 
@@ -84,6 +88,9 @@ static bool parse_opt(int opt, char *optarg)
 		string_or_die(&cmdline_option_deps, "%s", optarg);
 		atexit(free_deps);
 		cmdline_local = false;
+		return true;
+	case FLAG_STATUS:
+		cmdline_option_status = optarg_to_bool(optarg);
 		return true;
 	default:
 		return false;
@@ -156,6 +163,7 @@ enum swupd_code third_party_bundle_list_main(int argc, char **argv)
 	bundle_list_set_option_all(cmdline_option_all);
 	bundle_list_set_option_has_dep(cmdline_option_has_dep);
 	bundle_list_set_option_deps(cmdline_option_deps);
+	bundle_list_set_option_status(cmdline_option_status);
 
 	/* list the bundles */
 	ret_code = third_party_run_operation_multirepo(cmdline_repo, list_repo_bundles, SWUPD_OK, "bundle-list", steps_in_bundlelist);

--- a/src/bundle_info.c
+++ b/src/bundle_info.c
@@ -302,6 +302,7 @@ enum swupd_code bundle_info(char *bundle)
 	long bundle_size;
 	bool mix_exists;
 	bool installed = is_installed_bundle(bundle);
+	bool tracked = is_tracked_bundle(bundle);
 
 	/* get the very latest version available */
 	latest_version = get_latest_version(NULL);
@@ -399,7 +400,14 @@ enum swupd_code bundle_info(char *bundle)
 	free_string(&header);
 
 	/* status info */
-	info("Status: %s%s\n", installed ? "Installed" : "Not installed", file->is_experimental ? " (experimental)" : "");
+	char *status = NULL;
+	if (tracked) {
+		string_or_die(&status, "Explicitly installed");
+	} else if (installed) {
+		string_or_die(&status, "Installed");
+	}
+	info("Status: %s%s\n", status ? status : "Not installed", file->is_experimental ? " (experimental)" : "");
+	free_string(&status);
 
 	/* version info */
 	if (installed) {

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -968,12 +968,35 @@ exit:
 	return err;
 }
 
-/* Appends the (experimental) label if applicable to the bundle name */
-char *get_printable_bundle_name(const char *bundle_name, bool is_experimental)
+/* Appends the appropriate label to the bundle name */
+char *get_printable_bundle_name(const char *bundle_name, bool is_experimental, bool is_installed, bool is_tracked)
 {
 	char *printable_name = NULL;
+	char *details = NULL;
+	char *status = NULL;
 
-	string_or_die(&printable_name, "%s%s", bundle_name, is_experimental ? " (experimental)" : "");
+	if (is_installed || is_tracked) {
+		string_or_die(&status, "%s", is_installed && !is_tracked ? "installed" : "explicitly installed");
+	}
+
+	if (is_experimental) {
+		if (status) {
+			string_or_die(&details, "experimental, %s", status);
+		} else {
+			string_or_die(&details, "%s", "experimental");
+		}
+	} else if (status) {
+		string_or_die(&details, "%s", status);
+	}
+	free_string(&status);
+
+	if (details) {
+		string_or_die(&printable_name, "%s (%s)", bundle_name, details);
+	} else {
+		string_or_die(&printable_name, "%s", bundle_name);
+	}
+	free_string(&details);
+
 	return printable_name;
 }
 

--- a/src/search_file.c
+++ b/src/search_file.c
@@ -214,6 +214,7 @@ static void print_bundle(struct manifest *mom, struct manifest *m)
 	bool installed;
 	struct file *bundle_file;
 	bool is_experimental;
+	const bool DONT_SHOW_STATUS = false;
 
 	if (csv_format) {
 		return;
@@ -223,7 +224,7 @@ static void print_bundle(struct manifest *mom, struct manifest *m)
 	is_experimental = bundle_file ? bundle_file->is_experimental : false;
 	installed = is_installed_bundle(m->component);
 
-	name = get_printable_bundle_name(m->component, is_experimental);
+	name = get_printable_bundle_name(m->component, is_experimental, DONT_SHOW_STATUS, DONT_SHOW_STATUS);
 	print("\nBundle %s %s", name, installed ? "[installed] " : "");
 	free_string(&name);
 

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -306,7 +306,7 @@ extern bool string_in_list(char *string_to_check, struct list *list_to_check);
 extern bool is_compatible_format(int format_num);
 extern bool is_current_version(int version);
 extern bool on_new_format(void);
-extern char *get_printable_bundle_name(const char *bundle_name, bool is_experimental);
+extern char *get_printable_bundle_name(const char *bundle_name, bool is_experimental, bool is_installed, bool is_tracked);
 extern void print_regexp_error(int errcode, regex_t *regexp);
 extern bool is_url_allowed(const char *url);
 extern bool is_url_insecure(const char *url);
@@ -375,6 +375,7 @@ extern enum swupd_code list_bundles(void);
 extern void bundle_list_set_option_all(bool opt);
 extern void bundle_list_set_option_has_dep(char *bundle);
 extern void bundle_list_set_option_deps(char *bundle);
+extern void bundle_list_set_option_status(bool opt);
 
 /* clean.c */
 extern int clean_get_stats(void);

--- a/swupd.bash
+++ b/swupd.bash
@@ -51,7 +51,7 @@ _swupd()
 		opts="$global --force --recursive "
 		break;;
 		("bundle-list")
-		opts="$global --all --deps --has-dep "
+		opts="$global --all --deps --has-dep --status "
 		break;;
 		("bundle-info")
 		opts="$global --dependencies --files --version "

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -272,6 +272,7 @@ if [[ -n "$state" ]]; then
             '(help)'{-a,--all}'[List all available bundles for the current version of Clear Linux]'
             '(help)--deps=[List bundles included by BUNDLE]:deps: _swupd_installed_bundles -u'
             '(help)'{-D,--has-dep=}'[List dependency tree of all bundles which have BUNDLE as a dependency]:has-dep: _swupd_installed_bundles -u'
+            '(help --status)'[Show the installation status of the listed bundles]'
           )
           _arguments $lsbundle && ret=0
           ;;

--- a/test/functional/3rd-party/3rd-party-bundle-info-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-info-basic.bats
@@ -19,6 +19,10 @@ global_setup() {
 	add_third_party_repo "$TEST_NAME" 10 staging repo2
 	create_bundle    -n test-bundle1 -f /baz/file_1B -u repo2 "$TEST_NAME"
 	create_bundle    -n test-bundle3 -f /baz/file_3  -u repo2 "$TEST_NAME"
+	# when swupd initializes, if the tracking directory is empty, it will
+	# mark all installed bundles as tracked, to avoid this, let's add a dummy
+	# value to the tracking directory
+	sudo touch "$STATEDIR"/3rd-party/{repo1,repo2}/bundles/dummy
 
 }
 

--- a/test/functional/bundleinfo/bundle-info-basic.bats
+++ b/test/functional/bundleinfo/bundle-info-basic.bats
@@ -14,6 +14,10 @@ global_setup() {
 	update_bundle "$TEST_NAME" test-bundle1 --update /file_1
 	create_version "$TEST_NAME" 30 20
 	update_bundle "$TEST_NAME" test-bundle1 --add /foo/file_5
+	# when swupd initializes, if the tracking directory is empty, it will
+	# mark all installed bundles as tracked, to avoid this, let's add a dummy
+	# value to the tracking directory
+	sudo touch "$STATEDIR"/bundles/dummy
 
 }
 

--- a/test/functional/bundleinfo/bundle-info-status.bats
+++ b/test/functional/bundleinfo/bundle-info-status.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L    -n test-bundle1 -f /file_1 "$TEST_NAME"
+	create_bundle -L -t -n test-bundle2 -f /file_2 "$TEST_NAME"
+
+}
+
+test_setup() {
+
+	# do nothing, just overwrite the lib test_setup
+	return
+
+
+}
+
+test_teardown() {
+
+	# do nothing, just overwrite the lib test_setup
+	return
+
+
+}
+
+global_teardown() {
+
+	destroy_test_environment "$TEST_NAME"
+
+}
+
+@test "BIN013: Show info about a bundle installed in the system explicitly" {
+
+	# bundles explicitly installed by the user should show that distinction
+
+	run sudo sh -c "$SWUPD bundle-info $SWUPD_OPTS test-bundle2"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		_______________________________
+		 Info for bundle: test-bundle2
+		_______________________________
+		Status: Explicitly installed
+		Bundle test-bundle2 is up to date:
+		 - Installed bundle last updated in version: 10
+		 - Latest available version: 10
+		Bundle size:
+		 - Size of bundle: .* KB
+		 - Size bundle takes on disk \(includes dependencies\): .* KB
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}
+
+@test "BIN014: Show info about a bundle installed in the system implicitly" {
+
+	# bundles implicitly installed should just show as installed
+
+	run sudo sh -c "$SWUPD bundle-info $SWUPD_OPTS test-bundle1"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		_______________________________
+		 Info for bundle: test-bundle1
+		_______________________________
+		Status: Installed
+		Bundle test-bundle1 is up to date:
+		 - Installed bundle last updated in version: 10
+		 - Latest available version: 10
+		Bundle size:
+		 - Size of bundle: .* KB
+		 - Size bundle takes on disk \(includes dependencies\): .* KB
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}

--- a/test/functional/bundlelist/list-all.bats
+++ b/test/functional/bundlelist/list-all.bats
@@ -5,8 +5,10 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment "$TEST_NAME"
-	create_bundle -n test-bundle1 -f /foo "$TEST_NAME"
-	create_bundle -n test-bundle2 -f /bar "$TEST_NAME"
+	create_bundle       -n test-bundle1 -f /foo "$TEST_NAME"
+	create_bundle       -n test-bundle2 -f /bar "$TEST_NAME"
+	create_bundle -L    -n test-bundle3 -f /baz "$TEST_NAME"
+	create_bundle -L -t -n test-bundle4 -f /bat "$TEST_NAME"
 
 }
 
@@ -20,8 +22,30 @@ test_setup() {
 		 - os-core
 		 - test-bundle1
 		 - test-bundle2
+		 - test-bundle3
+		 - test-bundle4
 
-		Total: 3
+		Total: 5
+	EOM
+	)
+	assert_is_output --identical "$expected_output"
+
+}
+
+@test "LST026: List all available bundles and their installation status" {
+
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --all --status"
+
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		All available bundles:
+		 - os-core (installed)
+		 - test-bundle1
+		 - test-bundle2
+		 - test-bundle3 (installed)
+		 - test-bundle4 (explicitly installed)
+
+		Total: 5
 	EOM
 	)
 	assert_is_output --identical "$expected_output"

--- a/test/functional/bundlelist/list-installed.bats
+++ b/test/functional/bundlelist/list-installed.bats
@@ -8,8 +8,8 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment "$TEST_NAME"
-	create_bundle -L -n test-bundle1 -f /file_1 "$TEST_NAME"
-	create_bundle -L -n test-bundle2 -f /file_2 "$TEST_NAME"
+	create_bundle -L    -n test-bundle1 -f /file_1 "$TEST_NAME"
+	create_bundle -L -t -n test-bundle2 -f /file_2 "$TEST_NAME"
 	create_bundle -n test-bundle3 -f /file_3 "$TEST_NAME"
 
 }
@@ -20,12 +20,30 @@ test_setup() {
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS"
 
-	assert_status_is 0
+	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Installed bundles:
 		 - os-core
 		 - test-bundle1
 		 - test-bundle2
+
+		Total: 3
+	EOM
+	)
+	assert_is_output --identical "$expected_output"
+
+}
+
+@test "LST024: List all installed bundles and their installation status" {
+
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --status"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Installed bundles:
+		 - os-core
+		 - test-bundle1
+		 - test-bundle2 (explicitly installed)
 
 		Total: 3
 	EOM


### PR DESCRIPTION
The "bundle-list" command can be used to show all installed bundles in the system, however, currently there is no way to know which of those installed bundles were implicitly or explicitly installed. Issue #1272 was opened to implement a way of getting this information with swupd.

This PR implements the "--status" flag for bundle-list which can be used to show which bundles were explicitly or implicitly installed.

This PR also adds this information to the installation status of the bundle-info command.

Closes #1272