### PR TITLE
Testlib: including os-core in test bundles

### DIFF
--- a/test/functional/3rd-party/3rd-party-bundle-info-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-info-basic.bats
@@ -90,7 +90,8 @@ global_setup() {
 		Bundle size:
 		 - Size of bundle: .* KB
 		 - Size bundle takes on disk \\(includes dependencies\\): .* KB
-		Direct dependencies \\(1\\):
+		Direct dependencies \\(2\\):
+		 - os-core
 		 - test-bundle1
 		Files in bundle \\(includes dependencies\\):
 		 - /bar
@@ -98,12 +99,20 @@ global_setup() {
 		 - /foo
 		 - /foo/file_1A
 		 - /usr
+		 - /usr/lib
+		 - /usr/lib/os-release
 		 - /usr/share
 		 - /usr/share/clear
 		 - /usr/share/clear/bundles
+		 - /usr/share/clear/bundles/os-core
 		 - /usr/share/clear/bundles/test-bundle1
 		 - /usr/share/clear/bundles/test-bundle2
-		Total files: 10
+		 - /usr/share/clear/update-ca
+		 - /usr/share/clear/update-ca/Swupd_Root.pem
+		 - /usr/share/defaults
+		 - /usr/share/defaults/swupd
+		 - /usr/share/defaults/swupd/format
+		Total files: 18
 	EOM
 	)
 	assert_regex_is_output "$expected_output"

--- a/test/functional/3rd-party/3rd-party-bundle-list-deps.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-list-deps.bats
@@ -35,11 +35,12 @@ global_setup() {
 		Loading required manifests...
 
 		Bundles included by test-bundle2:
+		 - os-core
 		 - test-bundle3
 		 - test-bundle4
 		 - test-bundle5
 
-		Total: 3
+		Total: 4
 	EOM
 	)
 	assert_is_output --identical "$expected_output"

--- a/test/functional/bundleinfo/bundle-info-files.bats
+++ b/test/functional/bundleinfo/bundle-info-files.bats
@@ -64,18 +64,21 @@ global_setup() {
 		Bundle size:
 		 - Size of bundle: .* KB
 		 - Maximum amount of disk size the bundle will take if installed \\(includes dependencies\\): .* KB
-		Direct dependencies \\(1\\):
+		Direct dependencies \\(2\\):
+		 - os-core
 		 - test-bundle2
 		Files in bundle \\(includes dependencies\\):
 		 - /bar
 		 - /bar/file_4
+		 - /core
 		 - /file_1
 		 - /file_3
 		 - /foo
 		 - /foo/file_2
+		 - /usr/share/clear/bundles/os-core
 		 - /usr/share/clear/bundles/test-bundle1
 		 - /usr/share/clear/bundles/test-bundle2
-		Total files: 8
+		Total files: 10
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
@@ -98,19 +101,22 @@ global_setup() {
 		Bundle size:
 		 - Size of bundle: .* KB
 		 - Maximum amount of disk size the bundle will take if installed \\(includes dependencies\\): .* KB
-		Direct dependencies \\(1\\):
+		Direct dependencies \\(2\\):
+		 - os-core
 		 - test-bundle2
 		Files in bundle \\(includes dependencies\\):
 		 - /bar
 		 - /bar/file_4
+		 - /core
 		 - /file_1
 		 - /file_3
 		 - /file_5
 		 - /foo
 		 - /foo/file_2
+		 - /usr/share/clear/bundles/os-core
 		 - /usr/share/clear/bundles/test-bundle1
 		 - /usr/share/clear/bundles/test-bundle2
-		Total files: 9
+		Total files: 11
 	EOM
 	)
 	assert_regex_is_output "$expected_output"

--- a/test/functional/bundleinfo/bundle-info-includes.bats
+++ b/test/functional/bundleinfo/bundle-info-includes.bats
@@ -42,7 +42,8 @@ global_setup() {
 		Bundle size:
 		 - Size of bundle: .* KB
 		 - Maximum amount of disk size the bundle will take if installed \\(includes dependencies\\): .* KB
-		Direct dependencies \\(2\\):
+		Direct dependencies \\(3\\):
+		 - os-core
 		 - test-bundle2
 		 - test-bundle3 \\(optional\\)
 		Indirect dependencies \\(1\\):
@@ -70,7 +71,8 @@ global_setup() {
 		Bundle size:
 		 - Size of bundle: .* KB
 		 - Maximum amount of disk size the bundle will take if installed \\(includes dependencies\\): .* KB
-		Direct dependencies \\(3\\):
+		Direct dependencies \\(4\\):
+		 - os-core
 		 - test-bundle2
 		 - test-bundle5
 		 - test-bundle3 \\(optional\\)

--- a/test/functional/bundleinfo/bundle-info-optional.bats
+++ b/test/functional/bundleinfo/bundle-info-optional.bats
@@ -33,7 +33,8 @@ global_setup() {
 		Bundle size:
 		 - Size of bundle: .* KB
 		 - Maximum amount of disk size the bundle will take if installed \\(includes dependencies\\): .* KB
-		Direct dependencies \\(2\\):
+		Direct dependencies \\(3\\):
+		 - os-core
 		 - test-bundle2
 		 - test-bundle3 \\(optional\\)
 		Indirect dependencies \\(2\\):
@@ -65,7 +66,8 @@ global_setup() {
 		Bundle size:
 		 - Size of bundle: .* KB
 		 - Size bundle takes on disk \\(includes dependencies\\): .* KB
-		Direct dependencies \\(2\\):
+		Direct dependencies \\(3\\):
+		 - os-core
 		 - test-bundle2
 		 - test-bundle3 \\(optional, not installed\\)
 		Indirect dependencies \\(2\\):

--- a/test/functional/bundlelist/list-deps-flat.bats
+++ b/test/functional/bundlelist/list-deps-flat.bats
@@ -23,10 +23,11 @@ test_setup() {
 		Loading required manifests...
 
 		Bundles included by test-bundle1:
+		 - os-core
 		 - test-bundle2
 		 - test-bundle3
 
-		Total: 2
+		Total: 3
 	EOM
 	)
 	assert_is_output --identical "$expected_output"

--- a/test/functional/bundlelist/list-deps-nested.bats
+++ b/test/functional/bundlelist/list-deps-nested.bats
@@ -23,10 +23,11 @@ test_setup() {
 		Loading required manifests...
 
 		Bundles included by test-bundle1:
+		 - os-core
 		 - test-bundle2
 		 - test-bundle3
 
-		Total: 2
+		Total: 3
 	EOM
 	)
 	assert_is_output --identical "$expected_output"
@@ -43,10 +44,13 @@ test_setup() {
 
 		Bundles included by test-bundle1:
 		  * test-bundle1
+		    |-- os-core
 		    |-- test-bundle2
+		        |-- os-core
 		        |-- test-bundle3
+		            |-- os-core
 
-		Total: 2
+		Total: 3
 	EOM
 	)
 	assert_is_output --identical "$expected_output"

--- a/test/functional/diagnose/diagnose-bundles.bats
+++ b/test/functional/diagnose/diagnose-bundles.bats
@@ -39,7 +39,7 @@ test_setup() {
 		 -> Missing file: $PATH_PREFIX/foo/test-file1
 		Checking for corrupt files
 		Checking for extraneous files
-		Inspected 7 files
+		Inspected 9 files
 		  2 files were missing
 		Use "swupd repair" to correct the problems in the system
 		Diagnose successful
@@ -84,7 +84,7 @@ test_setup() {
 		 -> Missing file: $PATH_PREFIX/foo/test-file1
 		Checking for corrupt files
 		Checking for extraneous files
-		Inspected 4 files
+		Inspected 6 files
 		  2 files were missing
 		Use "swupd repair" to correct the problems in the system
 		Diagnose successful
@@ -115,7 +115,7 @@ test_setup() {
 		Checking for corrupt files
 		Checking for extraneous files
 		 -> File that should be deleted: $PATH_PREFIX/foo/test-file1
-		Inspected 7 files
+		Inspected 9 files
 		  1 file found which should be deleted
 		Use "swupd repair" to correct the problems in the system
 		Diagnose successful
@@ -161,7 +161,7 @@ test_setup() {
 		Checking for missing files
 		Checking for corrupt files
 		Checking for extraneous files
-		Inspected 4 files
+		Inspected 6 files
 		Diagnose successful
 	EOM
 	)

--- a/test/functional/diagnose/diagnose-path.bats
+++ b/test/functional/diagnose/diagnose-path.bats
@@ -195,10 +195,11 @@ test_setup() {
 		 - /usr/share/clear/bundles
 		Checking for missing files
 		Checking for corrupt files
+		 -> Hash mismatch for file: $PATH_PREFIX/usr/share/clear/bundles/os-core
 		 -> Hash mismatch for file: $PATH_PREFIX/usr/share/clear/bundles/test-bundle1
 		Checking for extraneous files
-		Inspected 1 file
-		  1 file did not match
+		Inspected 3 files
+		  2 files did not match
 		Use "swupd repair" to correct the problems in the system
 		Diagnose successful
 	EOM

--- a/test/functional/repair/repair-bundles.bats
+++ b/test/functional/repair/repair-bundles.bats
@@ -42,7 +42,7 @@ test_setup() {
 		 -> Missing file: $PATH_PREFIX/foo/test-file1 -> fixed
 		Repairing corrupt files
 		Removing extraneous files
-		Inspected 7 files
+		Inspected 9 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
 		    0 of 2 missing files were not replaced
@@ -94,7 +94,7 @@ test_setup() {
 		Repairing corrupt files
 		 -> Hash mismatch for file: $PATH_PREFIX/usr/share/clear/bundles/test-bundle1 -> fixed
 		Removing extraneous files
-		Inspected 4 files
+		Inspected 6 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
 		    0 of 2 missing files were not replaced
@@ -135,7 +135,7 @@ test_setup() {
 		 -> Hash mismatch for file: $PATH_PREFIX/usr/share/clear/bundles/test-bundle1 -> fixed
 		Removing extraneous files
 		 -> File that should be deleted: $PATH_PREFIX/foo/test-file1 -> deleted
-		Inspected 7 files
+		Inspected 9 files
 		  1 file did not match
 		    1 of 1 files were repaired
 		    0 of 1 files were not repaired
@@ -176,7 +176,7 @@ test_setup() {
 		 -> Missing file: $PATH_PREFIX/foo/test-file1 -> fixed
 		Repairing corrupt files
 		Removing extraneous files
-		Inspected 4 files
+		Inspected 6 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
 		    0 of 2 missing files were not replaced

--- a/test/functional/repair/repair-path.bats
+++ b/test/functional/repair/repair-path.bats
@@ -264,12 +264,13 @@ test_setup() {
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
 		Repairing corrupt files
+		 -> Hash mismatch for file: $PATH_PREFIX/usr/share/clear/bundles/os-core -> fixed
 		 -> Hash mismatch for file: $PATH_PREFIX/usr/share/clear/bundles/test-bundle1 -> fixed
 		Removing extraneous files
-		Inspected 1 file
-		  1 file did not match
-		    1 of 1 files were repaired
-		    0 of 1 files were not repaired
+		Inspected 3 files
+		  2 files did not match
+		    2 of 2 files were repaired
+		    0 of 2 files were not repaired
 		Calling post-update helper scripts
 		Repair successful
 	EOM

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -2460,6 +2460,7 @@ create_bundle() { # swupd_function
 	local repo_name
 	local content_dir
 	local third_party=false
+	local os_core_manifest
 
 	# If no parameters are received show help
 	if [ $# -eq 0 ]; then
@@ -2821,7 +2822,15 @@ create_bundle() { # swupd_function
 		done
 	fi
 
-	# 9) Add the bundle to the MoM (do not use -p option so the MoM's tar is created and signed)
+	# 9) if there is an os-core bundle, add it to the manifest as dependency
+	if [ "$bundle_name" != os-core ]; then
+		os_core_manifest=$(sudo find "$env_name"/"$content_dir"/ -name Manifest.os-core)
+		if [ -n "$os_core_manifest" ]; then
+			add_dependency_to_manifest "$manifest" os-core
+		fi
+	fi
+
+	# 10) Add the bundle to the MoM (do not use -p option so the MoM's tar is created and signed)
 	debug_msg "Adding bundle to the MoM"
 	if [ "$experimental" = true ]; then
 		add_to_manifest -e "$version_path"/Manifest.MoM "$manifest" "$bundle_name"
@@ -2829,19 +2838,19 @@ create_bundle() { # swupd_function
 		add_to_manifest "$version_path"/Manifest.MoM "$manifest" "$bundle_name"
 	fi
 
-	# 10) Create/renew manifest tars
+	# 11) Create/renew manifest tars
 	debug_msg "Creating the manifest tar"
 	sudo rm -f "$manifest".tar
 	create_tar "$manifest"
 
-	# 11) Create the subscription to the bundle if the local_bundle flag is enabled
+	# 12) Create the subscription to the bundle if the local_bundle flag is enabled
 	# all installed bundles in the system should have a file in this directory
 	if [ "$local_bundle" = true ]; then
 		debug_msg "Creating tracking file for bundle so it show as installed"
 		sudo touch "$target_path"/usr/share/clear/bundles/"$bundle_name"
 	fi
 
-	# 12) Create the tracking file for the bundle if the track_bundle flag is set
+	# 13) Create the tracking file for the bundle if the track_bundle flag is set
 	# all bundles specifically installed by a user should have a file in this directory
 	# bundles installed as dependencies should not have files here
 	if [ "$track_bundle" = true ]; then

--- a/test/functional/verify-legacy/verify-bundle.bats
+++ b/test/functional/verify-legacy/verify-bundle.bats
@@ -34,7 +34,7 @@ test_setup() {
 		 -> Missing file: $TEST_DIRNAME/testfs/target-dir/bar/test-file2 -> fixed
 		Repairing corrupt files
 		Removing extraneous files
-		Inspected 3 files
+		Inspected 5 files
 		  1 file was missing
 		    1 of 1 missing files were replaced
 		    0 of 1 missing files were not replaced
@@ -71,7 +71,7 @@ test_setup() {
 		 -> Missing file: $TEST_DIRNAME/testfs/target-dir/usr/share/clear/bundles/test-bundle3 -> fixed
 		Repairing corrupt files
 		Removing extraneous files
-		Inspected 3 files
+		Inspected 5 files
 		  3 files were missing
 		    3 of 3 missing files were replaced
 		    0 of 3 missing files were not replaced
@@ -107,7 +107,7 @@ test_setup() {
 		 -> Missing file: $TEST_DIRNAME/testfs/target-dir/foo/test-file1 -> fixed
 		Repairing corrupt files
 		Removing extraneous files
-		Inspected 6 files
+		Inspected 8 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
 		    0 of 2 missing files were not replaced


### PR DESCRIPTION
When creating test bundles, we are not including os-core in them by
default. This is how it works in production so we should do it so it
resembles the real production environment more accurately.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>