### PR TITLE
build_opts: Print third party build info on swupd -v

### DIFF
--- a/src/swupd_build_opts.h
+++ b/src/swupd_build_opts.h
@@ -28,6 +28,12 @@
 #define OPT_BZIP2 "-BZIP2"
 #endif
 
+#ifdef THIRDPARTY
+#define OPT_THIRD_PARTY "+THIRDPARTY"
+#else
+#define OPT_THIRD_PARTY "-THIRDPARTY"
+#endif
+
 #ifdef SIGNATURES
 #define OPT_SIGNATURES "+SIGVERIFY"
 #else
@@ -101,7 +107,7 @@
 #endif
 
 #define BUILD_OPTS \
-	OPT_BZIP2 " " OPT_SIGNATURES " " OPT_COVERAGE " " OPT_BSDTAR " " OPT_XATTRS " " OPT_SELINUX " " OPT_STATELESS
+	OPT_BZIP2 " " OPT_SIGNATURES " " OPT_COVERAGE " " OPT_BSDTAR " " OPT_XATTRS " " OPT_SELINUX " " OPT_STATELESS " " OPT_THIRD_PARTY
 
 #define BUILD_CONFIGURE                                          \
 	"mount point                  " MOUNT_POINT "\n"         \


### PR DESCRIPTION
We print all flags selected on build time on swupd -v. This is useful
to check if an specific swupd binary has one specific feature enabled.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>