### PR TITLE
3rd-party: regenerate the wrapper script if a binary changes during an update

### DIFF
--- a/src/3rd_party_repair.c
+++ b/src/3rd_party_repair.c
@@ -196,10 +196,15 @@ static bool parse_options(int argc, char **argv)
 	return true;
 }
 
+static enum swupd_code regenerate_binary_scripts(struct list *files_to_verify)
+{
+	return third_party_process_files(files_to_verify, "\nRegenerating 3rd-party bundle binaries...\n", "regenerate_binaries", third_party_update_wrapper_script);
+}
+
 static enum swupd_code repair_repos(UNUSED_PARAM char *unused)
 {
 	verify_set_option_version(cmdline_option_version);
-	return execute_verify();
+	return execute_verify_extra(regenerate_binary_scripts);
 }
 
 enum swupd_code third_party_repair_main(int argc, char **argv)
@@ -243,15 +248,16 @@ enum swupd_code third_party_repair_main(int argc, char **argv)
 	 *  8) remove_extraneous_files
 	 *  9) remove_extra_files (only with --picky or with --extra-files-only)
 	 *  10) run_postupdate_scripts
+	 *  11) regenerate_binaries
 	 */
 	if (cmdline_option_extra_files_only) {
-		steps_in_repair = 3;
+		steps_in_repair = 4;
 	} else if (cmdline_option_quick) {
-		steps_in_repair = 7;
+		steps_in_repair = 8;
 	} else if (cmdline_option_picky) {
-		steps_in_repair = 10;
+		steps_in_repair = 11;
 	} else {
-		steps_in_repair = 9;
+		steps_in_repair = 10;
 	}
 
 	/* run repair (verify --fix) */

--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -173,6 +173,13 @@ enum swupd_code third_party_remove_binary(struct file *file);
 enum swupd_code third_party_create_wrapper_script(struct file *file);
 
 /**
+ * @brief Function that regenerates a script to export a 3rd-party binary
+ *
+ * @param file the file struct of the binary to be exported
+ */
+enum swupd_code third_party_update_wrapper_script(struct file *file);
+
+/**
  * @brief Function that retrieves the content director of a 3rd-party repo
  */
 char *get_repo_content_path(const char *repo_name);

--- a/src/3rd_party_update.c
+++ b/src/3rd_party_update.c
@@ -127,54 +127,6 @@ static bool parse_options(int argc, char **argv)
 	return true;
 }
 
-static enum swupd_code update_binary_script(struct file *file)
-{
-	enum swupd_code ret_code = 0;
-	int ret;
-	char *bin_directory = NULL;
-	char *script = NULL;
-	char *binary = NULL;
-	char *filename = NULL;
-
-	if (!file || !third_party_file_is_binary(file)) {
-		return ret_code;
-	}
-
-	filename = file->filename;
-	bin_directory = third_party_get_bin_dir();
-	script = third_party_get_binary_path(sys_basename(filename));
-	binary = sys_path_join("%s/%s", globals.path_prefix, filename);
-
-	/* the binary is either new or changed in the update, in either case
-	 * we need to create the script */
-	if (sys_file_exists(binary)) {
-		/* if a script for the binary already exists, delete it */
-		ret = sys_rm(script);
-		if (ret && ret != -ENOENT) {
-			ret_code = SWUPD_COULDNT_REMOVE_FILE;
-			goto close_and_exit;
-		}
-		ret_code = third_party_create_wrapper_script(file);
-		goto close_and_exit;
-	}
-
-	/* if the binary was removed during the update then we need to
-	 * remove the script that exports it too */
-	if (file->is_deleted) {
-		ret = sys_rm(script);
-		if (ret) {
-			ret_code = SWUPD_COULDNT_REMOVE_FILE;
-		}
-	}
-
-close_and_exit:
-	free_and_clear_pointer(&binary);
-	free_and_clear_pointer(&script);
-	free_and_clear_pointer(&bin_directory);
-
-	return ret_code;
-}
-
 static enum swupd_code validate_permissions(struct file *file)
 {
 	enum swupd_code ret_code = SWUPD_OK;
@@ -245,7 +197,7 @@ static enum swupd_code validate_file_permissions(struct list *files_to_be_update
 
 static enum swupd_code update_exported_binaries(struct list *updated_files)
 {
-	return third_party_process_files(updated_files, "\nUpdating 3rd-party bundle binaries...\n", "update_binaries", update_binary_script);
+	return third_party_process_files(updated_files, "\nUpdating 3rd-party bundle binaries...\n", "update_binaries", third_party_update_wrapper_script);
 }
 
 static enum swupd_code update_repos(UNUSED_PARAM char *unused)

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -360,6 +360,7 @@ extern void update_set_option_keepcache(bool opt);
 
 /* verify.c */
 extern enum swupd_code execute_verify(void);
+extern enum swupd_code execute_verify_extra(extra_proc_fn_t post_verify_fn);
 extern void verify_set_option_download(bool opt);
 extern void verify_set_option_skip_optional(bool opt);
 extern void verify_set_option_force(bool opt);

--- a/src/verify.c
+++ b/src/verify.c
@@ -854,7 +854,7 @@ static struct list *keep_matching_path(struct list *all_files)
  * found to not match the manifest.  This is notably different from update,
  * which attempts to atomically (or nearly atomically) activate a set of
  * pre-computed and validated staged changes as a group. */
-enum swupd_code execute_verify(void)
+enum swupd_code execute_verify_extra(extra_proc_fn_t post_verify_fn)
 {
 	struct manifest *official_manifest = NULL;
 	int ret;
@@ -1303,6 +1303,11 @@ report_and_exit:
 
 	/* this concludes the critical section, after this point it's clean up time, the disk content is finished and final */
 
+	/* execute post-verify processing (if any) */
+	if (post_verify_fn) {
+		ret = post_verify_fn(files_to_verify);
+	}
+
 clean_and_exit:
 	if (cmdline_option_file) {
 		list_free_list(files_to_verify);
@@ -1396,6 +1401,11 @@ clean_args_and_exit:
 	counts = (struct file_counts){ 0 };
 
 	return ret;
+}
+
+enum swupd_code execute_verify(void)
+{
+	return execute_verify_extra(NULL);
 }
 
 enum swupd_code verify_main(int argc, char **argv)

--- a/test/functional/3rd-party/3rd-party-repair-basic.bats
+++ b/test/functional/3rd-party/3rd-party-repair-basic.bats
@@ -65,6 +65,7 @@ test_setup() {
 		    1 of 1 files were deleted
 		    0 of 1 files were not deleted
 		Calling post-update helper scripts
+		Regenerating 3rd-party bundle binaries...
 		Repair successful
 		____________________________
 		 3rd-Party Repo: test-repo2
@@ -77,6 +78,7 @@ test_setup() {
 		Removing extraneous files
 		Inspected 15 files
 		Calling post-update helper scripts
+		Regenerating 3rd-party bundle binaries...
 		Repair successful
 	EOM
 	)
@@ -98,6 +100,7 @@ test_setup() {
 		Removing extraneous files
 		Inspected 15 files
 		Calling post-update helper scripts
+		Regenerating 3rd-party bundle binaries...
 		Repair successful
 	EOM
 	)
@@ -126,6 +129,7 @@ test_setup() {
 		    1 of 1 files were repaired
 		    0 of 1 files were not repaired
 		Calling post-update helper scripts
+		Regenerating 3rd-party bundle binaries...
 		Repair successful
 	EOM
 	)
@@ -167,6 +171,7 @@ test_setup() {
 		    1 of 1 files were deleted
 		    0 of 1 files were not deleted
 		Calling post-update helper scripts
+		Regenerating 3rd-party bundle binaries...
 		Repair successful
 		____________________________
 		 3rd-Party Repo: test-repo2
@@ -184,6 +189,7 @@ test_setup() {
 		    1 of 1 files were deleted
 		    0 of 1 files were not deleted
 		Calling post-update helper scripts
+		Regenerating 3rd-party bundle binaries...
 		Repair successful
 	EOM
 	)
@@ -227,6 +233,7 @@ test_setup() {
 		    3 of 3 files were deleted
 		    0 of 3 files were not deleted
 		Calling post-update helper scripts
+		Regenerating 3rd-party bundle binaries...
 		Repair successful
 		____________________________
 		 3rd-Party Repo: test-repo2
@@ -240,6 +247,7 @@ test_setup() {
 		Removing extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo2/bat
 		Inspected 15 files
 		Calling post-update helper scripts
+		Regenerating 3rd-party bundle binaries...
 		Repair successful
 	EOM
 	)

--- a/test/functional/3rd-party/3rd-party-repair-exported-bin.bats
+++ b/test/functional/3rd-party/3rd-party-repair-exported-bin.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME" 10 1
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
+	create_bundle -L -t -n test-bundle1 -f /foo/file_1,/usr/bin/binary_1,/bin/binary_2,/bin/binary_3 -u repo1 "$TEST_NAME"
+
+	# make a change to a file so we have somthing to repair
+	write_to_protected_file -a "$TPTARGETDIR"/foo/file_1 "corrupting the file"
+	write_to_protected_file -a "$TPTARGETDIR"/bin/binary_2 "corrupting the file"
+
+	# add a line to the wrapper scripts for all binaries so we can tell
+	# if they were re-generated after the repair
+	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1 "TEST_STRING"
+	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2 "TEST_STRING"
+	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3 "TEST_STRING"
+
+}
+
+@test "TPR081: Repair a system that has a bundle with corrupt wrapper scripts from a 3rd-party repo" {
+
+	# pre-test checks
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	sudo grep -q "TEST_STRING" "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1 || exit 1
+	sudo grep -q "TEST_STRING" "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2 || exit 1
+	sudo grep -q "TEST_STRING" "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3 || exit 1
+
+	# every time a user repairs a system all the wrapper scripts for
+	# binaries should be regenerated, not only those that were repaired
+
+	run sudo sh -c "$SWUPD 3rd-party repair $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		_______________________
+		 3rd-Party Repo: repo1
+		_______________________
+		Diagnosing version 10
+		Downloading missing manifests...
+		Checking for corrupt files
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Adding any missing files
+		Repairing corrupt files
+		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/repo1/bin/binary_2 -> fixed
+		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/repo1/foo/file_1 -> fixed
+		Removing extraneous files
+		Inspected 20 files
+		  2 files did not match
+		    2 of 2 files were repaired
+		    0 of 2 files were not repaired
+		Calling post-update helper scripts
+		Regenerating 3rd-party bundle binaries...
+		Repair successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	sudo grep -vq "TEST_STRING" "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1 || exit 1
+	sudo grep -vq "TEST_STRING" "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2 || exit 1
+	sudo grep -vq "TEST_STRING" "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3 || exit 1
+
+}

--- a/test/functional/3rd-party/3rd-party-update-exported-bin.bats
+++ b/test/functional/3rd-party/3rd-party-update-exported-bin.bats
@@ -23,6 +23,10 @@ test_setup() {
 	update_bundle -p "$TEST_NAME" test-bundle1 --rename /bin/binary_3:/bin/binary_7 repo1
 	add_dependency_to_manifest "$TPWEBDIR"/20/Manifest.test-bundle1 test-bundle3
 
+	# let's add a line to the script for binary_2 so we can tell if it was
+	# re-generated after the update
+	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2 "TEST_STRING"
+
 }
 
 @test "TPR059: Update a 3rd-party bundle that has exported binaries" {
@@ -75,6 +79,7 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5
 	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6
 	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_7
+	sudo grep -vq "TEST_STRING" "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2 || exit 1
 
 }
 #WEIGHT=9


### PR DESCRIPTION
When updating a 3rd-party bundle, if any of its binaries is modified,
or the binary is new swupd needs to recreate the wrapper script.

During a 3rd-party repair, the wrapper scripts of all binaries verified
should be regenerated regardless of if the binary was repaired or not.

Related to #1413

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>