### PR TITLE
Enabling autoupdate of 3rd-party content

### DIFF
--- a/data/swupd-update.service.in
+++ b/data/swupd-update.service.in
@@ -4,3 +4,4 @@ Description=Update Software content
 [Service]
 Type=oneshot
 ExecStart=@prefix@/bin/swupd update --no-progress
+ExecStartPost=@prefix@/bin/swupd 3rd-party update --no-progress


### PR DESCRIPTION
Instead of creating a command and service for enabling and disabling autoupdates specifically for `3rd-party` content, this PR piggybacks into the current `swupd-update.service` to also perform an update of the 3rd-party content based on `swupd-update.timer`. This means the user will have to enable/disable autoupdate for both, the swupd upstream content and 3rd-party content.
 
Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>

Closes #1283