### PR TITLE
actions: cache dependencies for swupd

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -12,6 +12,16 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: cache-dependencies
+      id: cache-swupd-deps
+      uses: actions/cache@v1
+      with:
+        path: dependencies
+        key: swupd-dependencies
+
+    - name: build_dep
+      run:  scripts/github_actions/build_ci_dependencies.bash
+
     - name: build
       run:  scripts/github_actions/build_ci_style.bash
 
@@ -48,6 +58,16 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: cache-dependencies
+      id: cache-swupd-deps
+      uses: actions/cache@v1
+      with:
+        path: dependencies
+        key: swupd-dependencies
+
+    - name: build_dep
+      run:  scripts/github_actions/build_ci_dependencies.bash
+
     - name: build
       run:  scripts/github_actions/build_ci.bash
 
@@ -72,6 +92,16 @@ jobs:
        JOB_NUMBER: 2
     steps:
     - uses: actions/checkout@v1
+
+    - name: cache-dependencies
+      id: cache-swupd-deps
+      uses: actions/cache@v1
+      with:
+        path: dependencies
+        key: swupd-dependencies
+
+    - name: build_dep
+      run:  scripts/github_actions/build_ci_dependencies.bash
 
     - name: build
       run:  scripts/github_actions/build_ci.bash
@@ -98,6 +128,16 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: cache-dependencies
+      id: cache-swupd-deps
+      uses: actions/cache@v1
+      with:
+        path: dependencies
+        key: swupd-dependencies
+
+    - name: build_dep
+      run:  scripts/github_actions/build_ci_dependencies.bash
+
     - name: build
       run:  scripts/github_actions/build_ci.bash
 
@@ -122,6 +162,16 @@ jobs:
        JOB_NUMBER: 4
     steps:
     - uses: actions/checkout@v1
+
+    - name: cache-dependencies
+      id: cache-swupd-deps
+      uses: actions/cache@v1
+      with:
+        path: dependencies
+        key: swupd-dependencies
+
+    - name: build_dep
+      run:  scripts/github_actions/build_ci_dependencies.bash
 
     - name: build
       run:  scripts/github_actions/build_ci.bash
@@ -148,6 +198,16 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: cache-dependencies
+      id: cache-swupd-deps
+      uses: actions/cache@v1
+      with:
+        path: dependencies
+        key: swupd-dependencies
+
+    - name: build_dep
+      run:  scripts/github_actions/build_ci_dependencies.bash
+
     - name: build
       run:  scripts/github_actions/build_ci.bash
 
@@ -172,6 +232,16 @@ jobs:
        JOB_NUMBER: 6
     steps:
     - uses: actions/checkout@v1
+
+    - name: cache-dependencies
+      id: cache-swupd-deps
+      uses: actions/cache@v1
+      with:
+        path: dependencies
+        key: swupd-dependencies
+
+    - name: build_dep
+      run:  scripts/github_actions/build_ci_dependencies.bash
 
     - name: build
       run:  scripts/github_actions/build_ci.bash
@@ -198,6 +268,16 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: cache-dependencies
+      id: cache-swupd-deps
+      uses: actions/cache@v1
+      with:
+        path: dependencies
+        key: swupd-dependencies
+
+    - name: build_dep
+      run:  scripts/github_actions/build_ci_dependencies.bash
+
     - name: build
       run:  scripts/github_actions/build_ci.bash
 
@@ -222,6 +302,16 @@ jobs:
        JOB_NUMBER: 8
     steps:
     - uses: actions/checkout@v1
+
+    - name: cache-dependencies
+      id: cache-swupd-deps
+      uses: actions/cache@v1
+      with:
+        path: dependencies
+        key: swupd-dependencies
+
+    - name: build_dep
+      run:  scripts/github_actions/build_ci_dependencies.bash
 
     - name: build
       run:  scripts/github_actions/build_ci.bash
@@ -248,6 +338,16 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: cache-dependencies
+      id: cache-swupd-deps
+      uses: actions/cache@v1
+      with:
+        path: dependencies
+        key: swupd-dependencies
+
+    - name: build_dep
+      run:  scripts/github_actions/build_ci_dependencies.bash
+
     - name: build
       run:  scripts/github_actions/build_ci.bash
 
@@ -272,6 +372,16 @@ jobs:
        JOB_NUMBER: 10
     steps:
     - uses: actions/checkout@v1
+
+    - name: cache-dependencies
+      id: cache-swupd-deps
+      uses: actions/cache@v1
+      with:
+        path: dependencies
+        key: swupd-dependencies
+
+    - name: build_dep
+      run:  scripts/github_actions/build_ci_dependencies.bash
 
     - name: build
       run:  scripts/github_actions/build_ci.bash

--- a/scripts/github_actions/build_ci.bash
+++ b/scripts/github_actions/build_ci.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Install all dependencies available on ubuntu-latest from github actions to
+# build swupd and run all tests.
+# Builds swupd with configuration needed to run swupd tests
+
 set -e
 CORES=2
 
@@ -10,21 +14,6 @@ sudo ln -s /bin/systemctl /usr/bin/systemctl
 
 # Use rst2man from python3
 sudo ln -s /usr/share/docutils/scripts/python3/rst2man /usr/bin/rst2man.py
-
-# build bsdiff
-wget https://github.com/clearlinux/bsdiff/releases/download/v1.0.2/bsdiff-1.0.2.tar.xz
-tar -xvf bsdiff-1.0.2.tar.xz
-pushd bsdiff-1.0.2 && ./configure --prefix=/usr --disable-tests && make -j$CORES && sudo make install && popd
-
-## build curl
-wget https://curl.haxx.se/download/curl-7.64.0.tar.gz
-tar -xvf curl-7.64.0.tar.gz
-pushd curl-7.64.0 && ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu && make -j$CORES && sudo make install && popd
-
-# build libarchive
-wget https://github.com/libarchive/libarchive/archive/v3.3.1.tar.gz
-tar -xvf v3.3.1.tar.gz
-pushd libarchive-3.3.1 && autoreconf -fi && ./configure --prefix=/usr && make -j$CORES && sudo make install && popd
 
 # Build Swupd
 autoreconf --verbose --warnings=none --install --force

--- a/scripts/github_actions/build_ci_dependencies.bash
+++ b/scripts/github_actions/build_ci_dependencies.bash
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Build all custom dependencies needed by swupd:
+# - Curl
+# - Bsdiff
+# - libarchive
+#
+# As process is slow, it can be cached. If directory dependencies exists,
+# just install already build dependencies.
+
+set -e
+CORES=2
+
+# If alread exists, reuse
+if [ -d dependencies ]; then
+	pushd dependencies
+	for i in *; do
+		if [ -d "$i" ]; then
+			pushd "$i"
+			sudo make install
+			popd
+		fi
+	done
+
+	popd
+	exit
+fi
+
+mkdir dependencies
+pushd dependencies
+
+# build bsdiff
+wget https://github.com/clearlinux/bsdiff/releases/download/v1.0.2/bsdiff-1.0.2.tar.xz
+tar -xvf bsdiff-1.0.2.tar.xz
+pushd bsdiff-1.0.2 && ./configure --prefix=/usr --disable-tests && make -j"$CORES" && sudo make install && popd
+
+## build curl
+wget https://curl.haxx.se/download/curl-7.64.0.tar.gz
+tar -xvf curl-7.64.0.tar.gz
+pushd curl-7.64.0 && ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu && make -j"$CORES" && sudo make install && popd
+
+# build libarchive
+wget https://github.com/libarchive/libarchive/archive/v3.3.1.tar.gz
+tar -xvf v3.3.1.tar.gz
+pushd libarchive-3.3.1 && autoreconf -fi && ./configure --prefix=/usr && make -j"$CORES" && sudo make install && popd
+
+popd

--- a/scripts/github_actions/build_ci_style.bash
+++ b/scripts/github_actions/build_ci_style.bash
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Calls build_ci to install dependencies and build swupd.
+# Install dependencies needed to run compliance check, documentation check and
+# bash shell check
+
 set -e
 ./scripts/github_actions/build_ci.bash
 


### PR DESCRIPTION
Some packages we need to build swupd are not available on ubunutu-latest
so we need to download and build from source. This process is slow and
caching can save us some significant time on build.