### PR TITLE
Reordering 3rd-party subcommands in help

### DIFF
--- a/config
+++ b/config
@@ -157,6 +157,7 @@
 # Update the index used by search-file to speed up searches (boolean value)
 #update_search_file_index=<true/false>
 
+
 [bundle-add]
 
 #
@@ -356,6 +357,7 @@
 # Do not install optional bundles, also-add flag in Manifests (boolean value)
 #skip_optional=<true/false>
 
+
 [mirror]
 
 #
@@ -377,6 +379,13 @@
 #
 
 
+[3rd-party-add]
+
+#
+# Options for the "swupd 3rd-party add" command
+#
+
+
 [3rd-party-remove]
 
 #
@@ -387,6 +396,13 @@
 #force=<true/false>
 
 
+[3rd-party-list]
+
+#
+# Options for the "swupd 3rd-party list" command
+#
+
+
 [3rd-party-info]
 
 #
@@ -395,6 +411,43 @@
 
 # Specify the 3rd-party repository to use (string value)
 #repo=[REPOSITORY]
+
+
+[3rd-party-check-update]
+
+#
+# Options for the "swupd 3rd-party check-update" command
+#
+
+# Specify the 3rd-party repository to use (string value)
+#repo=[REPOSITORY]
+
+
+[3rd-party-update]
+
+#
+# Options for the "swupd 3rd-party update" command
+#
+
+# Specify the 3rd-party repository to use (string value)
+#repo=[REPOSITORY]
+
+# Update to the specified version
+# Possible values:
+# ..., 29890, 29900, 29910, ...                     (integer value)
+# latest - used to refer to the most recent version (string value)
+#version=<VERSION>
+
+# Download all content, but do not actually install the update (boolean value)
+#download=<true/false>
+
+# Show current OS version and latest version available on server, eEquivalent
+# to "swupd check-update" (boolean value)
+#status=<true/false>
+
+# Do not delete the swupd state directory content after updating the
+# system (boolean value)
+#keepcache=<true/false>
 
 
 [3rd-party-bundle-add]
@@ -551,10 +604,10 @@
 #extra_files_only=<true/false>
 
 
-[3rd-party-check-update]
+[3rd-party-clean]
 
 #
-# Options for the "swupd 3rd-party check-update" command
+# Options for the "swupd 3rd-party clean" command
 #
 
 # Specify the 3rd-party repository to use (string value)

--- a/src/3rd_party.c
+++ b/src/3rd_party.c
@@ -25,10 +25,11 @@
 #ifdef THIRDPARTY
 
 static struct subcmd third_party_commands[] = {
-	{ "info", "Show the version of third party repositories and the update URLs", third_party_info_main },
 	{ "add", "Add third party repository", third_party_add_main },
 	{ "remove", "Remove third party repository", third_party_remove_main },
 	{ "list", "List third party repository", third_party_list_main },
+	{ "info", "Show the version of third party repositories and the update URLs", third_party_info_main },
+	{ "check-update", "Check if a new version of a third party repository is available", third_party_check_update_main },
 	{ "update", "Update to latest version of a third party repository", third_party_update_main },
 	{ "bundle-add", "Install a bundle from a third party repository", third_party_bundle_add_main },
 	{ "bundle-remove", "Remove a bundle from a third party repository", third_party_bundle_remove_main },
@@ -36,7 +37,6 @@ static struct subcmd third_party_commands[] = {
 	{ "bundle-info", "Display information about a bundle in a third party repository", third_party_bundle_info_main },
 	{ "diagnose", "Verify content from a third party repository", third_party_diagnose_main },
 	{ "repair", "Repair local issues relative to a third party repository", third_party_repair_main },
-	{ "check-update", "Check if a new version of a third party repository is available", third_party_check_update_main },
 	{ "clean", "Clean cached files of a third party repository", third_party_clean_main },
 	{ 0 }
 };


### PR DESCRIPTION
Reordering so it matches the order of the regular swupd commands. Also
adding missing values to config file.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>