### PR TITLE
test: Reduce build time of bats test

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: build
-      run:  scripts/build_ci.bash
+      run:  scripts/build_ci_style.bash
 
     - name: check style
       run:  make compliant && make shellcheck && make docs-coverage

--- a/scripts/build_ci.bash
+++ b/scripts/build_ci.bash
@@ -4,12 +4,12 @@ CORES=2
 
 # Install dependencies from ubuntu
 sudo apt-get install python3-docutils
-sudo apt-get install shellcheck
-sudo apt-get install doxygen
 sudo apt-get install check
 sudo apt-get install bats
-sudo pip install coverxygen
 sudo ln -s /bin/systemctl /usr/bin/systemctl
+
+# Use rst2man from python3
+sudo ln -s /usr/share/docutils/scripts/python3/rst2man /usr/bin/rst2man.py
 
 # build bsdiff
 wget https://github.com/clearlinux/bsdiff/releases/download/v1.0.2/bsdiff-1.0.2.tar.xz
@@ -25,16 +25,6 @@ pushd curl-7.64.0 && ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gn
 wget https://github.com/libarchive/libarchive/archive/v3.3.1.tar.gz
 tar -xvf v3.3.1.tar.gz
 pushd libarchive-3.3.1 && autoreconf -fi && ./configure --prefix=/usr && make -j$CORES && sudo make install && popd
-
-# Use rst2man from python3
-sudo ln -s /usr/share/docutils/scripts/python3/rst2man /usr/bin/rst2man.py
-
-# Install new clang-format from llvm repository
-wget -O llvm.gpg.key https://apt.llvm.org/llvm-snapshot.gpg.key
-sudo apt-key add llvm.gpg.key
-sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main"
-sudo apt-get update
-sudo apt-get install -y clang-format-9
 
 # Build Swupd
 autoreconf --verbose --warnings=none --install --force

--- a/scripts/build_ci_style.bash
+++ b/scripts/build_ci_style.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+./scripts/build_ci.bash
+
+# Install dependencies from ubuntu
+sudo apt-get install shellcheck
+sudo apt-get install doxygen
+sudo pip install coverxygen
+
+# Install new clang-format from llvm repository
+wget -O llvm.gpg.key https://apt.llvm.org/llvm-snapshot.gpg.key
+sudo apt-key add llvm.gpg.key
+sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main"
+sudo apt-get update
+sudo apt-get install -y clang-format-9


### PR DESCRIPTION
There are some build requirements that are only necessary for style check.
Reduce the build time by running them only for style check job.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>