### PR TITLE
3rd-party: do not report telemetry on 3rd-party

### DIFF
--- a/src/3rd_party.c
+++ b/src/3rd_party.c
@@ -113,6 +113,7 @@ enum swupd_code third_party_main(int argc, char **argv)
 		return SWUPD_INVALID_OPTION;
 	}
 	optind = 0;
+	telemetry_disable();
 	ret = third_party_commands[index].mainfunc(argc - 1, argv + 1);
 
 	return ret;

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -32,6 +32,13 @@
 
 #define RECORD_VERSION 2
 
+static bool telemetry_enabled = true;
+
+void telemetry_disable(void)
+{
+	telemetry_enabled = false;
+}
+
 #ifdef DEBUG_MODE
 /*
  * Don't send telemetry reports when code built on debug mode
@@ -49,6 +56,10 @@ void telemetry(enum telemetry_severity level, const char *class, const char *fmt
 	char *filename_n;
 	char *newname;
 	int fd, ret;
+
+	if (!telemetry_enabled) {
+		return;
+	}
 
 	filename = sys_path_join("%s/%d.%s.%d.XXXXXX", globals.state_dir,
 				 RECORD_VERSION, class, level);

--- a/src/telemetry.h
+++ b/src/telemetry.h
@@ -25,6 +25,11 @@ enum telemetry_severity {
 };
 
 /**
+ * @brief Disables telemetry reports.
+ */
+void telemetry_disable(void);
+
+/**
  * @brief Create a telemetry record to be reported if telemetrics is enabled.
  */
 void telemetry(enum telemetry_severity level, const char *class, const char *fmt, ...);


### PR DESCRIPTION
Telemetry is used to report problems to main repository, so it doesn't
make sense to create telemetry report files for 3rd-party repositories.

Closes #1358

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>