### PR TITLE
Forcing the removal of corrupt 3rd-party repos

### DIFF
--- a/config
+++ b/config
@@ -377,6 +377,16 @@
 #
 
 
+[3rd-party-remove]
+
+#
+# Options for the "swupd 3rd-party remove" command
+#
+
+# Attempt to proceed even if non-critical errors found (boolean value)
+#force=<true/false>
+
+
 [3rd-party-bundle-add]
 
 #

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -679,6 +679,11 @@ SUBCOMMANDS
        Removes a 3rd-party repository along with all the content installed
        from it from the system.
 
+         -  ``force``
+
+         Attempt to proceed with the removal of the repo even if non-critical
+         errors found.
+
     -  ``list``
 
        Lists the 3rd-party repositories available to the system. These

--- a/swupd.bash
+++ b/swupd.bash
@@ -87,7 +87,7 @@ _swupd()
 		opts="$global --repo"
 		break;;
 		("remove")
-		opts="$global --repo"
+		opts="$global --repo --force"
 		break;;
 	esac
 	done

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -51,7 +51,7 @@ local -a installed all_bundles
 
     (( $#comma )) && local separator="-s ,"
     if (( ! $#installed )); then
-      _message -r "Can't find installed bundles."
+      _message -r "Cannot find installed bundles."
     elif (( ! $#return_only )); then
       (( ! $#unique )) && installed=(${installed:|words})
       _alternative "bundle:installed bundles: _values $separator $installed" && ret=0
@@ -91,7 +91,7 @@ local -a installed all_bundles
         _alternative "available bundles:available bundles: _values $separator $all_bundles" && ret=0
       fi
     else
-      _message -r "Can't find Manifest file."
+      _message -r "Cannot find Manifest file."
     fi
   }
 
@@ -178,7 +178,7 @@ if [[ -n "$state" ]]; then
         "mirror:Configure mirror url for swupd content"
         "clean:Clean cached files"
         "hashdump:Dump the HMAC hash of a file"
-        "3rd-party: Indicate Swupd to use user's third party repo"
+        "3rd-party: Manage third party repositories"
       )
       _describe -t subcmds 'swupd subcommand' subcmds && ret=0
       ;;
@@ -214,6 +214,7 @@ if [[ -n "$state" ]]; then
           remove)
           local -a remove; remove=(
           $global_opt
+          '(help status -x --force)'{-x,--force}'[Attempt to proceed even if non-critical errors found]'
           '(help)Positional arg: [repo-name]'
           _arguments $remove && ret=0
           ;;

--- a/test/functional/3rd-party/3rd-party-repo-remove-corrupt.bats
+++ b/test/functional/3rd-party/3rd-party-repo-remove-corrupt.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
+	create_bundle -L -t -n test-bundle1 -f /file_1,/bin/binary_1 -u repo1 "$TEST_NAME"
+	# delete some files to make the repo corrupt
+	sudo rm "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/usr/lib/os-release
+
+}
+
+@test "TPR074: Attempt to remove a corrupt third party repository" {
+
+	# user should still be able to remove corrupt 3rd-party repositories
+
+	run sudo sh -c "$SWUPD 3rd-party remove $SWUPD_OPTS repo1"
+
+	assert_status_is "$SWUPD_CURRENT_VERSION_UNKNOWN"
+	expected_output=$(cat <<-EOM
+		Error: Unable to determine current version for repository repo1
+		Error: The 3rd-party repository repo1 is corrupt and cannot be removed cleanly
+		To force the removal of the repository use the --force option
+		Please be aware that this may leave exported files in $PATH_PREFIX/$THIRD_PARTY_BIN_DIR
+		Failed to remove repository
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "TPR075: Force the removal of a corrupt third party repository" {
+
+	# user should still be able to remove corrupt 3rd-party repositories
+
+	run sudo sh -c "$SWUPD 3rd-party remove $SWUPD_OPTS repo1 --force"
+
+	assert_status_is "$SWUPD_CURRENT_VERSION_UNKNOWN"
+	expected_output=$(cat <<-EOM
+		Error: Unable to determine current version for repository repo1
+		Warning: The --force option is specified; forcing the removal of the repository
+		Please be aware that this may leave exported files in $PATH_PREFIX/$THIRD_PARTY_BIN_DIR
+		Removing repository repo1...
+		Repository and its content partially removed
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}


### PR DESCRIPTION
This commit allow users to force the deletion of corrupt 3rd-party repos
which will end up deleting most of the repo's files, except for the
scripts that exported files from that repo.

Closes #1343

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>