### PR TITLE
API: output for 3rd-party add, remove, list

### DIFF
--- a/src/3rd_party_add.c
+++ b/src/3rd_party_add.c
@@ -102,7 +102,7 @@ static bool confirm_certificate(const char *cert)
 	signature_print_info(cert);
 
 	info("\n");
-	info("To add the 3rd-party repository you need to accept this certificate\n");
+	print("To add the 3rd-party repository you need to accept this certificate\n");
 	return confirm_action();
 }
 
@@ -356,9 +356,9 @@ enum swupd_code third_party_add_main(int argc, char **argv)
 
 finish:
 	if (ret_code == SWUPD_OK) {
-		print("\nRepository added successfully\n");
+		info("\nRepository added successfully\n");
 	} else {
-		print("\nFailed to add repository\n");
+		info("\nFailed to add repository\n");
 	}
 
 	list_free_list_and_data(repos, repo_free_data);

--- a/src/3rd_party_remove.c
+++ b/src/3rd_party_remove.c
@@ -216,13 +216,13 @@ remove_repo:
 exit:
 	if (ret == SWUPD_OK) {
 		if (ret_partial == SWUPD_OK) {
-			print("\nRepository and its content removed successfully\n");
+			info("\nRepository and its content removed successfully\n");
 		} else {
-			print("\nRepository and its content partially removed\n");
+			info("\nRepository and its content partially removed\n");
 			ret = ret_partial;
 		}
 	} else {
-		print("\nFailed to remove repository\n");
+		info("\nFailed to remove repository\n");
 	}
 	manifest_free(mom);
 	free_and_clear_pointer(&repo_dir);

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -970,12 +970,12 @@ bool confirm_action(void)
 {
 	int response;
 
-	info("Do you want to continue? (y/N): ");
+	print("Do you want to continue? (y/N): ");
 	if (globals.user_interaction == INTERACTIVE) {
 		response = tolower(getchar());
-		info("\n");
+		print("\n");
 	} else {
-		info("%s\n", globals.user_interaction == NON_INTERACTIVE_ASSUME_YES ? "y" : "N");
+		print("%s\n", globals.user_interaction == NON_INTERACTIVE_ASSUME_YES ? "y" : "N");
 		info("The \"--assume=%s\" option was used\n", globals.user_interaction == NON_INTERACTIVE_ASSUME_YES ? "yes" : "no");
 		response = globals.user_interaction == NON_INTERACTIVE_ASSUME_YES ? 'y' : 'n';
 	}

--- a/src/signature.c
+++ b/src/signature.c
@@ -490,7 +490,7 @@ static void dump_file(const char *path)
 			break;
 		}
 
-		info("%s", line)
+		print("%s", line)
 	}
 
 	fclose(f);
@@ -514,8 +514,8 @@ void signature_print_info(const char *path)
 
 	subj = X509_NAME_oneline(X509_get_subject_name(cert), NULL, 0);
 	issuer = X509_NAME_oneline(X509_get_issuer_name(cert), NULL, 0);
-	info("Issuer: %s\n", subj);
-	info("Subject: %s\n", subj);
+	print("Issuer: %s\n", subj);
+	print("Subject: %s\n", subj);
 	info("\n");
 
 	dump_file(path);

--- a/test/functional/api/api-3rd-party-add.bats
+++ b/test/functional/api/api-3rd-party-add.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_third_party_repo "$TEST_NAME" 10 staging repo1
+	export repo1="$TPURL"
+
+}
+
+@test "API071: 3rd-party add --certpath CERTIFICATE" {
+
+	run sudo sh -c "$SWUPD 3rd-party add $SWUPD_OPTS my-repo file://$repo1 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	assert_output_is_empty
+
+}

--- a/test/functional/api/api-3rd-party-list.bats
+++ b/test/functional/api/api-3rd-party-list.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
+	export repo1="$TPURL"
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
+	export repo2="$TPURL"
+
+}
+
+@test "API073: 3rd-party list" {
+
+	run sudo sh -c "$SWUPD 3rd-party list $SWUPD_OPTS --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		repo1: file://$repo1
+		repo2: file://$repo2
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/api/api-3rd-party-remove.bats
+++ b/test/functional/api/api-3rd-party-remove.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
+
+}
+
+@test "API072: 3rd-party remove" {
+
+	run sudo sh -c "$SWUPD 3rd-party remove $SWUPD_OPTS repo1 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	assert_output_is_empty
+
+}

--- a/test/functional/only_in_ci_system/api-3rd-party-add.bats
+++ b/test/functional/only_in_ci_system/api-3rd-party-add.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	# Skip this test for local development because we write the certificate on /
+	# This is necessary because the default certificate location is hardcoded on build time and we
+	# need to run swupd without -C parameter to test this feature.
+	if [ -z "${RUNNING_IN_CI}" ]; then
+		skip "Skipping test because it will make changes to your system"
+	fi
+
+	create_test_environment "$TEST_NAME"
+
+	if [ ! -f /usr/share/clear/update-ca/Swupd_Root.pem ]; then
+		sudo mkdir -p /usr/share/clear/update-ca
+		sudo cp "$TEST_DIRNAME"/Swupd_Root.pem /usr/share/clear/update-ca
+		export CERT_WAS_INSTALLED=1
+	fi
+
+	create_third_party_repo "$TEST_NAME" 10 staging repo1
+	export repo1="$TPURL"
+
+}
+
+test_teardown() {
+
+	if [ -z "${RUNNING_IN_CI}" ]; then
+		return
+	fi
+
+	if [ -n "${CERT_WAS_INSTALLED}" ]; then
+		sudo rm usr/share/clear/update-ca/Swupd_Root.pem
+	fi
+
+}
+
+@test "API069: 3rd-party add" {
+
+	run sudo sh -c "echo 'y' | $SWUPD 3rd-party add $SWUPD_OPTS_NO_CERT my-repo file://$repo1 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Issuer: /C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost
+		Subject: /C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost
+		-----BEGIN CERTIFICATE-----
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		-----END CERTIFICATE-----
+		To add the 3rd-party repository you need to accept this certificate
+		Do you want to continue? (y/N):
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+}
+
+@test "API070: 3rd-party add --assume=yes" {
+
+	run sudo sh -c "$SWUPD 3rd-party add $SWUPD_OPTS_NO_CERT my-repo file://$repo1 --assume=yes --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Issuer: /C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost
+		Subject: /C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost
+		-----BEGIN CERTIFICATE-----
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		-----END CERTIFICATE-----
+		To add the 3rd-party repository you need to accept this certificate
+		Do you want to continue? (y/N):
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+}


### PR DESCRIPTION
This commit provides a minimal output to be displayed when the --quiet
flag is used for these commands:

- swupd 3rd-party add
- swupd 3rd-party remove
- swupd 3rd-party list

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>