### PR TITLE
Handle conflicting 3rd-party binaries

### DIFF
--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -537,21 +537,6 @@ void third_party_repo_header(const char *repo_name)
 	free_string(&header);
 }
 
-static bool is_binary(const char *filename)
-{
-	const char *binary_paths[] = { "/bin", "/usr/bin", "/usr/local/bin", NULL };
-	int i = 0;
-
-	while (binary_paths[i]) {
-		if (strncmp(filename, binary_paths[i], strlen(binary_paths[i])) == 0) {
-			return true;
-		}
-		i++;
-	}
-
-	return false;
-}
-
 bool third_party_file_is_binary(struct file *file)
 {
 	if (file->is_exported && is_binary(file->filename)) {

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -1217,3 +1217,18 @@ bool confirm_action(void)
 
 	return response == 'y';
 }
+
+bool is_binary(const char *filename)
+{
+	const char *binary_paths[] = { "/bin", "/usr/bin", "/usr/local/bin", NULL };
+	int i = 0;
+
+	while (binary_paths[i]) {
+		if (strncmp(filename, binary_paths[i], strlen(binary_paths[i])) == 0) {
+			return true;
+		}
+		i++;
+	}
+
+	return false;
+}

--- a/src/lib/list.c
+++ b/src/lib/list.c
@@ -355,7 +355,7 @@ struct list *list_filter_elements(struct list *list, filter_fn_t filter_fn, list
 	return list;
 }
 
-struct list *list_sorted_filter_common_elements(struct list *list1, struct list *list2, comparison_fn_t comparison_fn, list_free_data_fn_t list_free_data_fn)
+struct list *list_sorted_split_common_elements(struct list *list1, struct list *list2, struct list **common_elements, comparison_fn_t comparison_fn, list_free_data_fn_t list_free_data_fn)
 {
 	struct list *iter1, *iter2 = NULL;
 	struct list *preserver = NULL;
@@ -389,10 +389,22 @@ struct list *list_sorted_filter_common_elements(struct list *list1, struct list 
 		if (preserver == iter1) {
 			preserver = iter1->next;
 		}
+
+		/* if a list was provided to store the common elements,
+		 * store them, otherwise just remove the common element */
+		if (common_elements) {
+			*common_elements = list_prepend_data(*common_elements, item2);
+		}
+
 		iter1 = list_free_item(iter1, list_free_data_fn);
 	}
 
 	return preserver;
+}
+
+struct list *list_sorted_filter_common_elements(struct list *list1, struct list *list2, comparison_fn_t comparison_fn, list_free_data_fn_t list_free_data_fn)
+{
+	return list_sorted_split_common_elements(list1, list2, NULL, comparison_fn, list_free_data_fn);
 }
 
 void *list_remove(void *item_to_remove, struct list **list, comparison_fn_t comparison_fn)

--- a/src/lib/list.h
+++ b/src/lib/list.h
@@ -153,6 +153,11 @@ void *list_search(struct list *list, const void *item, comparison_fn_t compariso
 struct list *list_sorted_deduplicate(struct list *list, comparison_fn_t comparison_fn, list_free_data_fn_t list_free_data_fn);
 
 /**
+ * @brief Splits any element from sorted list list1 that happens to be in the sorted list list2 meeting the criteria and moves it to common_elements.
+ */
+struct list *list_sorted_split_common_elements(struct list *list1, struct list *list2, struct list **common_elements, comparison_fn_t comparison_fn, list_free_data_fn_t list_free_data_fn);
+
+/**
  * @brief Filters any element from sorted list list1 that happens to be in the sorted list list2 meeting the criteria.
  */
 struct list *list_sorted_filter_common_elements(struct list *list1, struct list *list2, comparison_fn_t comparison_fn, list_free_data_fn_t list_free_data_fn);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -321,6 +321,7 @@ extern void prettify_size(long size_in_bytes, char **pretty_size);
 extern int link_or_rename(const char *orig, const char *dest);
 extern int create_state_dirs(const char *state_dir_path);
 extern bool confirm_action(void);
+extern bool is_binary(const char *filename);
 
 /* subscription.c */
 typedef bool (*subs_fn_t)(struct list **subs, const char *component, int recursion, bool is_optional);
@@ -338,8 +339,9 @@ extern enum swupd_code execute_bundle_add(struct list *bundles_list);
 extern enum swupd_code execute_bundle_add_extra(struct list *bundles_list, extra_proc_fn_t pre_add_fn, extra_proc_fn_t post_add_fn, extra_proc_fn_t file_validation_fn);
 
 /* bundle_remove.c */
+typedef enum swupd_code (*remove_extra_proc_fn_t)(struct list *removed_files, struct list *common_files);
 extern enum swupd_code execute_remove_bundles(struct list *bundles);
-extern enum swupd_code execute_remove_bundles_extra(struct list *bundles, extra_proc_fn_t post_remove_fn);
+extern enum swupd_code execute_remove_bundles_extra(struct list *bundles, remove_extra_proc_fn_t post_remove_fn);
 extern void bundle_remove_set_option_force(bool opt);
 extern void bundle_remove_set_option_recursive(bool opt);
 

--- a/test/functional/3rd-party/3rd-party-bundle-add-export-bin.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-export-bin.bats
@@ -8,9 +8,13 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment "$TEST_NAME"
+	add_third_party_repo "$TEST_NAME" 10 1 repo1
 	# create a 3rd-party bundle that has a couple of binaries
-	add_third_party_repo "$TEST_NAME" 10 1 test-repo1
-	create_bundle -n test-bundle1 -f /file1,/foo/file_2,/usr/bin/file_3,/bin/file_4 -u test-repo1 "$TEST_NAME"
+	bin_file1=$(create_file -x "$TPWEBDIR"/10/files)
+	create_bundle -n test-bundle1 -f /file1,/foo/file_2,/usr/bin/bin_file1:"$bin_file1",/bin/bin_file2 -u repo1 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /file3,/usr/bin/bin_file1:"$bin_file1"                            -u repo1 "$TEST_NAME"
+	# let's make test-bundle2 contain /bin/bin_file1 but not export it
+	update_manifest "$TPWEBDIR"/10/Manifest.test-bundle2 file-status /usr/bin/bin_file1 F...
 
 }
 
@@ -25,7 +29,7 @@ test_setup() {
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Searching for bundle test-bundle1 in the 3rd-party repositories...
-		Bundle test-bundle1 found in 3rd-party repository test-repo1
+		Bundle test-bundle1 found in 3rd-party repository repo1
 		Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Loading required manifests...
 		Validating 3rd-party bundle binaries...
@@ -44,16 +48,16 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# the script files should have been generated for the exported files
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/file_3
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/file_4
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/bin_file1
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/bin_file2
 
 	# verify the content of the scripts is correct
-	run sudo sh -c "cat $TARGETDIR/$THIRD_PARTY_BIN_DIR/file_3"
+	run sudo sh -c "cat $TARGETDIR/$THIRD_PARTY_BIN_DIR/bin_file1"
 	expected_output=$(cat <<-EOM
 		#!/bin/bash
 		export PATH=.*
 		export LD_LIBRARY_PATH=.*
-		$PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/bin/file_3 .*
+		$PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/repo1/usr/bin/bin_file1 .*
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
@@ -66,18 +70,18 @@ test_setup() {
 	# in the target system, the bundle installation should be aborted
 
 	sudo mkdir -p "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"
-	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/file_3
+	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/bin_file1
 
 	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle1"
 
 	assert_status_is "$SWUPD_COULDNT_CREATE_FILE"
 	expected_output=$(cat <<-EOM
 		Searching for bundle test-bundle1 in the 3rd-party repositories...
-		Bundle test-bundle1 found in 3rd-party repository test-repo1
+		Bundle test-bundle1 found in 3rd-party repository repo1
 		Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Loading required manifests...
 		Validating 3rd-party bundle binaries...
-		Error: There is already a binary called file_3 in $PATH_PREFIX/opt/3rd-party/bin
+		Error: There is already a binary called bin_file1 in $PATH_PREFIX/opt/3rd-party/bin
 		Aborting bundle installation...
 		Failed to install 1 of 1 bundles
 	EOM
@@ -86,3 +90,113 @@ test_setup() {
 
 }
 #WEIGHT=8
+
+@test "TPR068: Adding bundles that share a binary" {
+
+	# installing two bundles that share the same binary should work as long
+	# as the bonary is only exported in one bundle
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle1 test-bundle2"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle1 in the 3rd-party repositories...
+		Bundle test-bundle1 found in 3rd-party repository repo1
+		Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Loading required manifests...
+		Validating 3rd-party bundle binaries...
+		Downloading packs for:
+		 - test-bundle1
+		Finishing packs extraction...
+		Validate downloaded files
+		No extra files need to be downloaded
+		Validating 3rd-party bundle file permissions...
+		Installing files...
+		Warning: post-update helper scripts skipped due to --no-scripts argument
+		Exporting 3rd-party bundle binaries...
+		Successfully installed 1 bundle
+		Searching for bundle test-bundle2 in the 3rd-party repositories...
+		Bundle test-bundle2 found in 3rd-party repository repo1
+		Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Loading required manifests...
+		Validating 3rd-party bundle binaries...
+		No packs need to be downloaded
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Validating 3rd-party bundle file permissions...
+		Installing files...
+		Warning: post-update helper scripts skipped due to --no-scripts argument
+		Exporting 3rd-party bundle binaries...
+		Successfully installed 1 bundle
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/bin_file1
+
+	# verify the content of the scripts is correct
+	run sudo sh -c "cat $TARGETDIR/$THIRD_PARTY_BIN_DIR/bin_file1"
+	expected_output=$(cat <<-EOM
+		#!/bin/bash
+		export PATH=.*
+		export LD_LIBRARY_PATH=.*
+		$PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/repo1/usr/bin/bin_file1 .*
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}
+
+@test "TPR069: Adding bundles that share a binary - reverse order" {
+
+	# installing two bundles that share the same binary should work as long
+	# as the bonary is only exported in one bundle
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle2 test-bundle1"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle2 in the 3rd-party repositories...
+		Bundle test-bundle2 found in 3rd-party repository repo1
+		Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Loading required manifests...
+		Validating 3rd-party bundle binaries...
+		No packs need to be downloaded
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Validating 3rd-party bundle file permissions...
+		Installing files...
+		Warning: post-update helper scripts skipped due to --no-scripts argument
+		Exporting 3rd-party bundle binaries...
+		Successfully installed 1 bundle
+		Searching for bundle test-bundle1 in the 3rd-party repositories...
+		Bundle test-bundle1 found in 3rd-party repository repo1
+		Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Loading required manifests...
+		Validating 3rd-party bundle binaries...
+		Downloading packs for:
+		 - test-bundle1
+		Finishing packs extraction...
+		Validate downloaded files
+		No extra files need to be downloaded
+		Validating 3rd-party bundle file permissions...
+		Installing files...
+		Warning: post-update helper scripts skipped due to --no-scripts argument
+		Exporting 3rd-party bundle binaries...
+		Successfully installed 1 bundle
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/bin_file1
+
+	# verify the content of the scripts is correct
+	run sudo sh -c "cat $TARGETDIR/$THIRD_PARTY_BIN_DIR/bin_file1"
+	expected_output=$(cat <<-EOM
+		#!/bin/bash
+		export PATH=.*
+		export LD_LIBRARY_PATH=.*
+		$PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/repo1/usr/bin/bin_file1 .*
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}

--- a/test/functional/3rd-party/3rd-party-bundle-remove-exported-bin.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-exported-bin.bats
@@ -8,31 +8,76 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment "$TEST_NAME"
-	# create a 3rd-party bundle that has a couple of binaries
-	add_third_party_repo "$TEST_NAME" 10 1 test-repo1
-	create_bundle -L -n test-bundle1 -f /file1,/foo/file_2,/usr/bin/file_3,/bin/file_4 -u test-repo1 "$TEST_NAME"
-	# create a 3rd-party bundle that shares the same binary
-	create_bundle -L -n test-bundle2 -f /file2,/usr/bin/file_3                         -u test-repo1 "$TEST_NAME"
+	add_third_party_repo "$TEST_NAME" 10 1 repo1
+	# create 3rd-party bundles that share a binary
+	bin_file1=$(create_file -x "$TPWEBDIR"/10/files)
+	create_bundle -L -n test-bundle1 -f /file1,/foo/file2,/usr/bin/bin_file1:"$bin_file1",/bin/bin_file2 -u repo1 "$TEST_NAME"
+	create_bundle -L -n test-bundle2 -f /file3,/usr/bin/bin_file1:"$bin_file1"                           -u repo1 "$TEST_NAME"
+	create_bundle -L -n test-bundle3 -f /file1,/usr/bin/bin_file1:"$bin_file1"                           -u repo1 "$TEST_NAME"
+	# let's make test-bundle3 contain /usr/bin/bin_file1 but not export it
+	update_manifest "$TPWEBDIR"/10/Manifest.test-bundle3 file-status /usr/bin/bin_file1 F...
+
 }
 
 @test "TPR058: Removing one bundle from a third party repo that exported binaries" {
 
 	# when deleting a 3rd-party bundle, all the binaries exported by the
 	# bundle should be removed as well
-
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/file_3
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/file_4
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file1
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file2
 
 	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS test-bundle1"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Searching for bundle test-bundle1 in the 3rd-party repositories...
-		Bundle test-bundle1 found in 3rd-party repository test-repo1
+		Bundle test-bundle1 found in 3rd-party repository repo1
 		The following bundles are being removed:
 		 - test-bundle1
 		Deleting bundle files...
-		Total deleted files: 6
+		Total deleted files: 5
+		Removing 3rd-party bundle binaries...
+		Successfully removed 1 bundle
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	# non-confilcting binary scripts should have been removed
+	assert_file_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file2
+
+	# script that are still being used by other bundles should not be removed
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file1
+
+}
+#WEIGHT=5
+
+@test "TPR070: Removing all third party bundles that exported a binary that is still needed but non-exported" {
+
+	# when deleting a 3rd-party bundle that has an exported binary, if another bundle still needs
+	# the binary but it did not export that binary, then the file should not be removed
+	# from the system but the script that exports the binary should
+
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file1
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file2
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS test-bundle1 test-bundle2"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle1 in the 3rd-party repositories...
+		Bundle test-bundle1 found in 3rd-party repository repo1
+		The following bundles are being removed:
+		 - test-bundle1
+		Deleting bundle files...
+		Total deleted files: 5
+		Removing 3rd-party bundle binaries...
+		Successfully removed 1 bundle
+		Searching for bundle test-bundle2 in the 3rd-party repositories...
+		Bundle test-bundle2 found in 3rd-party repository repo1
+		The following bundles are being removed:
+		 - test-bundle2
+		Deleting bundle files...
+		Total deleted files: 2
 		Removing 3rd-party bundle binaries...
 		Successfully removed 1 bundle
 	EOM
@@ -40,10 +85,38 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# non-confilcting scripts to binaries should have been removed
-	assert_file_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/file_4
-
-	# script to binaries that are still being used by another bundle should not be removed
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/file_3
+	assert_file_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file1
+	assert_file_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file2
+	assert_file_exists "$TPTARGETDIR"/usr/bin/bin_file1
 
 }
-#WEIGHT=5
+
+@test "TPR071: Removing one third party bundle that has a non-exported binary but exported by another bundle" {
+
+	# when deleting a 3rd-party bundle that has an non-exported binary,
+	# if another bundle needsthe binary, then the file should not be removed
+
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file1
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file2
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS test-bundle3"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle3 in the 3rd-party repositories...
+		Bundle test-bundle3 found in 3rd-party repository repo1
+		The following bundles are being removed:
+		 - test-bundle3
+		Deleting bundle files...
+		Total deleted files: 1
+		Removing 3rd-party bundle binaries...
+		Successfully removed 1 bundle
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file1
+	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file2
+	assert_file_exists "$TPTARGETDIR"/usr/bin/bin_file1
+
+}

--- a/test/functional/3rd-party/3rd-party-repo-add-certificate.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add-certificate.bats
@@ -38,9 +38,9 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_third_party_repo "$TEST_NAME" 10 staging test-repo1
-	repo1="$TPWEBDIR"
+	repo1="$TPURL"
 	create_third_party_repo "$TEST_NAME" 10 staging test-repo2
-	repo2="$TPWEBDIR"
+	repo2="$TPURL"
 }
 
 @test "TPR066: Add a single repo importing the certificate" {

--- a/test/functional/3rd-party/3rd-party-repo-add.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add.bats
@@ -12,9 +12,9 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_third_party_repo "$TEST_NAME" 10 staging test-repo1
-	repo1="$TPWEBDIR"
+	repo1="$TPURL"
 	create_third_party_repo "$TEST_NAME" 10 staging test-repo2
-	repo2="$TPWEBDIR"
+	repo2="$TPURL"
 
 }
 


### PR DESCRIPTION
When in a 3rd-party repository one bundle has one binary file that
is exported, and the same file is included in another bundle, only
it is not exported in this bundle, when we remove the bundle that
exports the file, the file should be unexported regardless of the file
still being installed since the bundle that is still in the system is
not exporting it.

Closes #1322

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>