### PR TITLE
Suggestion WIP: Create UNEXPECTED() macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,16 @@ AC_CHECK_LIB([pthread], [pthread_create])
 # Program checks
 AC_CHECK_PROGS(TAR, tar)
 
+# Enable/Disable debug mode
+AC_ARG_ENABLE(
+  [debug],
+  [AS_HELP_STRING([--enable-debug], [Enable debug mode (disabled by default)])]
+)
+AS_IF(
+  [test "x$enable_debug" == "xyes"],
+  [AC_DEFINE(DEBUG_MODE, 1, [Debug enabled])]
+)
+
 
 # Enable/disable options
 AC_ARG_ENABLE(

--- a/scripts/github_actions/build_ci.bash
+++ b/scripts/github_actions/build_ci.bash
@@ -17,7 +17,7 @@ sudo ln -s /usr/share/docutils/scripts/python3/rst2man /usr/bin/rst2man.py
 
 # Build Swupd
 autoreconf --verbose --warnings=none --install --force
-./configure CFLAGS="$CFLAGS -fsanitize=address -Werror" --prefix=/usr --with-fallback-capaths="$PWD"/swupd_test_certificates --with-systemdsystemunitdir=/usr/lib/systemd/system --with-config-file-path="$PWD"/testconfig
+./configure CFLAGS="$CFLAGS -fsanitize=address -Werror" --prefix=/usr --with-fallback-capaths="$PWD"/swupd_test_certificates --with-systemdsystemunitdir=/usr/lib/systemd/system --with-config-file-path="$PWD"/testconfig --enable-debug
 make -j$CORES
 
 # Needed to initialize the host for auto-update. Without these steps auto-update

--- a/src/lib/macros.h
+++ b/src/lib/macros.h
@@ -18,4 +18,14 @@
 /** @brief Return the max between 2 values. */
 #define MAX(_a, _b) ((_a) > (_b) ? (_a) : (_b))
 
+#ifdef DEBUG_MODE
+#define UNEXPECTED() abort()
+#else
+/**
+ * @brief To be used in all checks where we assume swupd should never get in to.
+ * This macro aborts execution only when DEBUG_MODE is used.
+ */
+#define UNEXPECTED()
+#endif
+
 #endif

--- a/src/target_root.c
+++ b/src/target_root.c
@@ -47,7 +47,7 @@ static int create_staging_renamedir(char *rename_tmpdir)
 		/* Not fatal but pretty scary, likely to really fail at the
 		 * next command too. Pass for now as printing may just cause
 		 * confusion */
-		;
+		UNEXPECTED();
 	}
 
 	ret = mkdir(rename_tmpdir, S_IRWXU);
@@ -526,6 +526,7 @@ enum swupd_code target_root_install_files(struct list *files, struct manifest *m
 	int ret = SWUPD_OK;
 
 	if (!list_is_sorted(files, cmp_file_filename_is_deleted)) {
+		UNEXPECTED();
 		debug("List of files to install is not sorted - fixing\n");
 		files = list_sort(files, cmp_file_filename_is_deleted);
 	}


### PR DESCRIPTION
    There are several points in swupd that we find conditions that should never
    happen, but we try to correct them anyway to be more reliable. Because of that
    we may hide programming mistakes that are corrected later.
    
    So, to make sure we are going to catch those problems in debug mode in our development
    machines and test environment, I am suggesting a UNEXPECTED() macro that aborts swupd
    if --enable-debug was used to build swupd.
    
    I am adding some examples on what we could do with that.

What are your opinions about that?