### PR TITLE
API: output for [3rd-party] check-update

### DIFF
--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -543,11 +543,10 @@ clean_and_exit:
 void third_party_repo_header(const char *repo_name)
 {
 	char *header = NULL;
-	bool quiet = (log_get_level() == LOG_ERROR);
 
 	string_or_die(&header, " 3rd-Party Repo: %s", repo_name);
 	print_header(header);
-	if (quiet) {
+	if (log_is_quiet()) {
 		print("[%s]\n", repo_name);
 	}
 	free_and_clear_pointer(&header);

--- a/src/check_update.c
+++ b/src/check_update.c
@@ -120,11 +120,12 @@ enum swupd_code check_update(void)
 	}
 
 	if (current_version < server_version) {
-		print("There is a new OS version available: %d\n", server_version);
+		info("There is a new OS version available: ");
+		print("%d\n", server_version);
 		update_motd(server_version);
 		return SWUPD_OK; /* update available */
 	} else if (current_version >= server_version) {
-		print("There are no updates available\n");
+		info("There are no updates available\n");
 	}
 	return SWUPD_NO; /* No update available */
 }

--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -140,3 +140,8 @@ void log_full(int log_level, FILE *out, const char *file, int line, const char *
 	/* clean memory assigned to arguments list */
 	va_end(ap);
 }
+
+bool log_is_quiet(void)
+{
+	return log_get_level() <= LOG_QUIET;
+}

--- a/src/lib/log.h
+++ b/src/lib/log.h
@@ -1,6 +1,7 @@
 #ifndef __SWUPD_LOG__
 #define __SWUPD_LOG__
 
+#include <stdbool.h>
 #include <stdio.h>
 
 #ifdef __cplusplus
@@ -16,6 +17,8 @@ extern "C" {
 #define LOG_ALWAYS 0
 /** @brief Only show messages printed error() and print(). */
 #define LOG_ERROR 2
+/** @brief Only show messages printed error() and print(). */
+#define LOG_QUIET LOG_ERROR
 /** @brief Only show messages printed warn(), error() and print(). */
 #define LOG_WARN 4
 /** @brief Only show messages printed info(), warn(), error() and print(). */
@@ -51,6 +54,11 @@ void log_set_level(int log_level);
  * set by log_set_level().
  */
 void log_full(int log_level, FILE *out, const char *file, int line, const char *label, const char *format, ...);
+
+/**
+ * @brief Check the log level to see if it is set to quiet.
+ */
+bool log_is_quiet(void);
 
 /** @brief Print messages using LOG_ALWAYS level. */
 #define print(_fmt, ...) log_full(LOG_ALWAYS, stdout, __FILE__, __LINE__, NULL, _fmt, ##__VA_ARGS__);

--- a/test/functional/api/api-3rd-party-checkupdate.bats
+++ b/test/functional/api/api-3rd-party-checkupdate.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo1
+	create_bundle -L -t -n test-bundle1 -f /foo/file_1 -u repo1 "$TEST_NAME"
+	create_version -p "$TEST_NAME" 20 10 staging repo1
+	update_bundle "$TEST_NAME" test-bundle1 --update /foo/file_1 repo1
+
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo2
+	create_bundle -L -t -n test-bundle2 -f /bar/file_2 -u repo2 "$TEST_NAME"
+
+}
+
+@test "API009: 3rd-party checkupdate" {
+
+	run sudo sh -c "$SWUPD 3rd-party check-update $SWUPD_OPTS --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		[repo1]
+		20
+		[repo2]
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API010: 3rd-party checkupdate (update available) with --repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party check-update $SWUPD_OPTS --repo repo1 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		20
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API011: 3rd-party checkupdate (up to date) with --repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party check-update $SWUPD_OPTS --repo repo2 --quiet"
+
+	assert_status_is "$SWUPD_NO"
+	assert_output_is_empty
+
+}

--- a/test/functional/api/api-checkupdate.bats
+++ b/test/functional/api/api-checkupdate.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_version "$TEST_NAME" 20
+
+}
+
+@test "API007: checkupdate (update available)" {
+
+	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		20
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API008: checkupdate (up to date)" {
+
+	# set current version to 20 so there are no updates available
+	set_current_version "$TEST_NAME" 20
+
+	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS --quiet"
+
+	assert_status_is "$SWUPD_NO"
+	assert_output_is_empty
+
+}

--- a/test/functional/checkupdate/chk-update-json.bats
+++ b/test/functional/checkupdate/chk-update-json.bats
@@ -26,7 +26,8 @@ test_setup() {
 		{ "type" : "start", "section" : "check-update" },
 		{ "type" : "info", "msg" : "Current OS version: 10" },
 		{ "type" : "info", "msg" : "Latest server version: 20" },
-		{ "type" : "info", "msg" : "There is a new OS version available: 20" },
+		{ "type" : "info", "msg" : "There is a new OS version available:" },
+		{ "type" : "info", "msg" : "20" },
 		{ "type" : "end", "section" : "check-update", "status" : 0 }
 		]
 	EOM


### PR DESCRIPTION
This commit provides a minimal output to be displayed when the --quiet
flag is used for these commands:
- swupd check-update
- swupd 3rd-party check-update

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>