### PR TITLE
3rd-party: Import certificate from 3rd-party repository on repo add

### DIFF
--- a/src/signature.h
+++ b/src/signature.h
@@ -57,6 +57,16 @@ bool signature_verify(const char *file, const char *sig_file, bool print_errors)
  */
 bool signature_verify_data(const unsigned char *data, size_t data_len, const unsigned char *sig_data, size_t sig_data_len, bool print_errors);
 
+/**
+ * Print extra information about the certificate pointed by PATH.
+ *
+ * Currently printing Issuer, Subject and the dump of the certificate data.
+ * Init is not required to run this function.
+*
+ * @param path the path to the certificate to be printed.
+ */
+void signature_print_info(const char *path);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -169,6 +169,7 @@ extern int main_verify(int current_version);
 extern enum swupd_code walk_tree(struct manifest *, const char *, bool, const regex_t *, struct file_counts *);
 
 extern int get_latest_version(char *v_url);
+extern int get_int_from_url(const char *url);
 extern enum swupd_code read_versions(int *current_version, int *server_version, char *path_prefix);
 extern int get_current_version(char *path_prefix);
 extern bool get_distribution_string(char *path_prefix, char *dist);

--- a/src/version.c
+++ b/src/version.c
@@ -34,36 +34,43 @@
 
 #define MAX_VERSION_STR_SIZE 11
 
-int get_server_format(int server_version)
+int get_int_from_url(const char *url)
 {
-	if (server_version < 0) {
-		return -1;
-	}
-
-	int ret, err = -1;
-	char *url;
-
-	char format_string[MAX_VERSION_STR_SIZE];
-	struct curl_file_data format = {
+	int err, value;
+	char tmp_string[MAX_VERSION_STR_SIZE];
+	struct curl_file_data tmp_data = {
 		MAX_VERSION_STR_SIZE, 0,
-		format_string
+		tmp_string
 	};
 
-	string_or_die(&url, "%s/%d/format", globals.version_url, server_version);
-	ret = swupd_curl_get_file_memory(url, &format);
-	free_string(&url);
-
-	if (ret) {
+	value = swupd_curl_get_file_memory(url, &tmp_data);
+	if (value) {
 		return -1;
 	}
 
-	format.data[format.len] = '\0';
-	err = strtoi_err(format.data, &ret);
+	tmp_data.data[tmp_data.len] = '\0';
+	err = strtoi_err(tmp_data.data, &value);
 	if (err != 0) {
 		return -1;
 	}
 
-	return ret;
+	return value;
+}
+
+int get_server_format(int server_version)
+{
+	char *url;
+	int value;
+
+	if (server_version < 0) {
+		return -1;
+	}
+
+	string_or_die(&url, "%s/%d/format", globals.version_url, server_version);
+	value = get_int_from_url(url);
+	free_string(&url);
+
+	return value;
 }
 
 int get_current_format(void)

--- a/test/functional/3rd-party/3rd-party-repo-add-certificate.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add-certificate.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+
+# Author: Otavio Pontes
+# Email: otavio.pontes@intel.com
+
+load "../testlib"
+
+export repo1
+export repo2
+
+global_setup() {
+	# Skip this test for local development because we write the certificate on /
+    # This is necessary because the default certificate location is hardcoded on build time and we
+	# need to run swupd without -C parameter to test this feature.
+	if [ -z "${RUNNING_IN_CI}" ]; then
+		return
+	fi
+
+	if [ ! -f /usr/share/clear/update-ca/Swupd_Root.pem ]; then
+		sudo mkdir -p /usr/share/clear/update-ca
+		sudo cp "$TEST_ROOT_DIR"/Swupd_Root.pem /usr/share/clear/update-ca
+		export CERT_WAS_INSTALLED=1
+	fi
+}
+
+global_teardown() {
+
+	if [ -z "${RUNNING_IN_CI}" ]; then
+		return
+	fi
+
+	if [ ! -z "${CERT_WAS_INSTALLED}" ]; then
+		sudo rm usr/share/clear/update-ca/Swupd_Root.pem
+	fi
+}
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_third_party_repo "$TEST_NAME" 10 staging test-repo1
+	repo1="$TPWEBDIR"
+	create_third_party_repo "$TEST_NAME" 10 staging test-repo2
+	repo2="$TPWEBDIR"
+}
+
+@test "TPR066: Add a single repo importing the certificate" {
+
+	run sudo sh -c "echo 'y' | $SWUPD 3rd-party add test-repo1 file://$repo1 $SWUPD_OPTS_NO_CERT"
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Adding 3rd-party repository test-repo1...
+		Importing 3rd-party repository public certificate:
+		Issuer: /C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost
+		Subject: /C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost
+		.*
+		Installing the required bundle 'os-core' from the repository...
+		Note that all bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Loading required manifests...
+		Downloading packs for:
+		 - os-core
+		Finishing packs extraction...
+		Validate downloaded files
+		No extra files need to be downloaded
+		Installing files...
+		Warning: post-update helper scripts skipped due to --no-scripts argument
+		Successfully installed 1 bundle
+		Repository added successfully
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+	run sudo sh -c "cat $STATEDIR/3rd-party/repo.ini"
+	expected_output=$(cat <<-EOM
+			[test-repo1]
+			url=file://$repo1
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	# make sure the os-core bundle of the repo is installed in the appropriate place
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/lib/os-release
+
+}
+
+@test "TPR067: Reject a certificate when adding a repository" {
+
+	run sudo sh -c "echo 'n' | $SWUPD 3rd-party add test-repo1 file://$repo1 $SWUPD_OPTS_NO_CERT"
+	assert_status_is "$SWUPD_BAD_CERT"
+	expected_output=$(cat <<-EOM
+		Adding 3rd-party repository test-repo1...
+		Importing 3rd-party repository public certificate:
+		Issuer: /C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost
+		Subject: /C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost
+		.*
+		Failed to add repository
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+}


### PR DESCRIPTION

When trying to add the repository for the first time, download the public
certificate published by the 3rd party repository and with a user confirmation,
use it to install the 3rd-party os-core. After that the official certificate will
be installed for future commands.
