### PR TITLE
API: output for [3rd-party] bundle-info

### DIFF
--- a/src/bundle.c
+++ b/src/bundle.c
@@ -44,7 +44,7 @@ bool is_installed_bundle(const char *bundle_name)
 	char *filename = NULL;
 	bool ret = true;
 
-	string_or_die(&filename, "%s/%s/%s", globals.path_prefix, BUNDLES_DIR, bundle_name);
+	filename = sys_path_join("%s/%s/%s", globals.path_prefix, BUNDLES_DIR, bundle_name);
 	ret = sys_file_exists(filename);
 	free_and_clear_pointer(&filename);
 
@@ -56,7 +56,7 @@ bool is_tracked_bundle(const char *bundle_name)
 	char *filename = NULL;
 	bool ret;
 
-	string_or_die(&filename, "%s/bundles/%s", globals.state_dir, bundle_name);
+	filename = sys_path_join("%s/bundles/%s", globals.state_dir, bundle_name);
 	ret = sys_file_exists(filename);
 	free_and_clear_pointer(&filename);
 

--- a/src/bundle_info.c
+++ b/src/bundle_info.c
@@ -403,7 +403,11 @@ enum swupd_code bundle_info(char *bundle)
 	} else if (installed) {
 		string_or_die(&status, "Installed");
 	}
-	info("Status: %s%s\n", status ? status : "Not installed", file->is_experimental ? " (experimental)" : "");
+	if (log_is_quiet() && !(cmdline_option_dependencies || cmdline_option_files)) {
+		print("%s%s\n", status ? status : "Not installed", file->is_experimental ? ", experimental" : "");
+	} else {
+		info("Status: %s%s\n", status ? status : "Not installed", file->is_experimental ? " (experimental)" : "");
+	}
 	free_and_clear_pointer(&status);
 
 	/* version info */
@@ -440,6 +444,10 @@ enum swupd_code bundle_info(char *bundle)
 	/* the --files flag was used */
 	if (cmdline_option_files) {
 
+		if (log_is_quiet() && cmdline_option_dependencies) {
+			/* leave a blank line between both lists */
+			print("\n");
+		}
 		struct list *bundle_files = NULL;
 		ret = get_bundle_files(manifest, mom, &bundle_files);
 		if (ret) {

--- a/test/functional/api/api-3rd-party-bundle-info.bats
+++ b/test/functional/api/api-3rd-party-bundle-info.bats
@@ -1,0 +1,184 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo1
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo2
+	create_bundle -L -t -n test-bundle1 -f /file_1a,/file_1b,/file_1c -u repo1 "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /file_2 -u repo2 "$TEST_NAME"
+	create_bundle -n test-bundle3 -f /file_3 -u repo2 "$TEST_NAME"
+	create_bundle -n test-bundle4 -f /file_4 -u repo2 "$TEST_NAME"
+	add_dependency_to_manifest "$TPWEBDIR"/10/Manifest.test-bundle2 test-bundle3
+	add_dependency_to_manifest "$TPWEBDIR"/10/Manifest.test-bundle3 test-bundle4
+
+}
+
+@test "API042: 3rd-party bundle-info BUNDLE" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-info $SWUPD_OPTS test-bundle1 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Explicitly installed
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API043: 3rd-party bundle-info BUNDLE --repo REPOSITORY" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-info $SWUPD_OPTS test-bundle2 --repo repo2 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Not installed
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API044: 3rd-party bundle-info BUNDLE --dependencies" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-info $SWUPD_OPTS test-bundle2 --dependencies --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		os-core
+		test-bundle3
+		test-bundle4
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API045: 3rd-party bundle-info BUNDLE --dependencies --repo REPOSITORY" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-info $SWUPD_OPTS test-bundle2 --dependencies --repo repo2 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		os-core
+		test-bundle3
+		test-bundle4
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API046: 3rd-party bundle-info BUNDLE --files" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-info $SWUPD_OPTS test-bundle1 --files --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		/usr/share/clear/bundles/test-bundle1
+		/usr
+		/usr/share
+		/usr/share/clear
+		/usr/share/clear/bundles
+		/file_1c
+		/file_1b
+		/file_1a
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API047: 3rd-party bundle-info BUNDLE --files --repo REPOSITORY" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-info $SWUPD_OPTS test-bundle1 --files --repo repo1 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		/usr/share/clear/bundles/test-bundle1
+		/usr
+		/usr/share
+		/usr/share/clear
+		/usr/share/clear/bundles
+		/file_1c
+		/file_1b
+		/file_1a
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API048: 3rd-party bundle-info BUNDLE --dependencies --files" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-info $SWUPD_OPTS test-bundle2 --dependencies --files --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		os-core
+		test-bundle3
+		test-bundle4
+
+		/file_2
+		/file_3
+		/file_4
+		/usr
+		/usr/lib
+		/usr/lib/os-release
+		/usr/share
+		/usr/share/clear
+		/usr/share/clear/bundles
+		/usr/share/clear/bundles/os-core
+		/usr/share/clear/bundles/test-bundle2
+		/usr/share/clear/bundles/test-bundle3
+		/usr/share/clear/bundles/test-bundle4
+		/usr/share/clear/update-ca
+		/usr/share/clear/update-ca/Swupd_Root.pem
+		/usr/share/defaults
+		/usr/share/defaults/swupd
+		/usr/share/defaults/swupd/format
+	EOM
+	)
+	assert_is_output --identical "$expected_output"
+
+}
+
+@test "API049: 3rd-party bundle-info BUNDLE --dependencies --files --repo REPOSITORY" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-info $SWUPD_OPTS test-bundle2 --dependencies --files --repo repo2 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		os-core
+		test-bundle3
+		test-bundle4
+
+		/file_2
+		/file_3
+		/file_4
+		/usr
+		/usr/lib
+		/usr/lib/os-release
+		/usr/share
+		/usr/share/clear
+		/usr/share/clear/bundles
+		/usr/share/clear/bundles/os-core
+		/usr/share/clear/bundles/test-bundle2
+		/usr/share/clear/bundles/test-bundle3
+		/usr/share/clear/bundles/test-bundle4
+		/usr/share/clear/update-ca
+		/usr/share/clear/update-ca/Swupd_Root.pem
+		/usr/share/defaults
+		/usr/share/defaults/swupd
+		/usr/share/defaults/swupd/format
+	EOM
+	)
+	assert_is_output --identical "$expected_output"
+
+}

--- a/test/functional/api/api-bundle-info.bats
+++ b/test/functional/api/api-bundle-info.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -t -n test-bundle1 -f /file_1a,/file_1b,/file_1c "$TEST_NAME"
+	create_bundle -e -n test-bundle2 -f /file_2 "$TEST_NAME"
+	create_bundle -n test-bundle3 -f /file_3 "$TEST_NAME"
+	create_bundle -n test-bundle4 -f /file_4 "$TEST_NAME"
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle2 test-bundle3
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle3 test-bundle4
+
+}
+
+@test "API037: bundle-info BUNDLE (installed)" {
+
+	run sudo sh -c "$SWUPD bundle-info $SWUPD_OPTS test-bundle1 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Explicitly installed
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API038: bundle-info BUNDLE (not installed)" {
+
+	run sudo sh -c "$SWUPD bundle-info $SWUPD_OPTS test-bundle2 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Not installed, experimental
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API039: bundle-info BUNDLE --dependencies" {
+
+	run sudo sh -c "$SWUPD bundle-info $SWUPD_OPTS test-bundle2 --dependencies --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		os-core
+		test-bundle3
+		test-bundle4
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API040: bundle-info BUNDLE --files" {
+
+	run sudo sh -c "$SWUPD bundle-info $SWUPD_OPTS test-bundle1 --files --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		/usr/share/clear/bundles/test-bundle1
+		/file_1c
+		/file_1b
+		/file_1a
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API041: bundle-info BUNDLE --dependencies --files" {
+
+	run sudo sh -c "$SWUPD bundle-info $SWUPD_OPTS test-bundle2 --dependencies --files --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		os-core
+		test-bundle3
+		test-bundle4
+
+		/core
+		/file_2
+		/file_3
+		/file_4
+		/usr/share/clear/bundles/os-core
+		/usr/share/clear/bundles/test-bundle2
+		/usr/share/clear/bundles/test-bundle3
+		/usr/share/clear/bundles/test-bundle4
+	EOM
+	)
+	assert_is_output --identical "$expected_output"
+
+}


### PR DESCRIPTION
This commit provides a minimal output to be displayed when the --quiet
flag is used for these commands:

- swupd bundle-info
- swupd 3rd-party bundle-info

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>