### PR TITLE
signature: Dummy signature_verify_data() function missing

### DIFF
--- a/src/signature.c
+++ b/src/signature.c
@@ -564,4 +564,9 @@ void signature_print_info(const char UNUSED_PARAM *path)
 {
 	return;
 }
+
+bool signature_verify_data(const unsigned char UNUSED_PARAM *data, size_t UNUSED_PARAM data_len, const unsigned char UNUSED_PARAM *sig_data, size_t UNUSED_PARAM sig_data_len, bool UNUSED_PARAM print_errors)
+{
+	return true;
+}
 #endif


### PR DESCRIPTION
When building swupd with --disable-signature we need to have all
signature functions with a dummy implementation that doesn't validate
the signature.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>