### PR TITLE
tests: Auto rebalance tests based on how long they take to long

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -3,6 +3,7 @@ name: C/C++ CI
 on: [push, pull_request]
 env:
    TRAVIS: true
+   NUM_JOBS: 10
 
 jobs:
   unit_and_style:
@@ -26,13 +27,24 @@ jobs:
     - name: run distcheck
       run:  make distcheck
 
+    - name: Validate bats tests
+      run:  |
+             TESTS=$(for i in $(seq $NUM_JOBS); do scripts/filter_bats_list.bash $i $NUM_JOBS; done|wc -l)
+             TOTAL=$(find test/functional/ -name "*.bats" | wc -l)
+             if [ "$TOTAL" -ne "$TESTS" ]; then
+                 echo "Error in filter_bats_test.bash script"
+                 exit 1
+             fi
+
     - name: print status
       if: failure()
       run: cat test-suite.log
 
-  test_3rd_party1:
+  test_job1:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+       JOB_NUMBER: 1
     steps:
     - uses: actions/checkout@v1
 
@@ -44,19 +56,20 @@ jobs:
 
     - name: run check
       run: |
-            THIRD_PARTY_TOTAL="$(find test/functional/3rd-party -name *.bats | wc -l)"
-            THIRD_PARTY_SUBGROUP1_TOTAL=9
-            THIRD_PARTY_SUBGROUP2_TOTAL="$((THIRD_PARTY_TOTAL - THIRD_PARTY_SUBGROUP1_TOTAL))"
-            THIRD_PARTY_SUBGROUP="$(find test/functional/3rd-party -name *.bats | head -n $THIRD_PARTY_SUBGROUP1_TOTAL | tr '\n' ' ')"
-            env TESTS="$THIRD_PARTY_SUBGROUP" make -e -j2 check
+            FILES="$(scripts/filter_bats_list.bash $JOB_NUMBER $NUM_JOBS)"
+            NUM_FILES="$(echo $FILES | tr ' ' '\n' | wc -l)"
+            echo "Running $NUM_FILES tests"
+            env TESTS="$(echo $FILES)" make -e -j2 check
 
     - name: print status
       if: failure()
       run: cat test-suite.log
 
-  test_3rd_party2:
+  test_job2:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+       JOB_NUMBER: 2
     steps:
     - uses: actions/checkout@v1
 
@@ -68,190 +81,20 @@ jobs:
 
     - name: run check
       run: |
-            THIRD_PARTY_TOTAL="$(find test/functional/3rd-party -name *.bats | wc -l)"
-            THIRD_PARTY_SUBGROUP1_TOTAL=9
-            THIRD_PARTY_SUBGROUP2_TOTAL="$((THIRD_PARTY_TOTAL - THIRD_PARTY_SUBGROUP1_TOTAL))"
-            THIRD_PARTY_SUBGROUP="$(find test/functional/3rd-party -name *.bats | tail -n $THIRD_PARTY_SUBGROUP2_TOTAL | tr '\n' ' ')"
-            env TESTS="$THIRD_PARTY_SUBGROUP" make -e -j2 check
+            FILES="$(scripts/filter_bats_list.bash $JOB_NUMBER $NUM_JOBS)"
+            NUM_FILES="$(echo $FILES | tr ' ' '\n' | wc -l)"
+            echo "Running $NUM_FILES tests"
+            env TESTS="$(echo $FILES)" make -e -j2 check
 
     - name: print status
       if: failure()
       run: cat test-suite.log
 
-  test_multiple:
+  test_job3:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: build
-      run:  scripts/build_ci.bash
-
-    - name: Run prereq
-      run:  test/functional/generate-cert.prereq
-
-    - name: run check
-      run: env TESTS="$(find test/functional/{autoupdate,checkupdate,hashdump,info,mirror,signature,usability,verify-legacy} -name *.bats -printf '%p ')" make -e -j2 check
-
-    - name: print status
-      if: failure()
-      run: cat test-suite.log
-
-  test_bundle_add:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: build
-      run:  scripts/build_ci.bash
-
-    - name: Run prereq
-      run:  test/functional/generate-cert.prereq
-
-    - name: run check
-      run: env TESTS="$(find test/functional/bundleadd -name *.bats -printf '%p ')" make -e -j2 check
-
-    - name: print status
-      if: failure()
-      run: cat test-suite.log
-
-  test_bundle_info:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: build
-      run:  scripts/build_ci.bash
-
-    - name: Run prereq
-      run:  test/functional/generate-cert.prereq
-
-    - name: run check
-      run: env TESTS="$(find test/functional/bundleinfo -name *.bats -printf '%p ')" make -e -j2 check
-
-    - name: print status
-      if: failure()
-      run: cat test-suite.log
-
-  test_bundle_list:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: build
-      run:  scripts/build_ci.bash
-
-    - name: Run prereq
-      run:  test/functional/generate-cert.prereq
-
-    - name: run check
-      run: env TESTS="$(find test/functional/bundlelist -name *.bats -printf '%p ')" make -e -j2 check
-
-    - name: print status
-      if: failure()
-      run: cat test-suite.log
-
-  test_bundle_remove:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: build
-      run:  scripts/build_ci.bash
-
-    - name: Run prereq
-      run:  test/functional/generate-cert.prereq
-
-    - name: run check
-      run: env TESTS="$(find test/functional/bundleremove -name *.bats -printf '%p ')" make -e -j2 check
-
-    - name: print status
-      if: failure()
-      run: cat test-suite.log
-
-  test_diagnose:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: build
-      run:  scripts/build_ci.bash
-
-    - name: Run prereq
-      run:  test/functional/generate-cert.prereq
-
-    - name: run check
-      run: env TESTS="$(find test/functional/diagnose -name *.bats -printf '%p ')" make -e -j2 check
-
-    - name: print status
-      if: failure()
-      run: cat test-suite.log
-
-  test_os_install:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: build
-      run:  scripts/build_ci.bash
-
-    - name: Run prereq
-      run:  test/functional/generate-cert.prereq
-
-    - name: run check
-      run: env TESTS="$(find test/functional/os-install -name *.bats -printf '%p ')" make -e -j2 check
-
-    - name: print status
-      if: failure()
-      run: cat test-suite.log
-
-  test_repair:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: build
-      run:  scripts/build_ci.bash
-
-    - name: Run prereq
-      run:  test/functional/generate-cert.prereq
-
-    - name: run check
-      run: env TESTS="$(find test/functional/repair -name *.bats -printf '%p ')" make -e -j2 check
-
-    - name: print status
-      if: failure()
-      run: cat test-suite.log
-
-  test_search:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: build
-      run:  scripts/build_ci.bash
-
-    - name: Run prereq
-      run:  test/functional/generate-cert.prereq
-
-    - name: run check
-      run: env TESTS="$(find test/functional/search -name *.bats -printf '%p ')" make -e -j2 check
-
-    - name: print status
-      if: failure()
-      run: cat test-suite.log
-
-  test_update1:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    env:
+       JOB_NUMBER: 3
     steps:
     - uses: actions/checkout@v1
 
@@ -263,19 +106,20 @@ jobs:
 
     - name: run check
       run: |
-            UPDATE_TOTAL="$(find test/functional/update -name *.bats | wc -l)"
-            UPDATE_SUBGROUP1_TOTAL=25
-            UPDATE_SUBGROUP2_TOTAL="$((UPDATE_TOTAL - UPDATE_SUBGROUP1_TOTAL))"
-            UPDATE_SUBGROUP="$(find test/functional/update -name *.bats | head -n $UPDATE_SUBGROUP1_TOTAL | tr '\n' ' ')"
-            env TESTS="$UPDATE_SUBGROUP" make -e -j2 check
+            FILES="$(scripts/filter_bats_list.bash $JOB_NUMBER $NUM_JOBS)"
+            NUM_FILES="$(echo $FILES | tr ' ' '\n' | wc -l)"
+            echo "Running $NUM_FILES tests"
+            env TESTS="$(echo $FILES)" make -e -j2 check
 
     - name: print status
       if: failure()
       run: cat test-suite.log
 
-  test_update2:
+  test_job4:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+       JOB_NUMBER: 4
     steps:
     - uses: actions/checkout@v1
 
@@ -287,11 +131,160 @@ jobs:
 
     - name: run check
       run: |
-            UPDATE_TOTAL="$(find test/functional/update -name *.bats | wc -l)"
-            UPDATE_SUBGROUP1_TOTAL=25
-            UPDATE_SUBGROUP2_TOTAL="$((UPDATE_TOTAL - UPDATE_SUBGROUP1_TOTAL))"
-            UPDATE_SUBGROUP="$(find test/functional/update -name *.bats | tail -n $UPDATE_SUBGROUP2_TOTAL | tr '\n' ' ')"
-            env TESTS="$UPDATE_SUBGROUP" make -e -j2 check
+            FILES="$(scripts/filter_bats_list.bash $JOB_NUMBER $NUM_JOBS)"
+            NUM_FILES="$(echo $FILES | tr ' ' '\n' | wc -l)"
+            echo "Running $NUM_FILES tests"
+            env TESTS="$(echo $FILES)" make -e -j2 check
+
+    - name: print status
+      if: failure()
+      run: cat test-suite.log
+
+  test_job5:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+       JOB_NUMBER: 5
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: build
+      run:  scripts/build_ci.bash
+
+    - name: Run prereq
+      run:  test/functional/generate-cert.prereq
+
+    - name: run check
+      run: |
+            FILES="$(scripts/filter_bats_list.bash $JOB_NUMBER $NUM_JOBS)"
+            NUM_FILES="$(echo $FILES | tr ' ' '\n' | wc -l)"
+            echo "Running $NUM_FILES tests"
+            env TESTS="$(echo $FILES)" make -e -j2 check
+
+    - name: print status
+      if: failure()
+      run: cat test-suite.log
+
+  test_job6:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+       JOB_NUMBER: 6
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: build
+      run:  scripts/build_ci.bash
+
+    - name: Run prereq
+      run:  test/functional/generate-cert.prereq
+
+    - name: run check
+      run: |
+            FILES="$(scripts/filter_bats_list.bash $JOB_NUMBER $NUM_JOBS)"
+            NUM_FILES="$(echo $FILES | tr ' ' '\n' | wc -l)"
+            echo "Running $NUM_FILES tests"
+            env TESTS="$(echo $FILES)" make -e -j2 check
+
+    - name: print status
+      if: failure()
+      run: cat test-suite.log
+
+  test_job7:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+       JOB_NUMBER: 7
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: build
+      run:  scripts/build_ci.bash
+
+    - name: Run prereq
+      run:  test/functional/generate-cert.prereq
+
+    - name: run check
+      run: |
+            FILES="$(scripts/filter_bats_list.bash $JOB_NUMBER $NUM_JOBS)"
+            NUM_FILES="$(echo $FILES | tr ' ' '\n' | wc -l)"
+            echo "Running $NUM_FILES tests"
+            env TESTS="$(echo $FILES)" make -e -j2 check
+
+    - name: print status
+      if: failure()
+      run: cat test-suite.log
+
+  test_job8:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+       JOB_NUMBER: 8
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: build
+      run:  scripts/build_ci.bash
+
+    - name: Run prereq
+      run:  test/functional/generate-cert.prereq
+
+    - name: run check
+      run: |
+            FILES="$(scripts/filter_bats_list.bash $JOB_NUMBER $NUM_JOBS)"
+            NUM_FILES="$(echo $FILES | tr ' ' '\n' | wc -l)"
+            echo "Running $NUM_FILES tests"
+            env TESTS="$(echo $FILES)" make -e -j2 check
+
+    - name: print status
+      if: failure()
+      run: cat test-suite.log
+
+  test_job9:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+       JOB_NUMBER: 9
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: build
+      run:  scripts/build_ci.bash
+
+    - name: Run prereq
+      run:  test/functional/generate-cert.prereq
+
+    - name: run check
+      run: |
+            FILES="$(scripts/filter_bats_list.bash $JOB_NUMBER $NUM_JOBS)"
+            NUM_FILES="$(echo $FILES | tr ' ' '\n' | wc -l)"
+            echo "Running $NUM_FILES tests"
+            env TESTS="$(echo $FILES)" make -e -j2 check
+
+    - name: print status
+      if: failure()
+      run: cat test-suite.log
+
+  test_job10:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+       JOB_NUMBER: 10
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: build
+      run:  scripts/build_ci.bash
+
+    - name: Run prereq
+      run:  test/functional/generate-cert.prereq
+
+    - name: run check
+      run: |
+            FILES="$(scripts/filter_bats_list.bash $JOB_NUMBER $NUM_JOBS)"
+            NUM_FILES="$(echo $FILES | tr ' ' '\n' | wc -l)"
+            echo "Running $NUM_FILES tests"
+            env TESTS="$(echo $FILES)" make -e -j2 check
 
     - name: print status
       if: failure()

--- a/scripts/filter_bats_list.bash
+++ b/scripts/filter_bats_list.bash
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Filter a list of jobs
+# Parameter 1: Job number
+# Parameter 2: Number of jobs
+#
+# To test if any test is missing:
+# for i in $(seq $NUM_JOBS); do
+#    ./scripts/filter_bats_list.bash $i $NUM_JOBS >> list;
+# done
+
+JOB_NUM=$1
+NUM_JOBS=$2
+DEFAULT_WEIGHT=6
+
+TEST_LIST=$(find test/functional/ -name "*.bats" | sort)
+
+TOTAL_WEIGHT=0
+for t in $TEST_LIST; do
+    WEIGHT=$(sed -n -e 's/^#WEIGHT=//p' "$t")
+    if [ -z "$WEIGHT" ]; then
+        WEIGHT="$DEFAULT_WEIGHT"
+    fi
+    TOTAL_WEIGHT=$((TOTAL_WEIGHT + WEIGHT))
+done
+
+NUM_TESTS="$((TOTAL_WEIGHT/(NUM_JOBS)))"
+START="$(((JOB_NUM - 1) * NUM_TESTS + 1))"
+END="$((JOB_NUM * NUM_TESTS))"
+
+COUNT=0
+for t in $TEST_LIST; do
+    WEIGHT=$(sed -n -e 's/^#WEIGHT=//p' "$t")
+    if [ -z "$WEIGHT" ]; then
+        WEIGHT="$DEFAULT_WEIGHT"
+    fi
+
+    COUNT=$((COUNT + WEIGHT))
+
+    if [ "$JOB_NUM" -ne "$NUM_JOBS" ] && [ $COUNT -gt $END ]; then
+        break
+    fi
+
+    if [ $COUNT -ge $START ]; then
+        echo "$t"
+    fi
+
+done

--- a/scripts/weight_tests.bash
+++ b/scripts/weight_tests.bash
@@ -1,0 +1,20 @@
+#!/bin/bash
+MAX_WEIGHT=40
+
+if [ -z "$1" ]; then
+    TESTS=$(find test/functional/ -name "*.bats")
+else
+    TESTS="$*"
+fi
+
+for t in $TESTS; do
+    echo "Running $t"
+    WEIGHT=$(($(/usr/bin/time -f %e "$t" 2>&1 |tail -n 1 |cut -d '.' -f 1)+1))
+    echo "$WEIGHT"
+    if [ $WEIGHT -gt "$MAX_WEIGHT" ]; then
+        WEIGHT="$MAX_WEIGHT"
+    fi
+
+    sed -i "/#WEIGHT/d" "$t"
+    echo "#WEIGHT=$WEIGHT" >> "$t"
+done

--- a/test/functional/3rd-party/3rd-party-allow-http.bats
+++ b/test/functional/3rd-party/3rd-party-allow-http.bats
@@ -82,3 +82,4 @@ global_teardown() {
 	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/my_repo/usr/share/clear/bundles/os-core
 	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/my_repo/usr/lib/os-release
 }
+#WEIGHT=4

--- a/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
@@ -137,3 +137,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/test-bundle2
 	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle2
 }
+#WEIGHT=21

--- a/test/functional/3rd-party/3rd-party-bundle-add-config-file.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-config-file.bats
@@ -68,3 +68,4 @@ test_setup() {
 	assert_file_not_exists "$TPSTATEDIR"/bundles/test-bundle3
 
 }
+#WEIGHT=6

--- a/test/functional/3rd-party/3rd-party-bundle-add-export-bin.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-export-bin.bats
@@ -84,3 +84,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=8

--- a/test/functional/3rd-party/3rd-party-bundle-add-multi-repo.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-multi-repo.bats
@@ -75,3 +75,4 @@ test_setup() {
 	assert_file_exists "$STATEDIR"/3rd-party/repo2/bundles/test-bundle1
 
 }
+#WEIGHT=13

--- a/test/functional/3rd-party/3rd-party-bundle-info-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-info-basic.bats
@@ -163,3 +163,4 @@ global_teardown() {
 	assert_regex_is_output "$expected_output"
 
 }
+#WEIGHT=9

--- a/test/functional/3rd-party/3rd-party-bundle-list-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-list-basic.bats
@@ -148,3 +148,4 @@ global_teardown() {
 	assert_is_output --identical "$expected_output"
 
 }
+#WEIGHT=8

--- a/test/functional/3rd-party/3rd-party-bundle-list-deps.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-list-deps.bats
@@ -85,3 +85,4 @@ global_teardown() {
 	assert_is_output --identical "$expected_output"
 
 }
+#WEIGHT=8

--- a/test/functional/3rd-party/3rd-party-bundle-remove-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-basic.bats
@@ -123,3 +123,4 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/test-bundle1
 
 }
+#WEIGHT=22

--- a/test/functional/3rd-party/3rd-party-bundle-remove-exported-bin.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-exported-bin.bats
@@ -46,3 +46,4 @@ test_setup() {
 	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/file_3
 
 }
+#WEIGHT=5

--- a/test/functional/3rd-party/3rd-party-bundle-remove-multi-repo.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-multi-repo.bats
@@ -100,3 +100,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=29

--- a/test/functional/3rd-party/3rd-party-check-update-basic.bats
+++ b/test/functional/3rd-party/3rd-party-check-update-basic.bats
@@ -94,3 +94,4 @@ global_teardown() {
 	assert_is_output --identical "$expected_output"
 
 }
+#WEIGHT=7

--- a/test/functional/3rd-party/3rd-party-diagnose-basic.bats
+++ b/test/functional/3rd-party/3rd-party-diagnose-basic.bats
@@ -235,3 +235,4 @@ global_teardown() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=9

--- a/test/functional/3rd-party/3rd-party-repair-basic.bats
+++ b/test/functional/3rd-party/3rd-party-repair-basic.bats
@@ -246,3 +246,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=38

--- a/test/functional/3rd-party/3rd-party-repo-add-negative.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add-negative.bats
@@ -84,3 +84,4 @@ global_teardown() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=3

--- a/test/functional/3rd-party/3rd-party-repo-add.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add.bats
@@ -90,3 +90,4 @@ test_setup() {
 	assert_is_output --identical "$expected_output"
 
 }
+#WEIGHT=8

--- a/test/functional/3rd-party/3rd-party-repo-list.bats
+++ b/test/functional/3rd-party/3rd-party-repo-list.bats
@@ -58,3 +58,4 @@ test_teardown(){
 	assert_is_output --identical "$expected_output"
 
 }
+#WEIGHT=1

--- a/test/functional/3rd-party/3rd-party-repo-remove-negative.bats
+++ b/test/functional/3rd-party/3rd-party-repo-remove-negative.bats
@@ -63,3 +63,4 @@ test_setup(){
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=11

--- a/test/functional/3rd-party/3rd-party-repo-remove.bats
+++ b/test/functional/3rd-party/3rd-party-repo-remove.bats
@@ -57,3 +57,4 @@ test_setup(){
 	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_5
 
 }
+#WEIGHT=11

--- a/test/functional/3rd-party/3rd-party-update-basic.bats
+++ b/test/functional/3rd-party/3rd-party-update-basic.bats
@@ -141,3 +141,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=32

--- a/test/functional/3rd-party/3rd-party-update-exported-bin.bats
+++ b/test/functional/3rd-party/3rd-party-update-exported-bin.bats
@@ -76,3 +76,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_7
 
 }
+#WEIGHT=9

--- a/test/functional/3rd-party/3rd-party-update-specific-version.bats
+++ b/test/functional/3rd-party/3rd-party-update-specific-version.bats
@@ -67,3 +67,4 @@ test_setup() {
 	assert_in_output "$expected_output"
 
 }
+#WEIGHT=10

--- a/test/functional/autoupdate/aup-basic.bats
+++ b/test/functional/autoupdate/aup-basic.bats
@@ -70,3 +70,4 @@ test_teardown() {
 	assert_file_not_exists "$PATH_PREFIX/etc/systemd/system/swupd-update.timer"
 
 }
+#WEIGHT=2

--- a/test/functional/bundleadd/add-alias-basic.bats
+++ b/test/functional/bundleadd/add-alias-basic.bats
@@ -331,3 +331,4 @@ global_teardown() {
 	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/alias-bundle1
 
 }
+#WEIGHT=7

--- a/test/functional/bundleadd/add-also-add-flag.bats
+++ b/test/functional/bundleadd/add-also-add-flag.bats
@@ -81,3 +81,4 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
 
 }
+#WEIGHT=8

--- a/test/functional/bundleadd/add-bad-hash-state.bats
+++ b/test/functional/bundleadd/add-bad-hash-state.bats
@@ -39,3 +39,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/bundleadd/add-bad-hash.bats
+++ b/test/functional/bundleadd/add-bad-hash.bats
@@ -37,3 +37,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/bundleadd/add-bad-manifest.bats
+++ b/test/functional/bundleadd/add-bad-manifest.bats
@@ -33,3 +33,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/bundleadd/add-basics.bats
+++ b/test/functional/bundleadd/add-basics.bats
@@ -255,3 +255,4 @@ global_teardown() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=6

--- a/test/functional/bundleadd/add-boot-file.bats
+++ b/test/functional/bundleadd/add-boot-file.bats
@@ -29,3 +29,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/bundleadd/add-boot-skip.bats
+++ b/test/functional/bundleadd/add-boot-skip.bats
@@ -30,3 +30,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/bundleadd/add-client-certificate.bats
+++ b/test/functional/bundleadd/add-client-certificate.bats
@@ -105,3 +105,4 @@ global_teardown() {
 	)
 	assert_regex_in_output "$expected_output"
 }
+#WEIGHT=4

--- a/test/functional/bundleadd/add-directory.bats
+++ b/test/functional/bundleadd/add-directory.bats
@@ -28,3 +28,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/bundleadd/add-experimental.bats
+++ b/test/functional/bundleadd/add-experimental.bats
@@ -38,3 +38,4 @@ test_teardown() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/bundleadd/add-fall-back-to-fullfile.bats
+++ b/test/functional/bundleadd/add-fall-back-to-fullfile.bats
@@ -98,3 +98,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=6

--- a/test/functional/bundleadd/add-include.bats
+++ b/test/functional/bundleadd/add-include.bats
@@ -140,3 +140,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=9

--- a/test/functional/bundleadd/add-install-time.bats
+++ b/test/functional/bundleadd/add-install-time.bats
@@ -49,3 +49,4 @@ test_setup() {
 	assert_regex_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/bundleadd/add-json.bats
+++ b/test/functional/bundleadd/add-json.bats
@@ -96,3 +96,4 @@ test_setup() {
 	assert_in_output "$expected_output2"
 
 }
+#WEIGHT=3

--- a/test/functional/bundleadd/add-multiple.bats
+++ b/test/functional/bundleadd/add-multiple.bats
@@ -33,3 +33,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=4

--- a/test/functional/bundleadd/add-no-disk-space.bats
+++ b/test/functional/bundleadd/add-no-disk-space.bats
@@ -149,3 +149,4 @@ test_setup() {
 	assert_regex_is_output "$expected_output"
 
 }
+#WEIGHT=13

--- a/test/functional/bundleadd/add-no-signature.bats
+++ b/test/functional/bundleadd/add-no-signature.bats
@@ -48,3 +48,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/test-file
 
 }
+#WEIGHT=3

--- a/test/functional/bundleadd/add-overwrite-files.bats
+++ b/test/functional/bundleadd/add-overwrite-files.bats
@@ -46,3 +46,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/file1
 
 }
+#WEIGHT=3

--- a/test/functional/bundleadd/add-skip-scripts.bats
+++ b/test/functional/bundleadd/add-skip-scripts.bats
@@ -28,3 +28,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/bundleadd/add-uses-fullfile.bats
+++ b/test/functional/bundleadd/add-uses-fullfile.bats
@@ -31,3 +31,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/bundleadd/add-uses-zeropack.bats
+++ b/test/functional/bundleadd/add-uses-zeropack.bats
@@ -44,3 +44,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=3

--- a/test/functional/bundleadd/add-verify-fix-path.bats
+++ b/test/functional/bundleadd/add-verify-fix-path.bats
@@ -38,3 +38,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/foo/bar/test-file1
 
 }
+#WEIGHT=3

--- a/test/functional/bundleinfo/bundle-info-basic.bats
+++ b/test/functional/bundleinfo/bundle-info-basic.bats
@@ -152,3 +152,4 @@ global_teardown() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=5

--- a/test/functional/bundleinfo/bundle-info-files.bats
+++ b/test/functional/bundleinfo/bundle-info-files.bats
@@ -136,3 +136,4 @@ global_teardown() {
 	assert_regex_is_output "$expected_output"
 
 }
+#WEIGHT=4

--- a/test/functional/bundleinfo/bundle-info-includes.bats
+++ b/test/functional/bundleinfo/bundle-info-includes.bats
@@ -101,3 +101,4 @@ global_teardown() {
 	assert_regex_is_output "$expected_output"
 
 }
+#WEIGHT=6

--- a/test/functional/bundleinfo/bundle-info-optional.bats
+++ b/test/functional/bundleinfo/bundle-info-optional.bats
@@ -96,3 +96,4 @@ global_teardown() {
 	assert_regex_is_output "$expected_output"
 
 }
+#WEIGHT=5

--- a/test/functional/bundleinfo/bundle-info-status.bats
+++ b/test/functional/bundleinfo/bundle-info-status.bats
@@ -82,3 +82,4 @@ global_teardown() {
 	assert_regex_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/bundlelist/list-all.bats
+++ b/test/functional/bundlelist/list-all.bats
@@ -51,3 +51,4 @@ test_setup() {
 	assert_is_output --identical "$expected_output"
 
 }
+#WEIGHT=6

--- a/test/functional/bundlelist/list-client-certificate.bats
+++ b/test/functional/bundlelist/list-client-certificate.bats
@@ -102,3 +102,4 @@ global_teardown() {
 	)
 	assert_regex_in_output "$expected_output"
 }
+#WEIGHT=3

--- a/test/functional/bundlelist/list-deps-flat.bats
+++ b/test/functional/bundlelist/list-deps-flat.bats
@@ -32,3 +32,4 @@ test_setup() {
 	assert_is_output --identical "$expected_output"
 
 }
+#WEIGHT=3

--- a/test/functional/bundlelist/list-deps-invalid-bundle.bats
+++ b/test/functional/bundlelist/list-deps-invalid-bundle.bats
@@ -15,3 +15,4 @@ load "../testlib"
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=1

--- a/test/functional/bundlelist/list-deps-nested.bats
+++ b/test/functional/bundlelist/list-deps-nested.bats
@@ -52,3 +52,4 @@ test_setup() {
 	assert_is_output --identical "$expected_output"
 
 }
+#WEIGHT=6

--- a/test/functional/bundlelist/list-experimental.bats
+++ b/test/functional/bundlelist/list-experimental.bats
@@ -116,3 +116,4 @@ global_teardown() {
 	assert_is_output --identical "$expected_output"
 
 }
+#WEIGHT=3

--- a/test/functional/bundlelist/list-has-dep-nested-not-installed.bats
+++ b/test/functional/bundlelist/list-has-dep-nested-not-installed.bats
@@ -27,3 +27,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=3

--- a/test/functional/bundlelist/list-has-dep-nested-server.bats
+++ b/test/functional/bundlelist/list-has-dep-nested-server.bats
@@ -32,3 +32,4 @@ test_setup() {
 	assert_is_output --identical "$expected_output"
 
 }
+#WEIGHT=3

--- a/test/functional/bundlelist/list-has-dep-nested.bats
+++ b/test/functional/bundlelist/list-has-dep-nested.bats
@@ -58,3 +58,4 @@ test_setup() {
 	assert_is_output --identical "$expected_output"
 
 }
+#WEIGHT=6

--- a/test/functional/bundlelist/list-installed.bats
+++ b/test/functional/bundlelist/list-installed.bats
@@ -51,3 +51,4 @@ test_setup() {
 	assert_is_output --identical "$expected_output"
 
 }
+#WEIGHT=5

--- a/test/functional/bundlelist/list-json.bats
+++ b/test/functional/bundlelist/list-json.bats
@@ -41,3 +41,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/bundlelist/list-no-deps.bats
+++ b/test/functional/bundlelist/list-no-deps.bats
@@ -24,3 +24,4 @@ test_setup() {
 	assert_is_output --identical "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/bundlelist/list-no-disk-space.bats
+++ b/test/functional/bundlelist/list-no-disk-space.bats
@@ -65,3 +65,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=5

--- a/test/functional/bundlelist/list-none-has-deps.bats
+++ b/test/functional/bundlelist/list-none-has-deps.bats
@@ -24,3 +24,4 @@ test_setup() {
 	assert_is_output --identical "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/bundlelist/list-quiet.bats
+++ b/test/functional/bundlelist/list-quiet.bats
@@ -47,3 +47,4 @@ test_setup() {
 	assert_is_output --identical "$expected_output"
 
 }
+#WEIGHT=5

--- a/test/functional/bundleremove/remove-basics.bats
+++ b/test/functional/bundleremove/remove-basics.bats
@@ -210,3 +210,4 @@ global_teardown() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=5

--- a/test/functional/bundleremove/remove-boot-file.bats
+++ b/test/functional/bundleremove/remove-boot-file.bats
@@ -31,3 +31,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=3

--- a/test/functional/bundleremove/remove-client-certificate.bats
+++ b/test/functional/bundleremove/remove-client-certificate.bats
@@ -106,3 +106,4 @@ global_teardown() {
 	)
 	assert_regex_in_output "$expected_output"
 }
+#WEIGHT=4

--- a/test/functional/bundleremove/remove-include-nested.bats
+++ b/test/functional/bundleremove/remove-include-nested.bats
@@ -246,3 +246,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/common
 
 }
+#WEIGHT=17

--- a/test/functional/bundleremove/remove-include.bats
+++ b/test/functional/bundleremove/remove-include.bats
@@ -32,3 +32,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=3

--- a/test/functional/bundleremove/remove-json.bats
+++ b/test/functional/bundleremove/remove-json.bats
@@ -41,3 +41,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/bundleremove/remove-no-disk-space.bats
+++ b/test/functional/bundleremove/remove-no-disk-space.bats
@@ -98,3 +98,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=6

--- a/test/functional/bundleremove/remove-optional-bundles.bats
+++ b/test/functional/bundleremove/remove-optional-bundles.bats
@@ -44,3 +44,4 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
 
 }
+#WEIGHT=3

--- a/test/functional/bundleremove/remove-os-core.bats
+++ b/test/functional/bundleremove/remove-os-core.bats
@@ -17,3 +17,4 @@ load "../testlib"
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=1

--- a/test/functional/bundleremove/remove-parse-args.bats
+++ b/test/functional/bundleremove/remove-parse-args.bats
@@ -10,3 +10,4 @@ load "../testlib"
 	assert_in_output "Error: missing bundle(s) to be removed"
 
 }
+#WEIGHT=1

--- a/test/functional/bundleremove/remove-recursive.bats
+++ b/test/functional/bundleremove/remove-recursive.bats
@@ -225,3 +225,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/test-file6
 
 }
+#WEIGHT=21

--- a/test/functional/bundleremove/remove-with-dependency.bats
+++ b/test/functional/bundleremove/remove-with-dependency.bats
@@ -39,3 +39,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/checkupdate/chk-update-client-certificate.bats
+++ b/test/functional/checkupdate/chk-update-client-certificate.bats
@@ -107,3 +107,4 @@ global_teardown() {
 	)
 	assert_regex_in_output "$expected_output"
 }
+#WEIGHT=4

--- a/test/functional/checkupdate/chk-update-format-bump.bats
+++ b/test/functional/checkupdate/chk-update-format-bump.bats
@@ -47,3 +47,4 @@ test_setup() {
 	assert_status_is "$SWUPD_OK"
 
 }
+#WEIGHT=13

--- a/test/functional/checkupdate/chk-update-json.bats
+++ b/test/functional/checkupdate/chk-update-json.bats
@@ -34,3 +34,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=1

--- a/test/functional/checkupdate/chk-update-new-version.bats
+++ b/test/functional/checkupdate/chk-update-new-version.bats
@@ -27,3 +27,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/checkupdate/chk-update-no-server-content.bats
+++ b/test/functional/checkupdate/chk-update-no-server-content.bats
@@ -23,3 +23,4 @@ test_setup() {
 	assert_in_output "$expected_output"
 
 }
+#WEIGHT=1

--- a/test/functional/checkupdate/chk-update-no-target-content.bats
+++ b/test/functional/checkupdate/chk-update-no-target-content.bats
@@ -23,3 +23,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=1

--- a/test/functional/checkupdate/chk-update-slow-server.bats
+++ b/test/functional/checkupdate/chk-update-slow-server.bats
@@ -35,3 +35,4 @@ test_teardown() {
 	)
 	assert_is_output "$expected_output"
 }
+#WEIGHT=4

--- a/test/functional/checkupdate/chk-update-version-match.bats
+++ b/test/functional/checkupdate/chk-update-version-match.bats
@@ -16,3 +16,4 @@ load "../testlib"
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=1

--- a/test/functional/diagnose/diagnose-also-add.bats
+++ b/test/functional/diagnose/diagnose-also-add.bats
@@ -73,3 +73,4 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 }
+#WEIGHT=7

--- a/test/functional/diagnose/diagnose-basics.bats
+++ b/test/functional/diagnose/diagnose-basics.bats
@@ -64,3 +64,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/usr/untracked_file3
 
 }
+#WEIGHT=5

--- a/test/functional/diagnose/diagnose-boot-file.bats
+++ b/test/functional/diagnose/diagnose-boot-file.bats
@@ -32,3 +32,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/usr/lib/kernel/testfile
 
 }
+#WEIGHT=2

--- a/test/functional/diagnose/diagnose-bundles.bats
+++ b/test/functional/diagnose/diagnose-bundles.bats
@@ -168,3 +168,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=18

--- a/test/functional/diagnose/diagnose-client-certificate.bats
+++ b/test/functional/diagnose/diagnose-client-certificate.bats
@@ -102,3 +102,4 @@ global_teardown() {
 	)
 	assert_regex_in_output "$expected_output"
 }
+#WEIGHT=3

--- a/test/functional/diagnose/diagnose-directory-tree-deleted.bats
+++ b/test/functional/diagnose/diagnose-directory-tree-deleted.bats
@@ -41,3 +41,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/testdir1/testdir2/testfile
 
 }
+#WEIGHT=2

--- a/test/functional/diagnose/diagnose-flags.bats
+++ b/test/functional/diagnose/diagnose-flags.bats
@@ -70,3 +70,4 @@ load "../testlib"
 	assert_in_output "Error: --bundles and --extra-files-only options are mutually exclusive"
 
 }
+#WEIGHT=2

--- a/test/functional/diagnose/diagnose-good.bats
+++ b/test/functional/diagnose/diagnose-good.bats
@@ -29,3 +29,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/diagnose/diagnose-json.bats
+++ b/test/functional/diagnose/diagnose-json.bats
@@ -98,3 +98,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=4

--- a/test/functional/diagnose/diagnose-missing-file.bats
+++ b/test/functional/diagnose/diagnose-missing-file.bats
@@ -33,3 +33,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/bar/test-file2
 
 }
+#WEIGHT=2

--- a/test/functional/diagnose/diagnose-path.bats
+++ b/test/functional/diagnose/diagnose-path.bats
@@ -206,3 +206,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=33

--- a/test/functional/diagnose/diagnose-picky-downgrade.bats
+++ b/test/functional/diagnose/diagnose-picky-downgrade.bats
@@ -50,3 +50,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/usr/share/defaults/swupd/contenturl
 
 }
+#WEIGHT=4

--- a/test/functional/diagnose/diagnose-picky-whitelist.bats
+++ b/test/functional/diagnose/diagnose-picky-whitelist.bats
@@ -52,3 +52,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/usr/foo/bar/file2
 
 }
+#WEIGHT=2

--- a/test/functional/diagnose/diagnose-picky.bats
+++ b/test/functional/diagnose/diagnose-picky.bats
@@ -76,3 +76,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=4

--- a/test/functional/hashdump/hashdump-file-hash.bats
+++ b/test/functional/hashdump/hashdump-file-hash.bats
@@ -71,3 +71,4 @@ global_teardown() {
 	assert_regex_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/info/info-basic.bats
+++ b/test/functional/info/info-basic.bats
@@ -49,3 +49,4 @@ test_teardown() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/mirror/mirror-allow-http.bats
+++ b/test/functional/mirror/mirror-allow-http.bats
@@ -91,3 +91,4 @@ global_teardown() {
 	)
 	assert_in_output "$expected_output"
 }
+#WEIGHT=72

--- a/test/functional/mirror/mirror-createdir-negative.bats
+++ b/test/functional/mirror/mirror-createdir-negative.bats
@@ -61,3 +61,4 @@ global_teardown() {
 	assert_regex_is_output "$expected_output"
 
 }
+#WEIGHT=1

--- a/test/functional/mirror/mirror-createdir.bats
+++ b/test/functional/mirror/mirror-createdir.bats
@@ -90,3 +90,4 @@ global_teardown() {
 	assert_equal "https://example.com/swupd-file" "$(<"$TARGETDIR"/etc/swupd/mirror_versionurl)"
 
 }
+#WEIGHT=2

--- a/test/functional/mirror/mirror-json.bats
+++ b/test/functional/mirror/mirror-json.bats
@@ -38,3 +38,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=1

--- a/test/functional/mirror/mirror-set-unset-invalid.bats
+++ b/test/functional/mirror/mirror-set-unset-invalid.bats
@@ -103,3 +103,4 @@ global_teardown() {
 	assert_in_output "$expected_output"
 }
 
+#WEIGHT=2

--- a/test/functional/mirror/mirror-set-unset.bats
+++ b/test/functional/mirror/mirror-set-unset.bats
@@ -180,3 +180,4 @@ global_teardown() {
 	assert_file_not_exists "$TARGETDIR"/etc/swupd/mirror_contenturl
 	assert_file_not_exists "$TARGETDIR"/etc/swupd/mirror_versionurl
 }
+#WEIGHT=2

--- a/test/functional/os-install/install-also-add.bats
+++ b/test/functional/os-install/install-also-add.bats
@@ -52,3 +52,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/bar/test-file3
 
 }
+#WEIGHT=4

--- a/test/functional/os-install/install-bad.bats
+++ b/test/functional/os-install/install-bad.bats
@@ -71,3 +71,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/file_2
 
 }
+#WEIGHT=4

--- a/test/functional/os-install/install-basics.bats
+++ b/test/functional/os-install/install-basics.bats
@@ -94,3 +94,4 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/core
 
 }
+#WEIGHT=3

--- a/test/functional/os-install/install-download.bats
+++ b/test/functional/os-install/install-download.bats
@@ -40,3 +40,4 @@ test_setup() {
 	assert_file_exists "$STATEDIR"/staged/"$core_hash"
 
 }
+#WEIGHT=1

--- a/test/functional/os-install/install-json.bats
+++ b/test/functional/os-install/install-json.bats
@@ -72,3 +72,4 @@ test_setup() {
 	assert_in_output "$expected_output2"
 
 }
+#WEIGHT=1

--- a/test/functional/os-install/install-latest-missing.bats
+++ b/test/functional/os-install/install-latest-missing.bats
@@ -28,3 +28,4 @@ test_setup() {
 	assert_in_output "$expected_output"
 
 }
+#WEIGHT=1

--- a/test/functional/os-install/install-multiple.bats
+++ b/test/functional/os-install/install-multiple.bats
@@ -64,3 +64,4 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/var/lib/swupd/bundles/os-core
 
 }
+#WEIGHT=4

--- a/test/functional/os-install/install-no-also-add.bats
+++ b/test/functional/os-install/install-no-also-add.bats
@@ -50,3 +50,4 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/bar/test-file3
 
 }
+#WEIGHT=4

--- a/test/functional/os-install/install-no-fullfile-fallback.bats
+++ b/test/functional/os-install/install-no-fullfile-fallback.bats
@@ -39,3 +39,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=1

--- a/test/functional/os-install/install-no-packs.bats
+++ b/test/functional/os-install/install-no-packs.bats
@@ -46,3 +46,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/core
 
 }
+#WEIGHT=1

--- a/test/functional/os-install/install-statedir-cache-offline.bats
+++ b/test/functional/os-install/install-statedir-cache-offline.bats
@@ -176,3 +176,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/core
 
 }
+#WEIGHT=5

--- a/test/functional/os-install/install-statedir-cache.bats
+++ b/test/functional/os-install/install-statedir-cache.bats
@@ -154,3 +154,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/core
 
 }
+#WEIGHT=4

--- a/test/functional/os-install/install-version.bats
+++ b/test/functional/os-install/install-version.bats
@@ -112,3 +112,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/core
 
 }
+#WEIGHT=7

--- a/test/functional/repair/repair-add-missing-include-old.bats
+++ b/test/functional/repair/repair-add-missing-include-old.bats
@@ -49,3 +49,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/test-file2
 
 }
+#WEIGHT=3

--- a/test/functional/repair/repair-add-missing-include.bats
+++ b/test/functional/repair/repair-add-missing-include.bats
@@ -49,3 +49,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/bar/test-file2
 
 }
+#WEIGHT=3

--- a/test/functional/repair/repair-basics.bats
+++ b/test/functional/repair/repair-basics.bats
@@ -182,3 +182,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/usr/untracked_file3
 
 }
+#WEIGHT=13

--- a/test/functional/repair/repair-boot-file-deleted.bats
+++ b/test/functional/repair/repair-boot-file-deleted.bats
@@ -37,3 +37,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/usr/lib/kernel/testfile
 
 }
+#WEIGHT=2

--- a/test/functional/repair/repair-boot-file.bats
+++ b/test/functional/repair/repair-boot-file.bats
@@ -44,3 +44,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/usr/lib/kernel/testfile
 
 }
+#WEIGHT=2

--- a/test/functional/repair/repair-boot-skip.bats
+++ b/test/functional/repair/repair-boot-skip.bats
@@ -39,3 +39,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/usr/lib/kernel/testfile
 
 }
+#WEIGHT=2

--- a/test/functional/repair/repair-bundles.bats
+++ b/test/functional/repair/repair-bundles.bats
@@ -187,3 +187,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=14

--- a/test/functional/repair/repair-deleted-include-manifest.bats
+++ b/test/functional/repair/repair-deleted-include-manifest.bats
@@ -37,3 +37,4 @@ test_setup() {
 	assert_regex_is_output "$expected_output"
 
 }
+#WEIGHT=3

--- a/test/functional/repair/repair-directory-tree-deleted.bats
+++ b/test/functional/repair/repair-directory-tree-deleted.bats
@@ -46,3 +46,4 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/testdir1/testdir2/testfile
 
 }
+#WEIGHT=2

--- a/test/functional/repair/repair-empty-dir-deleted.bats
+++ b/test/functional/repair/repair-empty-dir-deleted.bats
@@ -39,3 +39,4 @@ test_setup() {
 	assert_dir_not_exists "$TARGETDIR"/testdir
 
 }
+#WEIGHT=2

--- a/test/functional/repair/repair-flags.bats
+++ b/test/functional/repair/repair-flags.bats
@@ -37,3 +37,4 @@ load "../testlib"
 	assert_in_output "Error: --extra-files-only and --picky options are mutually exclusive"
 
 }
+#WEIGHT=2

--- a/test/functional/repair/repair-format-mismatch-overdrive.bats
+++ b/test/functional/repair/repair-format-mismatch-overdrive.bats
@@ -48,3 +48,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=7

--- a/test/functional/repair/repair-format-mismatch.bats
+++ b/test/functional/repair/repair-format-mismatch.bats
@@ -28,3 +28,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=7

--- a/test/functional/repair/repair-ghosted.bats
+++ b/test/functional/repair/repair-ghosted.bats
@@ -36,3 +36,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/foo
 
 }
+#WEIGHT=2

--- a/test/functional/repair/repair-ignore-also-add.bats
+++ b/test/functional/repair/repair-ignore-also-add.bats
@@ -86,3 +86,4 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/bar/test-file3
 
 }
+#WEIGHT=7

--- a/test/functional/repair/repair-json.bats
+++ b/test/functional/repair/repair-json.bats
@@ -164,3 +164,4 @@ test_setup() {
 	assert_in_output "$expected_output2"
 
 }
+#WEIGHT=4

--- a/test/functional/repair/repair-missing-file.bats
+++ b/test/functional/repair/repair-missing-file.bats
@@ -42,3 +42,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/bar/test-file2
 
 }
+#WEIGHT=2

--- a/test/functional/repair/repair-no-disk-space.bats
+++ b/test/functional/repair/repair-no-disk-space.bats
@@ -109,3 +109,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=12

--- a/test/functional/repair/repair-path.bats
+++ b/test/functional/repair/repair-path.bats
@@ -277,3 +277,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=39

--- a/test/functional/repair/repair-picky-downgrade.bats
+++ b/test/functional/repair/repair-picky-downgrade.bats
@@ -127,3 +127,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
 
 }
+#WEIGHT=11

--- a/test/functional/repair/repair-picky-ghosted-missing.bats
+++ b/test/functional/repair/repair-picky-ghosted-missing.bats
@@ -44,3 +44,4 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/usr/foo
 
 }
+#WEIGHT=3

--- a/test/functional/repair/repair-picky-ghosted.bats
+++ b/test/functional/repair/repair-picky-ghosted.bats
@@ -43,3 +43,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/usr/foo
 
 }
+#WEIGHT=3

--- a/test/functional/repair/repair-picky.bats
+++ b/test/functional/repair/repair-picky.bats
@@ -83,3 +83,4 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/usr/foo/bar/file2
 
 }
+#WEIGHT=4

--- a/test/functional/repair/repair-skip-scripts.bats
+++ b/test/functional/repair/repair-skip-scripts.bats
@@ -38,3 +38,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/usr/lib/kernel/testfile
 
 }
+#WEIGHT=3

--- a/test/functional/repair/repair-unsafe-to-delete.bats
+++ b/test/functional/repair/repair-unsafe-to-delete.bats
@@ -39,3 +39,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=3

--- a/test/functional/repair/repair-version-mismatch-overdrive.bats
+++ b/test/functional/repair/repair-version-mismatch-overdrive.bats
@@ -44,3 +44,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/repair/repair-version-mismatch.bats
+++ b/test/functional/repair/repair-version-mismatch.bats
@@ -27,3 +27,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/search/search-client-certificate.bats
+++ b/test/functional/search/search-client-certificate.bats
@@ -103,3 +103,4 @@ global_teardown() {
 	)
 	assert_regex_in_output "$expected_output"
 }
+#WEIGHT=4

--- a/test/functional/search/search-content-check-negative.bats
+++ b/test/functional/search/search-content-check-negative.bats
@@ -78,3 +78,4 @@ global_teardown() {
 
 }
 
+#WEIGHT=2

--- a/test/functional/search/search-content-check-positive.bats
+++ b/test/functional/search/search-content-check-positive.bats
@@ -226,3 +226,4 @@ global_teardown() {
 	assert_regex_in_output "$expected_output"
 
 }
+#WEIGHT=5

--- a/test/functional/search/search-experimental.bats
+++ b/test/functional/search/search-experimental.bats
@@ -123,3 +123,4 @@ global_teardown() {
 	assert_regex_in_output "$expected_output"
 
 }
+#WEIGHT=4

--- a/test/functional/search/search-json.bats
+++ b/test/functional/search/search-json.bats
@@ -43,3 +43,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/search/search-no-disk-space.bats
+++ b/test/functional/search/search-no-disk-space.bats
@@ -73,3 +73,4 @@ test_setup() {
 	assert_regex_is_output "$expected_output"
 
 }
+#WEIGHT=4

--- a/test/functional/search/search-sort.bats
+++ b/test/functional/search/search-sort.bats
@@ -147,3 +147,4 @@ global_teardown() {
 	assert_regex_in_output "$expected_output"
 
 }
+#WEIGHT=5

--- a/test/functional/search/search-version.bats
+++ b/test/functional/search/search-version.bats
@@ -44,3 +44,4 @@ test_setup() {
 	assert_regex_is_output "$expected_output"
 
 }
+#WEIGHT=3

--- a/test/functional/signature/cert-chain.bats
+++ b/test/functional/signature/cert-chain.bats
@@ -174,3 +174,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/test-file
 
 }
+#WEIGHT=17

--- a/test/functional/signature/corrupted-certificate.bats
+++ b/test/functional/signature/corrupted-certificate.bats
@@ -49,3 +49,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/test-file
 
 }
+#WEIGHT=3

--- a/test/functional/signature/corrupted-signature.bats
+++ b/test/functional/signature/corrupted-signature.bats
@@ -54,3 +54,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/test-file
 
 }
+#WEIGHT=3

--- a/test/functional/signature/invalid-certificate.bats
+++ b/test/functional/signature/invalid-certificate.bats
@@ -53,3 +53,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/test-file
 
 }
+#WEIGHT=4

--- a/test/functional/signature/key-rotation.bats
+++ b/test/functional/signature/key-rotation.bats
@@ -156,3 +156,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/core
 
 }
+#WEIGHT=19

--- a/test/functional/signature/no-signature.bats
+++ b/test/functional/signature/no-signature.bats
@@ -51,3 +51,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/test-file
 
 }
+#WEIGHT=3

--- a/test/functional/signature/permission-incorrect.bats
+++ b/test/functional/signature/permission-incorrect.bats
@@ -24,3 +24,4 @@ test_setup() {
 	assert_in_output "700"
 
 }
+#WEIGHT=2

--- a/test/functional/signature/version-sig-check.bats
+++ b/test/functional/signature/version-sig-check.bats
@@ -65,3 +65,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=5

--- a/test/functional/update/update-boot-file.bats
+++ b/test/functional/update/update-boot-file.bats
@@ -40,3 +40,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/usr/lib/kernel/testfile
 
 }
+#WEIGHT=2

--- a/test/functional/update/update-boot-skip.bats
+++ b/test/functional/update/update-boot-skip.bats
@@ -41,3 +41,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/usr/lib/kernel/testfile
 
 }
+#WEIGHT=2

--- a/test/functional/update/update-bundle-removed.bats
+++ b/test/functional/update/update-bundle-removed.bats
@@ -53,3 +53,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
 
 }
+#WEIGHT=5

--- a/test/functional/update/update-client-certificate.bats
+++ b/test/functional/update/update-client-certificate.bats
@@ -107,3 +107,4 @@ global_teardown() {
 	)
 	assert_regex_in_output "$expected_output"
 }
+#WEIGHT=4

--- a/test/functional/update/update-deleted-include-manifest.bats
+++ b/test/functional/update/update-deleted-include-manifest.bats
@@ -37,3 +37,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=3

--- a/test/functional/update/update-download.bats
+++ b/test/functional/update/update-download.bats
@@ -36,3 +36,4 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/foo
 }
 
+#WEIGHT=2

--- a/test/functional/update/update-fail-to-get-mom.bats
+++ b/test/functional/update/update-fail-to-get-mom.bats
@@ -46,3 +46,4 @@ test_setup() {
 	assert_regex_is_output "$expected_output"
 
 }
+#WEIGHT=2

--- a/test/functional/update/update-ignore-also-add.bats
+++ b/test/functional/update/update-ignore-also-add.bats
@@ -53,3 +53,4 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/bar/testfile2
 
 }
+#WEIGHT=4

--- a/test/functional/update/update-include-old-bundle-with-tracked-file.bats
+++ b/test/functional/update/update-include-old-bundle-with-tracked-file.bats
@@ -53,3 +53,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/ftb3
 
 }
+#WEIGHT=9

--- a/test/functional/update/update-include-old-bundle.bats
+++ b/test/functional/update/update-include-old-bundle.bats
@@ -50,3 +50,4 @@ test_setup() {
 
 }
 
+#WEIGHT=3

--- a/test/functional/update/update-include.bats
+++ b/test/functional/update/update-include.bats
@@ -77,3 +77,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/foo/testfile7
 
 }
+#WEIGHT=9

--- a/test/functional/update/update-json.bats
+++ b/test/functional/update/update-json.bats
@@ -89,3 +89,4 @@ test_setup() {
 	assert_regex_in_output "$expected_output3"
 
 }
+#WEIGHT=4

--- a/test/functional/update/update-manifest-delta.bats
+++ b/test/functional/update/update-manifest-delta.bats
@@ -85,3 +85,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=8

--- a/test/functional/update/update-minversion.bats
+++ b/test/functional/update/update-minversion.bats
@@ -41,3 +41,4 @@ test_setup() {
 	)
 	assert_in_output "$expected_output"
 }
+#WEIGHT=2

--- a/test/functional/update/update-missing-os-core.bats
+++ b/test/functional/update/update-missing-os-core.bats
@@ -44,3 +44,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/testfile1
 
 }
+#WEIGHT=3

--- a/test/functional/update/update-newest-added.bats
+++ b/test/functional/update/update-newest-added.bats
@@ -43,3 +43,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=3

--- a/test/functional/update/update-newest-deleted.bats
+++ b/test/functional/update/update-newest-deleted.bats
@@ -51,3 +51,4 @@ test_setup() {
 
 }
 
+#WEIGHT=6

--- a/test/functional/update/update-newest-ghosted.bats
+++ b/test/functional/update/update-newest-ghosted.bats
@@ -41,3 +41,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/core
 
 }
+#WEIGHT=2

--- a/test/functional/update/update-no-disk-space.bats
+++ b/test/functional/update/update-no-disk-space.bats
@@ -182,3 +182,4 @@ test_setup() {
 	assert_in_output "$expected_output2"
 
 }
+#WEIGHT=14

--- a/test/functional/update/update-non-responsive.bats
+++ b/test/functional/update/update-non-responsive.bats
@@ -145,3 +145,4 @@ test_teardown() {
 	assert_file_exists "$TARGETDIR"/test_file1
 
 }
+#WEIGHT=40

--- a/test/functional/update/update-older-server-version.bats
+++ b/test/functional/update/update-older-server-version.bats
@@ -58,3 +58,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=3

--- a/test/functional/update/update-re-update-bad-os-release.bats
+++ b/test/functional/update/update-re-update-bad-os-release.bats
@@ -46,3 +46,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/core
 
 }
+#WEIGHT=7

--- a/test/functional/update/update-re-update-required.bats
+++ b/test/functional/update/update-re-update-required.bats
@@ -58,3 +58,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/core
 
 }
+#WEIGHT=7

--- a/test/functional/update/update-rename-ghosted.bats
+++ b/test/functional/update/update-rename-ghosted.bats
@@ -50,3 +50,4 @@ test_setup() {
 
 }
 
+#WEIGHT=5

--- a/test/functional/update/update-rename.bats
+++ b/test/functional/update/update-rename.bats
@@ -45,3 +45,4 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/foo/testfile3
 
 }
+#WEIGHT=3

--- a/test/functional/update/update-search-file-index.bats
+++ b/test/functional/update/update-search-file-index.bats
@@ -72,3 +72,4 @@ test_setup() {
 	assert_file_not_exists "$STATEDIR"/10/Manifest.test-bundle1
 }
 
+#WEIGHT=5

--- a/test/functional/update/update-show-time.bats
+++ b/test/functional/update/update-show-time.bats
@@ -57,3 +57,4 @@ test_setup() {
 	assert_regex_in_output "$expected_output"
 
 }
+#WEIGHT=3

--- a/test/functional/update/update-skip-scripts.bats
+++ b/test/functional/update/update-skip-scripts.bats
@@ -42,3 +42,4 @@ test_setup() {
 	# The file should still be added
 	assert_file_exists "$TARGETDIR"/testfile
 }
+#WEIGHT=3

--- a/test/functional/update/update-skip-verified-fullfiles.bats
+++ b/test/functional/update/update-skip-verified-fullfiles.bats
@@ -49,3 +49,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/foo
 
 }
+#WEIGHT=3

--- a/test/functional/update/update-slow-server.bats
+++ b/test/functional/update/update-slow-server.bats
@@ -68,3 +68,4 @@ test_teardown() {
 	assert_file_exists "$TARGETDIR"/foo/bar
 
 }
+#WEIGHT=40

--- a/test/functional/update/update-statedir-bad-hash.bats
+++ b/test/functional/update/update-statedir-bad-hash.bats
@@ -46,3 +46,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/test-file
 
 }
+#WEIGHT=2

--- a/test/functional/update/update-status-no-server-content.bats
+++ b/test/functional/update/update-status-no-server-content.bats
@@ -21,3 +21,4 @@ test_setup() {
 	)
 	assert_in_output "$expected_output"
 }
+#WEIGHT=1

--- a/test/functional/update/update-status-no-target-content.bats
+++ b/test/functional/update/update-status-no-target-content.bats
@@ -23,3 +23,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=1

--- a/test/functional/update/update-status.bats
+++ b/test/functional/update/update-status.bats
@@ -75,3 +75,4 @@ global_teardown() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=1

--- a/test/functional/update/update-to-same-version.bats
+++ b/test/functional/update/update-to-same-version.bats
@@ -60,3 +60,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=3

--- a/test/functional/update/update-use-full-file.bats
+++ b/test/functional/update/update-use-full-file.bats
@@ -44,3 +44,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/core
 
 }
+#WEIGHT=2

--- a/test/functional/update/update-use-pack.bats
+++ b/test/functional/update/update-use-pack.bats
@@ -42,3 +42,4 @@ test_setup() {
 	assert_files_equal "$TARGETDIR"/core "$TEST_NAME"/web-dir/100/files/"$fhash"
 
 }
+#WEIGHT=2

--- a/test/functional/update/update-verify-fix-path-hash-mismatch.bats
+++ b/test/functional/update/update-verify-fix-path-hash-mismatch.bats
@@ -51,3 +51,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/usr/foo/test-file
 
 }
+#WEIGHT=3

--- a/test/functional/update/update-verify-fix-path-missing-dir.bats
+++ b/test/functional/update/update-verify-fix-path-missing-dir.bats
@@ -50,3 +50,4 @@ test_setup() {
 
 }
 
+#WEIGHT=3

--- a/test/functional/update/update-verify-fullfile-hash.bats
+++ b/test/functional/update/update-verify-fullfile-hash.bats
@@ -46,3 +46,4 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/core
 
 }
+#WEIGHT=2

--- a/test/functional/update/update-with-mirror.bats
+++ b/test/functional/update/update-with-mirror.bats
@@ -58,3 +58,4 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/file_3
 
 }
+#WEIGHT=3

--- a/test/functional/update/update-with-old-mirror.bats
+++ b/test/functional/update/update-with-old-mirror.bats
@@ -61,3 +61,4 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/file_3
 
 }
+#WEIGHT=3

--- a/test/functional/update/update-with-slightly-old-mirror.bats
+++ b/test/functional/update/update-with-slightly-old-mirror.bats
@@ -61,3 +61,4 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/file_3
 
 }
+#WEIGHT=3

--- a/test/functional/usability/usa-completion-basic.bats
+++ b/test/functional/usability/usa-completion-basic.bats
@@ -39,3 +39,4 @@ test_teardown() {
 	grep -q  'opts="--help --no-xattrs --path --debug --quiet "' "$SWUPD_DIR"/swupd.bash
 
 }
+#WEIGHT=1

--- a/test/functional/usability/usa-config-file.bats
+++ b/test/functional/usability/usa-config-file.bats
@@ -262,3 +262,4 @@ global_teardown() {
 	assert_in_output "$expected_output"
 
 }
+#WEIGHT=4

--- a/test/functional/usability/usa-download-retries.bats
+++ b/test/functional/usability/usa-download-retries.bats
@@ -98,3 +98,4 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+#WEIGHT=14

--- a/test/functional/usability/usa-external-modules.bats
+++ b/test/functional/usability/usa-external-modules.bats
@@ -64,3 +64,4 @@ test_teardown() {
 	assert_in_output "Fake search invoked successfully with these arguments: arg1 arg2 arg3"
 
 }
+#WEIGHT=1

--- a/test/functional/verify-legacy/verify-bundle.bats
+++ b/test/functional/verify-legacy/verify-bundle.bats
@@ -147,3 +147,4 @@ test_setup() {
 	assert_in_output "$expected_output"
 
 }
+#WEIGHT=9

--- a/test/functional/verify-legacy/verify-flags.bats
+++ b/test/functional/verify-legacy/verify-flags.bats
@@ -74,3 +74,4 @@ load "../testlib"
 	assert_in_output "Error: '--manifest latest' only supported with the --install option"
 
 }
+#WEIGHT=2


### PR DESCRIPTION
This patch adds 2 scripts used to balance test execution. The weight_tests.bash
runs all tests and sets a weight to them based on how long they take to run. The
other, filter_bats_list.bash, use this information to split the tests in groups to
be executed by github actions.
When a new test is added the script will consider it with an average weight, so this
shouldn't unbalance the system right away. After some time, if we notice that the
system is not balanced anymore we can just run the weight_tests.bash again to rebalance.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>