### PR TITLE
API: output for [3rd-party] bundle-add

### DIFF
--- a/src/bundle_add.c
+++ b/src/bundle_add.c
@@ -149,18 +149,18 @@ static void print_summary(int bundles_requested, int already_installed, int bund
 	/* print totals */
 	int bundles_failed = bundles_requested - bundles_installed - already_installed;
 	if (bundles_failed > 0) {
-		print("Failed to install %i of %i bundles\n", bundles_failed, bundles_requested - already_installed);
+		info("Failed to install %i of %i bundles\n", bundles_failed, bundles_requested - already_installed);
 	} else if (bundles_installed > 0) {
-		print("%snstalled %i bundle%s\n", (rc == SWUPD_OK ? "Successfully i" : "I"), bundles_installed, (bundles_installed > 1 ? "s" : ""));
+		info("%snstalled %i bundle%s\n", (rc == SWUPD_OK ? "Successfully i" : "I"), bundles_installed, (bundles_installed > 1 ? "s" : ""));
 	}
 	if (dependencies_installed > 0) {
-		print("%i bundle%s\n", dependencies_installed, (dependencies_installed > 1 ? "s were installed as dependencies" : " was installed as dependency"));
+		info("%i bundle%s\n", dependencies_installed, (dependencies_installed > 1 ? "s were installed as dependencies" : " was installed as dependency"));
 	}
 	if ((bundles_installed > 0 || dependencies_installed > 0) && rc != SWUPD_OK) {
-		print("Some files from the installed bundle%s may be missing\n", (bundles_installed + dependencies_installed > 1 ? "s" : ""));
+		info("Some files from the installed bundle%s may be missing\n", (bundles_installed + dependencies_installed > 1 ? "s" : ""));
 	}
 	if (already_installed > 0) {
-		print("%i bundle%s already installed\n", already_installed, (already_installed > 1 ? "s were" : " was"));
+		info("%i bundle%s already installed\n", already_installed, (already_installed > 1 ? "s were" : " was"));
 	}
 }
 

--- a/test/functional/api/api-3rd-party-bundle-add.bats
+++ b/test/functional/api/api-3rd-party-bundle-add.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
+	create_bundle -n test-bundle1 -f /file_1 -u repo1 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /file_2a -u repo1 "$TEST_NAME"
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
+	create_bundle -n test-bundle2 -f /file_2b -u repo2 "$TEST_NAME"
+
+}
+
+@test "API021: 3rd-party bundle-add" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-add test-bundle1 $SWUPD_OPTS --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	assert_output_is_empty
+
+}
+
+@test "API022: 3rd-party bundle-add with --repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-add test-bundle1 $SWUPD_OPTS --repo repo1 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	assert_output_is_empty
+
+}

--- a/test/functional/api/api-bundle-add.bats
+++ b/test/functional/api/api-bundle-add.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n test-bundle1 -f /foo/file_1 "$TEST_NAME"
+
+}
+
+@test "API020: bundle-add" {
+
+	run sudo sh -c "$SWUPD bundle-add test-bundle1 $SWUPD_OPTS --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	assert_output_is_empty
+
+}


### PR DESCRIPTION
This commit provides a minimal output to be displayed when the --quiet
flag is used for these commands:

- swupd bundle-add
- swupd 3rd-party bundle-add

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>