### PR TITLE
verify: Quick and extra files are not mutually exclusive

### DIFF
--- a/src/3rd_party_diagnose.c
+++ b/src/3rd_party_diagnose.c
@@ -163,16 +163,6 @@ static bool parse_options(int argc, char **argv)
 			return false;
 		}
 	}
-	if (cmdline_option_quick) {
-		if (cmdline_option_picky) {
-			error("--quick and --picky options are mutually exclusive\n");
-			return false;
-		}
-		if (cmdline_option_extra_files_only) {
-			error("--quick and --extra-files-only options are mutually exclusive\n");
-			return false;
-		}
-	}
 	if (cmdline_option_extra_files_only) {
 		if (cmdline_option_picky) {
 			error("--extra-files-only and --picky options are mutually exclusive\n");

--- a/src/3rd_party_repair.c
+++ b/src/3rd_party_repair.c
@@ -151,16 +151,6 @@ static bool parse_options(int argc, char **argv)
 	}
 
 	/* flag restrictions */
-	if (cmdline_option_quick) {
-		if (cmdline_option_picky) {
-			error("--quick and --picky options are mutually exclusive\n");
-			return false;
-		}
-		if (cmdline_option_extra_files_only) {
-			error("--quick and --extra-files-only options are mutually exclusive\n");
-			return false;
-		}
-	}
 	if (cmdline_option_extra_files_only) {
 		if (cmdline_option_picky) {
 			error("--extra-files-only and --picky options are mutually exclusive\n");

--- a/src/repair.c
+++ b/src/repair.c
@@ -158,16 +158,6 @@ static bool parse_options(int argc, char **argv)
 	}
 
 	/* flag restrictions */
-	if (cmdline_option_quick) {
-		if (cmdline_option_picky) {
-			error("--quick and --picky options are mutually exclusive\n");
-			return false;
-		}
-		if (cmdline_option_extra_files_only) {
-			error("--quick and --extra-files-only options are mutually exclusive\n");
-			return false;
-		}
-	}
 	if (cmdline_option_extra_files_only) {
 		if (cmdline_option_picky) {
 			error("--extra-files-only and --picky options are mutually exclusive\n");

--- a/src/verify.c
+++ b/src/verify.c
@@ -770,16 +770,6 @@ static bool parse_options(int argc, char **argv)
 	}
 
 	/* flag restrictions for both, "verify" and "diagnose" */
-	if (cmdline_option_quick) {
-		if (cmdline_option_picky) {
-			error("--quick and --picky options are mutually exclusive\n");
-			return false;
-		}
-		if (cmdline_option_extra_files_only) {
-			error("--quick and --extra-files-only options are mutually exclusive\n");
-			return false;
-		}
-	}
 	if (cmdline_option_extra_files_only) {
 		if (cmdline_option_picky) {
 			error("--extra-files-only and --picky options are mutually exclusive\n");

--- a/test/functional/diagnose/diagnose-flags.bats
+++ b/test/functional/diagnose/diagnose-flags.bats
@@ -9,24 +9,6 @@ load "../testlib"
 
 	# Some flags are mutually exclusive
 
-	# --quick & --picky
-	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --quick --picky"
-	assert_status_is "$SWUPD_INVALID_OPTION"
-	assert_in_output "Error: --quick and --picky options are mutually exclusive"
-
-	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --picky --quick"
-	assert_status_is "$SWUPD_INVALID_OPTION"
-	assert_in_output "Error: --quick and --picky options are mutually exclusive"
-
-	# --quick & --extra-files-only
-	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --quick --extra-files-only"
-	assert_status_is "$SWUPD_INVALID_OPTION"
-	assert_in_output "Error: --quick and --extra-files-only options are mutually exclusive"
-
-	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --extra-files-only --quick"
-	assert_status_is "$SWUPD_INVALID_OPTION"
-	assert_in_output "Error: --quick and --extra-files-only options are mutually exclusive"
-
 	# --picky & --extra-files-only
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --picky --extra-files-only"
 	assert_status_is "$SWUPD_INVALID_OPTION"

--- a/test/functional/repair/repair-flags.bats
+++ b/test/functional/repair/repair-flags.bats
@@ -9,24 +9,6 @@ load "../testlib"
 
 	# Some flags are mutually exclusive
 
-	# --quick & --picky
-	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --quick --picky"
-	assert_status_is "$SWUPD_INVALID_OPTION"
-	assert_in_output "Error: --quick and --picky options are mutually exclusive"
-
-	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --picky --quick"
-	assert_status_is "$SWUPD_INVALID_OPTION"
-	assert_in_output "Error: --quick and --picky options are mutually exclusive"
-
-	# --quick & --extra-files-only
-	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --quick --extra-files-only"
-	assert_status_is "$SWUPD_INVALID_OPTION"
-	assert_in_output "Error: --quick and --extra-files-only options are mutually exclusive"
-
-	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --extra-files-only --quick"
-	assert_status_is "$SWUPD_INVALID_OPTION"
-	assert_in_output "Error: --quick and --extra-files-only options are mutually exclusive"
-
 	# --picky & --extra-files-only
 	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --picky --extra-files-only"
 	assert_status_is "$SWUPD_INVALID_OPTION"

--- a/test/functional/verify-legacy/verify-flags.bats
+++ b/test/functional/verify-legacy/verify-flags.bats
@@ -9,24 +9,6 @@ load "../testlib"
 
 	# Some flags are mutually exclusive
 
-	# --quick & --picky
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --quick --picky"
-	assert_status_is "$SWUPD_INVALID_OPTION"
-	assert_in_output "Error: --quick and --picky options are mutually exclusive"
-
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --picky --quick"
-	assert_status_is "$SWUPD_INVALID_OPTION"
-	assert_in_output "Error: --quick and --picky options are mutually exclusive"
-
-	# --quick & --extra-files-only
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --quick --extra-files-only"
-	assert_status_is "$SWUPD_INVALID_OPTION"
-	assert_in_output "Error: --quick and --extra-files-only options are mutually exclusive"
-
-	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --extra-files-only --quick"
-	assert_status_is "$SWUPD_INVALID_OPTION"
-	assert_in_output "Error: --quick and --extra-files-only options are mutually exclusive"
-
 	# --picky & --extra-files-only
 	run sudo sh -c "$SWUPD verify $SWUPD_OPTS --picky --extra-files-only"
 	assert_status_is "$SWUPD_INVALID_OPTION"


### PR DESCRIPTION
According to the man page, "Omit checking hash values. Instead only looks
for missing files and directories and/or symlinks.".

When --quick and --picky or --extra-files-only is used that's exactly what
swupd does, so there's no reason to block that.

For --picky there's a real use case that is repair your system without hash
checks. For --extra-files-only in practice the --quick will be ignored, but
it's not inconsistent, so there's no reason to block it.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>