### PR TITLE
3rd-party: Make 3rd-party default in the build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,11 +74,11 @@ AS_IF(
 
 AC_ARG_ENABLE(
   [third-party],
-  [AS_HELP_STRING([--enable-third-party], [Enable 3rd-party (disabled by default)])]
+  [AS_HELP_STRING([--disable-third-party], [Disable 3rd-party (enabled by default)])]
 )
-THIRDPARTY="no"
+THIRDPARTY="yes"
 AS_IF(
-  [test "x$enable_third_party" = "xyes"],
+  [test "x$enable_third_party" != "xno"],
   [AC_DEFINE(THIRDPARTY, 1, [Enable third party])
      THIRDPARTY="yes"],
   [THIRDPARTY="no"]

--- a/scripts/build_ci.bash
+++ b/scripts/build_ci.bash
@@ -28,7 +28,7 @@ pushd libarchive-3.3.1 && autoreconf -fi && ./configure --prefix=/usr && make -j
 
 # Build Swupd
 autoreconf --verbose --warnings=none --install --force
-./configure CFLAGS="$CFLAGS -fsanitize=address -Werror" --prefix=/usr --enable-third-party --with-fallback-capaths=./swupd_test_certificates --with-systemdsystemunitdir=/usr/lib/systemd/system --with-config-file-path=./testconfig
+./configure CFLAGS="$CFLAGS -fsanitize=address -Werror" --prefix=/usr --with-fallback-capaths=./swupd_test_certificates --with-systemdsystemunitdir=/usr/lib/systemd/system --with-config-file-path=./testconfig
 make -j$CORES
 
 # Needed to initialize the host for auto-update. Without these steps auto-update


### PR DESCRIPTION
Instead of requiring an --enable-third-party, as 3rd-party was already
released, we can make it default.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>