### PR TITLE
Removing extra step from 3rd-party remove

### DIFF
--- a/src/3rd_party_remove.c
+++ b/src/3rd_party_remove.c
@@ -168,7 +168,6 @@ enum swupd_code third_party_remove_main(int argc, char **argv)
 	}
 
 	/* remove the repo's exported binaries from the system */
-	progress_next_step("load_manifests", PROGRESS_BAR);
 	ret = third_party_process_files(mom->files, "\nRemoving 3rd-party bundle binaries...\n", "remove_binaries", third_party_remove_binary);
 
 exit:


### PR DESCRIPTION
This extra step was causing the percentage to be printed twice:
```
$ sudo ./swupd 3rd-party remove swupd-master
Loading required manifests...
 [100%]

Removing repository swupd-master...

Removing 3rd-party bundle binaries...
 [100%]

 [100%]
```

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>