### PR TITLE
Testlib: keep the current status on type change

### DIFF
--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -3412,6 +3412,7 @@ update_bundle() { # swupd_function
 	local pre_ver
 	local pre_hash
 	local existing_file
+	local current_status
 
 	# If no parameters are received show usage
 	if [ $# -eq 0 ]; then
@@ -3645,12 +3646,13 @@ update_bundle() { # swupd_function
 			sudo rm -f "$version_path"/files/"$fhash".tar
 
 			# if the file changed type, update the manifest accordingly
+			current_status=$(get_entry_from_manifest "$bundle_manifest" "$fname" | awk '{ print $1 }')
 			if [ -L "$version_path"/files/"$new_fhash" ]; then
-				update_manifest -p "$bundle_manifest" file-status "$fname" "L..."
+				update_manifest -p "$bundle_manifest" file-status "$fname" "L${current_status:1}"
 			elif [ -d "$version_path"/files/"$new_fhash" ]; then
-				update_manifest -p "$bundle_manifest" file-status "$fname" "D..."
+				update_manifest -p "$bundle_manifest" file-status "$fname" "D${current_status:1}"
 			else
-				update_manifest -p "$bundle_manifest" file-status "$fname" "F..."
+				update_manifest -p "$bundle_manifest" file-status "$fname" "F${current_status:1}"
 			fi
 
 		fi


### PR DESCRIPTION
When updating a bundle using testlib, if the file is updated, and the
update includes a file type change, testlib was updating the manifest
with the correct type but was overwriting the other status flags, so if
a file was marked as 'x' (exported) before, that flag was being removed.

This commit fixes the issue by only updating the flag that relates to
the file type.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>