### PR TITLE
Rename misleading function name free_string()

### DIFF
--- a/src/3rd_party_bundle_add.c
+++ b/src/3rd_party_bundle_add.c
@@ -116,8 +116,8 @@ static enum swupd_code validate_binary(struct file *file)
 		error("There is already a binary called %s in %s\n", sys_basename(filename), bin_directory);
 		ret_code = SWUPD_COULDNT_CREATE_FILE;
 	}
-	free_string(&script);
-	free_string(&bin_directory);
+	free_and_clear_pointer(&script);
+	free_and_clear_pointer(&bin_directory);
 
 	return ret_code;
 }
@@ -142,7 +142,7 @@ static enum swupd_code validate_permissions(struct file *file)
 		ret_code = SWUPD_INVALID_FILE;
 	}
 
-	free_string(&staged_file);
+	free_and_clear_pointer(&staged_file);
 
 	return ret_code;
 }

--- a/src/3rd_party_bundle_list.c
+++ b/src/3rd_party_bundle_list.c
@@ -36,12 +36,12 @@ static bool cmdline_option_status = false;
 
 static void free_has_dep(void)
 {
-	free_string(&cmdline_option_has_dep);
+	free_and_clear_pointer(&cmdline_option_has_dep);
 }
 
 static void free_deps(void)
 {
-	free_string(&cmdline_option_deps);
+	free_and_clear_pointer(&cmdline_option_deps);
 }
 
 static void print_help(void)

--- a/src/3rd_party_bundle_remove.c
+++ b/src/3rd_party_bundle_remove.c
@@ -127,7 +127,7 @@ static enum swupd_code remove_bundle_binaries(struct list *removed_files, struct
 		}
 	}
 
-	free_string(&script);
+	free_and_clear_pointer(&script);
 
 	return ret_code;
 }

--- a/src/3rd_party_diagnose.c
+++ b/src/3rd_party_diagnose.c
@@ -99,7 +99,7 @@ static bool parse_opt(int opt, char *optarg)
 			error("--picky-tree must be an absolute path, for example /usr\n\n");
 			return false;
 		}
-		free_string(&cmdline_option_picky_tree);
+		free_and_clear_pointer(&cmdline_option_picky_tree);
 		cmdline_option_picky_tree = strdup_or_die(optarg);
 		return true;
 	case 'w':
@@ -215,7 +215,7 @@ enum swupd_code third_party_diagnose_main(int argc, char **argv)
 	ret_code = swupd_init(SWUPD_ALL);
 	if (ret_code != SWUPD_OK) {
 		error("Failed swupd initialization, exiting now\n");
-		free_string(&cmdline_option_picky_tree);
+		free_and_clear_pointer(&cmdline_option_picky_tree);
 		return ret_code;
 	}
 
@@ -247,7 +247,7 @@ enum swupd_code third_party_diagnose_main(int argc, char **argv)
 	/* diagnose 3rd-party bundles */
 	ret_code = third_party_run_operation_multirepo(cmdline_option_repo, diagnose_repos, SWUPD_OK, "diagnose", steps_in_diagnose);
 
-	free_string(&cmdline_option_picky_tree);
+	free_and_clear_pointer(&cmdline_option_picky_tree);
 	if (picky_whitelist) {
 		regfree(picky_whitelist);
 		picky_whitelist = NULL;

--- a/src/3rd_party_remove.c
+++ b/src/3rd_party_remove.c
@@ -178,7 +178,7 @@ exit:
 		print("\nFailed to remove repository\n");
 	}
 	manifest_free(mom);
-	free_string(&repo_dir);
+	free_and_clear_pointer(&repo_dir);
 	list_free_list_and_data(repos, repo_free_data);
 	list_free_list_and_data(installed_bundles, free);
 	swupd_deinit();

--- a/src/3rd_party_repair.c
+++ b/src/3rd_party_repair.c
@@ -106,7 +106,7 @@ static bool parse_opt(int opt, char *optarg)
 			error("--picky-tree must be an absolute path, for example /usr\n\n");
 			return false;
 		}
-		free_string(&cmdline_option_picky_tree);
+		free_and_clear_pointer(&cmdline_option_picky_tree);
 		cmdline_option_picky_tree = strdup_or_die(optarg);
 		return true;
 	case 'w':
@@ -217,7 +217,7 @@ enum swupd_code third_party_repair_main(int argc, char **argv)
 	ret_code = swupd_init(SWUPD_ALL);
 	if (ret_code != SWUPD_OK) {
 		error("Failed swupd initialization, exiting now\n");
-		free_string(&cmdline_option_picky_tree);
+		free_and_clear_pointer(&cmdline_option_picky_tree);
 		return ret_code;
 	}
 
@@ -257,7 +257,7 @@ enum swupd_code third_party_repair_main(int argc, char **argv)
 	/* run repair (verify --fix) */
 	ret_code = third_party_run_operation_multirepo(cmdline_option_repo, repair_repos, SWUPD_OK, "repair", steps_in_repair);
 
-	free_string(&cmdline_option_picky_tree);
+	free_and_clear_pointer(&cmdline_option_picky_tree);
 	if (picky_whitelist) {
 		regfree(picky_whitelist);
 		picky_whitelist = NULL;

--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -100,7 +100,7 @@ struct list *third_party_get_repos(void)
 	}
 
 	repos = list_head(repos);
-	free_string(&repo_config_file_path);
+	free_and_clear_pointer(&repo_config_file_path);
 
 	return repos;
 }
@@ -217,7 +217,7 @@ exit:
 	if (fp) {
 		fclose(fp);
 	}
-	free_string(&repo_config_file_path);
+	free_and_clear_pointer(&repo_config_file_path);
 	return ret;
 }
 
@@ -296,26 +296,26 @@ enum swupd_code third_party_set_repo(struct repo *repo, bool sigcheck)
 		if (!signature_init(globals.cert_path, NULL)) {
 			signature_deinit();
 			error("Unable to validate the certificate %s\n\n", repo_cert_path);
-			free_string(&repo_cert_path);
+			free_and_clear_pointer(&repo_cert_path);
 			return SWUPD_SIGNATURE_VERIFICATION_FAILED;
 		}
 	}
-	free_string(&repo_cert_path);
+	free_and_clear_pointer(&repo_cert_path);
 
 	repo_path_prefix = get_repo_content_path(repo->name);
 	set_path_prefix(repo_path_prefix);
-	free_string(&repo_path_prefix);
+	free_and_clear_pointer(&repo_path_prefix);
 
 	/* make sure there are state directories for the 3rd-party
 	 * repo if not there already */
 	repo_state_dir = get_repo_state_dir(repo->name);
 	if (create_state_dirs(repo_state_dir)) {
-		free_string(&repo_state_dir);
+		free_and_clear_pointer(&repo_state_dir);
 		error("Unable to create the state directories for repository %s\n\n", repo->name);
 		return SWUPD_COULDNT_CREATE_DIR;
 	}
 	set_state_dir(repo_state_dir);
-	free_string(&repo_state_dir);
+	free_and_clear_pointer(&repo_state_dir);
 
 	return SWUPD_OK;
 }
@@ -523,7 +523,7 @@ enum swupd_code third_party_run_operation_multirepo(const char *repo, process_bu
 	/* free data */
 clean_and_exit:
 	list_free_list_and_data(repos, repo_free_data);
-	free_string(&steps_title);
+	free_and_clear_pointer(&steps_title);
 
 	return ret_code;
 }
@@ -534,7 +534,7 @@ void third_party_repo_header(const char *repo_name)
 
 	string_or_die(&header, " 3rd-Party Repo: %s", repo_name);
 	print_header(header);
-	free_string(&header);
+	free_and_clear_pointer(&header);
 }
 
 bool third_party_file_is_binary(struct file *file)
@@ -594,8 +594,8 @@ enum swupd_code third_party_remove_binary(struct file *file)
 		}
 	}
 
-	free_string(&script);
-	free_string(&binary);
+	free_and_clear_pointer(&script);
+	free_and_clear_pointer(&binary);
 
 	return ret_code;
 }
@@ -671,11 +671,11 @@ close_and_exit:
 	if (fp) {
 		fclose(fp);
 	}
-	free_string(&binary);
-	free_string(&script);
-	free_string(&bin_directory);
-	free_string(&third_party_bin_path);
-	free_string(&third_party_ld_path);
+	free_and_clear_pointer(&binary);
+	free_and_clear_pointer(&script);
+	free_and_clear_pointer(&bin_directory);
+	free_and_clear_pointer(&third_party_bin_path);
+	free_and_clear_pointer(&third_party_ld_path);
 
 	return ret_code;
 }

--- a/src/3rd_party_update.c
+++ b/src/3rd_party_update.c
@@ -161,9 +161,9 @@ static enum swupd_code update_binary_script(struct file *file)
 	}
 
 close_and_exit:
-	free_string(&binary);
-	free_string(&script);
-	free_string(&bin_directory);
+	free_and_clear_pointer(&binary);
+	free_and_clear_pointer(&script);
+	free_and_clear_pointer(&bin_directory);
 
 	return ret_code;
 }
@@ -209,8 +209,8 @@ static enum swupd_code validate_permissions(struct file *file)
 		ret_code = SWUPD_INVALID_FILE;
 	}
 
-	free_string(&staged_file);
-	free_string(&original_file);
+	free_and_clear_pointer(&staged_file);
+	free_and_clear_pointer(&original_file);
 
 	return ret_code;
 }

--- a/src/binary_loader.c
+++ b/src/binary_loader.c
@@ -81,8 +81,8 @@ enum swupd_code binary_loader_main(int argc, char **argv)
 
 end:
 	free(params);
-	free_string(&binary_name);
-	free_string(&full_binary_path);
+	free_and_clear_pointer(&binary_name);
+	free_and_clear_pointer(&full_binary_path);
 
 	return ret;
 }

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -46,7 +46,7 @@ bool is_installed_bundle(const char *bundle_name)
 
 	string_or_die(&filename, "%s/%s/%s", globals.path_prefix, BUNDLES_DIR, bundle_name);
 	ret = sys_file_exists(filename);
-	free_string(&filename);
+	free_and_clear_pointer(&filename);
 
 	return ret;
 }
@@ -58,7 +58,7 @@ bool is_tracked_bundle(const char *bundle_name)
 
 	string_or_die(&filename, "%s/bundles/%s", globals.state_dir, bundle_name);
 	ret = sys_file_exists(filename);
-	free_string(&filename);
+	free_and_clear_pointer(&filename);
 
 	return ret;
 }
@@ -232,8 +232,8 @@ out:
 	if (ret) {
 		debug("Issue creating tracking file in %s for %s\n", tracking_dir, bundle_name);
 	}
-	free_string(&tracking_dir);
-	free_string(&tracking_file);
+	free_and_clear_pointer(&tracking_dir);
+	free_and_clear_pointer(&tracking_file);
 }
 
 void track_bundle(const char *bundle_name)

--- a/src/bundle_add.c
+++ b/src/bundle_add.c
@@ -115,13 +115,13 @@ static int check_disk_space_availability(struct list *to_install_bundles)
 	bundle_size = get_manifest_list_contentsize(to_install_bundles);
 	filepath = sys_path_join(globals.path_prefix, "/usr/");
 	if (!sys_file_exists(filepath)) {
-		free_string(&filepath);
+		free_and_clear_pointer(&filepath);
 		return 0;
 	}
 
 	/* Calculate free space on filepath */
 	fs_free = get_available_space(filepath);
-	free_string(&filepath);
+	free_and_clear_pointer(&filepath);
 	timelist_timer_stop(globals.global_times); // closing: Check disk space availability
 
 	/* Add 10% to bundle_size as a 'fudge factor' */
@@ -269,7 +269,7 @@ static struct list *generate_bundles_to_install(struct list *bundles)
 		if (strcmp(bundle, alias_list_str) != 0) {
 			info("Alias %s will install bundle(s): %s\n", bundle, alias_list_str);
 		}
-		free_string(&alias_list_str);
+		free_and_clear_pointer(&alias_list_str);
 		bundles_list = list_concat(alias_bundles, bundles_list);
 	}
 
@@ -485,7 +485,7 @@ clean_and_exit:
 	list_free_list_and_data(installed_bundles, manifest_free_data);
 	list_free_list_and_data(bundles, free);
 	manifest_free(mom);
-	free_string(&bundles_list_str);
+	free_and_clear_pointer(&bundles_list_str);
 
 	return ret;
 }

--- a/src/bundle_info.c
+++ b/src/bundle_info.c
@@ -205,7 +205,7 @@ static void print_bundle_size(struct manifest *manifest, long size, bool bundle_
 	info("\nBundle size:\n");
 	prettify_size(manifest->contentsize, &pretty_size);
 	info(" - Size of bundle: %s\n", pretty_size);
-	free_string(&pretty_size);
+	free_and_clear_pointer(&pretty_size);
 
 	prettify_size(size, &pretty_size);
 	if (bundle_installed) {
@@ -213,7 +213,7 @@ static void print_bundle_size(struct manifest *manifest, long size, bool bundle_
 	} else {
 		info(" - Maximum amount of disk size the bundle will take if installed (includes dependencies): %s\n", pretty_size);
 	}
-	free_string(&pretty_size);
+	free_and_clear_pointer(&pretty_size);
 }
 
 static long get_bundle_size(struct manifest *mom, bool bundle_installed)
@@ -397,7 +397,7 @@ enum swupd_code bundle_info(char *bundle)
 	char *header = NULL;
 	string_or_die(&header, " Info for bundle: %s", bundle);
 	print_header(header);
-	free_string(&header);
+	free_and_clear_pointer(&header);
 
 	/* status info */
 	char *status = NULL;
@@ -407,7 +407,7 @@ enum swupd_code bundle_info(char *bundle)
 		string_or_die(&status, "Installed");
 	}
 	info("Status: %s%s\n", status ? status : "Not installed", file->is_experimental ? " (experimental)" : "");
-	free_string(&status);
+	free_and_clear_pointer(&status);
 
 	/* version info */
 	if (installed) {

--- a/src/bundle_list.c
+++ b/src/bundle_list.c
@@ -48,7 +48,7 @@ void bundle_list_set_option_has_dep(char *bundle)
 	if (!bundle) {
 		return;
 	}
-	free_string(&cmdline_option_has_dep);
+	free_and_clear_pointer(&cmdline_option_has_dep);
 	cmdline_option_has_dep = bundle;
 	cmdline_local = false;
 }
@@ -58,7 +58,7 @@ void bundle_list_set_option_deps(char *bundle)
 	if (!bundle) {
 		return;
 	}
-	free_string(&cmdline_option_deps);
+	free_and_clear_pointer(&cmdline_option_deps);
 	cmdline_option_deps = bundle;
 	cmdline_local = false;
 }
@@ -70,12 +70,12 @@ void bundle_list_set_option_status(bool opt)
 
 static void free_has_dep(void)
 {
-	free_string(&cmdline_option_has_dep);
+	free_and_clear_pointer(&cmdline_option_has_dep);
 }
 
 static void free_deps(void)
 {
-	free_string(&cmdline_option_deps);
+	free_and_clear_pointer(&cmdline_option_deps);
 }
 
 static void print_help(void)
@@ -195,7 +195,7 @@ static enum swupd_code list_local_bundles(int version)
 	bundles = get_dir_files_sorted(path);
 	if (!bundles && errno) {
 		error("couldn't open bundles directory");
-		free_string(&path);
+		free_and_clear_pointer(&path);
 		return SWUPD_COULDNT_LIST_DIR;
 	}
 
@@ -223,7 +223,7 @@ static enum swupd_code list_local_bundles(int version)
 
 	list_free_list_and_data(bundles, free);
 
-	free_string(&path);
+	free_and_clear_pointer(&path);
 	manifest_free(MoM);
 
 	return SWUPD_OK;
@@ -340,7 +340,7 @@ static enum swupd_code list_installable_bundles(int version)
 			name = get_printable_bundle_name(file->filename, file->is_experimental, cmdline_option_status && is_installed_bundle(file->filename), cmdline_option_status && is_tracked_bundle(file->filename));
 			info(" - ");
 			print("%s\n", name);
-			free_string(&name);
+			free_and_clear_pointer(&name);
 		} else {
 			print("%s\n", file->filename);
 		}
@@ -409,7 +409,7 @@ static enum swupd_code show_bundle_reqd_by(const char *bundle_name, bool server,
 	char *msg;
 	string_or_die(&msg, "\n%s bundles that have %s as a dependency:\n", server ? "All" : "Installed", bundle_name);
 	number_of_reqd = required_by(&reqd_by, bundle_name, current_manifest, 0, NULL, msg, INCLUDE_OPTIONAL_DEPS);
-	free_string(&msg);
+	free_and_clear_pointer(&msg);
 	if (reqd_by == NULL) {
 		info("\nNo bundles have %s as a dependency\n", bundle_name);
 		ret = SWUPD_OK;

--- a/src/bundle_remove.c
+++ b/src/bundle_remove.c
@@ -136,11 +136,11 @@ static void remove_tracked(const char *bundle)
 {
 	char *destdir = get_tracking_dir();
 	char *tracking_file = sys_path_join(destdir, bundle);
-	free_string(&destdir);
+	free_and_clear_pointer(&destdir);
 	/* we don't care about failures here since any weird state in the tracking
 	 * dir MUST be handled gracefully */
 	sys_rm(tracking_file);
-	free_string(&tracking_file);
+	free_and_clear_pointer(&tracking_file);
 }
 
 static int filter_file_to_delete(const void *a, const void *b)
@@ -199,7 +199,7 @@ static enum swupd_code validate_bundle(const char *bundle, struct manifest *mom,
 	/* check if bundle is required by another installed bundle */
 	string_or_die(&msg, "\nBundle \"%s\" is required by the following bundles:\n", bundle);
 	number_of_reqd = required_by(reqd_by, bundle, mom, 0, bundles, msg, DONT_INCLUDE_OPTIONAL_DEPS);
-	free_string(&msg);
+	free_and_clear_pointer(&msg);
 	if (number_of_reqd > 0) {
 		/* the bundle is required by other bundles */
 		return SWUPD_NO;
@@ -456,7 +456,7 @@ out:
 		  current_version,
 		  ret_code,
 		  total_curl_sz);
-	free_string(&bundles_list_str);
+	free_and_clear_pointer(&bundles_list_str);
 	print("\nFailed to remove bundle(s)\n");
 
 	return ret_code;

--- a/src/clean.c
+++ b/src/clean.c
@@ -128,7 +128,7 @@ static enum swupd_code remove_if(const char *path, bool dry_run, remove_predicat
 	char *file = NULL;
 
 	while (true) {
-		free_string(&file);
+		free_and_clear_pointer(&file);
 		ret = SWUPD_OK;
 
 		/* Reset errno to distinguish between a previous
@@ -274,7 +274,7 @@ static char *read_mom_contents(int version)
 	char *mom_path = NULL;
 	string_or_die(&mom_path, "%s/%d/Manifest.MoM", globals.state_dir, version);
 	FILE *f = fopen(mom_path, "r");
-	free_string(&mom_path);
+	free_and_clear_pointer(&mom_path);
 	if (!f) {
 		/* This is a best effort. */
 		return NULL;
@@ -379,7 +379,7 @@ static enum swupd_code clean_staged_manifests(const char *path, bool dry_run, bo
 			stats.bytes_removed += size;
 		}
 
-		free_string(&version_dir);
+		free_and_clear_pointer(&version_dir);
 		if (ret != 0) {
 			break;
 		}
@@ -430,7 +430,7 @@ enum swupd_code clean_main(int argc, char **argv)
 		print("%d files removed\n", stats.files_removed);
 		print("%s freed\n", bytes_removed_pretty);
 	}
-	free_string(&bytes_removed_pretty);
+	free_and_clear_pointer(&bytes_removed_pretty);
 
 	swupd_deinit();
 	progress_finish_steps(ret);
@@ -456,7 +456,7 @@ enum swupd_code clean_statedir(bool dry_run, bool all)
 
 	staged_dir = sys_path_join(globals.state_dir, "staged");
 	ret = remove_if(staged_dir, dry_run, is_fullfile);
-	free_string(&staged_dir);
+	free_and_clear_pointer(&staged_dir);
 	if (ret != SWUPD_OK) {
 		return ret;
 	}

--- a/src/config_loader.c
+++ b/src/config_loader.c
@@ -79,6 +79,6 @@ bool config_loader_set_opt(char *section, char *opt, char *value, void *data)
 	}
 
 exit:
-	free_string(&flag);
+	free_and_clear_pointer(&flag);
 	return ret;
 }

--- a/src/curl.c
+++ b/src/curl.c
@@ -99,7 +99,7 @@ static CURLcode swupd_curl_set_optional_client_cert(CURL *curl)
 	}
 
 exit:
-	free_string(&client_cert_path);
+	free_and_clear_pointer(&client_cert_path);
 	return curl_ret;
 }
 
@@ -244,7 +244,7 @@ static bool perform_curl_init(const char *url)
 				break;
 			}
 		}
-		free_string(&str);
+		free_and_clear_pointer(&str);
 	}
 
 exit:
@@ -283,7 +283,7 @@ void swupd_curl_cleanup(void)
 
 	curl_easy_cleanup(curl);
 	curl = NULL;
-	free_string(&capath);
+	free_and_clear_pointer(&capath);
 	curl_global_cleanup();
 }
 

--- a/src/curl_async.c
+++ b/src/curl_async.c
@@ -150,8 +150,8 @@ static void free_curl_file(struct swupd_curl_parallel_handle *h, struct multi_cu
 		h->free_cb(file->data);
 	}
 
-	free_string(&file->url);
-	free_string(&file->file.path);
+	free_and_clear_pointer(&file->url);
+	free_and_clear_pointer(&file->file.path);
 	if (curl != NULL) {
 		/* Must remove handle out of multi queue first!*/
 		curl_multi_remove_handle(h->mcurl, curl);

--- a/src/delta.c
+++ b/src/delta.c
@@ -168,7 +168,7 @@ void apply_deltas(struct manifest *current_manifest)
 			string_or_die(&filename, "%s/%s", globals.path_prefix, file->filename);
 
 			if (!compute_hash_from_file(filename, hash) || !hash_equal(file->hash, hash)) {
-				free_string(&filename);
+				free_and_clear_pointer(&filename);
 				bad_on_sys = true;
 				continue;
 			}
@@ -187,16 +187,16 @@ void apply_deltas(struct manifest *current_manifest)
 		}
 
 		apply_one_delta(found, to_staged, delta_file, to);
-		free_string(&found);
+		free_and_clear_pointer(&found);
 
 	next:
 		/* Always remove delta files. Once applied the full staged file will be
 		 * available, so no need to keep the delta around. */
 		sys_rm(delta_file);
-		free_string(&delta_file);
-		free_string(&to_staged);
+		free_and_clear_pointer(&delta_file);
+		free_and_clear_pointer(&to_staged);
 	}
 
 	closedir(dir);
-	free_string(&delta_dir);
+	free_and_clear_pointer(&delta_dir);
 }

--- a/src/extra_files.c
+++ b/src/extra_files.c
@@ -97,7 +97,7 @@ static bool handle(const char *filename, bool is_dir, bool fix)
 		print(" -> Extra file: %s%s\n", temp, is_dir ? "/" : "");
 		ret = false;
 	}
-	free_string(&temp);
+	free_and_clear_pointer(&temp);
 
 	return ret;
 }
@@ -180,7 +180,7 @@ enum swupd_code walk_tree(struct manifest *manifest, const char *start, bool fix
 	}
 tidy:
 	for (int i = 0; i < nF; i++) {
-		free_string(&F[i].filename);
+		free_and_clear_pointer(&F[i].filename);
 	}
 	free(F);
 	F = NULL;

--- a/src/filedesc.c
+++ b/src/filedesc.c
@@ -112,7 +112,7 @@ static void dump_file_descriptor_leaks_int(int n, void *a)
 			warn("Possible filedescriptor leak: fd_number=\"%d\",fd_details=\"%s\"\n", n, buffer);
 		}
 	}
-	free_string(&filename);
+	free_and_clear_pointer(&filename);
 }
 
 void dump_file_descriptor_leaks(void)

--- a/src/fullfile.c
+++ b/src/fullfile.c
@@ -45,8 +45,8 @@ static int download_mix_file(struct file *file)
 		warn("Failed to copy local mix file: %s\n", file->staging);
 	}
 
-	free_string(&url);
-	free_string(&filename);
+	free_and_clear_pointer(&url);
+	free_and_clear_pointer(&filename);
 
 	return ret;
 }
@@ -59,8 +59,8 @@ static int download_file(struct swupd_curl_parallel_handle *download_handle, str
 	string_or_die(&filename, "%s/download/.%s.tar", globals.state_dir, file->hash);
 	string_or_die(&url, "%s/%i/files/%s.tar", globals.content_url, file->last_change, file->hash);
 	ret = swupd_curl_parallel_download_enqueue(download_handle, url, filename, file->hash, file);
-	free_string(&url);
-	free_string(&filename);
+	free_and_clear_pointer(&url);
+	free_and_clear_pointer(&filename);
 
 	return ret;
 }
@@ -101,13 +101,13 @@ static double fullfile_query_total_download_size(struct list *files)
 			total_size += size;
 		} else {
 			debug("The header for file %s could not be downloaded\n", file->filename);
-			free_string(&url);
+			free_and_clear_pointer(&url);
 			return -SWUPD_COULDNT_DOWNLOAD_FILE;
 		}
 
 		count++;
 		debug("File: %s (%.2lf MB)\n", url, (double)size / 1000000);
-		free_string(&url);
+		free_and_clear_pointer(&url);
 	}
 
 	debug("Number of files to download: %d\n", count);
@@ -135,10 +135,10 @@ static int get_cached_fullfile(struct file *file)
 					ret = 0;
 				}
 			}
-			free_string(&targetfile_cache);
+			free_and_clear_pointer(&targetfile_cache);
 		}
 	}
-	free_string(&targetfile);
+	free_and_clear_pointer(&targetfile);
 
 	return ret;
 }

--- a/src/globals.c
+++ b/src/globals.c
@@ -83,7 +83,7 @@ static void set_json_format(bool on)
 void set_content_url(char *url)
 {
 	if (globals.content_url) {
-		free_string(&globals.content_url);
+		free_and_clear_pointer(&globals.content_url);
 	}
 
 	globals.content_url = strdup_or_die(url);
@@ -125,7 +125,7 @@ static bool set_default_content_url(void)
 
 found:
 	set_content_url(new_content_url);
-	free_string(&new_content_url);
+	free_and_clear_pointer(&new_content_url);
 	return true;
 }
 
@@ -133,7 +133,7 @@ found:
 void set_version_url(char *url)
 {
 	if (globals.version_url) {
-		free_string(&globals.version_url);
+		free_and_clear_pointer(&globals.version_url);
 	}
 
 	globals.version_url = strdup_or_die(url);
@@ -175,7 +175,7 @@ static bool set_default_version_url(void)
 
 found:
 	set_version_url(new_version_url);
-	free_string(&new_version_url);
+	free_and_clear_pointer(&new_version_url);
 	return true;
 }
 
@@ -217,7 +217,7 @@ bool set_state_dir(char *path)
 		return false;
 	}
 
-	free_string(&globals.state_dir);
+	free_and_clear_pointer(&globals.state_dir);
 	string_or_die(&globals.state_dir, "%s", path);
 
 	return true;
@@ -246,7 +246,7 @@ bool set_state_dir_cache(char *path)
 		return false;
 	}
 
-	free_string(&globals.state_dir_cache);
+	free_and_clear_pointer(&globals.state_dir_cache);
 	string_or_die(&globals.state_dir_cache, "%s", path);
 
 	return true;
@@ -273,7 +273,7 @@ static bool set_format_string(char *format)
 	}
 
 	if (globals.format_string) {
-		free_string(&globals.format_string);
+		free_and_clear_pointer(&globals.format_string);
 	}
 
 	globals.format_string = strdup_or_die(format);
@@ -307,7 +307,7 @@ static bool set_default_format_string()
 
 found:
 	result = set_format_string(new_format_string);
-	free_string(&new_format_string);
+	free_and_clear_pointer(&new_format_string);
 	return result;
 }
 
@@ -376,7 +376,7 @@ void set_default_path_prefix()
 void set_cert_path(char *path)
 {
 	if (globals.cert_path) {
-		free_string(&globals.cert_path);
+		free_and_clear_pointer(&globals.cert_path);
 	}
 
 	globals.cert_path = strdup_or_die(path);
@@ -396,8 +396,8 @@ bool set_default_urls()
 {
 	/* we need to also unset the mirror urls from the cache and set it to
 	 * the central version */
-	free_string(&globals.version_url);
-	free_string(&globals.content_url);
+	free_and_clear_pointer(&globals.version_url);
+	free_and_clear_pointer(&globals.content_url);
 	if (!set_default_version_url()) {
 		return false;
 	}
@@ -437,7 +437,7 @@ bool set_assume_option(char *option)
 		ret = false;
 	}
 
-	free_string(&option_lower);
+	free_and_clear_pointer(&option_lower);
 
 	return ret;
 }
@@ -497,22 +497,22 @@ bool globals_init(void)
 
 void globals_deinit(void)
 {
-	/* freeing all globals and set ALL them to NULL (via free_string)
+	/* freeing all globals and set ALL them to NULL (via free_and_clear_pointer)
 	 * to avoid memory corruption on multiple calls
 	 * to swupd_init() */
-	free_string(&globals.content_url);
-	free_string(&globals.version_url);
-	free_string(&globals.path_prefix);
-	free_string(&globals.format_string);
-	free_string(&globals.mounted_dirs);
-	free_string(&globals.state_dir);
-	free_string(&globals.state_dir_cache);
+	free_and_clear_pointer(&globals.content_url);
+	free_and_clear_pointer(&globals.version_url);
+	free_and_clear_pointer(&globals.path_prefix);
+	free_and_clear_pointer(&globals.format_string);
+	free_and_clear_pointer(&globals.mounted_dirs);
+	free_and_clear_pointer(&globals.state_dir);
+	free_and_clear_pointer(&globals.state_dir_cache);
 	timelist_free(globals.global_times);
 	globals.global_times = NULL;
-	free_string(&globals_bkp.path_prefix);
-	free_string(&globals_bkp.state_dir);
-	free_string(&globals_bkp.version_url);
-	free_string(&globals_bkp.content_url);
+	free_and_clear_pointer(&globals_bkp.path_prefix);
+	free_and_clear_pointer(&globals_bkp.state_dir);
+	free_and_clear_pointer(&globals_bkp.version_url);
+	free_and_clear_pointer(&globals_bkp.content_url);
 }
 
 void save_cmd(char **argv)
@@ -765,11 +765,11 @@ static bool load_flags_in_config(char *command, struct option *opts_array, const
 		if (config_file_parse(config_file, config_loader_set_opt, &loader_data)) {
 			config_found = true;
 		}
-		free_string(&config_file);
+		free_and_clear_pointer(&config_file);
 	}
 
-	free_string(&full_command);
-	free_string(&str);
+	free_and_clear_pointer(&full_command);
+	free_and_clear_pointer(&str);
 #endif
 	return config_found;
 }

--- a/src/hash.c
+++ b/src/hash.c
@@ -95,7 +95,7 @@ static void hmac_sha256_for_data(char *hash,
 	}
 
 	hash_assign(digest_str, hash);
-	free_string(&digest_str);
+	free_and_clear_pointer(&digest_str);
 }
 
 static void hmac_sha256_for_string(char *hash,
@@ -133,7 +133,7 @@ static void hmac_compute_key(const char *filename,
 	}
 
 	if (xattrs_blob_len != 0) {
-		free_string(&xattrs_blob);
+		free_and_clear_pointer(&xattrs_blob);
 	}
 }
 
@@ -295,7 +295,7 @@ int verify_bundle_hash(struct manifest *mom, struct file *bundle)
 	}
 
 out:
-	free_string(&cached);
-	free_string(&local);
+	free_and_clear_pointer(&cached);
+	free_and_clear_pointer(&local);
 	return ret;
 }

--- a/src/hashdump.c
+++ b/src/hashdump.c
@@ -136,7 +136,7 @@ enum swupd_code hashdump_main(int argc, char **argv)
 		}
 	}
 
-	free_string(&fullname);
-	free_string(&file.filename);
+	free_and_clear_pointer(&fullname);
+	free_and_clear_pointer(&file.filename);
 	return SWUPD_OK;
 }

--- a/src/lib/archives.c
+++ b/src/lib/archives.c
@@ -175,7 +175,7 @@ int archives_extract_to(const char *tarfile, const char *outputdir)
 		char *fullpath;
 		string_or_die(&fullpath, "%s/%s", outputdir, archive_entry_pathname(entry));
 		archive_entry_set_pathname(entry, fullpath);
-		free_string(&fullpath);
+		free(fullpath);
 
 		/* A hardlink must point to a real file, so set its output directory too. */
 		const char *original_hardlink = archive_entry_hardlink(entry);
@@ -183,7 +183,7 @@ int archives_extract_to(const char *tarfile, const char *outputdir)
 			char *new_hardlink;
 			string_or_die(&new_hardlink, "%s/%s", outputdir, original_hardlink);
 			archive_entry_set_hardlink(entry, new_hardlink);
-			free_string(&new_hardlink);
+			free(new_hardlink);
 		}
 
 		/* write archive header, if successful continue to copy data */

--- a/src/lib/config_file.c
+++ b/src/lib/config_file.c
@@ -71,7 +71,7 @@ bool config_file_parse(const char *filename, parse_config_fn_t parse_config_fn, 
 		/* check the line to see if the line is a section */
 		if (line[0] == '[' && *(line_ptr - 1) == ']') {
 			*(line_ptr - 1) = '\0';
-			free_string(&section);
+			free(section);
 			/* keys and sections in INI files are case insensitive,
 			 * so we should convert them to a lower case first */
 			section = str_tolower(line + 1);
@@ -107,11 +107,11 @@ bool config_file_parse(const char *filename, parse_config_fn_t parse_config_fn, 
 		if (parse_config_fn && !parse_config_fn(section, lkey, value, data)) {
 			warn("Unrecognized option '%s=%s' from section [%s] in the configuration file\n", key, value, section);
 		}
-		free_string(&lkey);
+		free(lkey);
 	}
 
 close_and_exit:
-	free_string(&section);
+	free(section);
 	fclose(config_file);
 	return ret;
 }

--- a/src/lib/formatter_json.c
+++ b/src/lib/formatter_json.c
@@ -74,10 +74,8 @@ static void json_message(const char *msg_type, const char *msg, va_list args_lis
 		fflush(stdout);
 	}
 
-	free_string(&full_msg);
-	if (type) {
-		free_string(&type);
-	}
+	free(full_msg);
+	free(type);
 }
 
 void json_start(const char *op)

--- a/src/lib/strings.c
+++ b/src/lib/strings.c
@@ -66,14 +66,6 @@ char *str_or_die(const char *fmt, ...)
 	return str;
 }
 
-void free_string(char **s)
-{
-	if (s) {
-		free(*s);
-		*s = NULL;
-	}
-}
-
 char *string_join(const char *separator, struct list *strings)
 {
 	char *str, *ret;
@@ -189,7 +181,7 @@ bool strtobool(const char *str)
 	}
 
 	/* return false for everything else */
-	free_string(&str_lower);
+	free(str_lower);
 	return ret;
 }
 

--- a/src/lib/strings.h
+++ b/src/lib/strings.h
@@ -33,11 +33,6 @@ char *str_or_die(const char *fmt, ...);
 char *strdup_or_die(const char *const str);
 
 /**
- * Free string and set it's value to NULL.
- */
-void free_string(char **s);
-
-/**
  * Join strings from string list separated by the separator.
  */
 char *string_join(const char *separator, struct list *string);

--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -454,8 +454,8 @@ static int sys_rm_dir_recursive(const char *path)
 			continue;
 		}
 
-		free_string(&filename);
-		string_or_die(&filename, "%s/%s", path, entry->d_name);
+		free(filename);
+		filename = str_or_die("%s/%s", path, entry->d_name);
 
 		ret = sys_rm_recursive(filename);
 		if (ret) {
@@ -468,7 +468,7 @@ static int sys_rm_dir_recursive(const char *path)
 
 exit:
 	closedir(dir);
-	free_string(&filename);
+	free(filename);
 	return ret;
 }
 

--- a/src/lib/timelist.c
+++ b/src/lib/timelist.c
@@ -177,7 +177,7 @@ void timelist_free(timelist *head)
 
 	while (!TAILQ_EMPTY(head)) {
 		t = TAILQ_LAST(head, timelist);
-		free_string(&t->name);
+		free(t->name);
 		TAILQ_REMOVE(head, t, times);
 		free(t);
 	}

--- a/src/lock.c
+++ b/src/lock.c
@@ -68,11 +68,11 @@ int p_lockfile(void)
 
 	if (lock_fd < 0) {
 		error("failed to open %s: %s\n", lockfile, strerror(errno));
-		free_string(&lockfile);
+		free_and_clear_pointer(&lockfile);
 		return -1;
 	}
 
-	free_string(&lockfile);
+	free_and_clear_pointer(&lockfile);
 
 	/* try to get an advisory region lock for the file */
 	ret = fcntl(lock_fd, F_SETLK, &fl);

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -118,7 +118,7 @@ static int try_manifest_delta_download(int from, int to, char *component)
 	if (!sys_file_exists(manifest_delta)) {
 		string_or_die(&url, "%s/%i/Manifest-%s-delta-from-%i", globals.content_url, to, component, from);
 		ret = swupd_curl_get_file(url, manifest_delta);
-		free_string(&url);
+		free_and_clear_pointer(&url);
 		if (ret != 0) {
 			unlink(manifest_delta);
 			goto out;
@@ -141,10 +141,10 @@ static int try_manifest_delta_download(int from, int to, char *component)
 	}
 
 out:
-	free_string(&to_manifest);
-	free_string(&to_dir);
-	free_string(&from_manifest);
-	free_string(&manifest_delta);
+	free_and_clear_pointer(&to_manifest);
+	free_and_clear_pointer(&to_dir);
+	free_and_clear_pointer(&from_manifest);
+	free_and_clear_pointer(&manifest_delta);
 	return ret;
 }
 
@@ -190,7 +190,7 @@ static int retrieve_manifest(int previous_version, int version, char *component,
 		ret = 0;
 		goto out;
 	}
-	free_string(&filename);
+	free_and_clear_pointer(&filename);
 
 	/* If it's mix content just hardlink instead of curl download */
 	if (is_mix) {
@@ -201,8 +201,8 @@ static int retrieve_manifest(int previous_version, int version, char *component,
 		if (ret == 0) {
 			goto untar;
 		}
-		free_string(&filename);
-		free_string(&url);
+		free_and_clear_pointer(&filename);
+		free_and_clear_pointer(&url);
 	}
 
 	/* Either we're not on mix or it failed, try curl-ing the file if link didn't work */
@@ -226,10 +226,10 @@ untar:
 	}
 
 out:
-	free_string(&dir);
-	free_string(&filename);
-	free_string(&filename_cache);
-	free_string(&url);
+	free_and_clear_pointer(&dir);
+	free_and_clear_pointer(&filename);
+	free_and_clear_pointer(&filename_cache);
+	free_and_clear_pointer(&url);
 	return ret;
 }
 
@@ -268,17 +268,17 @@ static void remove_manifest_files(char *filename, int version, char *hash)
 
 		string_or_die(&file, "%s/%i/Manifest.%s", state_dirs[i], version, filename);
 		unlink(file);
-		free_string(&file);
+		free_and_clear_pointer(&file);
 		string_or_die(&file, "%s/%i/Manifest.%s.tar", state_dirs[i], version, filename);
 		unlink(file);
-		free_string(&file);
+		free_and_clear_pointer(&file);
 		string_or_die(&file, "%s/%i/Manifest.%s.sig", state_dirs[i], version, filename);
 		unlink(file);
-		free_string(&file);
+		free_and_clear_pointer(&file);
 		if (hash != NULL) {
 			string_or_die(&file, "%s/%i/Manifest.%s.%s", state_dirs[i], version, filename, hash);
 			unlink(file);
-			free_string(&file);
+			free_and_clear_pointer(&file);
 		}
 	}
 }
@@ -335,10 +335,10 @@ static bool mom_signature_verify(const char *data_url, const char *data_filename
 		result = false;
 	}
 out:
-	free_string(&local);
-	free_string(&sig_filename);
-	free_string(&sig_url);
-	free_string(&sig_filename_cache);
+	free_and_clear_pointer(&local);
+	free_and_clear_pointer(&sig_filename);
+	free_and_clear_pointer(&sig_url);
+	free_and_clear_pointer(&sig_filename_cache);
 	return result;
 }
 /* Loads the MoM (Manifest of Manifests) for VERSION.
@@ -400,16 +400,16 @@ retry_load:
 		if (needs_sig_verification && !mom_signature_verify(url, filename, version, mix_exists)) {
 			/* cleanup and try one more time, statedir could have got corrupt/stale */
 			if (retried == false && !mix_exists) {
-				free_string(&filename);
-				free_string(&url);
+				free_and_clear_pointer(&filename);
+				free_and_clear_pointer(&url);
 				manifest_free(manifest);
 				remove_manifest_files("MoM", version, NULL);
 				retried = true;
 				goto retry_load;
 			}
 			error("Signature verification failed for manifest version %d\n", version);
-			free_string(&filename);
-			free_string(&url);
+			free_and_clear_pointer(&filename);
+			free_and_clear_pointer(&url);
 			manifest_free(manifest);
 			if (err) {
 				*err = SWUPD_SIGNATURE_VERIFICATION_FAILED;
@@ -418,8 +418,8 @@ retry_load:
 		}
 	}
 
-	free_string(&filename);
-	free_string(&url);
+	free_and_clear_pointer(&filename);
+	free_and_clear_pointer(&url);
 	return manifest;
 }
 
@@ -942,7 +942,7 @@ void remove_files_in_manifest_from_fs(struct manifest *m)
 			 * this is a limitation */
 			count--;
 		}
-		free_string(&fullfile);
+		free_and_clear_pointer(&fullfile);
 	}
 	info("Total deleted files: %i\n", count);
 }

--- a/src/manifest_parser.c
+++ b/src/manifest_parser.c
@@ -301,6 +301,6 @@ void manifest_free(struct manifest *manifest)
 	if (manifest->optional) {
 		list_free_list_and_data(manifest->optional, free);
 	}
-	free_string(&manifest->component);
+	free_and_clear_pointer(&manifest->component);
 	free(manifest);
 }

--- a/src/mirror.c
+++ b/src/mirror.c
@@ -122,8 +122,8 @@ static int unset_mirror_url()
 	ret1 = sys_rm(content_path);
 	ret2 = sys_rm(version_path);
 
-	free_string(&content_path);
-	free_string(&version_path);
+	free_and_clear_pointer(&content_path);
+	free_and_clear_pointer(&version_path);
 
 	// No errors
 	if ((ret1 == -ENOENT && !ret2) ||
@@ -184,7 +184,7 @@ static enum swupd_code write_to_path(const char *content, const char *path)
 	}
 
 out:
-	free_string(&dir);
+	free_and_clear_pointer(&dir);
 	return ret;
 }
 
@@ -254,8 +254,8 @@ static bool mirror_is_set(void)
 	content_path = sys_path_join(globals.path_prefix, MIRROR_CONTENT_URL_PATH);
 	mirror_set = sys_filelink_exists(version_path) && sys_filelink_exists(content_path);
 
-	free_string(&version_path);
-	free_string(&content_path);
+	free_and_clear_pointer(&version_path);
+	free_and_clear_pointer(&content_path);
 
 	return mirror_set;
 }
@@ -338,8 +338,8 @@ int handle_mirror_if_stale(void)
 	get_latest_version("");
 
 out:
-	free_string(&fullpath);
-	free_string(&ret_str);
+	free_and_clear_pointer(&fullpath);
+	free_and_clear_pointer(&ret_str);
 	return ret;
 }
 

--- a/src/os_install.c
+++ b/src/os_install.c
@@ -171,10 +171,10 @@ enum swupd_code install_main(int argc, char **argv)
 	char *new_os_state = sys_path_join(globals.path_prefix, "/var/lib/swupd");
 	if (create_state_dirs(new_os_state)) {
 		ret = SWUPD_COULDNT_CREATE_DIR;
-		free_string(&new_os_state);
+		free_and_clear_pointer(&new_os_state);
 		return ret;
 	}
-	free_string(&new_os_state);
+	free_and_clear_pointer(&new_os_state);
 
 	/* set options needed for the install in the verify command */
 	verify_set_option_quick(true);

--- a/src/packs.c
+++ b/src/packs.c
@@ -81,8 +81,8 @@ static void download_free_data(void *data)
 		return;
 	}
 
-	free_string(&pack_data->url);
-	free_string(&pack_data->filename);
+	free_and_clear_pointer(&pack_data->url);
+	free_and_clear_pointer(&pack_data->filename);
 	free(pack_data);
 }
 
@@ -125,15 +125,15 @@ static int download_pack(struct swupd_curl_parallel_handle *download_handle, int
 		string_or_die(&url, "%s/%i/pack-%s-from-%i.tar", MIX_STATE_DIR, newversion, module, oldversion);
 		err = link(url, filename);
 		if (err) {
-			free_string(&filename);
-			free_string(&url);
+			free_and_clear_pointer(&filename);
+			free_and_clear_pointer(&url);
 			return err;
 		}
 		info("Linked %s to %s\n", url, filename);
 
 		err = finalize_pack_download(module, newversion, filename);
-		free_string(&url);
-		free_string(&filename);
+		free_and_clear_pointer(&url);
+		free_and_clear_pointer(&filename);
 	} else {
 		struct pack_data *pack_data;
 
@@ -182,13 +182,13 @@ static double packs_query_total_download_size(struct list *subs, struct manifest
 			total_size += size;
 		} else {
 			debug("The pack header for bundle %s could not be downloaded\n", sub->component);
-			free_string(&url);
+			free_and_clear_pointer(&url);
 			return -SWUPD_COULDNT_DOWNLOAD_FILE;
 		}
 
 		count++;
 		debug("Pack: %s (%.2lf MB)\n", url, (double)size / 1000000);
-		free_string(&url);
+		free_and_clear_pointer(&url);
 	}
 
 	debug("Number of packs to download: %d\n", count);
@@ -216,10 +216,10 @@ static int get_cached_packs(struct sub *sub)
 					ret = 0;
 				}
 			}
-			free_string(&targetfile_cache);
+			free_and_clear_pointer(&targetfile_cache);
 		}
 	}
-	free_string(&targetfile);
+	free_and_clear_pointer(&targetfile);
 
 	return ret;
 }
@@ -296,7 +296,7 @@ int download_subscribed_packs(struct list *subs, struct manifest *mom, bool requ
 	/* show the packs size only if > 1 MB */
 	string_or_die(&packs_size, "(%.2lf MB) ", (double)download_progress.total_download_size / 1000000);
 	info("Downloading packs %sfor:\n", ((double)download_progress.total_download_size / 1000000) > 1 ? packs_size : "");
-	free_string(&packs_size);
+	free_and_clear_pointer(&packs_size);
 	for (iter = list_head(need_download); iter; iter = iter->next) {
 		sub = iter->data;
 

--- a/src/repair.c
+++ b/src/repair.c
@@ -105,7 +105,7 @@ static bool parse_opt(int opt, char *optarg)
 			error("--picky-tree must be an absolute path, for example /usr\n\n");
 			return false;
 		}
-		free_string(&cmdline_option_picky_tree);
+		free_and_clear_pointer(&cmdline_option_picky_tree);
 		cmdline_option_picky_tree = strdup_or_die(optarg);
 		return true;
 	case 'w':
@@ -212,7 +212,7 @@ regex_t *compile_whitelist(const char *whitelist_pattern)
 	}
 
 done:
-	free_string(&full_regex);
+	free_and_clear_pointer(&full_regex);
 	return picky_whitelist;
 }
 
@@ -282,9 +282,9 @@ enum swupd_code repair_main(int argc, char **argv)
 	ret = execute_verify();
 
 	if (cmdline_option_picky_tree != cmdline_option_file) {
-		free_string(&cmdline_option_file);
+		free_and_clear_pointer(&cmdline_option_file);
 	}
-	free_string(&cmdline_option_picky_tree);
+	free_and_clear_pointer(&cmdline_option_picky_tree);
 	if (picky_whitelist) {
 		regfree(picky_whitelist);
 		picky_whitelist = NULL;

--- a/src/scripts.c
+++ b/src/scripts.c
@@ -60,7 +60,7 @@ static void update_boot(void)
 	} else {
 		string_or_die(&scriptname, "%s/usr/bin/clr-boot-manager", globals.path_prefix);
 		run_script_if_exists(scriptname, "update", "--path", globals.path_prefix, NULL);
-		free_string(&scriptname);
+		free_and_clear_pointer(&scriptname);
 	}
 }
 
@@ -198,5 +198,5 @@ void scripts_run_pre_update(struct manifest *manifest)
 	}
 
 end:
-	free_string(&script);
+	free_and_clear_pointer(&script);
 }

--- a/src/search_file.c
+++ b/src/search_file.c
@@ -218,7 +218,7 @@ static void print_bundle(struct manifest *mom, struct manifest *m)
 
 	name = get_printable_bundle_name(m->component, is_experimental, DONT_SHOW_STATUS, DONT_SHOW_STATUS);
 	print("\nBundle %s %s", name, installed ? "[installed] " : "");
-	free_string(&name);
+	free_and_clear_pointer(&name);
 
 	print("(%li MB%s)", get_bundle_size(m->component) / 1000 / 1000,
 	      installed ? " on system" : " to install");

--- a/src/signature.c
+++ b/src/signature.c
@@ -41,8 +41,8 @@
 #include "config.h"
 #include "lib/log.h"
 #include "lib/macros.h"
-#include "lib/strings.h"
 #include "signature.h"
+#include "swupd.h"
 
 #ifdef SIGNATURES
 
@@ -202,7 +202,7 @@ error:
 		}
 	}
 
-	free_string(&errorstr);
+	free_and_clear_pointer(&errorstr);
 
 	if (sig_BIO) {
 		BIO_free(sig_BIO);
@@ -283,7 +283,7 @@ error:
 		warn("Signature check failed\n");
 	}
 
-	free_string(&errorstr);
+	free_and_clear_pointer(&errorstr);
 
 	if (sig) {
 		munmap(sig, sig_len);

--- a/src/staging.c
+++ b/src/staging.c
@@ -150,7 +150,7 @@ enum swupd_code do_staging(struct file *file, struct manifest *MoM)
 			}
 		}
 	}
-	free_string(&statfile);
+	free_and_clear_pointer(&statfile);
 
 	/* copy the file/directory to its final destination, if it is a file
 	 * keep its name with a .update prefix for now like this .update.(file_name)
@@ -187,7 +187,7 @@ enum swupd_code do_staging(struct file *file, struct manifest *MoM)
 		if (WIFEXITED(ret)) {
 			ret = WEXITSTATUS(ret);
 		}
-		free_string(&tarcommand);
+		free_and_clear_pointer(&tarcommand);
 		if (rename(rename_target, original)) {
 			ret = SWUPD_COULDNT_RENAME_DIR;
 			goto out;
@@ -232,7 +232,7 @@ enum swupd_code do_staging(struct file *file, struct manifest *MoM)
 			if (WIFEXITED(ret)) {
 				ret = WEXITSTATUS(ret);
 			}
-			free_string(&tarcommand);
+			free_and_clear_pointer(&tarcommand);
 			ret = rename(rename_target, original);
 			if (ret) {
 				ret = SWUPD_COULDNT_RENAME_FILE;
@@ -240,24 +240,24 @@ enum swupd_code do_staging(struct file *file, struct manifest *MoM)
 			}
 		}
 
-		free_string(&file->staging);
+		free_and_clear_pointer(&file->staging);
 		string_or_die(&file->staging, "%s%s/.update.%s", globals.path_prefix, rel_dir, base);
 		err = lstat(file->staging, &buf);
 		if (err != 0) {
-			free_string(&file->staging);
+			free_and_clear_pointer(&file->staging);
 			ret = SWUPD_COULDNT_CREATE_FILE;
 			goto out;
 		}
 	}
 
 out:
-	free_string(&target);
-	free_string(&targetpath);
-	free_string(&original);
-	free_string(&rename_target);
-	free_string(&rename_tmpdir);
-	free_string(&tmp);
-	free_string(&tmp2);
+	free_and_clear_pointer(&target);
+	free_and_clear_pointer(&targetpath);
+	free_and_clear_pointer(&original);
+	free_and_clear_pointer(&rename_target);
+	free_and_clear_pointer(&rename_tmpdir);
+	free_and_clear_pointer(&tmp);
+	free_and_clear_pointer(&tmp2);
 
 	return ret;
 }
@@ -271,7 +271,7 @@ int rename_staged_file_to_final(struct file *file)
 	string_or_die(&target, "%s%s", globals.path_prefix, file->filename);
 
 	if (!file->staging && !file->is_deleted && !file->is_dir) {
-		free_string(&target);
+		free_and_clear_pointer(&target);
 		return -1;
 	}
 
@@ -304,11 +304,11 @@ int rename_staged_file_to_final(struct file *file)
 			string_or_die(&lostnfound, "%slost+found", globals.path_prefix);
 			ret = mkdir(lostnfound, S_IRWXU);
 			if ((ret != 0) && (errno != EEXIST)) {
-				free_string(&lostnfound);
-				free_string(&target);
+				free_and_clear_pointer(&lostnfound);
+				free_and_clear_pointer(&target);
 				return ret;
 			}
-			free_string(&lostnfound);
+			free_and_clear_pointer(&lostnfound);
 
 			base = basename(file->filename);
 			string_or_die(&lostnfound, "%slost+found/%s", globals.path_prefix, base);
@@ -318,7 +318,7 @@ int rename_staged_file_to_final(struct file *file)
 				error("failed to move %s to lost+found: %s\n",
 				      base, strerror(errno));
 			}
-			free_string(&lostnfound);
+			free_and_clear_pointer(&lostnfound);
 		} else {
 			ret = rename(file->staging, target);
 			if (ret < 0) {
@@ -329,7 +329,7 @@ int rename_staged_file_to_final(struct file *file)
 		}
 	}
 
-	free_string(&target);
+	free_and_clear_pointer(&target);
 	return ret;
 }
 

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -38,7 +38,7 @@ static void free_subscription_data(void *data)
 {
 	struct sub *sub = (struct sub *)data;
 
-	free_string(&sub->component);
+	free_and_clear_pointer(&sub->component);
 	free(sub);
 }
 
@@ -88,7 +88,7 @@ void read_subscriptions(struct list **subs)
 		closedir(dir);
 	}
 
-	free_string(&path);
+	free_and_clear_pointer(&path);
 
 	/* Always add os-core */
 	if (!have_os_core) {

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -415,6 +415,11 @@ extern enum swupd_code clean_statedir(bool all, bool dry_run);
 /* Parameter parsing in global.c */
 extern struct global_const global;
 
+/**
+ * Free string and set it's value to NULL.
+ */
+extern void free_and_clear_pointer(char **s);
+
 enum swupd_code check_update();
 
 /* some disk sizes constants for the various features:

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -45,7 +45,7 @@ void telemetry(telem_prio_t level, const char *class, const char *fmt, ...)
 
 	fd = mkostemp(filename, O_CREAT | O_RDONLY);
 	if (fd < 0) {
-		free_string(&filename);
+		free_and_clear_pointer(&filename);
 		goto error;
 	}
 
@@ -60,15 +60,15 @@ void telemetry(telem_prio_t level, const char *class, const char *fmt, ...)
 
 	filename_n = sys_basename(filename);
 	if (!filename_n || !filename_n[0]) {
-		free_string(&filename);
+		free_and_clear_pointer(&filename);
 		goto error;
 	}
 
 	string_or_die(&newname, "%s/telemetry/%s", globals.state_dir, filename_n);
 
 	ret = rename(filename, newname);
-	free_string(&filename);
-	free_string(&newname);
+	free_and_clear_pointer(&filename);
+	free_and_clear_pointer(&newname);
 	if (ret < 0) {
 		goto error;
 	}

--- a/src/update.c
+++ b/src/update.c
@@ -216,9 +216,9 @@ static void save_manifest(int version)
 	mkdir_p(momdir);
 
 	copy(original, momfile);
-	free_string(&momdir);
-	free_string(&momfile);
-	free_string(&original);
+	free_and_clear_pointer(&momdir);
+	free_and_clear_pointer(&momfile);
+	free_and_clear_pointer(&original);
 }
 
 /* Checks to see if the given file is installed under the path_prefix. */
@@ -233,10 +233,10 @@ static bool is_installed_and_verified(struct file *file)
 	char *fullname = sys_path_join(globals.path_prefix, file->filename);
 
 	if (verify_file(file, fullname)) {
-		free_string(&fullname);
+		free_and_clear_pointer(&fullname);
 		return true;
 	}
-	free_string(&fullname);
+	free_and_clear_pointer(&fullname);
 	return false;
 }
 

--- a/src/verify.c
+++ b/src/verify.c
@@ -126,7 +126,7 @@ void verify_set_option_version(int ver)
 
 void verify_set_option_statedir_cache(char *path)
 {
-	free_string(&cmdline_option_statedir_cache);
+	free_and_clear_pointer(&cmdline_option_statedir_cache);
 	cmdline_option_statedir_cache = path;
 }
 
@@ -147,7 +147,7 @@ void verify_set_picky_whitelist(regex_t *whitelist)
 
 void verify_set_picky_tree(char *picky_tree)
 {
-	free_string(&cmdline_option_picky_tree);
+	free_and_clear_pointer(&cmdline_option_picky_tree);
 	cmdline_option_picky_tree = picky_tree;
 }
 
@@ -158,7 +158,7 @@ void verify_set_extra_files_only(bool opt)
 
 void verify_set_option_file(char *path)
 {
-	free_string(&cmdline_option_file);
+	free_and_clear_pointer(&cmdline_option_file);
 	cmdline_option_file = path;
 }
 
@@ -259,7 +259,7 @@ static int check_files_hash(struct list *files)
 
 		fullname = sys_path_join(globals.path_prefix, f->filename);
 		valid = cmdline_option_quick ? verify_file_lazy(fullname) : verify_file(f, fullname);
-		free_string(&fullname);
+		free_and_clear_pointer(&fullname);
 		if (valid) {
 			f->do_not_update = 1;
 		} else {
@@ -340,7 +340,7 @@ static void check_warn_freespace(const struct file *file)
 
 out:
 	info("\tContinuing operation...\n");
-	free_string(&original);
+	free_and_clear_pointer(&original);
 }
 
 /* for each missing but expected file, (re)add the file */
@@ -419,7 +419,7 @@ static void add_missing_files(struct manifest *official_manifest, struct list *f
 			}
 		}
 	out:
-		free_string(&fullname);
+		free_and_clear_pointer(&fullname);
 	progress:
 		progress_report(complete, list_length);
 	}
@@ -468,7 +468,7 @@ static void check_and_fix_one(struct file *file, struct manifest *official_manif
 		print(" -> not fixed\n");
 	}
 end:
-	free_string(&fullname);
+	free_and_clear_pointer(&fullname);
 }
 
 static void deal_with_hash_mismatches(struct manifest *official_manifest, struct list *files_to_verify, bool repair)
@@ -586,7 +586,7 @@ static void remove_orphaned_files(struct list *files_to_verify, bool repair)
 		}
 		close(fd);
 	out:
-		free_string(&fullname);
+		free_and_clear_pointer(&fullname);
 	progress:
 		progress_report(complete, list_length);
 	}
@@ -645,7 +645,7 @@ static bool parse_opt(int opt, char *optarg)
 			error("--picky-tree must be an absolute path, for example /usr\n\n");
 			return false;
 		}
-		free_string(&cmdline_option_picky_tree);
+		free_and_clear_pointer(&cmdline_option_picky_tree);
 		cmdline_option_picky_tree = strdup_or_die(optarg);
 		return true;
 	case 'w':
@@ -802,7 +802,7 @@ static enum swupd_code deal_with_extra_files(struct manifest *manifest, bool fix
 	char *start = sys_path_join(globals.path_prefix, cmdline_option_picky_tree);
 	info("%s extra files under %s\n", fix ? "Removing" : "Checking for", start);
 	ret = walk_tree(manifest, start, fix, picky_whitelist, &counts);
-	free_string(&start);
+	free_and_clear_pointer(&start);
 
 	return ret;
 }
@@ -1126,7 +1126,7 @@ enum swupd_code execute_verify(void)
 		if (files_to_verify) {
 			char *file_path = sys_path_join(globals.path_prefix, cmdline_option_file);
 			info("Limiting diagnose to the following %s:\n", is_dir(file_path) ? "directory (recursively)" : "file");
-			free_string(&file_path);
+			free_and_clear_pointer(&file_path);
 			info(" - %s\n", cmdline_option_file);
 		} else {
 			/* we are done, nothing to be done */
@@ -1243,7 +1243,7 @@ brick_the_system_and_clean_curl:
 				track_bundle_in_statedir(bundle, new_os_statedir);
 			}
 		}
-		free_string(&new_os_statedir);
+		free_and_clear_pointer(&new_os_statedir);
 	}
 
 	/* report a summary of what we managed to do and not do */
@@ -1417,7 +1417,7 @@ enum swupd_code verify_main(int argc, char **argv)
 	ret = swupd_init(SWUPD_ALL);
 	if (ret != SWUPD_OK) {
 		error("Failed swupd initialization, exiting now\n");
-		free_string(&cmdline_option_picky_tree);
+		free_and_clear_pointer(&cmdline_option_picky_tree);
 		return ret;
 	}
 
@@ -1445,7 +1445,7 @@ enum swupd_code verify_main(int argc, char **argv)
 	/* diagnose */
 	ret = execute_verify();
 
-	free_string(&cmdline_option_picky_tree);
+	free_and_clear_pointer(&cmdline_option_picky_tree);
 	if (picky_whitelist) {
 		regfree(picky_whitelist);
 		picky_whitelist = NULL;
@@ -1502,9 +1502,9 @@ enum swupd_code diagnose_main(int argc, char **argv)
 	ret = execute_verify();
 
 	if (cmdline_option_picky_tree != cmdline_option_file) {
-		free_string(&cmdline_option_file);
+		free_and_clear_pointer(&cmdline_option_file);
 	}
-	free_string(&cmdline_option_picky_tree);
+	free_and_clear_pointer(&cmdline_option_picky_tree);
 	if (picky_whitelist) {
 		regfree(picky_whitelist);
 		picky_whitelist = NULL;

--- a/src/version.c
+++ b/src/version.c
@@ -68,7 +68,7 @@ int get_server_format(int server_version)
 
 	string_or_die(&url, "%s/%d/format", globals.version_url, server_version);
 	value = get_int_from_url(url);
-	free_string(&url);
+	free_and_clear_pointer(&url);
 
 	return value;
 }
@@ -88,7 +88,7 @@ int get_current_format(void)
 	}
 
 out:
-	free_string(&temp_format_buffer);
+	free_and_clear_pointer(&temp_format_buffer);
 	return ret;
 }
 
@@ -112,14 +112,14 @@ static int get_sig_inmemory(char *url, struct curl_file_data *tmp_version_sig)
 	ret = swupd_curl_get_file_memory(sig_fname, tmp_version_sig);
 	if (ret != 0) {
 		warn("Failed to fetch signature file in memory: %s\n", sig_fname);
-		free_string(&tmp_version_sig->data);
+		free_and_clear_pointer(&tmp_version_sig->data);
 		tmp_version_sig->data = NULL;
 		ret = -ENOENT;
 		goto exit;
 	}
 
 exit:
-	free_string(&sig_fname);
+	free_and_clear_pointer(&sig_fname);
 	return ret;
 }
 
@@ -147,7 +147,7 @@ static int verify_signature(char *url, struct curl_file_data *tmp_version)
 				    tmp_version_sig.len, true)
 		  ? 0
 		  : -SWUPD_ERROR_SIGNATURE_VERIFICATION;
-	free_string(&tmp_version_sig.data);
+	free_and_clear_pointer(&tmp_version_sig.data);
 
 out:
 	return ret;
@@ -225,7 +225,7 @@ int get_latest_version(char *v_url)
 
 	string_or_die(&url, "%s/version/format%s/latest", v_url, globals.format_string);
 	ret = get_version_from_url(url);
-	free_string(&url);
+	free_and_clear_pointer(&url);
 	cached_version = ret;
 
 	return ret;
@@ -240,7 +240,7 @@ int version_get_absolute_latest(void)
 
 	string_or_die(&url, "%s/version/latest_version", globals.version_url);
 	ret = get_version_from_url(url);
-	free_string(&url);
+	free_and_clear_pointer(&url);
 
 	return ret;
 }
@@ -266,11 +266,11 @@ static bool get_osrelease_value(char *path_prefix, char *key, char *buff)
 	string_or_die(&releasefile, "%s/usr/lib/os-release", path_prefix);
 	file = fopen(releasefile, "rm");
 	if (!file) {
-		free_string(&releasefile);
+		free_and_clear_pointer(&releasefile);
 		string_or_die(&releasefile, "%s/etc/os-release", path_prefix);
 		file = fopen(releasefile, "rm");
 		if (!file) {
-			free_string(&releasefile);
+			free_and_clear_pointer(&releasefile);
 			return false;
 		}
 	}
@@ -301,8 +301,8 @@ static bool get_osrelease_value(char *path_prefix, char *key, char *buff)
 		}
 	}
 
-	free_string(&releasefile);
-	free_string(&keystr);
+	free_and_clear_pointer(&releasefile);
+	free_and_clear_pointer(&keystr);
 	fclose(file);
 	return keyfound;
 }
@@ -369,7 +369,7 @@ int read_mix_version_file(char *filename, char *path_prefix)
 	string_or_die(&buildstamp, "%s%s", path_prefix, filename);
 	file = fopen(buildstamp, "rm");
 	if (!file) {
-		free_string(&buildstamp);
+		free_and_clear_pointer(&buildstamp);
 		return v;
 	}
 
@@ -390,7 +390,7 @@ int read_mix_version_file(char *filename, char *path_prefix)
 			v = -1;
 		}
 	}
-	free_string(&buildstamp);
+	free_and_clear_pointer(&buildstamp);
 	fclose(file);
 	return v;
 }
@@ -401,7 +401,7 @@ void check_mix_versions(int *current_version, int *server_version, char *path_pr
 	char *format_file;
 	string_or_die(&format_file, MIX_STATE_DIR "version/format%s/latest", globals.format_string);
 	*server_version = read_mix_version_file(format_file, path_prefix);
-	free_string(&format_file);
+	free_and_clear_pointer(&format_file);
 }
 
 int update_device_latest_version(int version)
@@ -412,7 +412,7 @@ int update_device_latest_version(int version)
 	string_or_die(&path, "%s/version", globals.state_dir);
 	file = fopen(path, "w");
 	if (!file) {
-		free_string(&path);
+		free_and_clear_pointer(&path);
 		return -1;
 	}
 
@@ -420,6 +420,6 @@ int update_device_latest_version(int version)
 	fflush(file);
 	fdatasync(fileno(file));
 	fclose(file);
-	free_string(&path);
+	free_and_clear_pointer(&path);
 	return 0;
 }

--- a/src/xattrs.c
+++ b/src/xattrs.c
@@ -195,7 +195,7 @@ static void xattrs_do_action(xattrs_action_type_t action,
 		ret = xattr_get_value(src_filename, sorted_list[i], &value, &value_len,
 				      action);
 		if (ret < 0) {
-			free_string(&value);
+			free_and_clear_pointer(&value);
 			value_len = 0;
 			break;
 		}
@@ -205,7 +205,7 @@ static void xattrs_do_action(xattrs_action_type_t action,
 			 * case. */
 			ret = lsetxattr(dst_filename, sorted_list[i],
 					value, value_len, 0);
-			free_string(&value);
+			free_and_clear_pointer(&value);
 			if (ret < 0) {
 				break;
 			}
@@ -267,11 +267,11 @@ int xattrs_compare(const char *filename1, const char *filename2)
 	}
 out:
 	if (old_xattrs_len != 0) {
-		free_string(&old_xattrs);
+		free_and_clear_pointer(&old_xattrs);
 	}
 
 	if (new_xattrs_len != 0) {
-		free_string(&new_xattrs);
+		free_and_clear_pointer(&new_xattrs);
 	}
 
 	return ret;


### PR DESCRIPTION
Free string function has a misleading name and usage all over swupd.
This function was proably created to make sure global strings were
set to NULL after a free to prevent double free and invalid access
memory. But there's absolutly nothing in this function that makes it
exclusive or mandatory to free strings. The same argument could be
used to force users to set any pointer to NULL after freeing. Because
of that I'm prosing to rename it to free_and_clear_pointer() and making
it compatible to any pointer (void *).

As we don't set any other local pointer to NULL after a free(), I don't see
a reason to do that for strings. For global or local pointer that are reused,
I'm open to explictly set that to NULL or to use the free_and_clear_pointer()
helper, but I don't see why different pointers type should be treated differently.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>