### PR TITLE
Update exported binaries during a "swupd 3rd-party update"

### DIFF
--- a/src/3rd_party_bundle_add.c
+++ b/src/3rd_party_bundle_add.c
@@ -19,8 +19,6 @@
 
 #define _GNU_SOURCE
 
-#include <fcntl.h>
-
 #include "3rd_party_repos.h"
 #include "swupd.h"
 
@@ -28,11 +26,6 @@
 
 #define FLAG_SKIP_OPTIONAL 2000
 #define FLAG_SKIP_DISKSPACE_CHECK 2001
-
-#define SCRIPT_TEMPLATE "#!/bin/bash\n\n"                                \
-			"export PATH=%s:$PATH\n"                         \
-			"export LD_LIBRARY_PATH=%s:$LD_LIBRARY_PATH\n\n" \
-			"%s \"$@\"\n"
 
 static char **cmdline_bundles;
 static char *cmdline_repo = NULL;
@@ -101,86 +94,18 @@ static bool parse_options(int argc, char **argv)
 	return true;
 }
 
-static enum swupd_code create_wrapper_script(char *filename)
-{
-	enum swupd_code ret_code = 0;
-	int fd;
-	FILE *fp = NULL;
-	char *bin_directory = NULL;
-	char *script = NULL;
-	char *binary = NULL;
-	char *third_party_bin_path = NULL;
-	char *third_party_ld_path = NULL;
-	mode_t mode = 0755;
-
-	bin_directory = third_party_get_bin_dir();
-	script = third_party_get_binary_path(sys_basename(filename));
-	binary = sys_path_join(globals.path_prefix, filename);
-
-	if (!sys_filelink_is_executable(binary)) {
-		warn("File %s does not have 'execute' permission so it won't be exported\n", filename);
-		goto close_and_exit;
-	}
-
-	if (sys_file_exists(script)) {
-		/* the binary already exists, this condition should never happen
-		 * since we checked before installing */
-		ret_code = SWUPD_UNEXPECTED_CONDITION;
-		error("There is already a binary called %s in %s, it will be skipped\n", sys_basename(filename), bin_directory);
-		goto close_and_exit;
-	}
-
-	/* if the SWUPD_3RD_PARTY_BIN_DIR does not exist, attempt to create it */
-	if (mkdir_p(bin_directory)) {
-		ret_code = SWUPD_COULDNT_CREATE_DIR;
-		goto close_and_exit;
-	}
-
-	if (!is_dir(bin_directory)) {
-		error("The path %s for 3rd-party content exists but is not a directory\n", bin_directory);
-		ret_code = SWUPD_COULDNT_CREATE_DIR;
-		goto close_and_exit;
-	}
-
-	/* open the file with mode set to 0755 */
-	fd = open(script, O_RDWR | O_CREAT, mode);
-	if (fd < 0) {
-		error("The file %s failed to be created\n", script);
-		ret_code = SWUPD_COULDNT_CREATE_FILE;
-		goto close_and_exit;
-	}
-	fp = fdopen(fd, "w");
-	if (!fp) {
-		error("The file %s failed to be created\n", script);
-		ret_code = SWUPD_COULDNT_CREATE_FILE;
-		goto close_and_exit;
-	}
-
-	/* get the path for the 3rd-party content */
-	third_party_bin_path = str_or_die("%sbin:%susr/bin:%susr/local/bin", globals.path_prefix, globals.path_prefix, globals.path_prefix);
-	third_party_ld_path = str_or_die("%susr/lib64:%susr/local/lib64", globals.path_prefix, globals.path_prefix);
-
-	fprintf(fp, SCRIPT_TEMPLATE, third_party_bin_path, third_party_ld_path, binary);
-
-close_and_exit:
-	if (fp) {
-		fclose(fp);
-	}
-	free_string(&binary);
-	free_string(&script);
-	free_string(&bin_directory);
-	free_string(&third_party_bin_path);
-	free_string(&third_party_ld_path);
-
-	return ret_code;
-}
-
-static enum swupd_code validate_binary(char *filename)
+static enum swupd_code validate_binary(struct file *file)
 {
 	enum swupd_code ret_code = SWUPD_OK;
 	char *bin_directory = NULL;
 	char *script = NULL;
+	char *filename = NULL;
 
+	if (!file) {
+		return ret_code;
+	}
+
+	filename = file->filename;
 	bin_directory = third_party_get_bin_dir();
 	script = third_party_get_binary_path(sys_basename(filename));
 
@@ -197,7 +122,7 @@ static enum swupd_code validate_binary(char *filename)
 
 static enum swupd_code export_bundle_binaries(struct list *installed_files)
 {
-	return third_party_process_binaries(installed_files, "\nExporting 3rd-party bundle binaries...\n", "export_binaries", create_wrapper_script);
+	return third_party_process_binaries(installed_files, "\nExporting 3rd-party bundle binaries...\n", "export_binaries", third_party_create_wrapper_script);
 }
 
 static enum swupd_code validate_bundle_binaries(struct list *files_to_be_installed)

--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -34,8 +34,11 @@ struct repo {
 	char *url;
 };
 
-/** @brief Definition of a function that performs some processing on a given data */
-typedef enum swupd_code (*process_data_fn_t)(char *data_name);
+/** @brief Definition of a function that performs some processing on a given bundle */
+typedef enum swupd_code (*process_bundle_fn_t)(char *bundle_name);
+
+/** @brief Definition of a function that performs some processing on a given file */
+typedef enum swupd_code (*process_file_fn_t)(struct file *file);
 
 /** @brief Function that returns the path to the 3rd-party bin directory */
 char *third_party_get_bin_dir(void);
@@ -116,7 +119,7 @@ enum swupd_code third_party_set_repo(struct repo *repo, bool sigcheck);
  *
  * @returns a swupd_code
  */
-enum swupd_code third_party_run_operation(struct list *bundles, const char *repo, process_data_fn_t process_bundle_fn);
+enum swupd_code third_party_run_operation(struct list *bundles, const char *repo, process_bundle_fn_t process_bundle_fn);
 
 /**
  * @brief Performs an operation on 3rd-party repos.
@@ -129,7 +132,7 @@ enum swupd_code third_party_run_operation(struct list *bundles, const char *repo
  *
  * @returns a swupd_code
  */
-enum swupd_code third_party_run_operation_multirepo(const char *repo, process_data_fn_t process_bundle_fn, enum swupd_code expected_ret_code, const char *op_name, int op_steps);
+enum swupd_code third_party_run_operation_multirepo(const char *repo, process_bundle_fn_t process_bundle_fn, enum swupd_code expected_ret_code, const char *op_name, int op_steps);
 
 /**
  * @brief Prints a header with the repository name, useful when showing info from multiple repos.
@@ -153,14 +156,21 @@ bool third_party_file_is_binary(struct file *file);
  * @param step the name of the step to show during the reporting of progress
  * @param proc_binary_fn the function with the processing to be performed on each binary file
  */
-enum swupd_code third_party_process_binaries(struct list *files, const char *msg, const char *step, process_data_fn_t proc_binary_fn);
+enum swupd_code third_party_process_binaries(struct list *files, const char *msg, const char *step, process_file_fn_t proc_binary_fn);
 
 /**
  * @brief Function that removes a script to export a binary from the 3rd-party bin dir.
  *
- * @param filename the name of a binary file
+ * @param file the binary file struct
  */
-enum swupd_code third_party_remove_binary(char *filename);
+enum swupd_code third_party_remove_binary(struct file *file);
+
+/**
+ * @brief Function that creates a script to export a 3rd-party binary
+ *
+ * @param file the file struct of the binary to be exported
+ */
+enum swupd_code third_party_create_wrapper_script(struct file *file);
 
 #endif
 

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -349,6 +349,7 @@ extern void bundle_info_set_option_files(bool opt);
 
 /* update.c */
 extern enum swupd_code execute_update(void);
+extern enum swupd_code execute_update_extra(extra_proc_fn_t post_update_fn);
 extern void update_set_option_version(int opt);
 extern void update_set_option_download_only(bool opt);
 extern void update_set_option_keepcache(bool opt);

--- a/src/update.c
+++ b/src/update.c
@@ -287,7 +287,7 @@ static struct list *create_update_list(struct manifest *server)
 	return output;
 }
 
-enum swupd_code execute_update(void)
+enum swupd_code execute_update_extra(extra_proc_fn_t post_update_fn)
 {
 	int current_version = -1, server_version = -1;
 	int mix_current_version = -1, mix_server_version = -1;
@@ -522,8 +522,13 @@ version_check:
 	delete_motd();
 	timelist_timer_stop(globals.global_times); // closing: Update loop
 
-	/* Run any scripts that are needed to complete update */
 	if (!download_only) {
+		/* execute post-update processing (if any) */
+		if (post_update_fn) {
+			ret = post_update_fn(updates);
+		}
+
+		/* Run any scripts that are needed to complete update */
 		timelist_timer_start(globals.global_times, "Run post-update scripts");
 		progress_next_step("run_postupdate_scripts", PROGRESS_UNDEFINED);
 
@@ -631,6 +636,11 @@ clean_curl:
 	}
 
 	return ret;
+}
+
+enum swupd_code execute_update(void)
+{
+	return execute_update_extra(NULL);
 }
 
 static bool cmd_line_status = false;

--- a/test/functional/3rd-party/3rd-party-update-basic.bats
+++ b/test/functional/3rd-party/3rd-party-update-basic.bats
@@ -48,6 +48,7 @@ test_setup() {
 		No extra files need to be downloaded
 		Installing files...
 		Update was applied
+		Updating 3rd-party bundle binaries...
 		Warning: post-update helper scripts skipped due to --no-scripts argument
 		Update successful - System updated from version 10 to version 20
 	EOM
@@ -100,6 +101,7 @@ test_setup() {
 		No extra files need to be downloaded
 		Installing files...
 		Update was applied
+		Updating 3rd-party bundle binaries...
 		Warning: post-update helper scripts skipped due to --no-scripts argument
 		Update successful - System updated from version 10 to version 20
 		____________________________

--- a/test/functional/3rd-party/3rd-party-update-exported-bin.bats
+++ b/test/functional/3rd-party/3rd-party-update-exported-bin.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	# create an initial environment
+	create_test_environment "$TEST_NAME"
+	add_third_party_repo "$TEST_NAME" 10 staging repo1
+	create_bundle -L -t -n test-bundle1 -f /foo/file_1,/usr/bin/binary_1,/bin/binary_2,/bin/binary_3 -u repo1 "$TEST_NAME"
+	create_bundle       -n test-bundle2 -f /bar/file_2,/bin/binary_4                                 -u repo1 "$TEST_NAME"
+	create_bundle       -n test-bundle3 -f /bin/binary_5                                             -u repo1 "$TEST_NAME"
+
+	# create an update that adds, removes and updates binaries
+	create_version -p "$TEST_NAME" 20 10 staging repo1
+	update_bundle -p "$TEST_NAME" test-bundle1 --update /foo/file_1                 repo1
+	update_bundle -p "$TEST_NAME" test-bundle1 --update /bin/binary_2               repo1
+	update_bundle -p "$TEST_NAME" test-bundle1 --add    /usr/local/bin/binary_6     repo1
+	update_bundle -p "$TEST_NAME" test-bundle1 --delete /usr/bin/binary_1           repo1
+	update_bundle -p "$TEST_NAME" test-bundle1 --rename /bin/binary_3:/bin/binary_7 repo1
+	add_dependency_to_manifest "$TPWEBDIR"/20/Manifest.test-bundle1 test-bundle3
+
+}
+
+@test "TPR059: Update a 3rd-party bundle that has exported binaries" {
+
+	# pre-test checks
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+
+	# During an update, a bundle that contains binaries should have
+	# their scripts updated too
+
+	run sudo sh -c "$SWUPD 3rd-party update $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		_______________________
+		 3rd-Party Repo: repo1
+		_______________________
+		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Update started
+		Preparing to update from 10 to 20
+		Downloading packs for:
+		 - test-bundle3
+		 - test-bundle1
+		Finishing packs extraction...
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 1
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 2
+		    new files         : 6
+		    deleted files     : 2
+		Validate downloaded files
+		No extra files need to be downloaded
+		Installing files...
+		Update was applied
+		Updating 3rd-party bundle binaries...
+		Warning: post-update helper scripts skipped due to --no-scripts argument
+		Update successful - System updated from version 10 to version 20
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_4
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_7
+
+}

--- a/test/functional/3rd-party/3rd-party-update-specific-version.bats
+++ b/test/functional/3rd-party/3rd-party-update-specific-version.bats
@@ -43,6 +43,7 @@ test_setup() {
 		No extra files need to be downloaded
 		Installing files...
 		Update was applied
+		Updating 3rd-party bundle binaries...
 		Warning: post-update helper scripts skipped due to --no-scripts argument
 		Update successful - System updated from version 10 to version 20
 	EOM

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -2932,7 +2932,11 @@ update_bundle() { # swupd_function
 			new_file="$version_path"/files/"$new_fhash"
 			fname="${fname%:*}"
 		else
-			new_file=$(create_file "$version_path"/files)
+			if [ "$(dirname "$fname")" = "/bin" ] || [ "$(dirname "$fname")" = "/usr/bin" ] || [ "$(dirname "$fname")" = "/usr/local/bin" ]; then
+				new_file=$(create_file -x "$version_path"/files)
+			else
+				new_file=$(create_file "$version_path"/files)
+			fi
 		fi
 		add_to_manifest -p "$bundle_manifest" "$new_file" "$fname"
 


### PR DESCRIPTION
When a 3rd-party repository is updated, if one of the updated bundles
has updated binaries, the scripts that export those binaries should also
be updated. This commit implements that update.

Closes #1279
