### PR TITLE
Bug_fix: Do not follow symlinks when removing files during staging or update can end up removing incorrect files

### DIFF
--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -286,6 +286,29 @@ bool sys_file_exists(const char *filename)
 	return false;
 }
 
+bool sys_path_is_absolute(const char *filename)
+{
+	char *abspath = NULL;
+	bool ret = false;
+
+	abspath = realpath(filename, NULL);
+	if (!abspath) {
+		if (errno != ENOENT) {
+			error("Failed to get absolute path of %s (%s)\n", filename, strerror(errno));
+		}
+		ret = false;
+		goto exit;
+	}
+
+	if (strcmp(abspath, filename) == 0) {
+		ret = true;
+	}
+
+exit:
+	free(abspath);
+	return ret;
+}
+
 bool sys_filelink_exists(const char *filename)
 {
 	struct stat sb;

--- a/src/lib/sys.h
+++ b/src/lib/sys.h
@@ -105,6 +105,11 @@ bool sys_file_exists(const char *filename);
 bool sys_filelink_exists(const char *filename);
 
 /**
+ * @brief Checks if all elements of a path are absolute and don't contain symlinks
+ */
+bool sys_path_is_absolute(const char *filename);
+
+/**
  * @brief Checks if a file exists in the filesystem and is executable.
  * Follows symlinks
  */

--- a/test/functional/update/update-type-changes-dir-to-file.bats
+++ b/test/functional/update/update-type-changes-dir-to-file.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+
+	# create a directory with some content that will
+	# be used to create our test bundle
+	sudo mkdir -p "$TEST_NAME"/tmp/dir1
+	write_to_protected_file "$TEST_NAME"/tmp/file1 "$(generate_random_content)"
+	write_to_protected_file "$TEST_NAME"/tmp/common_file "$(generate_random_content)"
+	print "Content directory in version 10:\n\n $(tree "$TEST_NAME"/tmp)"
+
+	# create the bundle using the content from tmp/
+	create_bundle_from_content -t -n test-bundle1 -c "$TEST_NAME"/tmp "$TEST_NAME"
+
+	# create a new version
+	create_version "$TEST_NAME" 20 10
+
+	# make different updates in the content
+	sudo rm -rf "$TEST_NAME"/tmp/dir1
+	write_to_protected_file "$TEST_NAME"/tmp/dir1 "$(generate_random_content)" # dir1: dir -> file
+	sudo rm "$TEST_NAME"/tmp/file1
+	sudo mkdir -p "$TEST_NAME"/tmp/file1 # file1: file -> dir
+	write_to_protected_file -a "$TEST_NAME"/tmp/common_file "$(generate_random_content 1 20)" # common_file: updated
+	print "\nContent directory in version 20:\n\n $(tree "$TEST_NAME"/tmp)"
+
+	# create the update for the bundle using the updated content
+	update_bundle_from_content -n test-bundle1 -c "$TEST_NAME"/tmp "$TEST_NAME"
+
+}
+
+@test "UPD068: Updating a system where a bundle has files that change to directories and directories that changed to files" {
+
+	# updates should work properly regardless of file type changes
+	# this test covers the type change directory -> file
+	# this test covers the type change file -> directory
+
+	assert_file_exists "$TARGETDIR"/file1
+	assert_file_exists "$TARGETDIR"/common_file
+	assert_dir_exists "$TARGETDIR"/dir1
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Update started
+		Preparing to update from 10 to 20
+		Downloading packs for:
+		 - test-bundle1
+		Finishing packs extraction...
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 1
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 3
+		    new files         : 0
+		    deleted files     : 0
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Installing files...
+		Update was applied
+		Calling post-update helper scripts
+		2 files were not in a pack
+		Update successful - System updated from version 10 to version 20
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	assert_dir_exists "$TARGETDIR"/file1
+	assert_dir_not_exists "$TARGETDIR"/dir1
+	assert_file_exists "$TARGETDIR"/dir1
+	assert_file_exists "$TARGETDIR"/common_file
+	show_target
+
+}

--- a/test/functional/update/update-type-changes-file-to-recursive-symlink.bats
+++ b/test/functional/update/update-type-changes-file-to-recursive-symlink.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment -r "$TEST_NAME"
+	CONTENT="$TEST_NAME"/content_dir
+
+	# content for bundle test-bundle1
+	sudo mkdir -p "$CONTENT"/32/bits
+	sudo mkdir -p "$CONTENT"/32/ext
+	sudo mkdir "$CONTENT"/bits
+	sudo mkdir "$CONTENT"/ext
+	write_to_protected_file "$CONTENT"/bits/f1 "$(generate_random_content)"
+	write_to_protected_file "$CONTENT"/bits/f2 "$(generate_random_content)"
+	write_to_protected_file "$CONTENT"/bits/f3 "$(generate_random_content)"
+	write_to_protected_file "$CONTENT"/ext/f4 "$(generate_random_content)"
+	sudo cp "$CONTENT"/bits/f1 "$CONTENT"/32/bits/f1
+	sudo cp "$CONTENT"/bits/f2 "$CONTENT"/32/bits/f2
+	sudo cp "$CONTENT"/bits/f3 "$CONTENT"/32/bits/f3
+	sudo cp "$CONTENT"/ext/f4 "$CONTENT"/32/ext/f4
+
+	create_bundle_from_content -t -n test-bundle1 -c "$CONTENT" "$TEST_NAME"
+	print "Content directory in version 10:\n\n $(tree "$CONTENT")"
+
+	create_version -r "$TEST_NAME" 20 10
+
+	# content for update
+	sudo rm -rf "$CONTENT"/32
+	sudo ln -s --relative "$CONTENT" "$CONTENT"/32
+
+	update_bundle_from_content -n test-bundle1 -c "$CONTENT" "$TEST_NAME"
+	print "Content directory in version 20:\n\n $(tree "$CONTENT")"
+
+}
+
+@test "UPD069: Updating a system where a bundle has a directory that changed to become a symlink to ->." {
+
+	# if during an update, a directory is replaced by a symlink that causes recursion,
+	# meaning the symlink points to the current directory where itself resides (link -> .),
+	# swupd should still update correctly.
+	# Reference issue https://github.com/clearlinux/swupd-client/issues/890
+
+	assert_file_exists "$TARGETDIR"/bits/f1
+	assert_file_exists "$TARGETDIR"/bits/f2
+	assert_file_exists "$TARGETDIR"/bits/f3
+	assert_file_exists "$TARGETDIR"/ext/f4
+	assert_file_exists "$TARGETDIR"/32/bits/f1
+	assert_file_exists "$TARGETDIR"/32/bits/f2
+	assert_file_exists "$TARGETDIR"/32/bits/f3
+	assert_file_exists "$TARGETDIR"/32/ext/f4
+	assert_symlink_not_exists "$TARGETDIR"/32
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Update started
+		Preparing to update from 10 to 20
+		Downloading packs for:
+		 - os-core
+		 - test-bundle1
+		Finishing packs extraction...
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 2
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 3
+		    new files         : 0
+		    deleted files     : 6
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Installing files...
+		Update was applied
+		Calling post-update helper scripts
+		1 files were not in a pack
+		Update successful - System updated from version 10 to version 20
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	assert_file_exists "$TARGETDIR"/bits/f1
+	assert_file_exists "$TARGETDIR"/bits/f2
+	assert_file_exists "$TARGETDIR"/bits/f3
+	assert_file_exists "$TARGETDIR"/ext/f4
+	assert_symlink_exists "$TARGETDIR"/32
+	assert_file_exists "$TARGETDIR"/32/bits/f1
+	assert_file_exists "$TARGETDIR"/32/bits/f2
+	assert_file_exists "$TARGETDIR"/32/bits/f3
+	assert_file_exists "$TARGETDIR"/32/ext/f4
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
+	assert_status_is "$SWUPD_OK"
+
+}

--- a/test/functional/update/update-type-changes-file-to-symlink.bats
+++ b/test/functional/update/update-type-changes-file-to-symlink.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+
+	# create a directory with some content that will
+	# be used to create our test bundle
+	sudo mkdir -p "$TEST_NAME"/tmp/dir1/dir2
+	write_to_protected_file "$TEST_NAME"/tmp/file1 "$(generate_random_content)"
+	write_to_protected_file "$TEST_NAME"/tmp/dir1/dir2/file2 "$(generate_random_content)"
+	write_to_protected_file "$TEST_NAME"/tmp/file3 "$(generate_random_content)"
+	print "Content directory in version 10:\n\n $(tree "$TEST_NAME"/tmp)"
+
+	# create the bundle using the content from tmp/
+	create_bundle_from_content -t -n test-bundle1 -c "$TEST_NAME"/tmp "$TEST_NAME"
+
+	# create a new version
+	create_version "$TEST_NAME" 20 10
+
+	# make different updates in the content
+	sudo mv "$TEST_NAME"/tmp/file1 "$TEST_NAME"/tmp/new_file1
+	sudo ln -s --relative "$TEST_NAME"/tmp/new_file1 "$TEST_NAME"/tmp/file1 # file1: file -> symlink
+	sudo mv "$TEST_NAME"/tmp/dir1/dir2 "$TEST_NAME"/tmp/dir1/new_dir2
+	sudo ln -s --relative "$TEST_NAME"/tmp/dir1/new_dir2 "$TEST_NAME"/tmp/dir1/dir2 # dir2: dir -> symlink
+	write_to_protected_file -a "$TEST_NAME"/tmp/file3 "$(generate_random_content 1 20)" # file3: updated
+	write_to_protected_file "$TEST_NAME"/tmp/file4 "$(generate_random_content)" # file4: new file
+	print "\nContent directory in version 20:\n\n $(tree "$TEST_NAME"/tmp)"
+
+	# create the update for the bundle using the updated content
+	update_bundle_from_content -n test-bundle1 -c "$TEST_NAME"/tmp "$TEST_NAME"
+
+}
+
+@test "UPD066: Updating a system where a bundle has files that changed to symlinks" {
+
+	# updates should work properly regardless of file type changes
+	# this test covers the type change file -> symlink
+	# this test covers the type change directory -> symlink
+
+	assert_file_exists "$TARGETDIR"/file1
+	assert_dir_exists "$TARGETDIR"/dir1/dir2
+	assert_file_exists "$TARGETDIR"/dir1/dir2/file2
+	assert_file_exists "$TARGETDIR"/file3
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Update started
+		Preparing to update from 10 to 20
+		Downloading packs for:
+		 - test-bundle1
+		Finishing packs extraction...
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 1
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 3
+		    new files         : 4
+		    deleted files     : 1
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Installing files...
+		Update was applied
+		Calling post-update helper scripts
+		2 files were not in a pack
+		Update successful - System updated from version 10 to version 20
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	assert_symlink_exists "$TARGETDIR"/file1
+	assert_symlink_exists "$TARGETDIR"/dir1/dir2
+	assert_file_exists "$TARGETDIR"/dir1/dir2/file2
+	assert_file_exists "$TARGETDIR"/file3
+	assert_file_exists "$TARGETDIR"/file4
+	show_target
+
+}

--- a/test/functional/update/update-type-changes-symlink-to-file.bats
+++ b/test/functional/update/update-type-changes-symlink-to-file.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+
+	write_to_protected_file "$TEST_NAME"/external_file "$(generate_random_content)"
+	# create a directory with some content that will
+	# be used to create our test bundle
+	sudo mkdir -p "$TEST_NAME"/tmp/dir1/dirA
+	write_to_protected_file "$TEST_NAME"/tmp/fileA "$(generate_random_content)"
+	sudo ln -s --relative "$TEST_NAME"/tmp/fileA "$TEST_NAME"/tmp/file1
+	sudo ln -s --relative "$TEST_NAME"/tmp/dir1/dirA "$TEST_NAME"/tmp/dir1/dir2
+	write_to_protected_file "$TEST_NAME"/tmp/dir1/dir2/file2 "$(generate_random_content)"
+	write_to_protected_file "$TEST_NAME"/tmp/file3 "$(generate_random_content)"
+	sudo ln -s "$TEST_NAME"/external_file "$TEST_NAME"/tmp/external_file
+
+	# create the bundle using the content from tmp/
+	create_bundle_from_content -t -n test-bundle1 -c "$TEST_NAME"/tmp "$TEST_NAME"
+
+	# create a new version
+	create_version "$TEST_NAME" 20 10
+
+	# make different updates in the content
+	# change symlink /file1 to be a file
+	sudo rm "$TEST_NAME"/tmp/file1
+	sudo mv "$TEST_NAME"/tmp/fileA "$TEST_NAME"/tmp/file1
+	# change symlink /dir2 to be a dir
+	sudo rm "$TEST_NAME"/tmp/dir1/dir2
+	sudo mv "$TEST_NAME"/tmp/dir1/dirA "$TEST_NAME"/tmp/dir1/dir2
+	# change absolute symlink /external_file to be a file
+	sudo rm "$TEST_NAME"/tmp/external_file
+	sudo mv "$TEST_NAME"/external_file "$TEST_NAME"/tmp/external_file
+
+	# update file3
+	write_to_protected_file -a "$TEST_NAME"/tmp/file3 "$(generate_random_content 1 20)"
+	# add a new file to the bundle
+	write_to_protected_file "$TEST_NAME"/tmp/file4 "$(generate_random_content)"
+
+	# create the update for the bundle using the updated content
+	update_bundle_from_content -n test-bundle1 -c "$TEST_NAME"/tmp "$TEST_NAME"
+
+}
+
+@test "UPD067: Updating a system where a bundle has symlinks that changed to files" {
+
+	# updates should work properly regardless of file type changes
+	# this test covers the type change relative symlink -> file
+	# this test covers the type change absolute symlink -> file
+	# this test covers the type change symlink -> directory
+
+	assert_file_exists "$TARGETDIR"/fileA
+	assert_symlink_exists "$TARGETDIR"/file1
+	assert_dir_exists "$TARGETDIR"/dir1/dirA
+	assert_symlink_exists "$TARGETDIR"/dir1/dir2
+	assert_symlink_exists "$TARGETDIR"/external_file
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Update started
+		Preparing to update from 10 to 20
+		Downloading packs for:
+		 - test-bundle1
+		Finishing packs extraction...
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 1
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 4
+		    new files         : 2
+		    deleted files     : 3
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Installing files...
+		Update was applied
+		Calling post-update helper scripts
+		3 files were not in a pack
+		Update successful - System updated from version 10 to version 20
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	assert_symlink_not_exists "$TARGETDIR"/file1
+	assert_file_exists "$TARGETDIR"/file1
+	assert_symlink_not_exists "$TARGETDIR"/dir1/dir2
+	assert_dir_exists "$TARGETDIR"/dir1/dir2
+	assert_symlink_not_exists "$TARGETDIR"/external_file
+	assert_file_exists "$TARGETDIR"/external_file
+	assert_file_exists "$TARGETDIR"/dir1/dir2/file2
+	assert_file_exists "$TARGETDIR"/file3
+	assert_file_exists "$TARGETDIR"/file4
+
+}


### PR DESCRIPTION
When during an update a directory was removed and replaced by a symlink to another directory that contains one or more files with the same name  as files in the directory that was removed, swupd will remove the directory from the target system and then it will try to remove each one     of the files that were contained in the directory. Since the directory is now a symlink to another existing directory, it may end up deleting the files from the other directory. swupd should not follow links when removing files during the staging process.

Closes #890

Note: for the tests in this PR to work #1380 needs to be reviewed and merged first.