### PR TITLE
staging: don't convert symlinks to hardlinks

### DIFF
--- a/src/staging.c
+++ b/src/staging.c
@@ -24,6 +24,7 @@
 #define _GNU_SOURCE
 #include <assert.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -205,7 +206,12 @@ enum swupd_code do_staging(struct file *file, struct manifest *MoM)
 		 * inefficient.  So prefer hardlink and fall back if needed: */
 		ret = -1;
 		if (!file->is_config && !file->is_state && !file->use_xattrs) {
-			ret = link(original, target);
+			if (!file->is_link) {
+				ret = link(original, target);
+			} else {
+				ret = linkat(-1, original, -1, target,
+					     AT_SYMLINK_FOLLOW);
+			}
 		}
 		if (ret < 0) {
 			/* either the hardlink failed, or it was undesirable (config), do a tar-tar dance */


### PR DESCRIPTION
If there are multiple symlinks to the same destination, there
will only be one file in staging for all of the symlinks, and
the current code will opportunistically try to link(2) all of
them into their final destination.
This will usually succeed, but link(2) on linux doesn't follow
symlinks.

This means all the original symlinks will be converted from
being individual files into one file with multiple hardlinks.
As an example, we get this:

```
root@host:~# ls -li /a/bin/ash /a/bin/busybox.nosuid /a/bin/cat /a/bin/date
     24 lrwxrwxrwx  172 root     root            19 Mar  9  2018 /a/bin/ash -> /bin/busybox.nosuid
     26 -rwxr-xr-x    1 root     root        488760 Mar  9  2018 /a/bin/busybox.nosuid
     24 lrwxrwxrwx  172 root     root            19 Mar  9  2018 /a/bin/cat -> /bin/busybox.nosuid
     24 lrwxrwxrwx  172 root     root            19 Mar  9  2018 /a/bin/date -> /bin/busybox.nosuid
```

(all the 172 symlinks share the same inode 24), but we really
want the following (to match the original file system, from
which the update was created):

```
root@host:~# ls -li /b/bin/ash /b/bin/busybox.nosuid /b/bin/cat /b/bin/date
   3670 lrwxrwxrwx    1 root     root            19 Mar  9  2018 /b/bin/ash -> /bin/busybox.nosuid
     26 -rwxr-xr-x    1 root     root        488760 Mar  9  2018 /b/bin/busybox.nosuid
   3672 lrwxrwxrwx    1 root     root            19 Mar  9  2018 /b/bin/cat -> /b/bin/busybox.nosuid
   3679 lrwxrwxrwx    1 root     root            19 Mar  9  2018 /b/bin/date -> /b/bin/busybox.nosuid
```

There are two issues with this:
1) the file system structure created using the swupd client doesn't
   match the original file system (which was more like case /b)
2) it becomes impossible to copy the directory tree using bsdtar [1]

The first one is a real issue, while the 2nd case is a nuisance and
probably a bug in bsdtar (as GNU tar still works fine).

To fix this behaviour, we can simply use linkat(2) instead of
link(2) to instruct the kernel to follow the symlink if the
Manifest states that the file should be a symlink. This ensures
that the new file created is a symlink itself, not a hardlink to
a pre-existing symlink.
linkat(2) as used in this patch is available since linux v2.6.18
and glibc 2.10 as well as musl-libc.

[1] bsdtar seems to not like restoring symlinks sharing the same
inode:

```
root@host:~# bsdtar -C /a/ -cf - ./bin/ash ./bin/busybox.nosuid ./bin/cat ./bin/date | bsdtar -C /tmp/ -xf -
./bin/cat: Hard-link target './bin/ash' does not exist.
./bin/date: Hard-link target './bin/ash' does not exist.
bsdtar: Error exit delayed from previous errors.
root@host:~# ls -lA /tmp/bin/
-rwxr-xr-x    1 root     root        488760 Mar  9  2018 busybox.nosuid
```

vs.

```
root@host:~# bsdtar -C / -cf - ./bin/ash ./bin/busybox.nosuid ./bin/cat ./bin/date | bsdtar -C /tmp/ -xf -
root@host:~# ls -lA /tmp/bin/
lrwxrwxrwx    1 root     root            19 Mar  9  2018 ash -> /bin/busybox.nosuid
-rwxr-xr-x    1 root     root        488760 Mar  9  2018 busybox.nosuid
lrwxrwxrwx    1 root     root            19 Mar  9  2018 cat -> /bin/busybox.nosuid
lrwxrwxrwx    1 root     root            19 Mar  9  2018 date -> /bin/busybox.nosuid
```

Signed-off-by: André Draszik <git@andred.net>