### PR TITLE
API: output for [3rd-party] clean

### DIFF
--- a/src/3rd_party_clean.c
+++ b/src/3rd_party_clean.c
@@ -101,9 +101,9 @@ static enum swupd_code clean_repos_state(UNUSED_PARAM char *unused)
 	ret = clean_statedir(cmdline_option_dry_run, cmdline_option_all);
 	files_removed = clean_get_stats();
 	if (cmdline_option_dry_run) {
-		print("Would remove %d files\n", files_removed);
+		info("Would remove %d files\n", files_removed);
 	} else {
-		print("%d files removed\n", files_removed);
+		info("%d files removed\n", files_removed);
 	}
 
 	return ret;

--- a/src/clean.c
+++ b/src/clean.c
@@ -167,7 +167,7 @@ static enum swupd_code remove_if(const char *path, bool dry_run, remove_predicat
 		}
 
 		if (dry_run) {
-			info("%s\n", file);
+			print("%s\n", file);
 		} else {
 			ret = sys_rm(file);
 			if (ret != 0) {
@@ -417,11 +417,11 @@ enum swupd_code clean_main(int argc, char **argv)
 	/* TODO: Also print the bytes removed, need to take into account the hardlinks. */
 	prettify_size(stats.bytes_removed, &bytes_removed_pretty);
 	if (options.dry_run) {
-		print("Would remove %d files\n", stats.files_removed);
-		print("Aproximatelly %s would be freed\n", bytes_removed_pretty);
+		info("Would remove %d files\n", stats.files_removed);
+		info("Aproximatelly %s would be freed\n", bytes_removed_pretty);
 	} else {
-		print("%d files removed\n", stats.files_removed);
-		print("%s freed\n", bytes_removed_pretty);
+		info("%d files removed\n", stats.files_removed);
+		info("%s freed\n", bytes_removed_pretty);
 	}
 	free_and_clear_pointer(&bytes_removed_pretty);
 

--- a/test/functional/api/api-3rd-party-clean.bats
+++ b/test/functional/api/api-3rd-party-clean.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME" 10 1
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
+	STATE1="$TPSTATEDIR"
+	sudo mkdir "$STATE1"/10
+	sudo touch "$STATE1"/10/Manifest.test{1..3}
+	sudo touch "$STATE1"/pack-test{1..2}-from-0.tar
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
+	STATE2="$TPSTATEDIR"
+	sudo touch "$STATE2"/pack-test3-from-0.tar
+
+}
+
+
+@test "API065: 3rd-party clean" {
+
+	run sudo sh -c "$SWUPD 3rd-party clean $SWUPD_OPTS --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		[repo1]
+		[repo2]
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API066: 3rd-party clean --dry-run" {
+
+	run sudo sh -c "$SWUPD 3rd-party clean $SWUPD_OPTS --dry-run --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		\\[repo1\\]
+		$TEST_ROOT_DIR/$STATE1/pack-test.-from-0.tar
+		$TEST_ROOT_DIR/$STATE1/pack-test.-from-0.tar
+		$TEST_ROOT_DIR/$STATE1/10/Manifest.test.
+		$TEST_ROOT_DIR/$STATE1/10/Manifest.test.
+		$TEST_ROOT_DIR/$STATE1/10/Manifest.test.
+		\\[repo2\\]
+		$TEST_ROOT_DIR/$STATE2/pack-test3-from-0.tar
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}
+
+@test "API067: 3rd-party clean --dry-run --repo REPOSITORY" {
+
+	run sudo sh -c "$SWUPD 3rd-party clean $SWUPD_OPTS --dry-run --quiet --repo repo1"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		$TEST_ROOT_DIR/$STATE1/pack-test.-from-0.tar
+		$TEST_ROOT_DIR/$STATE1/pack-test.-from-0.tar
+		$TEST_ROOT_DIR/$STATE1/10/Manifest.test.
+		$TEST_ROOT_DIR/$STATE1/10/Manifest.test.
+		$TEST_ROOT_DIR/$STATE1/10/Manifest.test.
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}

--- a/test/functional/api/api-clean.bats
+++ b/test/functional/api/api-clean.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	sudo mkdir "$STATEDIR"/10
+	sudo touch "$STATEDIR"/10/Manifest.test{1..3}
+	sudo touch "$STATEDIR"/pack-test{1..2}-from-0.tar
+
+}
+
+@test "API063: clean" {
+
+	run sudo sh -c "$SWUPD clean $SWUPD_OPTS --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	assert_output_is_empty
+
+}
+
+@test "API064: clean --dry-run" {
+
+	run sudo sh -c "$SWUPD clean $SWUPD_OPTS --dry-run --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		$TEST_ROOT_DIR/$STATEDIR/pack-test.-from-0.tar
+		$TEST_ROOT_DIR/$STATEDIR/pack-test.-from-0.tar
+		$TEST_ROOT_DIR/$STATEDIR/10/Manifest.test.
+		$TEST_ROOT_DIR/$STATEDIR/10/Manifest.test.
+		$TEST_ROOT_DIR/$STATEDIR/10/Manifest.test.
+	EOM
+	)
+	assert_regex_is_output "$expected_output"
+
+}


### PR DESCRIPTION
This commit provides a minimal output to be displayed when the --quiet
flag is used for these commands:

- swupd clean
- swupd 3rd-party clean

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>