### PR TITLE
mirror: path_prefix is not processed before trying to set the mirror

### DIFF
--- a/src/mirror.c
+++ b/src/mirror.c
@@ -364,6 +364,9 @@ enum swupd_code mirror_main(int argc, char **argv)
 		print_help();
 		return SWUPD_INVALID_OPTION;
 	}
+	if (!globals.path_prefix) {
+		set_default_path_prefix();
+	}
 
 	progress_init_steps("mirror", steps_in_mirror);
 


### PR DESCRIPTION
We need to call globals_init (called by swupd_init) before calling any
function that uses path_prefix.
`mirror --set` using the default path is failing.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>