### PR TITLE
swupd_init: Make sure swupd is always runnin in an existing path

### DIFF
--- a/scripts/build_and_run_tests.bash
+++ b/scripts/build_and_run_tests.bash
@@ -54,7 +54,7 @@ main() {
 	export RUNNING_IN_CI=true
 	export JOB_COUNT
 	export BUILD_ONLY
-	local configure_args="--with-fallback-capaths=./swupd_test_certificates -with-systemdsystemunitdir=/usr/lib/systemd/system --with-config-file-path=./testconfig"
+	local configure_args="--with-fallback-capaths=""$PWD""/swupd_test_certificates -with-systemdsystemunitdir=/usr/lib/systemd/system --with-config-file-path=""$PWD""/testconfig"
 
 	# Run tests without any security optimization and with address sanitizer
 	CFLAGS="-fsanitize=address -fno-omit-frame-pointer -Werror" run_build --disable-optimizations "$configure_args"

--- a/scripts/github_actions/build_ci.bash
+++ b/scripts/github_actions/build_ci.bash
@@ -17,7 +17,7 @@ sudo ln -s /usr/share/docutils/scripts/python3/rst2man /usr/bin/rst2man.py
 
 # Build Swupd
 autoreconf --verbose --warnings=none --install --force
-./configure CFLAGS="$CFLAGS -fsanitize=address -Werror" --prefix=/usr --with-fallback-capaths=./swupd_test_certificates --with-systemdsystemunitdir=/usr/lib/systemd/system --with-config-file-path=./testconfig
+./configure CFLAGS="$CFLAGS -fsanitize=address -Werror" --prefix=/usr --with-fallback-capaths="$PWD"/swupd_test_certificates --with-systemdsystemunitdir=/usr/lib/systemd/system --with-config-file-path="$PWD"/testconfig
 make -j$CORES
 
 # Needed to initialize the host for auto-update. Without these steps auto-update

--- a/src/globals.c
+++ b/src/globals.c
@@ -381,7 +381,7 @@ void set_cert_path(char *path)
 		free_and_clear_pointer(&globals.cert_path);
 	}
 
-	globals.cert_path = strdup_or_die(path);
+	globals.cert_path = realpath(path, NULL);
 }
 
 static void set_default_cert_path()
@@ -745,8 +745,12 @@ static bool load_flags_in_config(char *command, struct option *opts_array, const
 	struct stat st;
 	char *ctx = NULL;
 	char *config_file = NULL;
-	char *str = strdup_or_die(CONFIG_FILE_PATH);
+	char *str = realpath(CONFIG_FILE_PATH, NULL);
 	char *full_command = NULL;
+
+	if (!str) {
+		return false;
+	}
 
 	/* the command we get here can actually be a subcommand, if that
 	 * is the case we need to build the section name as "command-subcommand",

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -482,6 +482,15 @@ enum swupd_code swupd_init(enum swupd_init_config config)
 		goto out_fds;
 	}
 
+	/*
+	 * Make sure all swupd commands are executed in a valid path.
+	 * getcwd errors are thrown if the directory where swupd was running is
+	 * deleted and this can occur when swupd removes files from the system.
+	 */
+	if (chdir(globals.path_prefix)) {
+		debug("chdir() to '%s' failed -  running swupd in current directory\n", globals.path_prefix);
+	}
+
 	get_mounted_directories();
 
 	if ((config & SWUPD_NO_ROOT) == 0) {


### PR DESCRIPTION
If the path where swupd is running is removed getcwd errors will occurs, mostly
because of multiple commands swupd executes. So move to directory "/", no mather
where swupd is going to be installed, to make sure the path is always existent.

Fixes #1078

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>