### PR TITLE
3rd-party: xdg env variable has a wrong name

### DIFF
--- a/src/3rd_party_repos.h
+++ b/src/3rd_party_repos.h
@@ -19,7 +19,7 @@ extern "C" {
 			"export PATH=%s:$PATH\n"                       \
 			"export LD_LIBRARY_PATH=%s:$LD_LIBRARY_PATH\n" \
 			"export XDG_DATA_DIRS=%s:$XDG_DATA_DIRS\n"     \
-			"export XDG_CONF_DIRS=%s:$XDG_CONF_DIRS\n"     \
+			"export XDG_CONFIG_DIRS=%s:$XDG_CONFIG_DIRS\n" \
 			"\n"                                           \
 			"%s \"$@\"\n"
 

--- a/test/functional/3rd-party/3rd-party-bundle-add-export-bin.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-export-bin.bats
@@ -195,7 +195,7 @@ test_setup() {
 		export PATH=.*
 		export LD_LIBRARY_PATH=.*
 		export XDG_DATA_DIRS=.*
-		export XDG_CONF_DIRS=.*
+		export XDG_CONFIG_DIRS=.*
 		$PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/repo1/usr/bin/bin_file1 .*
 	EOM
 	)

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -83,7 +83,7 @@ export SCRIPT_TEMPLATE="\
 export PATH=%s:\$PATH\n\
 export LD_LIBRARY_PATH=%s:\$LD_LIBRARY_PATH\n\
 export XDG_DATA_DIRS=%s:\$XDG_DATA_DIRS\n\
-export XDG_CONF_DIRS=%s:\$XDG_CONF_DIRS\n\
+export XDG_CONFIG_DIRS=%s:\$XDG_CONFIG_DIRS\n\
 \n\
 %s \"\$@\"\n"
 


### PR DESCRIPTION
XDG_CONFIG_DIRS variable was added with an incorrect name. XDG_CONF_DIRS was used instead.
Fixing that.

Fix #1443

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>