### PR TITLE
Bug fix: os-install --bundles with os-core fails

### DIFF
--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -580,7 +580,9 @@ SUBCOMMANDS
 
     Perform system software installation in the specified location. Install
     all files into `{path}` as specified by the ``swupd os-install {path}``
-    option. Useful to generate a new system root.
+    option. Useful to generate a new system root. The only bundle that will
+    be installed by default is ``os-core`` unless more bundles are specified
+    with the ``--bundles`` option.
 
     -  ``-V, --version={VERSION}``
 

--- a/src/os_install.c
+++ b/src/os_install.c
@@ -88,14 +88,12 @@ static bool parse_opt(int opt, char *optarg)
 		char *arg_copy = strdup_or_die(optarg);
 		char *token = strtok(arg_copy, ",");
 		while (token) {
-			if (strcmp(token, "os-core") != 0) {
-				cmdline_bundles = list_prepend_data(cmdline_bundles, strdup_or_die(token));
-			}
+			cmdline_bundles = list_prepend_data(cmdline_bundles, strdup_or_die(token));
 			token = strtok(NULL, ",");
 		}
 		free(arg_copy);
 		if (!cmdline_bundles) {
-			error("Missing --bundle argument\n\n");
+			error("Missing --bundles argument\n\n");
 			return false;
 		}
 		return true;

--- a/test/functional/os-install/install-multiple.bats
+++ b/test/functional/os-install/install-multiple.bats
@@ -64,4 +64,45 @@ test_setup() {
 	assert_file_not_exists "$TARGETDIR"/var/lib/swupd/bundles/os-core
 
 }
+
+@test "INS026: An OS install with user specified bundles that include os-core works correctly" {
+
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS --bundles test-bundle2,os-core"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Installing OS version 10 (latest)
+		Downloading missing manifests...
+		Downloading packs for:
+		 - test-bundle2
+		 - os-core
+		Finishing packs extraction...
+		Checking for corrupt files
+		Validate downloaded files
+		No extra files need to be downloaded
+		Installing base OS and selected bundles
+		Inspected 5 files
+		  5 files were missing
+		    5 of 5 missing files were installed
+		    0 of 5 missing files were not installed
+		Calling post-update helper scripts
+		Installation successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGETDIR"/foo/file_3
+	assert_file_exists "$TARGETDIR"/var/lib/swupd/bundles/test-bundle2
+	assert_file_exists "$TARGETDIR"/var/lib/swupd/bundles/os-core
+	# make sure non specified bundles were not installed
+	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGETDIR"/file_1
+	assert_file_not_exists "$TARGETDIR"/file_2
+	assert_file_not_exists "$TARGETDIR"/var/lib/swupd/bundles/test-bundle1
+	assert_file_not_exists "$TARGETDIR"/var/lib/swupd/bundles/test-bundle3
+	assert_file_not_exists "$TARGETDIR"/bar/file_4
+
+}
 #WEIGHT=4


### PR DESCRIPTION
When doing a system install with "os-install --bundles" if the list of
bundles to install includes only "os-core" the install fails.

This commit fixes the issue.

Closes #1369 

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>