### PR TITLE
Do not follow links when validating staged files

### DIFF
--- a/src/3rd_party_update.c
+++ b/src/3rd_party_update.c
@@ -181,7 +181,7 @@ static enum swupd_code validate_permissions(struct file *file)
 	}
 
 	string_or_die(&staged_file, "%s/staged/%s", globals.state_dir, file->hash);
-	if (stat(staged_file, &file_stats) == 0) {
+	if (lstat(staged_file, &file_stats) == 0) {
 		/* see if the file being updated has dangerous flags */
 		if ((file_stats.st_mode & S_ISUID) || (file_stats.st_mode & S_ISGID) || (file_stats.st_mode & S_ISVTX)) {
 			if (!file->peer) {
@@ -192,7 +192,7 @@ static enum swupd_code validate_permissions(struct file *file)
 				/* an existing file has dangerous flags, do not warn unless
 				 * the flags changed from non-dangerous to dangerous in the update */
 				original_file = sys_path_join(globals.path_prefix, file->filename);
-				if (stat(original_file, &original_file_stats) == 0) {
+				if (lstat(original_file, &original_file_stats) == 0) {
 					if (
 					    ((file_stats.st_mode & S_ISUID) && !(original_file_stats.st_mode & S_ISUID)) ||
 					    ((file_stats.st_mode & S_ISGID) && !(original_file_stats.st_mode & S_ISGID)) ||


### PR DESCRIPTION
When updating 3rd-party bundles, swupd validates the files to be updated
to make sure there were no changes in file permissions that could be
risky for the system, it uses stat to get the file permissions. The
problem is that stat follows links, and while the files are in staging,
the links are really pointing to invalid locations so stat will always
fail.

This commit fixes the problem by not following links when validating
file permissions.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>