### PR TITLE
docs: Replace vi with vim

### DIFF
--- a/config
+++ b/config
@@ -280,7 +280,7 @@
 #picky_whitelist=[RE]
 
 # Diagnose if BUNDLES are installed correctly (string value)
-# Example: --bundles=os-core,vi
+# Example: --bundles=xterm,vim
 #bundles=[BUNDLES]
 
 # Like --picky, but it only searches for extra files (boolean value)
@@ -307,7 +307,7 @@
 #quick=<true/false>
 
 # Repair BUNDLES that are not installed correctly (string value)
-# Example: --bundles=os-core,vi
+# Example: --bundles=xterm,vim
 #bundles=[BUNDLES]
 
 # Remove files which should not exist (boolean value)
@@ -340,7 +340,7 @@
 #force=<true/false>
 
 # Include the specified BUNDLES in the OS installation (string value)
-# Example: --bundles=os-core,vi
+# Example: --bundles=xterm,vim
 #bundles=[BUNDLES]
 
 # If the version to install is not the latest, it can be specified with this
@@ -557,7 +557,7 @@
 #picky_whitelist=[RE]
 
 # Diagnose if BUNDLES are installed correctly (string value)
-# Example: --bundles=os-core,vi
+# Example: --bundles=xterm,vim
 #bundles=[BUNDLES]
 
 # Like --picky, but it only searches for extra files (boolean value)
@@ -584,7 +584,7 @@
 #quick=<true/false>
 
 # Repair BUNDLES that are not installed correctly (string value)
-# Example: --bundles=os-core,vi
+# Example: --bundles=xterm,vim
 #bundles=[BUNDLES]
 
 # Remove files which should not exist (boolean value)

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -441,9 +441,9 @@ SUBCOMMANDS
 
        Examples:
 
-         -  ``--bundles os-core,vi``
+         -  ``--bundles xterm,vim``
 
-            Diagnoses only bundles `os-core` and `vi`.
+            Diagnoses only bundles `xterm` and `vim`.
 
     -  ``-Y, --picky``
 
@@ -521,9 +521,9 @@ SUBCOMMANDS
 
        Examples:
 
-         -  ``--bundles os-core,vi``
+         -  ``--bundles xterm,vim``
 
-            Repairs only bundles `os-core` and `vi`.
+            Repairs only bundles `xterm` and `vim`.
 
     -  ``-Y, --picky``
 
@@ -596,9 +596,9 @@ SUBCOMMANDS
 
        Examples:
 
-         -  ``--bundles xterm,vi``
+         -  ``--bundles xterm,vim``
 
-            Installs bundles `xterm` and `vi`, along with `os-core` (installed by default).
+            Installs bundles `xterm` and `vim`, along with `os-core` (installed by default).
 
     -  ``-s, --statedir-cache={PATH}``
 

--- a/src/3rd_party_diagnose.c
+++ b/src/3rd_party_diagnose.c
@@ -52,7 +52,7 @@ static void print_help(void)
 	print("   -V, --version=[VER]     Diagnose against manifest version VER\n");
 	print("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	print("   -q, --quick             Don't check for corrupt files, only find missing files\n");
-	print("   -B, --bundles=[BUNDLES] Forces swupd to only diagnose the specified BUNDLES. Example: --bundles=os-core,vi\n");
+	print("   -B, --bundles=[BUNDLES] Forces swupd to only diagnose the specified BUNDLES. Example: --bundles=xterm,vim\n");
 	print("   -Y, --picky             Also list files which should not exist. By default swupd only looks for them at /usr\n");
 	print("                           skipping /usr/lib/modules, /usr/lib/kernel, /usr/local, and /usr/src\n");
 	print("   -X, --picky-tree=[PATH] Changes the path where --picky and --extra-files-only look for extra files\n");

--- a/src/3rd_party_repair.c
+++ b/src/3rd_party_repair.c
@@ -53,7 +53,7 @@ static void print_help(void)
 	print("   -V, --version=[VER]     Compare against version VER to repair\n");
 	print("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	print("   -q, --quick             Don't compare hashes, only fix missing files\n");
-	print("   -B, --bundles=[BUNDLES] Forces swupd to only repair the specified BUNDLES. Example: --bundles=os-core,vi\n");
+	print("   -B, --bundles=[BUNDLES] Forces swupd to only repair the specified BUNDLES. Example: --bundles=xterm,vim\n");
 	print("   -Y, --picky             Also remove files which should not exist. By default swupd only looks for them at /usr\n");
 	print("                           skipping /usr/lib/modules, /usr/lib/kernel, /usr/local, and /usr/src\n");
 	print("   -X, --picky-tree=[PATH] Changes the path where --picky and --extra-files-only look for extra files\n");

--- a/src/os_install.c
+++ b/src/os_install.c
@@ -53,7 +53,7 @@ static void print_help(void)
 	print("Options:\n");
 	print("   -V, --version=[VER]         If the version to install is not the latest, it can be specified with this option\n");
 	print("   -x, --force                 Attempt to proceed even if non-critical errors found\n");
-	print("   -B, --bundles=[BUNDLES]     Include the specified BUNDLES in the OS installation. Example: --bundles=os-core,vi\n");
+	print("   -B, --bundles=[BUNDLES]     Include the specified BUNDLES in the OS installation. Example: --bundles=xterm,vim\n");
 	print("   -s, --statedir-cache=[PATH] After checking for content in the statedir, check the statedir-cache before downloading it over the network\n");
 	print("   --download                  Download all content, but do not actually install it\n");
 	print("   --skip-optional             Do not install optional bundles (also-add flag in Manifests)\n");

--- a/src/repair.c
+++ b/src/repair.c
@@ -68,7 +68,7 @@ static void print_help(void)
 	print("   -V, --version=[VER]     Compare against version VER to repair\n");
 	print("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	print("   -q, --quick             Don't compare hashes, only fix missing files\n");
-	print("   -B, --bundles=[BUNDLES] Forces swupd to only repair the specified BUNDLES. Example: --bundles=os-core,vi\n");
+	print("   -B, --bundles=[BUNDLES] Forces swupd to only repair the specified BUNDLES. Example: --bundles=xterm,vim\n");
 	print("   -Y, --picky             Also remove files which should not exist. By default swupd only looks for them at /usr\n");
 	print("                           skipping /usr/lib/modules, /usr/lib/kernel, /usr/local, and /usr/src\n");
 	print("   -X, --picky-tree=[PATH] Changes the path where --picky and --extra-files-only look for extra files\n");

--- a/src/verify.c
+++ b/src/verify.c
@@ -191,7 +191,7 @@ static void print_help(void)
 	print("   -V, --version=[VER]     %s against manifest version VER\n", cmdline_command_verify ? "Verify" : "Diagnose");
 	print("   -x, --force             Attempt to proceed even if non-critical errors found\n");
 	print("   -q, --quick             Don't check for corrupt files, only fix missing files\n");
-	print("   -B, --bundles=[BUNDLES] Forces swupd to only %s the specified BUNDLES. Example: --bundles=os-core,vi\n", cmdline_command_verify ? "verify" : "diagnose");
+	print("   -B, --bundles=[BUNDLES] Forces swupd to only %s the specified BUNDLES. Example: --bundles=xterm,vim\n", cmdline_command_verify ? "verify" : "diagnose");
 	print_if_verify("   -m, --manifest=[VER]    This option has been superseded. Please consider using the -V option instead\n");
 	print_if_verify("   -f, --fix               This option has been superseded, please consider using \"swupd repair\" instead\n");
 	print_if_verify("   -i, --install           This option has been superseded, please consider using \"swupd os-install\" instead\n");

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -327,7 +327,7 @@ if [[ -n "$state" ]]; then
             '(help -X --picky-tree)'{-X,--picky-tree=}'[Selects the sub-tree where --picky and --extra-files-only looks for extra files. Default\: /usr]:picky-tree: _path_files -/'
             '(help -w --picky-whitelist)'{-w,--picky-whitelist=}'[Directories that match the regex get skipped. Example\: /var|/etc/machine-id. Default\: /usr/lib/modules|/usr/lib/kernel|/usr/local|/usr/src]:picky-whitelist:()'
             '(help)--extra-files-only[Only list files which should not exist]'
-            '(help -B --bundles)'{-B,--bundles=}'[Forces swupd to only diagnose the specified BUNDLES. Example: --bundles=os-core,vi]:bundles:()'
+            '(help -B --bundles)'{-B,--bundles=}'[Forces swupd to only diagnose the specified BUNDLES. Example: --bundles=xterm,vim]:bundles:()'
             '(help)--file[Forces swupd to only diagnose the specified file or directory (recursively)]'
           )
           _arguments $diagnoses && ret=0
@@ -342,7 +342,7 @@ if [[ -n "$state" ]]; then
             '(help -w --picky-whitelist)'{-w,--picky-whitelist=}'[Directories that match the regex get skipped. Example: /var|/etc/machine-id. Default: /usr/lib/modules|/usr/lib/kernel|/usr/local|/usr/src]:picky-whitelist:()'
             '(help -X --picky-tree)'{-X,--picky-tree=}'[Selects the sub-tree where --picky and --extra-files-only looks for extra files. Default\: /usr]:picky-tree: _path_files -/'
             '(help)--extra-files-only[Only remove files which should not exist]'
-            '(help -B --bundles)'{-B,--bundles=}'[Forces swupd to only repair the specified BUNDLES. Example: --bundles=os-core,vi]:bundles:()'
+            '(help -B --bundles)'{-B,--bundles=}'[Forces swupd to only repair the specified BUNDLES. Example: --bundles=xterm,vim]:bundles:()'
             '(help)--file[Forces swupd to only repair the specified file or directory (recursively)]'
           )
           _arguments $repair && ret=0
@@ -351,7 +351,7 @@ if [[ -n "$state" ]]; then
           local -a osinstall; osinstall=(
             $global_opts
             '(help -x --force)'{-x,--force}'[Attempt to proceed even if non-critical errors found]'
-            '(help -B --bundles)'{-B,--bundles=}'[Include the specified BUNDLES in the OS installation. Example: --bundles=os-core,vi]:diagnose: _swupd_all_bundles'
+            '(help -B --bundles)'{-B,--bundles=}'[Include the specified BUNDLES in the OS installation. Example: --bundles=xterm,vim]:diagnose: _swupd_all_bundles'
             '(help -V --version)'{-V,--version=}'[If the version to install is not the latest, it can be specified with this option]:version:()'
             '(help -s --statedir-cache)'{-s,--statedir-cache=}'[After checking for content in the statedir, check the statedir-cache before downloading it over the network]'
             '(help status)--download[Download all content, but do not actually install it]'


### PR DESCRIPTION
Vi isn't a bundle anymore. Replacing all examples to vim.

Related to #1369

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>