### PR TITLE
Remove all exported binaries from 3rd-party bundles when removing a repo

### DIFF
--- a/src/3rd_party_bundle_remove.c
+++ b/src/3rd_party_bundle_remove.c
@@ -93,15 +93,20 @@ static bool parse_options(int argc, char **argv)
 	return true;
 }
 
-static enum swupd_code remove_bundle(char *bundle)
+static enum swupd_code remove_bundle_binaries(struct list *removed_files)
+{
+	return third_party_process_binaries(removed_files, "\nRemoving 3rd-party bundle binaries...\n", "remove_binaries", third_party_remove_binary);
+}
+
+static enum swupd_code remove_bundle(char *bundle_name)
 {
 	struct list *bundle_to_remove = NULL;
 	enum swupd_code ret = SWUPD_OK;
 
-	/* execute_remove_bundles expects a list */
-	bundle_to_remove = list_append_data(bundle_to_remove, bundle);
+	/* execute_remove_bundles_extra expects a list */
+	bundle_to_remove = list_append_data(bundle_to_remove, bundle_name);
 
-	ret = execute_remove_bundles(bundle_to_remove);
+	ret = execute_remove_bundles_extra(bundle_to_remove, remove_bundle_binaries);
 
 	list_free_list(bundle_to_remove);
 	return ret;
@@ -110,7 +115,7 @@ static enum swupd_code remove_bundle(char *bundle)
 enum swupd_code third_party_bundle_remove_main(int argc, char **argv)
 {
 	enum swupd_code ret_code = SWUPD_OK;
-	const int steps_in_bundle_remove = 2;
+	const int steps_in_bundle_remove = 3;
 	struct list *bundles = NULL;
 
 	if (!parse_options(argc, argv)) {
@@ -142,6 +147,7 @@ enum swupd_code third_party_bundle_remove_main(int argc, char **argv)
 	 * Steps for bundle-remove:
 	 *  1) load_manifests
 	 *  2) remove_files
+	 *  3) remove_binaries
 	 */
 	progress_init_steps("3rd-party-bundle-remove", steps_in_bundle_remove);
 

--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -583,4 +583,28 @@ enum swupd_code third_party_process_binaries(struct list *files, const char *msg
 	return ret_code;
 }
 
+enum swupd_code third_party_remove_binary(char *filename)
+{
+	enum swupd_code ret_code = SWUPD_OK;
+	int ret;
+	char *script = NULL;
+	char *binary = NULL;
+
+	script = third_party_get_binary_path(sys_basename(filename));
+	binary = sys_path_join(globals.path_prefix, filename);
+
+	if (!sys_file_exists(binary)) {
+		ret = sys_rm(script);
+		if (ret != 0 && ret != -ENOENT) {
+			error("File %s could not be removed\n\n", script);
+			ret_code = SWUPD_COULDNT_REMOVE_FILE;
+		}
+	}
+
+	free_string(&script);
+	free_string(&binary);
+
+	return ret_code;
+}
+
 #endif

--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -155,6 +155,13 @@ bool third_party_file_is_binary(struct file *file);
  */
 enum swupd_code third_party_process_binaries(struct list *files, const char *msg, const char *step, process_data_fn_t proc_binary_fn);
 
+/**
+ * @brief Function that removes a script to export a binary from the 3rd-party bin dir.
+ *
+ * @param filename the name of a binary file
+ */
+enum swupd_code third_party_remove_binary(char *filename);
+
 #endif
 
 #ifdef __cplusplus

--- a/src/bundle_remove.c
+++ b/src/bundle_remove.c
@@ -290,10 +290,10 @@ static void print_remove_summary(unsigned int requested, unsigned int bad, unsig
 /*  The function removes one or more bundles
  *  passed in the bundles list.
  */
-enum swupd_code execute_remove_bundles(struct list *bundles)
+enum swupd_code execute_remove_bundles_extra(struct list *bundles, extra_proc_fn_t post_remove_fn)
 {
-	int ret = SWUPD_OK;
-	int ret_code = 0;
+	enum swupd_code ret_code = SWUPD_OK;
+	enum swupd_code ret = SWUPD_OK;
 	unsigned int bad = 0;
 	unsigned int total = 0;
 	int current_version = CURRENT_OS_VERSION;
@@ -424,6 +424,10 @@ enum swupd_code execute_remove_bundles(struct list *bundles)
 		}
 	}
 
+	if (post_remove_fn) {
+		ret_code = post_remove_fn(files_to_remove);
+	}
+
 	/* print a summary of the remove operation */
 	print_remove_summary(total, bad, list_len(bundles_to_remove));
 
@@ -454,6 +458,11 @@ out:
 	print("\nFailed to remove bundle(s)\n");
 
 	return ret_code;
+}
+
+enum swupd_code execute_remove_bundles(struct list *bundles)
+{
+	return execute_remove_bundles_extra(bundles, NULL);
 }
 
 enum swupd_code bundle_remove_main(int argc, char **argv)

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -337,6 +337,7 @@ extern enum swupd_code execute_bundle_add_extra(struct list *bundles_list, extra
 
 /* bundle_remove.c */
 extern enum swupd_code execute_remove_bundles(struct list *bundles);
+extern enum swupd_code execute_remove_bundles_extra(struct list *bundles, extra_proc_fn_t post_remove_fn);
 extern void bundle_remove_set_option_force(bool opt);
 extern void bundle_remove_set_option_recursive(bool opt);
 

--- a/test/functional/3rd-party/3rd-party-bundle-remove-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-basic.bats
@@ -33,6 +33,7 @@ test_setup() {
 		 - test-bundle2
 		Deleting bundle files...
 		Total deleted files: 3
+		Removing 3rd-party bundle binaries...
 		Successfully removed 1 bundle
 	EOM
 	)
@@ -84,6 +85,7 @@ test_setup() {
 		 - test-bundle1
 		Deleting bundle files...
 		Total deleted files: 3
+		Removing 3rd-party bundle binaries...
 		Successfully removed 1 bundle
 		Searching for bundle upstream-bundle in the 3rd-party repositories...
 		Error: bundle upstream-bundle was not found in any 3rd-party repository
@@ -112,6 +114,7 @@ test_setup() {
 		 - test-bundle1
 		Deleting bundle files...
 		Total deleted files: 3
+		Removing 3rd-party bundle binaries...
 		Successfully removed 1 bundle
 	EOM
 	)

--- a/test/functional/3rd-party/3rd-party-bundle-remove-exported-bin.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-exported-bin.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	# create a 3rd-party bundle that has a couple of binaries
+	add_third_party_repo "$TEST_NAME" 10 1 test-repo1
+	create_bundle -L -n test-bundle1 -f /file1,/foo/file_2,/usr/bin/file_3,/bin/file_4 -u test-repo1 "$TEST_NAME"
+	# create a 3rd-party bundle that shares the same binary
+	create_bundle -L -n test-bundle2 -f /file2,/usr/bin/file_3                         -u test-repo1 "$TEST_NAME"
+}
+
+@test "TPR058: Removing one bundle from a third party repo that exported binaries" {
+
+	# when deleting a 3rd-party bundle, all the binaries exported by the
+	# bundle should be removed as well
+
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/file_3
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/file_4
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS test-bundle1"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle1 in the 3rd-party repositories...
+		Bundle test-bundle1 found in 3rd-party repository test-repo1
+		The following bundles are being removed:
+		 - test-bundle1
+		Deleting bundle files...
+		Total deleted files: 6
+		Removing 3rd-party bundle binaries...
+		Successfully removed 1 bundle
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	# non-confilcting scripts to binaries should have been removed
+	assert_file_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/file_4
+
+	# script to binaries that are still being used by another bundle should not be removed
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/file_3
+
+}

--- a/test/functional/3rd-party/3rd-party-bundle-remove-multi-repo.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-multi-repo.bats
@@ -49,6 +49,7 @@ test_setup() {
 		 - test-bundle1
 		Deleting bundle files...
 		Total deleted files: 3
+		Removing 3rd-party bundle binaries...
 		Successfully removed 1 bundle
 	EOM
 	)
@@ -68,6 +69,7 @@ test_setup() {
 		 - test-bundle2
 		Deleting bundle files...
 		Total deleted files: 6
+		Removing 3rd-party bundle binaries...
 		Successfully removed 1 bundle
 		1 bundle that was installed as a dependency was removed
 	EOM
@@ -90,6 +92,7 @@ test_setup() {
 		 - test-bundle1
 		Deleting bundle files...
 		Total deleted files: 6
+		Removing 3rd-party bundle binaries...
 		Successfully removed 1 bundle
 		1 bundle that depended on the specified bundle(s) was removed
 	EOM

--- a/test/functional/3rd-party/3rd-party-repo-remove.bats
+++ b/test/functional/3rd-party/3rd-party-repo-remove.bats
@@ -8,98 +8,52 @@ load "../testlib"
 test_setup(){
 
 	create_test_environment "$TEST_NAME"
+	# create a few 3rd-party repos within the test environment and add
+	# some bundles to them
+	add_third_party_repo "$TEST_NAME" 10 1 repo1
+	create_bundle -L -t -n test-bundle1 -f /file_1,/bin/binary_1           -u repo1 "$TEST_NAME"
 
-	contents=$(cat <<- EOM
-		\n
-		[test1]
-		url=www.abc.com
+	add_third_party_repo "$TEST_NAME" 10 1 repo2
+	create_bundle -L -t -n test-bundle2 -f /file_2,/bin/binary_2           -u repo2 "$TEST_NAME"
+	create_bundle -L -t -n test-bundle3 -f /file_3,/usr/bin/binary_3       -u repo2 "$TEST_NAME"
+	create_bundle -L -t -n test-bundle4 -f /file_4,/usr/local/bin/binary_4 -u repo2 "$TEST_NAME"
 
-		[test2]
-		url=www.efg.com
-
-		[test3]
-		url=www.xyz.com
-
-		[test4]
-		url=www.pqr.com
-		invalid=456
-
-		[test5]
-		url=www.lmn.com
-		\n
-	EOM
-	)
-
-	repo_config_file="$STATEDIR"/3rd-party/repo.ini
-	sudo mkdir -p "$STATEDIR"/3rd-party
-	sudo mkdir -p "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/{test1,test2,test3,test4,test5}
-	write_to_protected_file -a "$repo_config_file" "$contents"
-	sudo mkdir "$STATEDIR"/3rd-party/{test1,test2,test3,test4,test5}
-
-}
-
-test_teardown(){
-
-	destroy_test_environment "$TEST_NAME"
+	add_third_party_repo "$TEST_NAME" 10 1 repo3
+	create_bundle -L -t -n test-bundle5 -f /file_5,/usr/bin/binary_5       -u repo3 "$TEST_NAME"
 
 }
 
 @test "TPR008: Remove multiple repos" {
 
-	repo_config_file="$STATEDIR"/3rd-party/repo.ini
-
 	#remove at start of file
-	assert_dir_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/test1
-	assert_dir_exists "$STATEDIR"/3rd-party/test1
-	run sudo sh -c "$SWUPD 3rd-party remove test1 $SWUPD_OPTS"
+	assert_dir_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/repo1
+	assert_dir_exists "$STATEDIR"/3rd-party/repo1
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_4
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_5
+
+	run sudo sh -c "$SWUPD 3rd-party remove $SWUPD_OPTS repo2"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Removing repository test1...
+		Loading required manifests...
+		Removing repository repo2...
+		Removing 3rd-party bundle binaries...
 		Repository and its content removed successfully
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_dir_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/test1
-	assert_dir_not_exists "$STATEDIR"/3rd-party/test1
-
-	#remove at middle of file
-	assert_dir_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/test3
-	assert_dir_exists "$STATEDIR"/3rd-party/test3
-	run sudo sh -c "$SWUPD 3rd-party remove test3 $SWUPD_OPTS"
-	assert_status_is "$SWUPD_OK"
-	expected_output=$(cat <<-EOM
-		Removing repository test3...
-		Repository and its content removed successfully
-	EOM
-	)
-	assert_is_output "$expected_output"
-	assert_dir_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/test3
-	assert_dir_not_exists "$STATEDIR"/3rd-party/test3
-
-	#remove at end of file
-	assert_dir_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/test5
-	assert_dir_exists "$STATEDIR"/3rd-party/test5
-	run sudo sh -c "$SWUPD 3rd-party remove test5 $SWUPD_OPTS"
-	assert_status_is "$SWUPD_OK"
-	expected_output=$(cat <<-EOM
-		Removing repository test5...
-		Repository and its content removed successfully
-	EOM
-	)
-	assert_is_output "$expected_output"
-	assert_dir_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/test5
-	assert_dir_not_exists "$STATEDIR"/3rd-party/test5
-
-	expected_contents=$(cat <<- EOM
-		[test2]
-		url=www.efg.com
-
-		[test4]
-		url=www.pqr.com
-	EOM
-	)
-
-	run sudo sh -c "cat $repo_config_file"
-	assert_is_output --identical "$expected_contents"
+	assert_dir_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/repo1
+	assert_dir_exists "$STATEDIR"/3rd-party/repo1
+	assert_dir_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/repo2
+	assert_dir_not_exists "$STATEDIR"/3rd-party/repo2
+	assert_dir_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/repo3
+	assert_dir_exists "$STATEDIR"/3rd-party/repo3
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_file_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_file_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_file_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_4
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_5
 
 }


### PR DESCRIPTION
When a 3rd-party repository is removed, all the content installed from it must be removed from the system. But also those exported binaries from the repo being deleted should also be deleted.

This PR is built on top of #1303 and #1304 and they have to be reviewed first in that order.

Closes #1291 