### PR TITLE
API: output for [3rd-party] bundle-list

### DIFF
--- a/src/bundle_list.c
+++ b/src/bundle_list.c
@@ -176,7 +176,6 @@ static enum swupd_code list_local_bundles(int version)
 	struct manifest *MoM = NULL;
 	struct file *bundle_manifest = NULL;
 	int count = 0;
-	bool quiet = (log_get_level() == LOG_ERROR);
 
 	progress_next_step("load_manifests", PROGRESS_UNDEFINED);
 	if (version > 0) {
@@ -204,14 +203,14 @@ static enum swupd_code list_local_bundles(int version)
 		if (MoM) {
 			bundle_manifest = mom_search_bundle(MoM, sys_basename((char *)item->data));
 		}
-		if (bundle_manifest && !quiet) {
+		if (bundle_manifest) {
 			name = get_printable_bundle_name(bundle_manifest->filename, bundle_manifest->is_experimental, cmdline_option_status && is_installed_bundle(bundle_manifest->filename), cmdline_option_status && is_tracked_bundle(bundle_manifest->filename));
 			info(" - ");
 			print("%s\n", name);
 			free(name);
 		} else {
 			info(" - ");
-			print("%s\n", sys_basename((char *)item->data));
+			print("%s\n", sys_basename((char *)item->data))
 		}
 		count++;
 		item = item->next;
@@ -317,7 +316,6 @@ static enum swupd_code list_installable_bundles(int version)
 	struct file *file;
 	struct manifest *MoM = NULL;
 	int count = 0;
-	bool quiet = (log_get_level() == LOG_ERROR);
 
 	progress_next_step("load_manifests", PROGRESS_UNDEFINED);
 	MoM = load_mom(version, NULL);
@@ -331,14 +329,10 @@ static enum swupd_code list_installable_bundles(int version)
 	while (list) {
 		file = list->data;
 		list = list->next;
-		if (!quiet) {
-			name = get_printable_bundle_name(file->filename, file->is_experimental, cmdline_option_status && is_installed_bundle(file->filename), cmdline_option_status && is_tracked_bundle(file->filename));
-			info(" - ");
-			print("%s\n", name);
-			free_and_clear_pointer(&name);
-		} else {
-			print("%s\n", file->filename);
-		}
+		name = get_printable_bundle_name(file->filename, file->is_experimental, cmdline_option_status && is_installed_bundle(file->filename), cmdline_option_status && is_tracked_bundle(file->filename));
+		info(" - ");
+		print("%s\n", name);
+		free_and_clear_pointer(&name);
 		count++;
 	}
 	info("\nTotal: %d\n", count);

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -870,7 +870,7 @@ char *get_printable_bundle_name(const char *bundle_name, bool is_experimental, b
 
 	if (is_experimental) {
 		if (status) {
-			string_or_die(&details, "experimental, %s", status);
+			string_or_die(&details, "%s, experimental", status);
 		} else {
 			string_or_die(&details, "%s", "experimental");
 		}
@@ -880,7 +880,11 @@ char *get_printable_bundle_name(const char *bundle_name, bool is_experimental, b
 	free_and_clear_pointer(&status);
 
 	if (details) {
-		string_or_die(&printable_name, "%s (%s)", bundle_name, details);
+		if (log_is_quiet()) {
+			string_or_die(&printable_name, "%s: %s", bundle_name, details);
+		} else {
+			string_or_die(&printable_name, "%s (%s)", bundle_name, details);
+		}
 	} else {
 		string_or_die(&printable_name, "%s", bundle_name);
 	}

--- a/test/functional/api/api-3rd-party-bundle-list.bats
+++ b/test/functional/api/api-3rd-party-bundle-list.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME" 10 1
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
+	WEBDIR="$TPWEBDIR"
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
+	create_bundle -L -t -n test-bundle1 -f /file_1 -u repo1 "$TEST_NAME"
+	create_bundle -L -t -n test-bundle2 -f /file_2 -u repo1 "$TEST_NAME"
+	create_bundle       -n test-bundle3 -f /file_3 -u repo1 "$TEST_NAME"
+	create_bundle -L -t -n test-bundle4 -f /file_4 -u repo2 "$TEST_NAME"
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
+
+}
+
+@test "API029: 3rd-party bundle-list" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list $SWUPD_OPTS --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		[repo1]
+		os-core
+		test-bundle1
+		test-bundle2
+		[repo2]
+		os-core
+		test-bundle4
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API030: 3rd-party bundle-list --repo REPOSITORY" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list $SWUPD_OPTS --repo repo1 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		os-core
+		test-bundle1
+		test-bundle2
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API031: 3rd-party bundle-list --all" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list $SWUPD_OPTS --all --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		[repo1]
+		os-core
+		test-bundle1
+		test-bundle2
+		test-bundle3
+		[repo2]
+		os-core
+		test-bundle4
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API032: 3rd-party bundle-list --all --repo REPOSITORY" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list $SWUPD_OPTS --all --repo repo1 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		os-core
+		test-bundle1
+		test-bundle2
+		test-bundle3
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API033: 3rd-party bundle-list --has-dep BUNDLE" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list $SWUPD_OPTS --has-dep test-bundle2 --quiet"
+
+	assert_status_is "$SWUPD_BUNDLE_NOT_TRACKED"
+	expected_output=$(cat <<-EOM
+		[repo1]
+		test-bundle1
+		[repo2]
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API034: 3rd-party bundle-list --has-dep BUNDLE --repo REPOSITORY" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list $SWUPD_OPTS --has-dep test-bundle2 --repo repo1 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		test-bundle1
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API035: 3rd-party bundle-list --deps BUNDLE" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list $SWUPD_OPTS --deps test-bundle1 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		[repo1]
+		os-core
+		test-bundle2
+		[repo2]
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API036: 3rd-party bundle-list --deps BUNDLE --repo REPOSITORY" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list $SWUPD_OPTS --deps test-bundle1 --repo repo1 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		os-core
+		test-bundle2
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/api/api-bundle-list.bats
+++ b/test/functional/api/api-bundle-list.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -n test-bundle1 -f /file_1 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /file_2 "$TEST_NAME"
+	create_bundle -L -t -n test-bundle3 -f /file_3 "$TEST_NAME"
+	create_bundle -L -e -n test-bundle4 -f /file_4 "$TEST_NAME"
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle3 test-bundle4
+
+}
+
+@test "API023: bundle-list" {
+
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		os-core
+		test-bundle3
+		test-bundle4: experimental
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API024: bundle-list --all" {
+
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --all --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		os-core
+		test-bundle1
+		test-bundle2
+		test-bundle3
+		test-bundle4: experimental
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API025: bundle-list --has-dep BUNDLE" {
+
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --has-dep test-bundle4 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		test-bundle3
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API026: bundle-list --deps BUNDLE" {
+
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --deps test-bundle3 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		os-core
+		test-bundle4
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API027: bundle-list --status" {
+
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --status --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		os-core: installed
+		test-bundle3: explicitly installed
+		test-bundle4: installed, experimental
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API028: bundle-list --all --status" {
+
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --all --status --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		os-core: installed
+		test-bundle1
+		test-bundle2
+		test-bundle3: explicitly installed
+		test-bundle4: installed, experimental
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/bundlelist/list-experimental.bats
+++ b/test/functional/bundlelist/list-experimental.bats
@@ -91,7 +91,7 @@ global_setup() {
 	expected_output=$(cat <<-EOM
 		Installed bundles:
 		 - os-core (installed)
-		 - test-bundle1 (experimental, explicitly installed)
+		 - test-bundle1 (explicitly installed, experimental)
 
 		Total: 2
 	EOM


### PR DESCRIPTION
This commit provides a minimal output to be displayed when the --quiet
flag is used for these commands:

- swupd bundle-list
- swupd 3rd-party bundle-list

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>