### PR TITLE
Removing legacy verify command from autocompletion

### DIFF
--- a/swupd.bash
+++ b/swupd.bash
@@ -30,7 +30,7 @@ _swupd()
 		("$1")
 		opts="--help --version autoupdate bundle-add bundle-remove
 		bundle-list bundle-info hashdump update diagnose check-update search
-		search-file info clean mirror os-install repair verify 3rd-party"
+		search-file info clean mirror os-install repair 3rd-party"
 		break;;
 		("info")
 		opts="$global "
@@ -79,9 +79,6 @@ _swupd()
 		break;;
 		("hashdump")
 		opts="--help --no-xattrs --path --debug --quiet "
-		break;;
-		("verify")
-		opts="$global --version --manifest --fix --picky --picky-tree --picky-whitelist --install --quick --force --install "
 		break;;
 		("3rd-party")
 		opts="$global add remove list bundle-add bundle-list bundle-remove bundle-info update diagnose repair check-update clean "


### PR DESCRIPTION
The "verify" command was superceded many months ago. The command
still works and will continue to work for backward compatibility, but
users are discouraged to use it. To motivate users to use the newer
commands, all references to the legacy command has now been removed
from the swupd man page and the help menus.

This commit removes the command from the bash autocompletion script too.

This should have been done as part of PR #1231 

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>