### PR TITLE
API: output for [3rd-party] bundle-remove

### DIFF
--- a/src/bundle_remove.c
+++ b/src/bundle_remove.c
@@ -273,17 +273,17 @@ static void print_remove_summary(unsigned int requested, unsigned int bad, unsig
 	int deps_removed;
 
 	if (bad > 0) {
-		print("\nFailed to remove %i of %i bundles\n", bad, requested);
+		info("\nFailed to remove %i of %i bundles\n", bad, requested);
 	} else {
-		print("\nSuccessfully removed %i bundle%s\n", requested, (requested > 1 ? "s" : ""));
+		info("\nSuccessfully removed %i bundle%s\n", requested, (requested > 1 ? "s" : ""));
 	}
 
 	deps_removed = total_removed + bad - requested;
 	if (deps_removed > 0) {
 		if (cmdline_option_force) {
-			print("%i bundle%s\n", deps_removed, deps_removed > 1 ? "s that depended on the specified bundle(s) were removed" : " that depended on the specified bundle(s) was removed");
+			info("%i bundle%s\n", deps_removed, deps_removed > 1 ? "s that depended on the specified bundle(s) were removed" : " that depended on the specified bundle(s) was removed");
 		} else {
-			print("%i bundle%s\n", deps_removed, deps_removed > 1 ? "s that were installed as a dependency were removed" : " that was installed as a dependency was removed");
+			info("%i bundle%s\n", deps_removed, deps_removed > 1 ? "s that were installed as a dependency were removed" : " that was installed as a dependency was removed");
 		}
 	}
 }

--- a/test/functional/api/api-3rd-party-bundle-remove.bats
+++ b/test/functional/api/api-3rd-party-bundle-remove.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
+	create_bundle -L -t -n test-bundle1 -f /file_1 -u repo1 "$TEST_NAME"
+
+}
+
+@test "API018: 3rd-party bundle-remove" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove test-bundle1 $SWUPD_OPTS --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	assert_output_is_empty
+
+}
+
+@test "API019: 3rd-party bundle-remove with --repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove test-bundle1 $SWUPD_OPTS --repo repo1 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	assert_output_is_empty
+
+}

--- a/test/functional/api/api-bundle-remove.bats
+++ b/test/functional/api/api-bundle-remove.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -t -n test-bundle1 -f /file_1 "$TEST_NAME"
+
+}
+
+@test "API017: bundle-remove" {
+
+	run sudo sh -c "$SWUPD bundle-remove test-bundle1 $SWUPD_OPTS --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	assert_output_is_empty
+
+}


### PR DESCRIPTION
This commit provides a minimal output to be displayed when the --quiet
flag is used for these commands:

- swupd bundle-remove
- swupd 3rd-party bundle-remove

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>