### PR TITLE
Target root: Change the way we install directories and files

### DIFF
--- a/src/lib/macros.h
+++ b/src/lib/macros.h
@@ -19,7 +19,11 @@
 #define MAX(_a, _b) ((_a) > (_b) ? (_a) : (_b))
 
 #ifdef DEBUG_MODE
-#define UNEXPECTED() abort()
+#define UNEXPECTED()                                                                   \
+	do {                                                                           \
+		fprintf(stderr, "Unexpected condition (%s:%d)\n", __FILE__, __LINE__); \
+		abort();                                                               \
+	} while (0)
 #else
 /**
  * @brief To be used in all checks where we assume swupd should never get in to.

--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -85,7 +85,6 @@ int run_command_full_params(const char *stdout_file, const char *stderr_file, ch
 {
 	int pid, ret, child_ret;
 	const char *cmd = params[0];
-	int null_fd;
 	int pipe_fds[2];
 
 	if (log_get_level() == LOG_DEBUG) {
@@ -97,7 +96,7 @@ int run_command_full_params(const char *stdout_file, const char *stderr_file, ch
 		return -1;
 	};
 
-	pid = fork();
+	pid = vfork();
 	if (pid < 0) {
 		error("run_command %s failed: %i (%s)\n", cmd, errno, strerror(errno));
 		return -errno;
@@ -129,10 +128,9 @@ int run_command_full_params(const char *stdout_file, const char *stderr_file, ch
 
 	// Child
 	close(pipe_fds[0]);
-
 	/* replace the stdin with /dev/null. the underlying commands should never be
 	 * run interactively. */
-	null_fd = open("/dev/null", O_RDONLY);
+	int null_fd = open("/dev/null", O_RDONLY);
 	if (null_fd < 0) {
 		goto error_child;
 	}
@@ -167,11 +165,11 @@ int run_command_full_params(const char *stdout_file, const char *stderr_file, ch
 		error("run_command %s failed: %i (%s)\n", cmd, errno, strerror(errno));
 	}
 
-	exit(EXIT_FAILURE); // execve nevers return on success
+	_exit(EXIT_FAILURE); // execve nevers return on success
 	return 0;
 
 error_child:
-	exit(255);
+	_exit(255);
 	return 0;
 }
 

--- a/src/target_root.c
+++ b/src/target_root.c
@@ -278,7 +278,13 @@ static enum swupd_code stage_single_file(struct file *file, struct manifest *mom
 		if (!file->is_config && !file->is_state && !file->use_xattrs && !file->is_link) {
 			ret = link(fullfile_path, staged_file);
 		}
+
 		if (ret < 0) {
+			ret = copy(fullfile_path, staged_file);
+		}
+		if (ret < 0) {
+			// If file failed to link or copy
+			UNEXPECTED();
 			ret = install_file_using_tar(fullfile_path, target_path, target_basename);
 			if (ret) {
 				goto out;

--- a/src/target_root.c
+++ b/src/target_root.c
@@ -64,7 +64,7 @@ static int create_staging_renamedir(char *rename_tmpdir)
 //TODO: "stage_single_file is currently not able to be run in parallel"
 /* Consider adding a remove_leftovers() that runs in verify/fix in order to
  * allow this function to mkdtemp create folders for parallel build */
-enum swupd_code stage_single_file(struct file *file, struct manifest *mom)
+static enum swupd_code stage_single_file(struct file *file, struct manifest *mom)
 {
 	char *statfile = NULL;
 	char *dir, *base;

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -3511,7 +3511,7 @@ update_bundle() { # swupd_function
 
 	# if the option received an existing file, parse it
 	if [[ "$fname" = *":"* ]]; then
-		existing_file="${fname#*:}"
+		existing_file="${fname##*:}"
 		fname="${fname%:*}"
 	fi
 

--- a/test/functional/update/update-unusual-file-names.bats
+++ b/test/functional/update/update-unusual-file-names.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+# Author: Otavio Pontes
+# Email: otavio.pontes@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_version -p "$TEST_NAME" 20 10
+
+	update_bundle "$TEST_NAME" os-core --add "/usr/simple_file"
+	file=$(get_hash_from_manifest "$TEST_NAME"/web-dir/20/Manifest.os-core /usr/simple_file)
+
+	# Unusual directory names
+	update_bundle "$TEST_NAME" os-core --add "/usr/unusual_'dirname'/normal_file1"
+	update_bundle "$TEST_NAME" os-core --add '/usr/unusual_"dirname"/normal_file2'
+	update_bundle "$TEST_NAME" os-core --add '/usr/very_unusual_,¹²³!@#$%^&*()_;[]{}\`_name/normal_file3'
+	update_bundle "$TEST_NAME" os-core --add "/usr/unusual:dirname/normal_file4:""$TEST_NAME"/web-dir/20/files/"$file"
+
+	# Unusual file names
+	update_bundle "$TEST_NAME" os-core --add "/usr/unusual_files/'file1'"
+	update_bundle "$TEST_NAME" os-core --add '/usr/unusual_files/"file2"'
+	update_bundle "$TEST_NAME" os-core --add '/usr/unusual_files/very_unusual_,¹²³!@#$%^&*()_;[]{}\_file3'
+	update_bundle "$TEST_NAME" os-core --add "/usr/unusual_files/file:4:""$TEST_NAME"/web-dir/20/files/"$file"
+
+	# Unusual link names
+	create_bundle -n test-bundle1 -l "/usr/links/'link1'",'/usr/links/"link2"','/usr/links/very_unusual_¹²³!@#$%^&*()_;[]{}\_link3','/usr/links/link:4' "$TEST_NAME"
+	add_dependency_to_manifest "$WEBDIR"/20/Manifest.os-core test-bundle1
+
+}
+
+@test "UPD071: Unusual file name" {
+
+	# Check if installation of files with names using unusual characters
+	# are all successful.
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+	assert_status_is 0
+	expected_output=$(cat <<-EOM
+		Update started
+		Preparing to update from 10 to 20
+		Downloading packs for:
+		 - test-bundle1
+		 - os-core
+		Finishing packs extraction...
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 1
+		    new bundles       : 1
+		    deleted bundles   : 0
+		    changed files     : 0
+		    new files         : 25
+		    deleted files     : 0
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Installing files...
+		Update was applied
+		Calling post-update helper scripts
+		4 files were not in a pack
+		Update successful - System updated from version 10 to version 20
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+	assert_file_exists "$TARGETDIR""/usr/simple_file"
+
+	# Unusual dir names
+	assert_file_exists "$TARGETDIR""/usr/unusual_'dirname'/normal_file1"
+	assert_file_exists "$TARGETDIR"'/usr/unusual_"dirname"/normal_file2'
+	assert_file_exists "$TARGETDIR"'/usr/very_unusual_,¹²³!@#$%^&*()_;[]{}\`_name/normal_file3'
+	assert_file_exists "$TARGETDIR"'/usr/unusual:dirname/normal_file4'
+
+	# Unusual file names
+	assert_file_exists "$TARGETDIR""/usr/unusual_files/'file1'"
+	assert_file_exists "$TARGETDIR"'/usr/unusual_files/"file2"'
+	assert_file_exists "$TARGETDIR"'/usr/unusual_files/very_unusual_,¹²³!@#$%^&*()_;[]{}\_file3'
+	assert_file_exists "$TARGETDIR""/usr/unusual_files/file:4"
+
+	# Unusual link names
+	assert_symlink_exists "$TARGETDIR""/usr/links/'link1'"
+	assert_symlink_exists "$TARGETDIR"'/usr/links/"link2"'
+	assert_symlink_exists "$TARGETDIR"'/usr/links/very_unusual_¹²³!@#$%^&*()_;[]{}\_link3'
+	assert_symlink_exists "$TARGETDIR""/usr/links/link:4"
+}


### PR DESCRIPTION
Currently we install directories and files using a tar command piped to another tar command.
There are multiple problems related to that, like:
 - performance
 - dependency on tar binary
 - lack support on unusual characters on filenames

This pull request changes the way we install directories by creating them with mkdir and updating all attributes that we control on swupd, update directories by update all attributes and install files by using the cp binary, when link is not supported.

In some preliminary tests we got a nice improvement in installation speed, around 60~70% faster on big bundles, like desktop and os-clr-on-clr.

Related to #671 and  #640. Almost fixed and shouldn't be a problem anymore, but there are still changes required on install_dir_using_tar() and install_file_using_tar()