### PR TITLE
Testlib: fix bug regenerating hashes in MoM

### DIFF
--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1271,7 +1271,7 @@ update_hashes_in_mom() { # swupd_function
 
 	IFS=$'\n'
 	if [ "$(basename "$manifest")" = Manifest.MoM ]; then
-		bundles=("$(sudo cat "$manifest" | grep -x "M\\.\\.\\..*" | awk '{ print $4 }')")
+		bundles=("$(sudo cat "$manifest" | grep -x "M.\\.\\..*" | awk '{ print $4 }')")
 		for bundle in ${bundles[*]}; do
 			# if the hash of the manifest changed, update it
 			bundle_old_hash=$(get_hash_from_manifest "$manifest" "$bundle")


### PR DESCRIPTION
When a MoM contains an experimental bundle and the hashes in the MoM are
regenerated, the experimental bundles are being skipped. This commit
fixes that issue.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>