### PR TITLE
API: output for [3rd-party] info

### DIFF
--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -543,9 +543,13 @@ clean_and_exit:
 void third_party_repo_header(const char *repo_name)
 {
 	char *header = NULL;
+	bool quiet = (log_get_level() == LOG_ERROR);
 
 	string_or_die(&header, " 3rd-Party Repo: %s", repo_name);
 	print_header(header);
+	if (quiet) {
+		print("[%s]\n", repo_name);
+	}
 	free_and_clear_pointer(&header);
 }
 

--- a/src/info.c
+++ b/src/info.c
@@ -40,16 +40,18 @@ enum swupd_code print_update_conf_info(void)
 
 	if (current_version < 0) {
 		error("Unable to determine current OS version\n");
-		info("Installed version: unknown\n");
+		info("Installed version: ");
+		print("unknown\n");
 		ret = SWUPD_CURRENT_VERSION_UNKNOWN;
 	} else {
-		info("Installed version: %d", current_version);
+		info("Installed version: ");
+		print("%d", current_version);
 		if (current_format > 0) {
 			info_verbose(" (format %d)", current_format);
 		} else {
 			info_verbose(" (format unknown)");
 		}
-		info("\n");
+		print("\n");
 	}
 	info("Version URL:       %s\n", globals.version_url);
 	info("Content URL:       %s\n", globals.content_url);

--- a/test/functional/api/api-3rd-party-info.bats
+++ b/test/functional/api/api-3rd-party-info.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+
+	create_third_party_repo -a "$TEST_NAME" 60 1 repo1
+	create_third_party_repo -a "$TEST_NAME" 20 5 repo2
+
+}
+
+@test "API002: 3rd-party info" {
+
+	run sudo sh -c "$SWUPD 3rd-party info $SWUPD_OPTS --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		[repo1]
+		60
+		[repo2]
+		20
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API003: 3rd-party info with --repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party info $SWUPD_OPTS --quiet --repo repo1"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		60
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/api/api-info.bats
+++ b/test/functional/api/api-info.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME" 30123 20
+
+}
+
+@test "API001: info" {
+
+	run sudo sh -c "$SWUPD info $SWUPD_OPTS --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		30123
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/mirror/mirror-json.bats
+++ b/test/functional/mirror/mirror-json.bats
@@ -28,7 +28,8 @@ test_setup() {
 		{ "type" : "warning", "msg" : "The mirror was set up using HTTP. In order for autoupdate to continue working you will need to set allow_insecure_http=true in the swupd configuration file. Alternatively you can set the mirror using HTTPS (recommended)" },
 		{ "type" : "info", "msg" : "Mirror url set" },
 		{ "type" : "info", "msg" : "Distribution:      Swupd Test Distro" },
-		{ "type" : "info", "msg" : "Installed version: 10" },
+		{ "type" : "info", "msg" : "Installed version:" },
+		{ "type" : "info", "msg" : "10" },
 		{ "type" : "info", "msg" : "Version URL:       http://example.com/swupd-file" },
 		{ "type" : "info", "msg" : "Content URL:       http://example.com/swupd-file" },
 		{ "type" : "end", "section" : "mirror", "status" : 0 }

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -4025,6 +4025,7 @@ get_next_available_id() { # swupd_function
 	test_dir=$(basename "$(realpath "$test_dir")")
 	case "$test_dir" in
 		3rd-party) group=TPR;;
+		api) group=API;;
 		autoupdate) group=AUT;;
 		bundleadd) group=ADD;;
 		bundleremove) group=REM;;


### PR DESCRIPTION
This commit provides a minimal output to be displayed when the --quiet
flag is used for these commands:
- swupd info
- swupd 3rd-party info

Related to #1393 

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>