### PR TITLE
3rd-party: Regenerate wrapper on template change

### DIFF
--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -14,6 +14,15 @@ extern "C" {
 
 #ifdef THIRDPARTY
 
+/** Template used to generate wrapper scripts for 3rd-party binaries */
+#define SCRIPT_TEMPLATE "#!/bin/bash\n\n"                              \
+			"export PATH=%s:$PATH\n"                       \
+			"export LD_LIBRARY_PATH=%s:$LD_LIBRARY_PATH\n" \
+			"export XDG_DATA_DIRS=%s:$XDG_DATA_DIRS\n"     \
+			"export XDG_CONF_DIRS=%s:$XDG_CONF_DIRS\n"     \
+			"\n"                                           \
+			"%s \"$@\"\n"
+
 /** @brief Name of the directory where 3rd-party content and state should be stored */
 #define SWUPD_3RD_PARTY_DIRNAME "3rd-party"
 
@@ -25,6 +34,9 @@ extern "C" {
 
 /** @brief Full path to the directory where 3rd-party binaries are going to be installed */
 #define SWUPD_3RD_PARTY_BIN_DIR SWUPD_3RD_PARTY_DIR "/bin"
+
+/** @brief Name of the file that holds the copy of the current script template */
+#define SWUPD_3RD_PARTY_TEMPLATE_FILE "script.template"
 
 /** @brief Store information of a repository.  */
 struct repo {

--- a/src/lib/sys.h
+++ b/src/lib/sys.h
@@ -261,6 +261,29 @@ long sys_get_file_size(const char *filename);
  */
 int sys_dir_is_empty(const char *path);
 
+/**
+ * @brief Writes the specified content into a file
+ *
+ * @return 0 on success or a value < 0 on error
+ */
+int sys_write_file(char *file, void *content, size_t content_size);
+
+/**
+ * @brief Maps a file into memory.
+ *
+ * The function maps the file into a buffer and it also stores the length of the data
+ * in the file_length
+ *
+ * @return 0 on successfull mapping or an errno on error
+ */
+void *sys_mmap_file(const char *file, size_t *file_length);
+
+/**
+ * @brief Deletes the mapping for the specified address range
+ *
+ */
+void sys_mmap_free(void *buffer, size_t buffer_length);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -335,7 +335,7 @@ retry_load:
 		return NULL;
 	}
 
-	string_or_die(&filename, "%s/%i/Manifest.MoM", globals.state_dir, version);
+	filename = sys_path_join("%s/%i/Manifest.MoM", globals.state_dir, version);
 	string_or_die(&url, "%s/%i/Manifest.MoM", globals.content_url, version);
 
 	if (!globals.sigcheck) {

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -62,7 +62,7 @@ void read_subscriptions(struct list **subs)
 	DIR *dir;
 	struct dirent *ent;
 
-	string_or_die(&path, "%s/%s", globals.path_prefix, BUNDLES_DIR);
+	path = sys_path_join("%s/%s", globals.path_prefix, BUNDLES_DIR);
 
 	dir = opendir(path);
 	if (dir) {

--- a/src/version.c
+++ b/src/version.c
@@ -257,11 +257,11 @@ static bool get_osrelease_value(char *path_prefix, char *key, char *buff)
 	int keystring_len = 0;
 	bool keyfound = false;
 
-	string_or_die(&releasefile, "%s/usr/lib/os-release", path_prefix);
+	releasefile = sys_path_join("%s/usr/lib/os-release", path_prefix);
 	file = fopen(releasefile, "rm");
 	if (!file) {
 		free_and_clear_pointer(&releasefile);
-		string_or_die(&releasefile, "%s/etc/os-release", path_prefix);
+		releasefile = sys_path_join("%s/etc/os-release", path_prefix);
 		file = fopen(releasefile, "rm");
 		if (!file) {
 			free_and_clear_pointer(&releasefile);

--- a/test/functional/3rd-party/3rd-party-update-basic.bats
+++ b/test/functional/3rd-party/3rd-party-update-basic.bats
@@ -59,7 +59,7 @@ test_setup() {
 
 }
 
-@test "TPR037: Users can check if the 3rd-party bundles from a specifi repo are up to date" {
+@test "TPR037: Users can check if the 3rd-party bundles from a specific repo are up to date" {
 
 	run sudo sh -c "$SWUPD 3rd-party update $SWUPD_OPTS --repo test-repo1 --status"
 

--- a/test/functional/3rd-party/3rd-party-update-export-template-multi-repo.bats
+++ b/test/functional/3rd-party/3rd-party-update-export-template-multi-repo.bats
@@ -1,0 +1,221 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	# create a couple of 3rd-party repos with one installed bundle that has
+	# multiple binaries
+	create_test_environment -r "$TEST_NAME"
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo1
+	create_bundle -L -n test-bundle1 -f /usr/bin/binary_1,/bin/binary_2,/usr/local/bin/binary_3 -u repo1 "$TEST_NAME"
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo2
+	create_bundle -L -n test-bundle2 -f /usr/bin/binary_4,/bin/binary_5,/usr/local/bin/binary_6 -u repo2 "$TEST_NAME"
+
+	# create an update that updates only one of the bundle's binaries
+	create_version -r "$TEST_NAME" 20 10 staging repo1
+	update_bundle "$TEST_NAME" test-bundle1 --update /bin/binary_2 repo1
+
+	# add an update to the current template file
+	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE" "\nA little update\n"
+
+	# let's add a line to the scripts for all binaries so we can tell if
+	# they were re-generated after the update
+	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1 "TEST_STRING"
+	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2 "TEST_STRING"
+	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3 "TEST_STRING"
+	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_4 "TEST_STRING"
+	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5 "TEST_STRING"
+	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6 "TEST_STRING"
+
+}
+
+@test "TPR085: Update 3rd-party repositories that have exported binaries when the template has changed" {
+
+	# pre-test checks
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_4
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6
+
+	# If the template file is different than that in the swupd binary,
+	# all binaries should be re-generated regardless of if they were updated or not,
+	# also the template file should be updated
+
+	run sudo sh -c "$SWUPD 3rd-party update $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		_______________________
+		 3rd-Party Repo: repo1
+		_______________________
+		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Update started
+		Preparing to update from 10 to 20
+		Downloading packs for:
+		 - os-core
+		 - test-bundle1
+		Finishing packs extraction...
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 2
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 3
+		    new files         : 0
+		    deleted files     : 0
+		Validate downloaded files
+		No extra files need to be downloaded
+		Validating 3rd-party bundle file permissions...
+		Installing files...
+		Update was applied
+		Updating 3rd-party bundle binaries...
+		Warning: post-update helper scripts skipped due to --no-scripts argument
+		Update successful - System updated from version 10 to version 20
+		_______________________
+		 3rd-Party Repo: repo2
+		_______________________
+		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Update started
+		Version on server (10) is not newer than system version (10)
+		Update complete - System already up-to-date at version 10
+		The scripts that export binaries from 3rd-party repositories need to be regenerated
+		_______________________
+		 3rd-Party Repo: repo1
+		_______________________
+		Regenerating scripts...
+		Scripts regenerated successfully
+		_______________________
+		 3rd-Party Repo: repo2
+		_______________________
+		Regenerating scripts...
+		Scripts regenerated successfully
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	# post-test checks
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_not_in_output "TEST_STRING"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_not_in_output "TEST_STRING"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_not_in_output "TEST_STRING"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_4
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_4
+	assert_not_in_output "TEST_STRING"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5
+	assert_not_in_output "TEST_STRING"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6
+	assert_not_in_output "TEST_STRING"
+
+	# make sure the template file exists in the system and is correct
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE"
+	template_file=$(sudo cat "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE")
+	template=$(echo -e "$SCRIPT_TEMPLATE")
+	assert_equal "$template_file" "$template"
+
+}
+
+@test "TPR086: Update 3rd-party repository that has exported binaries when the template has changed using --repo" {
+
+	# pre-test checks
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_4
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6
+
+	# If the template file is different than that in the swupd binary,
+	# all binaries should be re-generated for all repositories,
+	# regardless of if they were updated or not and regardless of if a
+	# single repo was specified, also the template file should be updated
+
+	run sudo sh -c "$SWUPD 3rd-party update $SWUPD_OPTS --repo repo1"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Update started
+		Preparing to update from 10 to 20
+		Downloading packs for:
+		 - os-core
+		 - test-bundle1
+		Finishing packs extraction...
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 2
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 3
+		    new files         : 0
+		    deleted files     : 0
+		Validate downloaded files
+		No extra files need to be downloaded
+		Validating 3rd-party bundle file permissions...
+		Installing files...
+		Update was applied
+		Updating 3rd-party bundle binaries...
+		Warning: post-update helper scripts skipped due to --no-scripts argument
+		Update successful - System updated from version 10 to version 20
+		The scripts that export binaries from 3rd-party repositories need to be regenerated
+		_______________________
+		 3rd-Party Repo: repo1
+		_______________________
+		Regenerating scripts...
+		Scripts regenerated successfully
+		_______________________
+		 3rd-Party Repo: repo2
+		_______________________
+		Regenerating scripts...
+		Scripts regenerated successfully
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	# post-test checks
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_not_in_output "TEST_STRING"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_not_in_output "TEST_STRING"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_not_in_output "TEST_STRING"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_4
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_4
+	assert_not_in_output "TEST_STRING"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5
+	assert_not_in_output "TEST_STRING"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6
+	assert_not_in_output "TEST_STRING"
+
+	# make sure the template file exists in the system and is correct
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE"
+	template_file=$(sudo cat "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE")
+	template=$(echo -e "$SCRIPT_TEMPLATE")
+	assert_equal "$template_file" "$template"
+
+}

--- a/test/functional/3rd-party/3rd-party-update-export-template.bats
+++ b/test/functional/3rd-party/3rd-party-update-export-template.bats
@@ -1,0 +1,241 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	# create a 3rd-party repo with one installed bundle that has
+	# multiple binaries
+	create_test_environment -r "$TEST_NAME"
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo1
+	create_bundle -L -n test-bundle1 -f /usr/bin/binary_1,/bin/binary_2,/usr/local/bin/binary_3 -u repo1 "$TEST_NAME"
+
+	# create an update that updates only one of the bundle's binaries
+	create_version -r "$TEST_NAME" 20 10 staging repo1
+	update_bundle "$TEST_NAME" test-bundle1 --update /bin/binary_2 repo1
+
+	# let's add a line to the scripts for all binaries so we can tell if
+	# they were re-generated after the update
+	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1 "TEST_STRING"
+	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2 "TEST_STRING"
+	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3 "TEST_STRING"
+
+}
+
+@test "TPR082: Update a 3rd-party bundle that has exported binaries when the template has not changed" {
+
+	# pre-test checks
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+
+	# If the template file didn't change then only the binary that was
+	# udpated should be re-generated
+
+	run sudo sh -c "$SWUPD 3rd-party update $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		_______________________
+		 3rd-Party Repo: repo1
+		_______________________
+		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Update started
+		Preparing to update from 10 to 20
+		Downloading packs for:
+		 - os-core
+		 - test-bundle1
+		Finishing packs extraction...
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 2
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 3
+		    new files         : 0
+		    deleted files     : 0
+		Validate downloaded files
+		No extra files need to be downloaded
+		Validating 3rd-party bundle file permissions...
+		Installing files...
+		Update was applied
+		Updating 3rd-party bundle binaries...
+		Warning: post-update helper scripts skipped due to --no-scripts argument
+		Update successful - System updated from version 10 to version 20
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	# post-test checks
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_in_output "TEST_STRING"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_not_in_output "TEST_STRING"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_in_output "TEST_STRING"
+
+	# make sure the template file exists in the system and is correct
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE"
+	template_file=$(sudo cat "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE")
+	template=$(echo -e "$SCRIPT_TEMPLATE")
+	assert_equal "$template_file" "$template"
+
+}
+
+@test "TPR083: Update a 3rd-party bundle that has exported binaries when there is no template" {
+
+	# pre-test checks
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+
+	# delete the template from the system
+	sudo rm "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE"
+
+	# If the template file is not found all binaries should be re-generated
+	# regardless of if they were updated or not, also the template file
+	# should be created
+
+	run sudo sh -c "$SWUPD 3rd-party update $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		_______________________
+		 3rd-Party Repo: repo1
+		_______________________
+		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Update started
+		Preparing to update from 10 to 20
+		Downloading packs for:
+		 - os-core
+		 - test-bundle1
+		Finishing packs extraction...
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 2
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 3
+		    new files         : 0
+		    deleted files     : 0
+		Validate downloaded files
+		No extra files need to be downloaded
+		Validating 3rd-party bundle file permissions...
+		Installing files...
+		Update was applied
+		Updating 3rd-party bundle binaries...
+		Warning: post-update helper scripts skipped due to --no-scripts argument
+		Update successful - System updated from version 10 to version 20
+		The scripts that export binaries from 3rd-party repositories need to be regenerated
+		_______________________
+		 3rd-Party Repo: repo1
+		_______________________
+		Regenerating scripts...
+		Scripts regenerated successfully
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	# post-test checks
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_not_in_output "TEST_STRING"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_not_in_output "TEST_STRING"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_not_in_output "TEST_STRING"
+
+	# make sure the template file exists in the system and is correct
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE"
+	template_file=$(sudo cat "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE")
+	template=$(echo -e "$SCRIPT_TEMPLATE")
+	assert_equal "$template_file" "$template"
+
+}
+
+@test "TPR084: Update a 3rd-party bundle that has exported binaries when the template has changed" {
+
+	# pre-test checks
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+
+	# make a change to the template
+	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE" "random update"
+
+	# If the template file is different than that in the swupd binary,
+	# all binaries should be re-generated regardless of if they were updated or not,
+	# also the template file should be updated
+
+	run sudo sh -c "$SWUPD 3rd-party update $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		_______________________
+		 3rd-Party Repo: repo1
+		_______________________
+		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
+		Update started
+		Preparing to update from 10 to 20
+		Downloading packs for:
+		 - os-core
+		 - test-bundle1
+		Finishing packs extraction...
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 2
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 3
+		    new files         : 0
+		    deleted files     : 0
+		Validate downloaded files
+		No extra files need to be downloaded
+		Validating 3rd-party bundle file permissions...
+		Installing files...
+		Update was applied
+		Updating 3rd-party bundle binaries...
+		Warning: post-update helper scripts skipped due to --no-scripts argument
+		Update successful - System updated from version 10 to version 20
+		The scripts that export binaries from 3rd-party repositories need to be regenerated
+		_______________________
+		 3rd-Party Repo: repo1
+		_______________________
+		Regenerating scripts...
+		Scripts regenerated successfully
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	# post-test checks
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_not_in_output "TEST_STRING"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_not_in_output "TEST_STRING"
+
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_not_in_output "TEST_STRING"
+
+	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE"
+	assert_not_in_output "random update"
+
+	# make sure the template file exists in the system and is correct
+	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE"
+	template_file=$(sudo cat "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE")
+	template=$(echo -e "$SCRIPT_TEMPLATE")
+	assert_equal "$template_file" "$template"
+
+}

--- a/test/functional/3rd-party/3rd-party-update-exported-bin.bats
+++ b/test/functional/3rd-party/3rd-party-update-exported-bin.bats
@@ -8,14 +8,16 @@ load "../testlib"
 test_setup() {
 
 	# create an initial environment
-	create_test_environment "$TEST_NAME"
+	create_test_environment -r "$TEST_NAME"
+
 	create_third_party_repo -a "$TEST_NAME" 10 staging repo1
 	create_bundle -L -t -n test-bundle1 -f /foo/file_1,/usr/bin/binary_1,/bin/binary_2,/bin/binary_3 -u repo1 "$TEST_NAME"
 	create_bundle       -n test-bundle2 -f /bar/file_2,/bin/binary_4                                 -u repo1 "$TEST_NAME"
 	create_bundle       -n test-bundle3 -f /bin/binary_5                                             -u repo1 "$TEST_NAME"
 
 	# create an update that adds, removes and updates binaries
-	create_version -p "$TEST_NAME" 20 10 staging repo1
+	create_version -p -r "$TEST_NAME" 20 10 staging repo1
+
 	update_bundle -p "$TEST_NAME" test-bundle1 --update /foo/file_1                 repo1
 	update_bundle -p "$TEST_NAME" test-bundle1 --update /bin/binary_2               repo1
 	update_bundle -p "$TEST_NAME" test-bundle1 --add    /usr/local/bin/binary_6     repo1
@@ -51,13 +53,14 @@ test_setup() {
 		Preparing to update from 10 to 20
 		Downloading packs for:
 		 - test-bundle3
+		 - os-core
 		 - test-bundle1
 		Finishing packs extraction...
 		Statistics for going from version 10 to version 20:
-		    changed bundles   : 1
+		    changed bundles   : 2
 		    new bundles       : 0
 		    deleted bundles   : 0
-		    changed files     : 2
+		    changed files     : 4
 		    new files         : 6
 		    deleted files     : 2
 		Validate downloaded files

--- a/test/functional/3rd-party/3rd-party-update-exported-bin.bats
+++ b/test/functional/3rd-party/3rd-party-update-exported-bin.bats
@@ -16,13 +16,13 @@ test_setup() {
 	create_bundle       -n test-bundle3 -f /bin/binary_5                                             -u repo1 "$TEST_NAME"
 
 	# create an update that adds, removes and updates binaries
-	create_version -p -r "$TEST_NAME" 20 10 staging repo1
+	create_version -r "$TEST_NAME" 20 10 staging repo1
 
 	update_bundle -p "$TEST_NAME" test-bundle1 --update /foo/file_1                 repo1
 	update_bundle -p "$TEST_NAME" test-bundle1 --update /bin/binary_2               repo1
 	update_bundle -p "$TEST_NAME" test-bundle1 --add    /usr/local/bin/binary_6     repo1
 	update_bundle -p "$TEST_NAME" test-bundle1 --delete /usr/bin/binary_1           repo1
-	update_bundle -p "$TEST_NAME" test-bundle1 --rename /bin/binary_3:/bin/binary_7 repo1
+	update_bundle    "$TEST_NAME" test-bundle1 --rename /bin/binary_3:/bin/binary_7 repo1
 	add_dependency_to_manifest "$TPWEBDIR"/20/Manifest.test-bundle1 test-bundle3
 
 	# let's add a line to the script for binary_2 so we can tell if it was

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1565,6 +1565,7 @@ create_third_party_repo() { #swupd_function
 	debug_msg "3rd-party repo URL: $TPURL"
 
 	# if requested, add the new repo to the repo.ini file
+	# and the template file
 	sudo mkdir -p "$env_name"/testfs/target-dir/"$THIRD_PARTY_DIR"
 	if [ "$add" = true ]; then
 		{
@@ -1572,6 +1573,7 @@ create_third_party_repo() { #swupd_function
 			printf 'URL=%s\n\n' "file://$TPURL"
 			printf 'VERSION=%s\n\n' "$version"
 		} | sudo tee -a "$env_name"/testfs/target-dir/"$THIRD_PARTY_DIR"/repo.ini > /dev/null
+		write_to_protected_file "$env_name"/testfs/target-dir/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE" "$SCRIPT_TEMPLATE"
 	fi
 
 	# every 3rd-party repo needs to have at least the special os-core bundle,
@@ -1588,12 +1590,6 @@ create_third_party_repo() { #swupd_function
 		create_bundle -L -n os-core -v "$version" -f /usr/lib/os-release:"$OS_RELEASE",/usr/share/clear/update-ca/Swupd_Root.pem:"$cert",/usr/share/defaults/swupd/format:"$FORMAT" -u "$repo_name" "$env_name"
 	else
 		create_bundle -n os-core -v "$version" -f /usr/lib/os-release:"$OS_RELEASE",/usr/share/clear/update-ca/Swupd_Root.pem:"$cert",/usr/share/defaults/swupd/format:"$FORMAT" -u "$repo_name" "$env_name"
-	fi
-
-	# if requested, add the template file to the target system
-	if [ "$add" = true ]; then
-		sudo mkdir -p "$env_name"/testfs/target-dir/"$THIRD_PARTY_BIN_DIR"
-		write_to_protected_file "$env_name"/testfs/target-dir/"$THIRD_PARTY_BIN_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE" "$SCRIPT_TEMPLATE"
 	fi
 
 	if [ "$TEST_ENV_ONLY" = true ]; then
@@ -4639,6 +4635,10 @@ assert_equal() { # assertion
 	validate_param "$val2"
 
 	if [ "$val1" != "$val2" ]; then
+		echo "Assertion Failed"
+		echo "The two items being compared are not equal"
+		echo -e "Difference:\\n$sep"
+		diff -u <(echo "$val1") <(echo "$val2") || true
 		return 1
 	fi
 

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -16,6 +16,7 @@ export SWUPD_DIR="$FUNC_DIR/../.."
 export THIRD_PARTY_DIR="opt/3rd-party"
 export THIRD_PARTY_BUNDLES_DIR="$THIRD_PARTY_DIR/bundles"
 export THIRD_PARTY_BIN_DIR="$THIRD_PARTY_DIR/bin"
+export THIRD_PARTY_SCRIPT_TEMPLATE="script.template"
 
 # formatting variables
 export SPACE=" "
@@ -77,6 +78,14 @@ export SWUPD_INVALID_FILE=38  # file is missing or invalid
 
 # global constant
 export zero_hash="0000000000000000000000000000000000000000000000000000000000000000"
+export SCRIPT_TEMPLATE="\
+#!/bin/bash\n\n\
+export PATH=%s:\$PATH\n\
+export LD_LIBRARY_PATH=%s:\$LD_LIBRARY_PATH\n\
+export XDG_DATA_DIRS=%s:\$XDG_DATA_DIRS\n\
+export XDG_CONF_DIRS=%s:\$XDG_CONF_DIRS\n\
+\n\
+%s \"\$@\"\n"
 
 generate_random_content() { # swupd_function
 
@@ -1579,6 +1588,12 @@ create_third_party_repo() { #swupd_function
 		create_bundle -L -n os-core -v "$version" -f /usr/lib/os-release:"$OS_RELEASE",/usr/share/clear/update-ca/Swupd_Root.pem:"$cert",/usr/share/defaults/swupd/format:"$FORMAT" -u "$repo_name" "$env_name"
 	else
 		create_bundle -n os-core -v "$version" -f /usr/lib/os-release:"$OS_RELEASE",/usr/share/clear/update-ca/Swupd_Root.pem:"$cert",/usr/share/defaults/swupd/format:"$FORMAT" -u "$repo_name" "$env_name"
+	fi
+
+	# if requested, add the template file to the target system
+	if [ "$add" = true ]; then
+		sudo mkdir -p "$env_name"/testfs/target-dir/"$THIRD_PARTY_BIN_DIR"
+		write_to_protected_file "$env_name"/testfs/target-dir/"$THIRD_PARTY_BIN_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE" "$SCRIPT_TEMPLATE"
 	fi
 
 	if [ "$TEST_ENV_ONLY" = true ]; then


### PR DESCRIPTION
When the template used for creating the wrapper scripts changes, all
exported binaries should have the scripts regenerated during updates
regardless of if the binary changed.

Closes #1413