### PR TITLE
Use of --assume and --yes flags to confirm a cert

### DIFF
--- a/src/3rd_party_add.c
+++ b/src/3rd_party_add.c
@@ -94,18 +94,12 @@ static int remove_repo(const char *repo_name)
 
 static bool confirm_certificate(const char *cert)
 {
-	int c;
-
 	info("Importing 3rd-party repository public certificate:\n\n");
 	signature_print_info(cert);
 
 	info("\n");
-	info("Do you want to accept this certificate? (y/N): ");
-
-	c = tolower(getchar());
-	info("\n");
-
-	return c == 'y';
+	info("To add the 3rd-party repository you need to accept this certificate\n");
+	return confirm_action();
 }
 
 static int import_temp_certificate(int version, char *hash)


### PR DESCRIPTION
When users add a 3rd-party repository they are asked if they want to
trust the certificate, this commit makes possible to use the
--assume flag to answer that question.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>