### PR TITLE
3rd-party: Support adding symlinks to 3rd party repositories

### DIFF
--- a/src/3rd_party_bundle_add.c
+++ b/src/3rd_party_bundle_add.c
@@ -133,7 +133,7 @@ static enum swupd_code validate_permissions(struct file *file)
 	}
 
 	string_or_die(&staged_file, "%s/staged/%s", globals.state_dir, file->hash);
-	if (stat(staged_file, &file_stats) == 0) {
+	if (lstat(staged_file, &file_stats) == 0) {
 		if ((file_stats.st_mode & S_ISUID) || (file_stats.st_mode & S_ISGID) || (file_stats.st_mode & S_ISVTX)) {
 			warn("File %s has dangerous permissions\n", file->filename);
 			ret_code = SWUPD_NO;

--- a/test/functional/3rd-party/3rd-party-bundle-add-symlink.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-symlink.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+# Author: Otavio Pontes
+# Email: otavio.pontes@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n upstream-bundle -f /upstream_file "$TEST_NAME"
+
+	# create a couple 3rd-party repos within the test environment and add
+	# some bundles to them
+	create_third_party_repo -a "$TEST_NAME" 10 1 test-repo1
+
+	create_bundle -n test-bundle1 -b /foo/symlink -u test-repo1 "$TEST_NAME"
+}
+
+@test "TPR072: Adding a broken symlink to a 3rd-party repo" {
+
+	# users should be able to install bundles from 3rd-party repos
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle1"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Searching for bundle test-bundle1 in the 3rd-party repositories...
+		Bundle test-bundle1 found in 3rd-party repository test-repo1
+		Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Loading required manifests...
+		Validating 3rd-party bundle binaries...
+		No packs need to be downloaded
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Validating 3rd-party bundle file permissions...
+		Installing files...
+		Warning: post-update helper scripts skipped due to --no-scripts argument
+		Exporting 3rd-party bundle binaries...
+		Successfully installed 1 bundle
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_symlink_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/foo/symlink
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/test-bundle1
+
+}

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -3844,6 +3844,30 @@ assert_dir_not_exists() { # assertion
 
 }
 
+assert_symlink_exists() { # assertion
+
+	local vfile=$1
+	validate_param "$vfile"
+
+	if sudo test ! -L "$vfile"; then
+		print_assert_failure "File $vfile should exist, but it does not"
+		return 1
+	fi
+
+}
+
+assert_symlink_not_exists() { # assertion
+
+	local vfile=$1
+	validate_param "$vfile"
+
+	if sudo test -L "$vfile"; then
+		print_assert_failure "File $vfile should not exist, but it does"
+		return 1
+	fi
+
+}
+
 assert_file_exists() { # assertion
 
 	local vfile=$1


### PR DESCRIPTION
When a symlink is added to a 3rd-party repository it will be broken
on the statedir and stat command will fail. We need to use lstat, to
get information about the symlink and not the file that it's pointing
to.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>