### PR TITLE
Fixing a bug removing a 3rd-party repo that fails

### DIFF
--- a/src/3rd_party_remove.c
+++ b/src/3rd_party_remove.c
@@ -120,7 +120,8 @@ enum swupd_code third_party_remove_main(int argc, char **argv)
 	}
 
 	/* set the appropriate content_dir and state_dir for the selected 3rd-party repo */
-	if (third_party_set_repo(repo, globals.sigcheck)) {
+	ret = third_party_set_repo(repo, globals.sigcheck);
+	if (ret) {
 		goto exit;
 	}
 


### PR DESCRIPTION
When removing a 3rd-party repository, if there is an error while setting
up the global variables of the repository, the error code is lost and
swupd reports as if the removal was successful even when it failed. This
commit fixes that issue.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>