### PR TITLE
Show status for all bundles with --status

### DIFF
--- a/src/bundle_list.c
+++ b/src/bundle_list.c
@@ -176,7 +176,6 @@ static enum swupd_code list_local_bundles(int version)
 	struct manifest *MoM = NULL;
 	struct file *bundle_manifest = NULL;
 	int count = 0;
-	const bool DONT_SHOW = false;
 	bool quiet = (log_get_level() == LOG_ERROR);
 
 	progress_next_step("load_manifests", PROGRESS_UNDEFINED);
@@ -206,7 +205,7 @@ static enum swupd_code list_local_bundles(int version)
 			bundle_manifest = mom_search_bundle(MoM, sys_basename((char *)item->data));
 		}
 		if (bundle_manifest && !quiet) {
-			name = get_printable_bundle_name(bundle_manifest->filename, bundle_manifest->is_experimental, DONT_SHOW, cmdline_option_status && is_tracked_bundle(bundle_manifest->filename));
+			name = get_printable_bundle_name(bundle_manifest->filename, bundle_manifest->is_experimental, cmdline_option_status && is_installed_bundle(bundle_manifest->filename), cmdline_option_status && is_tracked_bundle(bundle_manifest->filename));
 			info(" - ");
 			print("%s\n", name);
 			free(name);

--- a/test/functional/bundlelist/list-experimental.bats
+++ b/test/functional/bundlelist/list-experimental.bats
@@ -90,7 +90,7 @@ global_setup() {
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Installed bundles:
-		 - os-core
+		 - os-core (installed)
 		 - test-bundle1 (experimental, explicitly installed)
 
 		Total: 2

--- a/test/functional/bundlelist/list-installed.bats
+++ b/test/functional/bundlelist/list-installed.bats
@@ -41,8 +41,8 @@ test_setup() {
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Installed bundles:
-		 - os-core
-		 - test-bundle1
+		 - os-core (installed)
+		 - test-bundle1 (installed)
 		 - test-bundle2 (explicitly installed)
 
 		Total: 3


### PR DESCRIPTION
When listing bundles using "swupd bundle-list --status" we were
distinguishing bundles that were explicitly installed, by marking them
as such and since bundle-list shows only bundles tha are installed, bundles
that were not marked as explicitelly installed were assumed to be
just installed.

When we use "bundle-list --all --status" (which shows installed and
uninstalled bundles), we were marking files as "installed", "explicitly
installed" and bundles without any of these distinctions were assumed to
be not installed. This could cause confusion.

This PR changes the "bundle-list --status" so we always label bundles
as either "implicitly installed" or "installed" (even though it couls
sound a little redundant) so it is consistent with the way they are
labeled during "bundle-list --all --status".

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>