### PR TITLE
Updating list to run clr-boot-manager

### DIFF
--- a/src/heuristics.c
+++ b/src/heuristics.c
@@ -118,11 +118,20 @@ static void boot_file_heuristics(struct file *file)
 	}
 }
 
+static void boot_manager_heuristics(struct file *file)
+{
+	if ((strcmp(file->filename, "/usr/bin/clr-boot-manager") == 0) ||
+	    (strcmp(file->filename, "/usr/share/syslinux/ldlinux.c32") == 0)) {
+		globals.need_update_bootloader = true;
+	}
+}
+
 void apply_heuristics(struct file *file)
 {
 	runtime_state_heuristics(file);
 	boot_file_heuristics(file);
 	config_file_heuristics(file);
+	boot_manager_heuristics(file);
 }
 
 /* Determines whether or not FILE should be ignored for this swupd action. Note

--- a/src/update.c
+++ b/src/update.c
@@ -499,7 +499,7 @@ clean_curl:
 
 	if (ret == 0) {
 		if (nonpack > 0) {
-			info("%i files were not in a pack\n", nonpack);
+			info("%i file%s not in a pack\n", nonpack, nonpack != 1 ? "s were" : " was");
 		}
 		if (!download_only) {
 			if (current_version < server_version) {

--- a/test/functional/update/update-boot-manager.bats
+++ b/test/functional/update/update-boot-manager.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment -r "$TEST_NAME"
+	CONTENT="$TEST_NAME"/content_dir
+
+	# content for bundle test-bundle1
+	sudo mkdir -p "$CONTENT"/usr/bin
+	write_to_protected_file "$CONTENT"/usr/bin/clr-boot-manager '#!/usr/bin/env bash\necho "hello"\n'
+	sudo chmod +x "$CONTENT"/usr/bin/clr-boot-manager
+	create_bundle_from_content -t -n test-bundle1 -c "$CONTENT" "$TEST_NAME"
+	print "Content directory in version 10:\n\n $(tree "$CONTENT")"
+
+	# content for update
+	create_version -r "$TEST_NAME" 20 10
+	write_to_protected_file -a "$CONTENT"/usr/bin/clr-boot-manager 'echo "world"\n'
+	update_bundle_from_content -n test-bundle1 -c "$CONTENT" "$TEST_NAME"
+	print "Content directory in version 20:\n\n $(tree "$CONTENT")"
+
+}
+
+@test "UPD072: Updating clr-boot-manager" {
+
+	# an update that includes an update for clr-boot-manager should
+	# trigger the clear-boot-manager script
+
+	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
+
+	assert_status_is "$SWUPD_OK"
+	 expected_output=$(cat <<-EOM
+		Update started
+		Preparing to update from 10 to 20
+		Downloading packs for:
+		 - os-core
+		 - test-bundle1
+		Finishing packs extraction...
+		Statistics for going from version 10 to version 20:
+		    changed bundles   : 2
+		    new bundles       : 0
+		    deleted bundles   : 0
+		    changed files     : 3
+		    new files         : 0
+		    deleted files     : 0
+		Validate downloaded files
+		Starting download of remaining update content. This may take a while...
+		Installing files...
+		Update was applied
+		Calling post-update helper scripts
+		External command: hello
+		External command: world
+		1 file was not in a pack
+		Update successful - System updated from version 10 to version 20
+	EOM
+	)
+	assert_is_output "$expected_output"
+	show_target
+
+}

--- a/test/functional/update/update-type-changes-file-to-recursive-symlink.bats
+++ b/test/functional/update/update-type-changes-file-to-recursive-symlink.bats
@@ -77,7 +77,7 @@ test_setup() {
 		Installing files...
 		Update was applied
 		Calling post-update helper scripts
-		1 files were not in a pack
+		1 file was not in a pack
 		Update successful - System updated from version 10 to version 20
 	EOM
 	)

--- a/test/functional/update/update-use-full-file.bats
+++ b/test/functional/update/update-use-full-file.bats
@@ -36,7 +36,7 @@ test_setup() {
 		Installing files...
 		Update was applied
 		Calling post-update helper scripts
-		1 files were not in a pack
+		1 file was not in a pack
 		Update successful - System updated from version 10 to version 100
 	EOM
 	)

--- a/test/functional/update/update-verify-fix-path-hash-mismatch.bats
+++ b/test/functional/update/update-verify-fix-path-hash-mismatch.bats
@@ -46,7 +46,7 @@ test_setup() {
 		Installing files...
 		Update was applied
 		Calling post-update helper scripts
-		1 files were not in a pack
+		1 file was not in a pack
 		Update successful - System updated from version 10 to version 100
 	EOM
 	)

--- a/test/functional/update/update-verify-fix-path-missing-dir.bats
+++ b/test/functional/update/update-verify-fix-path-missing-dir.bats
@@ -39,7 +39,7 @@ test_setup() {
 		Installing files...
 		Update was applied
 		Calling post-update helper scripts
-		1 files were not in a pack
+		1 file was not in a pack
 		Update successful - System updated from version 10 to version 100
 	EOM
 	)


### PR DESCRIPTION
This commit adds the following files to trigger the execution of
clr-boot-manager:
- /usr/bin/clr-boot-manager
- /usr/share/syslinux/ldlinux.c32

Closes #1415

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>