### PR TITLE
Rename variable used to identify if tests are running in a CI

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -2,7 +2,7 @@ name: C/C++ CI
 
 on: [push, pull_request]
 env:
-   TRAVIS: true
+   RUNNING_IN_CI: true
    NUM_JOBS: 10
 
 jobs:

--- a/test/functional/bundleadd/add-client-certificate.bats
+++ b/test/functional/bundleadd/add-client-certificate.bats
@@ -11,8 +11,8 @@ global_setup() {
 
 	# Skip this test for local development because it takes a long time. To run this test locally,
 	# configure swupd with --with-fallback-capaths=<path to top level of repo>/swupd_test_certificates
-	# and run: TRAVIS=true make check
-	if [ -z "${TRAVIS}" ]; then
+	# and run: RUNNING_IN_CI=true make check
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 
@@ -38,7 +38,7 @@ global_setup() {
 
 test_setup() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		skip "Skipping client certificate tests for local development, test runs in CI"
 	fi
 
@@ -49,7 +49,7 @@ test_setup() {
 
 test_teardown() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 
@@ -60,7 +60,7 @@ test_teardown() {
 
 global_teardown() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 

--- a/test/functional/bundlelist/list-client-certificate.bats
+++ b/test/functional/bundlelist/list-client-certificate.bats
@@ -11,8 +11,8 @@ global_setup() {
 
 	# Skip this test for local development because it takes a long time. To run this test locally,
 	# configure swupd with --with-fallback-capaths=<path to top level of repo>/swupd_test_certificates
-	# and run: TRAVIS=true make check
-	if [ -z "${TRAVIS}" ]; then
+	# and run: RUNNING_IN_CI=true make check
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 
@@ -37,7 +37,7 @@ global_setup() {
 
 test_setup() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		skip "Skipping client certificate tests for local development, test runs in CI"
 	fi
 
@@ -48,7 +48,7 @@ test_setup() {
 
 test_teardown() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 
@@ -58,7 +58,7 @@ test_teardown() {
 
 global_teardown() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 

--- a/test/functional/bundleremove/remove-client-certificate.bats
+++ b/test/functional/bundleremove/remove-client-certificate.bats
@@ -11,8 +11,8 @@ global_setup() {
 
 	# Skip this test for local development because it takes a long time. To run this test locally,
 	# configure swupd with --with-fallback-capaths=<path to top level of repo>/swupd_test_certificates
-	# and run: TRAVIS=true make check
-	if [ -z "${TRAVIS}" ]; then
+	# and run: RUNNING_IN_CI=true make check
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 
@@ -38,7 +38,7 @@ global_setup() {
 
 test_setup() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		skip "Skipping client certificate tests for local development, test runs in CI"
 	fi
 
@@ -51,7 +51,7 @@ test_setup() {
 
 test_teardown() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 
@@ -61,7 +61,7 @@ test_teardown() {
 
 global_teardown() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 

--- a/test/functional/checkupdate/chk-update-client-certificate.bats
+++ b/test/functional/checkupdate/chk-update-client-certificate.bats
@@ -11,8 +11,8 @@ global_setup() {
 
 	# Skip this test for local development because it takes a long time. To run this test locally,
 	# configure swupd with --with-fallback-capaths=<path to top level of repo>/swupd_test_certificates
-	# and run: TRAVIS=true make check
-	if [ -z "${TRAVIS}" ]; then
+	# and run: RUNNING_IN_CI=true make check
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 
@@ -40,7 +40,7 @@ global_setup() {
 
 test_setup() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		skip "Skipping client certificate tests for local development, test runs in CI"
 	fi
 
@@ -53,7 +53,7 @@ test_setup() {
 
 test_teardown() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 
@@ -63,7 +63,7 @@ test_teardown() {
 
 global_teardown() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 

--- a/test/functional/diagnose/diagnose-client-certificate.bats
+++ b/test/functional/diagnose/diagnose-client-certificate.bats
@@ -11,8 +11,8 @@ global_setup() {
 
 	# Skip this test for local development because it takes a long time. To run this test locally,
 	# configure swupd with --with-fallback-capaths=<path to top level of repo>/swupd_test_certificates
-	# and run: TRAVIS=true make check
-	if [ -z "${TRAVIS}" ]; then
+	# and run: RUNNING_IN_CI=true make check
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 
@@ -37,7 +37,7 @@ global_setup() {
 
 test_setup() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		skip "Skipping client certificate tests for local development, test runs in CI"
 	fi
 
@@ -48,7 +48,7 @@ test_setup() {
 
 test_teardown() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 
@@ -58,7 +58,7 @@ test_teardown() {
 
 global_teardown() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 

--- a/test/functional/search/search-client-certificate.bats
+++ b/test/functional/search/search-client-certificate.bats
@@ -11,8 +11,8 @@ global_setup() {
 
 	# Skip this test for local development because it takes a long time. To run this test locally,
 	# configure swupd with --with-fallback-capaths=<path to top level of repo>/swupd_test_certificates
-	# and run: TRAVIS=true make check
-	if [ -z "${TRAVIS}" ]; then
+	# and run: RUNNING_IN_CI=true make check
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 
@@ -38,7 +38,7 @@ global_setup() {
 
 test_setup() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		skip "Skipping client certificate tests for local development, test runs in CI"
 	fi
 
@@ -49,7 +49,7 @@ test_setup() {
 
 test_teardown() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 
@@ -59,7 +59,7 @@ test_teardown() {
 
 global_teardown() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 

--- a/test/functional/update/update-client-certificate.bats
+++ b/test/functional/update/update-client-certificate.bats
@@ -11,8 +11,8 @@ global_setup() {
 
 	# Skip this test for local development because it takes a long time. To run this test locally,
 	# configure swupd with --with-fallback-capaths=<path to top level of repo>/swupd_test_certificates
-	# and run: TRAVIS=true make check
-	if [ -z "${TRAVIS}" ]; then
+	# and run: RUNNING_IN_CI=true make check
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 
@@ -40,7 +40,7 @@ global_setup() {
 
 test_setup() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		skip "Skipping client certificate tests for local development, test runs in CI"
 	fi
 
@@ -53,7 +53,7 @@ test_setup() {
 
 test_teardown() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 
@@ -63,7 +63,7 @@ test_teardown() {
 
 global_teardown() {
 
-	if [ -z "${TRAVIS}" ]; then
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		return
 	fi
 

--- a/test/functional/update/update-non-responsive.bats
+++ b/test/functional/update/update-non-responsive.bats
@@ -10,10 +10,10 @@ test_setup() {
 	# Skip this test if not running in Travis CI, because test takes too long for
 	# local development.
 	# To run this locally along with all other tests do:
-	#    TRAVIS=true make check
+	#    RUNNING_IN_CI=true make check
 	# or to run only this test locally do:
-	#    TRAVIS=true bats update-non-responsive.bats
-	if [ -z "$TRAVIS" ]; then
+	#    RUNNING_IN_CI=true bats update-non-responsive.bats
+	if [ -z "$RUNNING_IN_CI" ]; then
 		skip "Skipping slow test for local development, test only runs in CI"
 	fi
 
@@ -35,7 +35,7 @@ test_setup() {
 test_teardown() {
 
 	# teardown only if in travis CI
-	if [ -n "$TRAVIS" ]; then
+	if [ -n "$RUNNING_IN_CI" ]; then
 		destroy_test_environment "$TEST_NAME"
 	fi
 

--- a/test/functional/update/update-slow-server.bats
+++ b/test/functional/update/update-slow-server.bats
@@ -5,8 +5,8 @@ load "../testlib"
 test_setup() {
 
 	# Skip this test if not running in Travis CI, because test takes too long for
-	# local development. To run this locally do: TRAVIS=true make check
-	if [ -z "${TRAVIS}" ]; then
+	# local development. To run this locally do: RUNNING_IN_CI=true make check
+	if [ -z "${RUNNING_IN_CI}" ]; then
 		skip "Skipping slow test for local development, test only runs in CI"
 	fi
 	create_test_environment "$TEST_NAME"
@@ -25,7 +25,7 @@ test_setup() {
 test_teardown() {
 
 	# teardown only if in travis CI
-	if [ -n "${TRAVIS}" ]; then
+	if [ -n "${RUNNING_IN_CI}" ]; then
 		destroy_test_environment "$TEST_NAME"
 	fi
 

--- a/test/functional/usability/usa-external-modules.bats
+++ b/test/functional/usability/usa-external-modules.bats
@@ -9,8 +9,8 @@ file_created=false
 
 test_setup() {
 
-	if [ -z "$TRAVIS" ]; then
-		skip "This test is intended to run only in Travis (use TRAVIS=true to run it anyway)..."
+	if [ -z "$RUNNING_IN_CI" ]; then
+		skip "This test is intended to run only in Travis (use RUNNING_IN_CI=true to run it anyway)..."
 	fi
 
 	if [ ! -e /usr/bin/swupd-search ]; then
@@ -31,7 +31,7 @@ test_setup() {
 
 test_teardown() {
 
-	if [ -z "$TRAVIS" ]; then
+	if [ -z "$RUNNING_IN_CI" ]; then
 		return
 	fi
 


### PR DESCRIPTION
Rename from TRAVIS to RUNNING_IN_CI

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>