### PR TITLE
Fixing progress type on diagnosing extra files

### DIFF
--- a/src/verify.c
+++ b/src/verify.c
@@ -801,6 +801,7 @@ static enum swupd_code deal_with_extra_files(struct manifest *manifest, bool fix
 	info("%s extra files under %s\n", fix ? "Removing" : "Checking for", start);
 	ret = walk_tree(manifest, start, fix, picky_whitelist, &counts);
 	free_and_clear_pointer(&start);
+	info("\n");
 
 	return ret;
 }
@@ -1208,7 +1209,7 @@ enum swupd_code execute_verify_extra(extra_proc_fn_t post_verify_fn)
 extra_files:
 	if (cmdline_option_picky || cmdline_option_extra_files_only) {
 		timelist_timer_start(globals.global_times, "Removing extra files");
-		progress_next_step("remove_extra_files", PROGRESS_BAR);
+		progress_next_step("remove_extra_files", PROGRESS_UNDEFINED);
 		deal_with_extra_files(official_manifest, cmdline_option_fix);
 		timelist_timer_stop(globals.global_times);
 	}

--- a/test/functional/repair/repair-json.bats
+++ b/test/functional/repair/repair-json.bats
@@ -137,7 +137,7 @@ test_setup() {
 		{ "type" : "progress", "currentStep" : 8, "totalSteps" : 10, "stepCompletion" : 88, "stepDescription" : "remove_extraneous_files" },
 		{ "type" : "progress", "currentStep" : 8, "totalSteps" : 10, "stepCompletion" : 94, "stepDescription" : "remove_extraneous_files" },
 		{ "type" : "progress", "currentStep" : 8, "totalSteps" : 10, "stepCompletion" : 100, "stepDescription" : "remove_extraneous_files" },
-		{ "type" : "progress", "currentStep" : 9, "totalSteps" : 10, "stepCompletion" : 0, "stepDescription" : "remove_extra_files" },
+		{ "type" : "progress", "currentStep" : 9, "totalSteps" : 10, "stepCompletion" : -1, "stepDescription" : "remove_extra_files" },
 		{ "type" : "info", "msg" : "Removing extra files under $PATH_PREFIX/usr" },
 		{ "type" : "info", "msg" : " -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/versionurl" },
 		{ "type" : "info", "msg" : " -> deleted" },


### PR DESCRIPTION
When dealing with extra files during a "verify" action, we cannot really
tell how far in the process we are, so we should be defining that step
as PROGRESS_UNDEFINED. Since we are using a PROGRESS_BAR, it is causing
to show an extra "[100%]" at the end of the diagnose process.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>