### PR TITLE
3rd-party:bug_fix: don't add unreachable repos

### DIFF
--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -47,7 +47,7 @@ static char *get_repo_config_path(void)
 	return str_or_die("%s/%s/%s", globals_bkp.path_prefix, SWUPD_3RD_PARTY_DIR, "repo.ini");
 }
 
-static char *get_repo_content_path(const char *repo_name)
+char *get_repo_content_path(const char *repo_name)
 {
 	return str_or_die("%s%s/%s", globals_bkp.path_prefix, SWUPD_3RD_PARTY_BUNDLES_DIR, repo_name);
 }

--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -172,6 +172,11 @@ enum swupd_code third_party_remove_binary(struct file *file);
  */
 enum swupd_code third_party_create_wrapper_script(struct file *file);
 
+/**
+ * @brief Function that retrieves the content director of a 3rd-party repo
+ */
+char *get_repo_content_path(const char *repo_name);
+
 #endif
 
 #ifdef __cplusplus

--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -548,3 +548,36 @@ long sys_get_file_size(const char *filename)
 	}
 	return -errno;
 }
+
+int sys_dir_is_empty(const char *path)
+{
+	DIR *dir;
+	struct dirent *entry;
+	int ret = 1;
+
+	dir = opendir(path);
+	if (dir == NULL) {
+		ret = -errno;
+		goto exit;
+	}
+
+	while (true) {
+		entry = readdir(dir);
+		if (!entry) {
+			break;
+		}
+
+		if (!strcmp(entry->d_name, ".") ||
+		    !strcmp(entry->d_name, "..")) {
+			continue;
+		}
+
+		/* the directory is not empty*/
+		ret = 0;
+		break;
+	}
+
+exit:
+	closedir(dir);
+	return ret;
+}

--- a/src/lib/sys.h
+++ b/src/lib/sys.h
@@ -233,6 +233,7 @@ long sys_file_hardlink_count(const char *file);
  * @return Return the size of a file or a negative number on errors.
  */
 long sys_get_file_size(const char *filename);
+
 /**
  * @brief Run a systemctl command with the informed parameters.
  */
@@ -243,6 +244,13 @@ long sys_get_file_size(const char *filename);
  */
 #define systemctl_cmd_path(path, ...) \
 	path ? run_command_quiet(SYSTEMCTL, "--root", path, __VA_ARGS__) : run_command_quiet(SYSTEMCTL, __VA_ARGS__)
+
+/**
+ * @brief function that checks if a directory is empty
+ *
+ * @return 1 if the directory is empty, 0 if it is not empty, < 0 on errors
+ */
+int sys_dir_is_empty(const char *path);
 
 #ifdef __cplusplus
 }

--- a/test/functional/3rd-party/3rd-party-repo-add-certificate.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add-certificate.bats
@@ -48,11 +48,11 @@ test_setup() {
 	run sudo sh -c "echo 'y' | $SWUPD 3rd-party add test-repo1 file://$repo1 $SWUPD_OPTS_NO_CERT"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Adding 3rd-party repository test-repo1...
 		Importing 3rd-party repository public certificate:
 		Issuer: /C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost
 		Subject: /C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost
 		.*
+		Adding 3rd-party repository test-repo1...
 		Installing the required bundle 'os-core' from the repository...
 		Note that all bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Loading required manifests...
@@ -88,7 +88,6 @@ test_setup() {
 	run sudo sh -c "echo 'n' | $SWUPD 3rd-party add test-repo1 file://$repo1 $SWUPD_OPTS_NO_CERT"
 	assert_status_is "$SWUPD_BAD_CERT"
 	expected_output=$(cat <<-EOM
-		Adding 3rd-party repository test-repo1...
 		Importing 3rd-party repository public certificate:
 		Issuer: /C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost
 		Subject: /C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost

--- a/test/functional/3rd-party/3rd-party-repo-add-negative.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add-negative.bats
@@ -73,11 +73,10 @@ global_teardown() {
 	)
 	assert_in_output "$expected_output"
 
-	run sudo sh -c "$SWUPD 3rd-party add test-repo1 https://abc.com $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD 3rd-party add test-repo1 file://$repo $SWUPD_OPTS"
 	assert_status_is "$SWUPD_INVALID_OPTION"
 	expected_output=$(cat <<-EOM
-		Adding 3rd-party repository test-repo1...
-		Error: The repository test-repo1 already exists
+		Error: A 3rd-party repository called "test-repo1" already exists
 		Failed to add repository
 	EOM
 	)


### PR DESCRIPTION
When adding a 3rd-party repo, if the repo cannot be added it is reverted
back. However if a user uses an incorrect URL that hangs and the user
cancels the process, the repo add is never rolled back, which will cause
the invalid repo to be left in the system.

This commit fixes the issue by making sure the repo is reachable and
somewhat valid before adding it to the config file.

Closes #1384

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>