### PR TITLE
Move 3rd-party repo.ini out of the state directory

### DIFF
--- a/src/3rd_party_add.c
+++ b/src/3rd_party_add.c
@@ -254,6 +254,7 @@ enum swupd_code third_party_add_main(int argc, char **argv)
 	 */
 	progress_init_steps("third-party-add", step_in_third_party_add);
 
+	/* The last two in reverse are the repo-name, repo-url */
 	name = argv[argc - 2];
 	url = argv[argc - 1];
 
@@ -262,7 +263,7 @@ enum swupd_code third_party_add_main(int argc, char **argv)
 		goto finish;
 	}
 
-	/* The last two in reverse are the repo-name, repo-url */
+	/* add the repo configuration to the repo.ini file */
 	progress_next_step("add_repo", PROGRESS_UNDEFINED);
 	info("Adding 3rd-party repository %s...\n\n", name);
 	ret = third_party_add_repo(name, url);

--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -44,7 +44,7 @@ char *third_party_get_binary_path(const char *binary_name)
 
 static char *get_repo_config_path(void)
 {
-	return str_or_die("%s/%s/%s", globals_bkp.state_dir, SWUPD_3RD_PARTY_DIRNAME, "repo.ini");
+	return str_or_die("%s/%s/%s", globals_bkp.path_prefix, SWUPD_3RD_PARTY_DIR, "repo.ini");
 }
 
 static char *get_repo_content_path(const char *repo_name)

--- a/test/functional/3rd-party/3rd-party-allow-http.bats
+++ b/test/functional/3rd-party/3rd-party-allow-http.bats
@@ -71,7 +71,7 @@ global_teardown() {
 	assert_in_output "$expected_output"
 	assert_in_output "Repository added successfully"
 
-	run sudo sh -c "cat $STATEDIR/3rd-party/repo.ini"
+	run sudo sh -c "cat $PATH_PREFIX/$THIRD_PARTY_DIR/repo.ini"
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		[my_repo]

--- a/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
@@ -12,10 +12,10 @@ test_setup() {
 
 	# create a couple 3rd-party repos within the test environment and add
 	# some bundles to them
-	add_third_party_repo "$TEST_NAME" 10 1 test-repo1
+	create_third_party_repo -a "$TEST_NAME" 10 1 test-repo1
 	create_bundle -n test-bundle1 -f /foo/file_1 -u test-repo1 "$TEST_NAME"
 
-	add_third_party_repo "$TEST_NAME" 10 1 test-repo2
+	create_third_party_repo -a "$TEST_NAME" 10 1 test-repo2
 	create_bundle -n test-bundle2 -f /foo/file_2 -u test-repo2 "$TEST_NAME"
 	create_bundle -n test-bundle3 -f /bar/file_3 -u test-repo2 "$TEST_NAME"
 

--- a/test/functional/3rd-party/3rd-party-bundle-add-config-file.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-config-file.bats
@@ -11,7 +11,7 @@ test_setup() {
 
 	# create a 3rd-party repo within the test environment and add
 	# a few bundles in the 3rd-party repo
-	add_third_party_repo "$TEST_NAME" 10
+	create_third_party_repo -a "$TEST_NAME" 10
 	create_bundle -n test-bundle1 -f /foo/file_1 -u test-repo "$TEST_NAME"
 	create_bundle -n test-bundle2 -f /bar/file_2 -u test-repo "$TEST_NAME"
 	create_bundle -n test-bundle3 -f /file_3     -u test-repo "$TEST_NAME"

--- a/test/functional/3rd-party/3rd-party-bundle-add-dangerous-flags.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-dangerous-flags.bats
@@ -8,7 +8,7 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment "$TEST_NAME"
-	add_third_party_repo "$TEST_NAME" 10 1 repo1
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
 
 	# create a file with the setuid flag set
 	file_2=$(create_file -u "$TPWEBDIR"/10/files)

--- a/test/functional/3rd-party/3rd-party-bundle-add-export-bin.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-export-bin.bats
@@ -8,7 +8,7 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment "$TEST_NAME"
-	add_third_party_repo "$TEST_NAME" 10 1 repo1
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
 	# create a 3rd-party bundle that has a couple of binaries
 	bin_file1=$(create_file -x "$TPWEBDIR"/10/files)
 	create_bundle -n test-bundle1 -f /file1,/foo/file_2,/usr/bin/bin_file1:"$bin_file1",/bin/bin_file2 -u repo1 "$TEST_NAME"

--- a/test/functional/3rd-party/3rd-party-bundle-add-multi-repo.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-multi-repo.bats
@@ -10,11 +10,11 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 
 	# create a couple of 3rd-party repos with bundles
-	add_third_party_repo "$TEST_NAME" 10 staging repo1
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo1
 	create_bundle -n test-bundle1 -f /foo/file_1A -u repo1 "$TEST_NAME"
 	create_bundle -n test-bundle2 -f /bar/file_2 -u repo1 "$TEST_NAME"
 
-	add_third_party_repo "$TEST_NAME" 10 staging repo2
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo2
 	create_bundle -n test-bundle1 -f /baz/file_1B -u repo2 "$TEST_NAME"
 
 }

--- a/test/functional/3rd-party/3rd-party-bundle-info-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-info-basic.bats
@@ -11,12 +11,12 @@ global_setup() {
 	create_bundle -n test-bundle-upstream -f /file_upstream "$TEST_NAME"
 
 	# create a couple of 3rd-party repos with bundles
-	add_third_party_repo "$TEST_NAME" 10 staging repo1
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo1
 	create_bundle    -n test-bundle1 -f /foo/file_1A -u repo1 "$TEST_NAME"
 	create_bundle -L -n test-bundle2 -f /bar/file_2  -u repo1 "$TEST_NAME"
 	add_dependency_to_manifest "$TEST_NAME"/3rd-party/repo1/10/Manifest.test-bundle2 test-bundle1
 
-	add_third_party_repo "$TEST_NAME" 10 staging repo2
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo2
 	create_bundle    -n test-bundle1 -f /baz/file_1B -u repo2 "$TEST_NAME"
 	create_bundle    -n test-bundle3 -f /baz/file_3  -u repo2 "$TEST_NAME"
 	# when swupd initializes, if the tracking directory is empty, it will

--- a/test/functional/3rd-party/3rd-party-bundle-list-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-list-basic.bats
@@ -11,11 +11,11 @@ global_setup() {
 	create_bundle -n test-bundle-upstream -f /file_upstream "$TEST_NAME"
 
 	# create a couple of 3rd-party repos with bundles
-	add_third_party_repo "$TEST_NAME" 10 staging repo1
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo1
 	create_bundle    -n test-bundle1 -f /foo/file_1A -u repo1 "$TEST_NAME"
 	create_bundle -L -n test-bundle2 -f /bar/file_2  -u repo1 "$TEST_NAME"
 
-	add_third_party_repo "$TEST_NAME" 10 staging repo2
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo2
 	create_bundle    -n test-bundle1 -f /baz/file_1B -u repo2 "$TEST_NAME"
 	create_bundle -L -n test-bundle3 -f /baz/file_3  -u repo2 "$TEST_NAME"
 

--- a/test/functional/3rd-party/3rd-party-bundle-list-deps.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-list-deps.bats
@@ -10,7 +10,7 @@ global_setup() {
 	create_test_environment "$TEST_NAME"
 
 	# create a 3rd-party repo with bundles that have dependencies
-	add_third_party_repo "$TEST_NAME" 10 staging repo1
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo1
 	create_bundle  -n test-bundle1 -f /foo/file_1 -u repo1 "$TEST_NAME"
 	create_bundle  -n test-bundle2 -f /bar/file_2 -u repo1 "$TEST_NAME"
 	create_bundle  -n test-bundle3 -f /baz/file_3 -u repo1 "$TEST_NAME"

--- a/test/functional/3rd-party/3rd-party-bundle-remove-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-basic.bats
@@ -12,10 +12,10 @@ test_setup() {
 
 	# create a couple 3rd-party repos within the test environment and add
 	# some bundles to them
-	add_third_party_repo "$TEST_NAME" 10 1 test-repo1
+	create_third_party_repo -a "$TEST_NAME" 10 1 test-repo1
 	create_bundle -L -t -n test-bundle1 -f /foo/file_1 -u test-repo1 "$TEST_NAME"
 
-	add_third_party_repo "$TEST_NAME" 10 1 test-repo2
+	create_third_party_repo -a "$TEST_NAME" 10 1 test-repo2
 	create_bundle -L -t -n test-bundle2 -f /foo/file_2 -u test-repo2 "$TEST_NAME"
 	create_bundle -L -t -n test-bundle3 -f /bar/file_3 -u test-repo2 "$TEST_NAME"
 

--- a/test/functional/3rd-party/3rd-party-bundle-remove-exported-bin.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-exported-bin.bats
@@ -8,7 +8,7 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment "$TEST_NAME"
-	add_third_party_repo "$TEST_NAME" 10 1 repo1
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
 	# create 3rd-party bundles that share a binary
 	bin_file1=$(create_file -x "$TPWEBDIR"/10/files)
 	create_bundle -L -n test-bundle1 -f /file1,/foo/file2,/usr/bin/bin_file1:"$bin_file1",/bin/bin_file2 -u repo1 "$TEST_NAME"

--- a/test/functional/3rd-party/3rd-party-bundle-remove-multi-repo.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-multi-repo.bats
@@ -12,10 +12,10 @@ test_setup() {
 
 	# create a couple 3rd-party repos within the test environment and add
 	# some bundles to them
-	add_third_party_repo "$TEST_NAME" 10 1 test-repo1
+	create_third_party_repo -a "$TEST_NAME" 10 1 test-repo1
 	create_bundle -L -n test-bundle1 -f /foo/file_1 -u test-repo1 "$TEST_NAME"
 
-	add_third_party_repo "$TEST_NAME" 10 1 test-repo2
+	create_third_party_repo -a "$TEST_NAME" 10 1 test-repo2
 	create_bundle -L -t -n test-bundle1 -f /foo/file_2 -u test-repo2 "$TEST_NAME"
 	create_bundle -L    -n test-bundle2 -f /bar/file_3 -u test-repo2 "$TEST_NAME"
 	add_dependency_to_manifest "$TEST_NAME"/3rd-party/test-repo2/10/Manifest.test-bundle1 test-bundle2

--- a/test/functional/3rd-party/3rd-party-check-update-basic.bats
+++ b/test/functional/3rd-party/3rd-party-check-update-basic.bats
@@ -10,12 +10,12 @@ global_setup() {
 	create_test_environment "$TEST_NAME"
 
 	# create a couple of 3rd-party repos with bundles
-	add_third_party_repo "$TEST_NAME" 10 staging test-repo1
+	create_third_party_repo -a "$TEST_NAME" 10 staging test-repo1
 	create_bundle -L -t -n test-bundle1 -f /foo/file_1 -u test-repo1 "$TEST_NAME"
 	create_version -p "$TEST_NAME" 20 10 staging test-repo1
 	update_bundle "$TEST_NAME" test-bundle1 --update /foo/file_1 test-repo1
 
-	add_third_party_repo "$TEST_NAME" 10 staging test-repo2
+	create_third_party_repo -a "$TEST_NAME" 10 staging test-repo2
 	create_bundle -L -t -n test-bundle2 -f /bar/file_2 -u test-repo2 "$TEST_NAME"
 
 }

--- a/test/functional/3rd-party/3rd-party-diagnose-basic.bats
+++ b/test/functional/3rd-party/3rd-party-diagnose-basic.bats
@@ -10,7 +10,7 @@ global_setup() {
 	create_test_environment "$TEST_NAME" 10 1
 
 	# add a 3rd-party repo with some "findings" for diagnose
-	add_third_party_repo "$TEST_NAME" 10 1 test-repo1
+	create_third_party_repo -a "$TEST_NAME" 10 1 test-repo1
 	create_bundle -L -t -n test-bundle1 -f /foo/file_1,/bar/file_2 -u test-repo1 "$TEST_NAME"
 	create_version -p "$TEST_NAME" 20 10 1 test-repo1
 	update_bundle -p "$TEST_NAME" test-bundle1 --update /foo/file_1 test-repo1
@@ -19,7 +19,7 @@ global_setup() {
 	set_current_version "$TEST_NAME" 20 test-repo1
 
 	# add another 3rd-party repo that has nothing to get fixed
-	add_third_party_repo "$TEST_NAME" 10 1 test-repo2
+	create_third_party_repo -a "$TEST_NAME" 10 1 test-repo2
 	create_bundle -L -t -n test-bundle2 -f /baz/file_3 -u test-repo2 "$TEST_NAME"
 
 	# adding an untracked files into an untracked directory (/bat)

--- a/test/functional/3rd-party/3rd-party-repair-basic.bats
+++ b/test/functional/3rd-party/3rd-party-repair-basic.bats
@@ -10,7 +10,7 @@ test_setup() {
 	create_test_environment "$TEST_NAME" 10 1
 
 	# add a 3rd-party repo with some "findings" for diagnose
-	add_third_party_repo "$TEST_NAME" 10 1 test-repo1
+	create_third_party_repo -a "$TEST_NAME" 10 1 test-repo1
 	create_bundle -L -t -n test-bundle1 -f /foo/file_1,/bar/file_2 -u test-repo1 "$TEST_NAME"
 	create_version -p "$TEST_NAME" 20 10 1 test-repo1
 	update_bundle -p "$TEST_NAME" test-bundle1 --update /foo/file_1 test-repo1
@@ -19,7 +19,7 @@ test_setup() {
 	set_current_version "$TEST_NAME" 20 test-repo1
 
 	# add another 3rd-party repo that has nothing to get fixed
-	add_third_party_repo "$TEST_NAME" 10 1 test-repo2
+	create_third_party_repo -a "$TEST_NAME" 10 1 test-repo2
 	create_bundle -L -t -n test-bundle2 -f /baz/file_3 -u test-repo2 "$TEST_NAME"
 
 	# adding an untracked files into an untracked directory (/bat)

--- a/test/functional/3rd-party/3rd-party-repo-add-certificate.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add-certificate.bats
@@ -69,7 +69,7 @@ test_setup() {
 	)
 	assert_regex_is_output "$expected_output"
 
-	run sudo sh -c "cat $STATEDIR/3rd-party/repo.ini"
+	run sudo sh -c "cat $PATH_PREFIX/$THIRD_PARTY_DIR/repo.ini"
 	expected_output=$(cat <<-EOM
 			[test-repo1]
 			url=file://$repo1

--- a/test/functional/3rd-party/3rd-party-repo-add.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add.bats
@@ -40,7 +40,7 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 
-	run sudo sh -c "cat $STATEDIR/3rd-party/repo.ini"
+	run sudo sh -c "cat $PATH_PREFIX/$THIRD_PARTY_DIR/repo.ini"
 	expected_output=$(cat <<-EOM
 			[test-repo1]
 			url=file://$repo1
@@ -77,7 +77,7 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/os-core
 	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/lib/os-release
 
-	run sudo sh -c "cat $STATEDIR/3rd-party/repo.ini"
+	run sudo sh -c "cat $PATH_PREFIX/$THIRD_PARTY_DIR/repo.ini"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 			[test-repo1]

--- a/test/functional/3rd-party/3rd-party-repo-list.bats
+++ b/test/functional/3rd-party/3rd-party-repo-list.bats
@@ -28,7 +28,7 @@ test_setup(){
 	EOM
 	)
 
-	repo_config_file="$STATEDIR"/3rd-party/repo.ini
+	repo_config_file="$PATH_PREFIX"/"$THIRD_PARTY_DIR"/repo.ini
 	run sudo sh -c "mkdir -p $STATEDIR/3rd-party/"
 	run sudo sh -c "mkdir -p $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/{test1,test2,test3,test4,test5}"
 	write_to_protected_file -a "$repo_config_file" "$contents"

--- a/test/functional/3rd-party/3rd-party-repo-remove-negative.bats
+++ b/test/functional/3rd-party/3rd-party-repo-remove-negative.bats
@@ -51,7 +51,7 @@ test_setup(){
 
 @test "TPR011: Negative test, Remove a repo on a new system" {
 
-	run sudo sh -c "rm -r $STATEDIR/3rd-party"
+	run sudo sh -c "rm -r $PATH_PREFIX/$THIRD_PARTY_DIR"
 
 	run sudo sh -c "$SWUPD 3rd-party remove $SWUPD_OPTS repo1"
 	assert_status_is "$SWUPD_INVALID_REPOSITORY"

--- a/test/functional/3rd-party/3rd-party-repo-remove-negative.bats
+++ b/test/functional/3rd-party/3rd-party-repo-remove-negative.bats
@@ -11,7 +11,7 @@ test_setup(){
 
 	# create a few 3rd-party repos within the test environment and add
 	# some bundles to them
-	add_third_party_repo "$TEST_NAME" 10 1 repo1
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
 	create_bundle -L -t -n test-bundle1 -f /file_1,/bin/binary_1 -u repo1 "$TEST_NAME"
 
 }

--- a/test/functional/3rd-party/3rd-party-repo-remove.bats
+++ b/test/functional/3rd-party/3rd-party-repo-remove.bats
@@ -10,15 +10,15 @@ test_setup(){
 	create_test_environment "$TEST_NAME"
 	# create a few 3rd-party repos within the test environment and add
 	# some bundles to them
-	add_third_party_repo "$TEST_NAME" 10 1 repo1
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
 	create_bundle -L -t -n test-bundle1 -f /file_1,/bin/binary_1           -u repo1 "$TEST_NAME"
 
-	add_third_party_repo "$TEST_NAME" 10 1 repo2
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
 	create_bundle -L -t -n test-bundle2 -f /file_2,/bin/binary_2           -u repo2 "$TEST_NAME"
 	create_bundle -L -t -n test-bundle3 -f /file_3,/usr/bin/binary_3       -u repo2 "$TEST_NAME"
 	create_bundle -L -t -n test-bundle4 -f /file_4,/usr/local/bin/binary_4 -u repo2 "$TEST_NAME"
 
-	add_third_party_repo "$TEST_NAME" 10 1 repo3
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo3
 	create_bundle -L -t -n test-bundle5 -f /file_5,/usr/bin/binary_5       -u repo3 "$TEST_NAME"
 
 }

--- a/test/functional/3rd-party/3rd-party-update-basic.bats
+++ b/test/functional/3rd-party/3rd-party-update-basic.bats
@@ -9,8 +9,8 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME"
 
-	add_third_party_repo "$TEST_NAME" 10 staging test-repo1
-	add_third_party_repo "$TEST_NAME" 10 staging test-repo2
+	create_third_party_repo -a "$TEST_NAME" 10 staging test-repo1
+	create_third_party_repo -a "$TEST_NAME" 10 staging test-repo2
 
 	create_bundle -L -t -n test-bundle1 -f /foo/file_1 -u test-repo1 "$TEST_NAME"
 	create_bundle       -n test-bundle2 -f /bar/file_2 -u test-repo1 "$TEST_NAME"

--- a/test/functional/3rd-party/3rd-party-update-dangerous-flags.bats
+++ b/test/functional/3rd-party/3rd-party-update-dangerous-flags.bats
@@ -8,7 +8,7 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment "$TEST_NAME"
-	add_third_party_repo "$TEST_NAME" 10 staging repo1
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo1
 
 	file_1=$(create_file "$TPWEBDIR"/10/files)
 	# create a file with a dangerous flag (setuid)

--- a/test/functional/3rd-party/3rd-party-update-exported-bin.bats
+++ b/test/functional/3rd-party/3rd-party-update-exported-bin.bats
@@ -9,7 +9,7 @@ test_setup() {
 
 	# create an initial environment
 	create_test_environment "$TEST_NAME"
-	add_third_party_repo "$TEST_NAME" 10 staging repo1
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo1
 	create_bundle -L -t -n test-bundle1 -f /foo/file_1,/usr/bin/binary_1,/bin/binary_2,/bin/binary_3 -u repo1 "$TEST_NAME"
 	create_bundle       -n test-bundle2 -f /bar/file_2,/bin/binary_4                                 -u repo1 "$TEST_NAME"
 	create_bundle       -n test-bundle3 -f /bin/binary_5                                             -u repo1 "$TEST_NAME"

--- a/test/functional/3rd-party/3rd-party-update-specific-version.bats
+++ b/test/functional/3rd-party/3rd-party-update-specific-version.bats
@@ -9,7 +9,7 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME"
 
-	add_third_party_repo "$TEST_NAME" 10 staging test-repo1
+	create_third_party_repo -a "$TEST_NAME" 10 staging test-repo1
 	create_bundle -L -t -n test-bundle1 -f /foo/file_1 -u test-repo1 "$TEST_NAME"
 	create_version -p "$TEST_NAME" 20 10 staging test-repo1
 	update_bundle "$TEST_NAME" test-bundle1 --update /foo/file_1 test-repo1

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1506,7 +1506,7 @@ create_third_party_repo() { #swupd_function
 			printf '[%s]\n\n' "$repo_name"
 			printf 'URL=%s\n\n' "file://$TPURL"
 			printf 'VERSION=%s\n\n' "$version"
-		} | sudo tee -a "$STATEDIR"/3rd-party/repo.ini > /dev/null
+		} | sudo tee -a "$env_name"/testfs/target-dir/"$THIRD_PARTY_DIR"/repo.ini > /dev/null
 	fi
 
 	# every 3rd-party repo needs to have at least the special os-core bundle,


### PR DESCRIPTION
The repo.ini file was being created in the swupd state directory, this
was not ideal since it prevented the state directory from being used for
multiple target paths.

This commit moves the repo.ini file out of the state directory and into
the 3rd-party content directory.