### PR TITLE
Warn user when a 3rd-party binary isn't executable

### DIFF
--- a/src/3rd_party_bundle_add.c
+++ b/src/3rd_party_bundle_add.c
@@ -118,6 +118,7 @@ static enum swupd_code create_wrapper_script(char *filename)
 	binary = sys_path_join(globals.path_prefix, filename);
 
 	if (!sys_filelink_is_executable(binary)) {
+		warn("File %s does not have 'execute' permission so it won't be exported\n", filename);
 		goto close_and_exit;
 	}
 


### PR DESCRIPTION
This commit notifies the user that the 3rd-party bundle they installed
isn't configured properly so they can know something about the quality
of the 3rd-party repository they are using.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>