### PR TITLE
sys: Also remove trailing separators in sys_path_join()

### DIFF
--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -445,7 +445,8 @@ char *sys_path_join(const char *fmt, ...)
 
 	/* remove all duplicated PATH_SEPARATOR from the path */
 	for (i = j = 0; i < len; i++) {
-		if (path[i] == PATH_SEPARATOR && path[i + 1] == PATH_SEPARATOR) {
+		if (path[i] == PATH_SEPARATOR &&
+		    (path[i + 1] == PATH_SEPARATOR || path[i + 1] == '\0')) {
 			/* duplicated PATH_SEPARATOR, throw it away */
 			continue;
 		}


### PR DESCRIPTION
Always remove the last slash of a path when using sys_path_join().
This is needed because some functions compare different paths and the
trailing slash will lead to incorrect results.

For example:
    - sys_path_is_absolute(sys_path_join("/usr/")) returns false.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>