### PR TITLE
3rd-party: add force option to "3rd-party add"

### DIFF
--- a/config
+++ b/config
@@ -385,6 +385,9 @@
 # Options for the "swupd 3rd-party add" command
 #
 
+# Attempt to proceed even if non-critical errors found (boolean value)
+#force=<true/false>
+
 
 [3rd-party-remove]
 

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -676,6 +676,11 @@ SUBCOMMANDS
 
        Adds a 3rd-party repository.
 
+         -  ``force``
+
+         Attempt to proceed with the removal of the repo even if non-critical
+         errors found.
+
     -  ``remove``
 
        Removes a 3rd-party repository along with all the content installed

--- a/swupd.bash
+++ b/swupd.bash
@@ -84,7 +84,7 @@ _swupd()
 		opts="$global add remove list bundle-add bundle-list bundle-remove bundle-info update diagnose repair check-update clean info "
 		break;;
 		("add")
-		opts="$global --repo"
+		opts="$global --repo --force"
 		break;;
 		("remove")
 		opts="$global --repo --force"

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -209,6 +209,7 @@ if [[ -n "$state" ]]; then
                 add)
                     local -a add; add=(
                         $global_opt
+                        '(help status -x --force)'{-x,--force}'[Attempt to proceed even if non-critical errors found]'
                         '(help)Positional arg: [repo-name]'
                         '(help)Positional arg: [repo-url]'
                     )

--- a/test/functional/3rd-party/3rd-party-repo-add-force.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add-force.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_third_party_repo "$TEST_NAME" 10 staging repo1
+	# create an empty content directory that matches the repo name
+	sudo mkdir -p "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1
+
+}
+
+@test "TPR078: Try adding a 3rd-party repo that has an empty content directory conflict" {
+
+	# when adding a 3rd-party repo, if a directory with the same name already exists
+	# and is not empty, swupd should warn the user and abort unless the --force option is used
+	# if the directory exists, but is empty, the process should continue business as usual
+
+	run sudo sh -c "$SWUPD 3rd-party add repo1 file://$TPURL $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Adding 3rd-party repository repo1...
+		Installing the required bundle 'os-core' from the repository...
+		Note that all bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Loading required manifests...
+		Downloading packs for:
+		 - os-core
+		Finishing packs extraction...
+		Validate downloaded files
+		No extra files need to be downloaded
+		Installing files...
+		Warning: post-update helper scripts skipped due to --no-scripts argument
+		Successfully installed 1 bundle
+		Repository added successfully
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "TPR079: Try adding a 3rd-party repo that has a content directory conflict" {
+
+	# when adding a 3rd-party repo, if a directory with the same name already exists
+	# and is not empty, swupd should warn the user and abort unless the --force option is used
+	# if the directory exists, but is empty, the process should continue business as usual
+
+	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/leftover
+
+	run sudo sh -c "$SWUPD 3rd-party add repo1 file://$TPURL $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_INVALID_REPOSITORY"
+	expected_output=$(cat <<-EOM
+		Error: A content directory for a 3rd-party repository called "repo1" already exists at $PATH_PREFIX//opt/3rd-party/bundles/repo1, aborting...
+		To force the removal of the directory and continue adding the repository use the --force option
+		Failed to add repository
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "TPR080: Force adding a 3rd-party repo that has a content directory conflict" {
+
+	# when adding a 3rd-party repo, if a directory with the same name already exists
+	# and is not empty, swupd should warn the user and abort unless the --force option is used
+	# if the directory exists, but is empty, the process should continue business as usual
+
+	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/leftover
+
+	run sudo sh -c "$SWUPD 3rd-party add repo1 file://$TPURL $SWUPD_OPTS --force"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Warning: A content directory for a 3rd-party repository called "repo1" already exists at $PATH_PREFIX//opt/3rd-party/bundles/repo1
+		The --force option was used; forcing the removal of the directory
+		Adding 3rd-party repository repo1...
+		Installing the required bundle 'os-core' from the repository...
+		Note that all bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Loading required manifests...
+		Downloading packs for:
+		 - os-core
+		Finishing packs extraction...
+		Validate downloaded files
+		No extra files need to be downloaded
+		Installing files...
+		Warning: post-update helper scripts skipped due to --no-scripts argument
+		Successfully installed 1 bundle
+		Repository added successfully
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}


### PR DESCRIPTION
When swupd is adding a 3rd-party repo and it finds a non empty directory
that matches the repo's name in the content path it warns the user and
aborts. This may have been caused by a corrupt repo.

This commit adds a --force flag to allow users to instruct swupd to
remove the existing directory and its conent and continue adding the
3rd-party repo.

Closes #1388

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>