### PR TITLE
Multi-repo operations skip bad repo

### DIFF
--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -504,15 +504,17 @@ enum swupd_code third_party_run_operation_multirepo(const char *repo, process_bu
 		for (iter = repos; iter; iter = iter->next) {
 			selected_repo = iter->data;
 
+			/* set the repo's header */
+			third_party_repo_header(selected_repo->name);
+
 			/* set the appropriate variables for the selected 3rd-party repo */
 			ret = third_party_set_repo(selected_repo, globals.sigcheck);
 			if (ret) {
+				/* if one repo failed to set up, we can still try the rest of
+				 * the repos, but keep the error */
 				ret_code = ret;
-				goto clean_and_exit;
+				continue;
 			}
-
-			/* set the repo's header */
-			third_party_repo_header(selected_repo->name);
 
 			ret = process_bundle_fn(NULL);
 			if (ret != expected_ret_code) {


### PR DESCRIPTION
When running an operation that should run in all the 3rd-party repos
installed, if one repo fails to set up, the process is aborted and the
operation is never performed in the repos after the failed repo.

This PR changes the proces so if one repo fails to set up it is just
skipped so the operation is attempted in the other repos.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>