### PR TITLE
Add support for 'x' in the manifest parser

### DIFF
--- a/src/manifest_parser.c
+++ b/src/manifest_parser.c
@@ -219,6 +219,8 @@ struct manifest *manifest_parse(const char *component, const char *filename, boo
 		} else if (line[3] == 'm') {
 			file->is_mix = 1;
 			manifest->is_mix = 1;
+		} else if (line[3] == 'x') {
+			file->is_exported = 1;
 		}
 
 		c2 = strchr(c, '\t');

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -134,6 +134,7 @@ struct file {
 	unsigned int is_orphan : 1;
 	unsigned int is_mix : 1;
 	unsigned int is_experimental : 1;
+	unsigned int is_exported : 1;
 	unsigned int do_not_update : 1;
 
 	struct file *peer; /* same file in another manifest */


### PR DESCRIPTION
Add the 'x' to the manifest parser in the 4th column of file attributes,
this will indicate a file should be "exported".

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>