### PR TITLE
Backup global variables used by 3rd-party ops

### DIFF
--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -16,8 +16,15 @@ extern "C" {
 
 /** @brief Name of the directory where 3rd-party content and state should be stored */
 #define SWUPD_3RD_PARTY_DIRNAME "3rd-party"
+
+/** @brief Full path to the main directory for 3rd-party */
+#define SWUPD_3RD_PARTY_DIR "/opt/" SWUPD_3RD_PARTY_DIRNAME
+
 /** @brief Full path to the directory where 3rd-party content is going to be installed. */
-#define SWUPD_3RD_PARTY_BUNDLES_DIR "/opt/" SWUPD_3RD_PARTY_DIRNAME "/bundles"
+#define SWUPD_3RD_PARTY_BUNDLES_DIR SWUPD_3RD_PARTY_DIR "/bundles"
+
+/** @brief Full path to the directory where 3rd-party binaries are going to be installed */
+#define SWUPD_3RD_PARTY_BIN_DIR SWUPD_3RD_PARTY_DIR "/bin"
 
 /** @brief Store information of a repository.  */
 struct repo {
@@ -29,6 +36,12 @@ struct repo {
 
 /** @brief Definition of a function that performs an action on a given bundle */
 typedef enum swupd_code (*run_operation_fn_t)(char *bundle);
+
+/** @brief Function that returns the path to the 3rd-party bin directory */
+char *third_party_get_bin_dir(void);
+
+/** @brief Function that returns the path to a 3rd-party binary */
+char *third_party_get_binary_path(const char *binary_name);
 
 /**
  * @brief Free repo pointed by @c repo.
@@ -90,7 +103,7 @@ int third_party_remove_repo_directory(const char *repo_name);
  *
  * @returns a swupd_code
  */
-enum swupd_code third_party_set_repo(const char *state_dir, const char *path_prefix, struct repo *repo, bool sigcheck);
+enum swupd_code third_party_set_repo(struct repo *repo, bool sigcheck);
 
 /**
  * @brief strcmp like function to search for a repo based on its name

--- a/src/globals.c
+++ b/src/globals.c
@@ -51,6 +51,8 @@ struct globals globals = {
 	.update_server_port = -1,
 };
 
+struct globals_bkp globals_bkp;
+
 /* NOTE: Today the content and version server urls are the same in
  * all cases.  It is highly likely these will eventually differ, eg:
  * swupd-version.01.org and swupd-files.01.org as this enables
@@ -452,6 +454,14 @@ bool globals_init(void)
 		globals.global_times = timelist_new();
 	}
 
+	/* backup the global variables that are likely to be modified by
+	 * some processed like when working with 3rd-party repositories
+	 * so we can recover them */
+	globals_bkp.path_prefix = strdup_or_die(globals.path_prefix);
+	globals_bkp.state_dir = strdup_or_die(globals.state_dir);
+	globals_bkp.version_url = strdup_or_die(globals.version_url);
+	globals_bkp.content_url = strdup_or_die(globals.content_url);
+
 	return true;
 }
 
@@ -469,6 +479,10 @@ void globals_deinit(void)
 	free_string(&globals.state_dir_cache);
 	timelist_free(globals.global_times);
 	globals.global_times = NULL;
+	free_string(&globals_bkp.path_prefix);
+	free_string(&globals_bkp.state_dir);
+	free_string(&globals_bkp.version_url);
+	free_string(&globals_bkp.content_url);
 }
 
 void save_cmd(char **argv)

--- a/src/globals.h
+++ b/src/globals.h
@@ -52,6 +52,15 @@ extern struct globals {
 	timelist *global_times;
 } globals;
 
+/* Struct that holds the original values of some global variables,
+ * useful to recover the values after modifying them */
+extern struct globals_bkp {
+	char *path_prefix;
+	char *state_dir;
+	char *version_url;
+	char *content_url;
+} globals_bkp;
+
 struct global_options {
 	const struct option *longopts;
 	const int longopts_len;


### PR DESCRIPTION
When running 3rd-party operations, most of the times these need to
overwrite some of the global variables in order to reuse the code
use for normal swupd operations.

This commit add means to backup those global variables, so they can be
recovered as necessary.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>