### PR TITLE
Staging: Don't create hardlinks when installing symlinks

### DIFF
--- a/src/staging.c
+++ b/src/staging.c
@@ -201,7 +201,7 @@ enum swupd_code do_staging(struct file *file, struct manifest *MoM)
 		 * might have for overlaid mounts.  The use of tar is a simple way to copy, but
 		 * inefficient.  So prefer hardlink and fall back if needed: */
 		ret = -1;
-		if (!file->is_config && !file->is_state && !file->use_xattrs) {
+		if (!file->is_config && !file->is_state && !file->use_xattrs && !file->is_link) {
 			ret = link(original, target);
 		}
 		if (ret < 0) {

--- a/test/functional/os-install/install-hardlink-symlink.bats
+++ b/test/functional/os-install/install-hardlink-symlink.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+# Author: Otavio Pontes
+# Email: otavio.pontes@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment -e "$TEST_NAME" 10
+	create_bundle -n os-core -h /core,/core2,/core3 -H /symlink,/symlink2,/symlink3 "$TEST_NAME"
+
+}
+
+@test "INS027: Check if hardlinks are preserved" {
+
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS --path $TARGETDIR"
+	assert_status_is "$SWUPD_OK"
+	run sudo sh -c "$SWUPD clean --all $SWUPD_OPTS --path $TARGETDIR"
+	assert_status_is "$SWUPD_OK"
+
+	run stat --printf=%h "$TARGETDIR"/core
+	assert_status_is "0"
+	assert_is_output "3"
+
+	run stat --printf=%h "$TARGETDIR"/core2
+	assert_status_is "0"
+	assert_is_output "3"
+
+	run stat --printf=%h "$TARGETDIR"/core3
+	assert_status_is "0"
+	assert_is_output "3"
+
+}
+
+@test "INS028: Check if symlink hardlinks are not preserved" {
+
+	# There are known bugs on bsdtar to extract hardlink to symlinks,
+	# so we avoid to have them on swupd.
+
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS --path $TARGETDIR"
+	assert_status_is "$SWUPD_OK"
+	run sudo sh -c "$SWUPD clean --all $SWUPD_OPTS --path $TARGETDIR"
+	assert_status_is "$SWUPD_OK"
+
+	run stat --printf=%h "$TARGETDIR"/symlink
+	assert_status_is "0"
+	assert_is_output "1"
+
+	run stat --printf=%h "$TARGETDIR"/symlink2
+	assert_status_is "0"
+	assert_is_output "1"
+
+	run stat --printf=%h "$TARGETDIR"/symlink3
+	assert_status_is "0"
+	assert_is_output "1"
+
+}


### PR DESCRIPTION
    Staging: Don't create hardlinks when installing symlinks
    
    Alternative solution to solution proposed on #1318
    
    Instead of trying to create a link just don't try to link symlinks.
    Tested patch using bsdtar and implemented automated testing to
    validate solution.
    
    Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>
