### PR TITLE
Force to run all 3rd-party commands with root

### DIFF
--- a/src/3rd_party_bundle_list.c
+++ b/src/3rd_party_bundle_list.c
@@ -149,11 +149,7 @@ enum swupd_code third_party_bundle_list_main(int argc, char **argv)
 		return SWUPD_INVALID_OPTION;
 	}
 
-	if (cmdline_local && !is_root()) {
-		ret_code = swupd_init(SWUPD_NO_ROOT);
-	} else {
-		ret_code = swupd_init(SWUPD_ALL);
-	}
+	ret_code = swupd_init(SWUPD_ALL);
 	if (ret_code != SWUPD_OK) {
 		error("Failed swupd initialization, exiting now\n");
 		return ret_code;

--- a/src/3rd_party_check_update.c
+++ b/src/3rd_party_check_update.c
@@ -93,7 +93,7 @@ enum swupd_code third_party_check_update_main(int argc, char **argv)
 		return SWUPD_INVALID_OPTION;
 	}
 
-	ret_code = swupd_init(SWUPD_NO_ROOT);
+	ret_code = swupd_init(SWUPD_ALL);
 	if (ret_code != SWUPD_OK) {
 		return ret_code;
 	}

--- a/src/3rd_party_list.c
+++ b/src/3rd_party_list.c
@@ -83,7 +83,7 @@ enum swupd_code third_party_list_main(int argc, char **argv)
 		print_help();
 		return SWUPD_INVALID_OPTION;
 	}
-	ret = swupd_init(SWUPD_NO_ROOT);
+	ret = swupd_init(SWUPD_ALL);
 	if (ret != SWUPD_OK) {
 		return ret;
 	}

--- a/src/3rd_party_remove.c
+++ b/src/3rd_party_remove.c
@@ -81,7 +81,7 @@ enum swupd_code third_party_remove_main(int argc, char **argv)
 		return SWUPD_INVALID_OPTION;
 	}
 
-	ret = swupd_init(SWUPD_NO_ROOT);
+	ret = swupd_init(SWUPD_ALL);
 	if (ret != SWUPD_OK) {
 		return ret;
 	}


### PR DESCRIPTION
Some of the regular swupd commands can be run with a regular user, for
example check-update, however this is not the case for 3rd-party
commands, all of them require root privileges since they all need to at
least read data from root owned directories.

This commit enables swupd to require root privileges for all 3rd-party
commands at initialization time.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>