### PR TITLE
docs: Explicitly adding a list of files in the doc check exclude list

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -266,7 +266,7 @@ functional-check:
 
 docs-coverage:
 	doxygen docs/Doxyfile || die; \
-	python -m coverxygen --xml-dir xml/ --src-dir ./ --output doc-coverage.info --exclude ".*/src/.*" --include ".*/src/lib/.*" --format json || die; \
+	python -m coverxygen --xml-dir xml/ --src-dir ./ --output doc-coverage.info --exclude ".*/src/globals.h" --exclude ".*/src/swupd_build_opts.h" --exclude ".*/src/swupd_build_variant.h" --exclude ".*/src/swupd_exit_codes.h" --exclude ".*/src/swupd.h" --exclude ".*/src/swupd_internal.h" --exclude ".*/src/manifest.h" --exclude ".*/src/swupd_curl_internal.h" --exclude ".*/src/swupd_curl.h" --format json || die; \
 	if [ "$$(cat doc-coverage.info | grep documented.*false | wc -l)" -gt "0" ]; then \
 		echo "Public functions or data added on headers but not documented on src/lib "; \
 		exit 1; \

--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -14,16 +14,20 @@ extern "C" {
 
 #ifdef THIRDPARTY
 
+/** @brief Name of the directory where 3rd-party content and state should be stored */
 #define SWUPD_3RD_PARTY_DIRNAME "3rd-party"
+/** @brief Full path to the directory where 3rd-party content is going to be installed. */
 #define SWUPD_3RD_PARTY_BUNDLES_DIR "/opt/" SWUPD_3RD_PARTY_DIRNAME "/bundles"
 
 /** @brief Store information of a repository.  */
 struct repo {
+	/** @brief repo's name */
 	char *name;
+	/** @brief repo's url */
 	char *url;
 };
 
-/* @brief Definition of a function that performs an action on a given bundle */
+/** @brief Definition of a function that performs an action on a given bundle */
 typedef enum swupd_code (*run_operation_fn_t)(char *bundle);
 
 /**

--- a/src/alias.c
+++ b/src/alias.c
@@ -29,6 +29,11 @@
 #include "config.h"
 #include "swupd.h"
 
+struct alias_lookup {
+	char *alias;
+	struct list *bundles;
+};
+
 void free_alias_lookup(void *lookup)
 {
 	struct alias_lookup *l = (struct alias_lookup *)lookup;

--- a/src/alias.h
+++ b/src/alias.h
@@ -8,11 +8,6 @@
 
 #include "lib/list.h"
 
-struct alias_lookup {
-	char *alias;
-	struct list *bundles;
-};
-
 /**
  * @brief Deep free on alias_lookup structs
  */

--- a/src/config_loader.h
+++ b/src/config_loader.h
@@ -13,7 +13,7 @@ extern "C" {
 #include <stdbool.h>
 
 /**
- * @brief Type of function that sets options for a command based on parsed values
+ * @brief Type of function that sets options for a section based on parsed values
  */
 typedef bool (*parse_opt_fn_t)(int opt, char *optarg);
 
@@ -21,9 +21,13 @@ typedef bool (*parse_opt_fn_t)(int opt, char *optarg);
  * @brief Data structed used by config_loader_set_opt()
  */
 struct config_loader_data {
+	/** @brief Swupd subcommand being executed */
 	char *command;
+	/** @brief Array with available opts. */
 	const struct option *available_opts;
+	/** @brief Function to parse global options */
 	parse_opt_fn_t parse_global_opt;
+	/** @brief Function to parse subcommand specific options */
 	parse_opt_fn_t parse_command_opt;
 };
 

--- a/src/swupd_comp_functions.h
+++ b/src/swupd_comp_functions.h
@@ -10,44 +10,46 @@
 extern "C" {
 #endif
 
-/* compare file->filename with file->filename */
+/** @brief compare file->filename with file->filename */
 int cmp_file_filename(const void *a, const void *b);
 
-/* compare a pointer to file->filename with a pointer to file->filename */
+/** @brief compare a pointer to file->filename with a pointer to file->filename */
 int cmp_file_filename_ptr(const void *a, const void *b);
 
-/* compare file->hash with file->hash */
+/** @brief compare file->hash with file->hash */
 int cmp_file_hash(const void *a, const void *b);
 
-/* compare filerecord->filename with filerecord->filename */
+/** @brief compare filerecord->filename with filerecord->filename */
 int cmp_filerecord_filename(const void *a, const void *b);
 
-/* compare manifest->component with manifest->component */
+/** @brief compare manifest->component with manifest->component */
 int cmp_manifest_component(const void *a, const void *b);
 
-/* compare sub->component with sub->component */
+/** @brief compare sub->component with sub->component */
 int cmp_subscription_component(const void *a, const void *b);
 
-/* compare manifest->component with a string */
+/** @brief compare manifest->component with a string */
 int cmp_manifest_component_string(const void *a, const void *b);
 
-/* compare file->filename with a string */
+/** @brief compare file->filename with a string */
 int cmp_file_filename_string(const void *a, const void *b);
 
-/* compare sub->component with a string */
+/** @brief compare sub->component with a string */
 int cmp_sub_component_string(const void *a, const void *b);
 
-/* compare a string with filerecord->filename */
+/** @brief compare a string with filerecord->filename */
 int cmp_string_filerecord_filename(const void *a, const void *b);
 
-/* compare file->filename with file->filename
- * @returns an inverse result */
+/**
+ * @brief compare file->filename with file->filename
+ * @returns an inverse result
+ */
 int cmp_file_filename_reverse(const void *a, const void *b);
 
-/* compare file->hash, file->last_change with file->hash, file->last_change */
+/** @brief compare file->hash, file->last_change with file->hash, file->last_change */
 int cmp_file_hash_last_change(const void *a, const void *b);
 
-/* compare file->filename, file->is_deleted with file->filename, file->is_deleted */
+/** @brief compare file->filename, file->is_deleted with file->filename, file->is_deleted */
 int cmp_file_filename_is_deleted(const void *a, const void *b);
 
 #ifdef __cplusplus

--- a/src/swupd_progress.h
+++ b/src/swupd_progress.h
@@ -10,20 +10,25 @@
 extern "C" {
 #endif
 
-#define UNUSED_PARAM __attribute__((__unused__))
+#include "swupd.h"
 
-#include <curl/curl.h>
-
-/* struct to hold information about the overall download progress (including many files) */
+/**
+ * @brief struct to hold information about the overall download progress (including many files).
+ */
 struct download_progress {
-	long total_download_size; /* total number of bytes to download */
-	long downloaded;	  /* total of bytes downloaded so far */
+	/** @brief total number of bytes to download. */
+	long total_download_size;
+	/** @brief total of bytes downloaded so far. */
+	long downloaded;
 };
 
-/* struct to hold information about one file download progress */
+/** @brief struct to hold information about one file download progress. */
 struct file_progress {
+	/** @brief file size. */
 	long file_size;
+	/** @brief downloaded. */
 	long downloaded;
+	/** @brief pointer to a struct holding information about the overall progress. */
 	struct download_progress *overall_progress;
 };
 

--- a/src/xattrs.h
+++ b/src/xattrs.h
@@ -34,7 +34,7 @@ void xattrs_copy(const char *src_filename, const char *dst_filename);
  */
 void xattrs_get_blob(const char *filename, char **blob, size_t *blob_len);
 
-/*
+/**
  * @brief Compare the extended attributes from one file to another.
  *
  * @param filename1 The first file used for the extended attributes


### PR DESCRIPTION
We have a list of header files that weren't documented yet. Add them explicitly
to the check to prevent us to lower the quality of the documentation of headers
that are well documented.

Also fixing some documentation that weren't included because of incorrect style.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>