### PR TITLE
Bug_fix: In closing steps in multi-repo ops

### DIFF
--- a/src/3rd_party_bundle_list.c
+++ b/src/3rd_party_bundle_list.c
@@ -165,7 +165,6 @@ enum swupd_code third_party_bundle_list_main(int argc, char **argv)
 	ret_code = third_party_run_operation_multirepo(cmdline_repo, list_repo_bundles, SWUPD_OK, "bundle-list", steps_in_bundlelist);
 
 	swupd_deinit();
-	progress_finish_steps(ret_code);
 
 	return ret_code;
 }

--- a/src/3rd_party_check_update.c
+++ b/src/3rd_party_check_update.c
@@ -102,7 +102,6 @@ enum swupd_code third_party_check_update_main(int argc, char **argv)
 	ret_code = third_party_run_operation_multirepo(cmdline_option_repo, check_update_repo, SWUPD_NO, "check-update", steps_in_checkupdate);
 
 	swupd_deinit();
-	progress_finish_steps(ret_code);
 
 	return ret_code;
 }

--- a/src/3rd_party_clean.c
+++ b/src/3rd_party_clean.c
@@ -130,7 +130,6 @@ enum swupd_code third_party_clean_main(int argc, char **argv)
 	ret_code = third_party_run_operation_multirepo(cmdline_option_repo, clean_repos_state, SWUPD_OK, "clean", steps_in_clean);
 
 	swupd_deinit();
-	progress_finish_steps(ret_code);
 
 	return ret_code;
 }

--- a/src/3rd_party_diagnose.c
+++ b/src/3rd_party_diagnose.c
@@ -253,7 +253,6 @@ enum swupd_code third_party_diagnose_main(int argc, char **argv)
 		picky_whitelist = NULL;
 	}
 	swupd_deinit();
-	progress_finish_steps(ret_code);
 
 	return ret_code;
 }

--- a/src/3rd_party_info.c
+++ b/src/3rd_party_info.c
@@ -107,7 +107,6 @@ enum swupd_code third_party_info_main(int UNUSED_PARAM argc, char UNUSED_PARAM *
 	ret_code = third_party_run_operation_multirepo(cmdline_repo, show_repo_info, SWUPD_OK, "info", steps_in_third_party_info);
 
 	swupd_deinit();
-	progress_finish_steps(ret_code);
 
 	return ret_code;
 }

--- a/src/3rd_party_repair.c
+++ b/src/3rd_party_repair.c
@@ -269,7 +269,6 @@ enum swupd_code third_party_repair_main(int argc, char **argv)
 		picky_whitelist = NULL;
 	}
 	swupd_deinit();
-	progress_finish_steps(ret_code);
 
 	return ret_code;
 }

--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -520,12 +520,14 @@ enum swupd_code third_party_run_operation_multirepo(const char *repo, process_bu
 				 * keep the error */
 				ret_code = ret;
 			}
+
 			info("\n\n");
 		}
 	}
 
 	/* free data */
 clean_and_exit:
+	progress_finish_steps(ret_code);
 	list_free_list_and_data(repos, repo_free_data);
 	free_and_clear_pointer(&steps_title);
 

--- a/src/3rd_party_update.c
+++ b/src/3rd_party_update.c
@@ -328,7 +328,6 @@ exit:
 	free_and_clear_pointer(&template_file);
 	sys_mmap_free(template, template_len);
 	swupd_deinit();
-	progress_finish_steps(ret_code);
 
 	return ret_code;
 }

--- a/src/progress.c
+++ b/src/progress.c
@@ -209,6 +209,11 @@ void progress_finish_steps(int status)
 	if (current_step != total_steps) {
 		debug("Warning: Less steps than expected were executed for the current operation: expected (%d), executed (%d)\n", current_step, total_steps);
 	}
+
+	/* reset value of static variables in case a new progress is used */
+	title = NULL;
+	total_steps = 0;
+	current_step = 0;
 }
 
 void progress_next_step(const char *step_title, enum progress_type type)

--- a/test/functional/3rd-party/3rd-party-json-output-multirepo.bats
+++ b/test/functional/3rd-party/3rd-party-json-output-multirepo.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+
+	# create a couple of 3rd-party repos with bundles
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo1
+	create_bundle -L -n test-bundle1 -f /foo/file_1 -u repo1 "$TEST_NAME"
+	create_third_party_repo -a "$TEST_NAME" 10 staging repo2
+
+}
+
+@test "TPR089: Using the --json-output flag with functions that run in multiple repos specifying a repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list $SWUPD_OPTS --json-output --repo repo1"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		[
+		{ "type" : "start", "section" : "3rd-party-bundle-list" },
+		{ "type" : "info", "msg" : "Installed bundles:" },
+		{ "type" : "info", "msg" : " -" },
+		{ "type" : "info", "msg" : "os-core" },
+		{ "type" : "info", "msg" : " -" },
+		{ "type" : "info", "msg" : "test-bundle1" },
+		{ "type" : "info", "msg" : " Total: 2" },
+		{ "type" : "end", "section" : "3rd-party-bundle-list", "status" : 0 }
+		]
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+}
+
+@test "TPR090: Using the --json-output flag to show progress with functions that run in multiple repos specifying a repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list $SWUPD_OPTS_PROGRESS --json-output --repo repo1"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		[
+		{ "type" : "start", "section" : "3rd-party-bundle-list" },
+		{ "type" : "progress", "currentStep" : 1, "totalSteps" : 2, "stepCompletion" : -1, "stepDescription" : "load_manifests" },
+		{ "type" : "progress", "currentStep" : 1, "totalSteps" : 2, "stepCompletion" : 100, "stepDescription" : "load_manifests" },
+		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 2, "stepCompletion" : -1, "stepDescription" : "list_bundles" },
+		{ "type" : "info", "msg" : "Installed bundles:" },
+		{ "type" : "info", "msg" : " -" },
+		{ "type" : "info", "msg" : "os-core" },
+		{ "type" : "info", "msg" : " -" },
+		{ "type" : "info", "msg" : "test-bundle1" },
+		{ "type" : "info", "msg" : " Total: 2" },
+		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 2, "stepCompletion" : 100, "stepDescription" : "list_bundles" },
+		{ "type" : "end", "section" : "3rd-party-bundle-list", "status" : 0 }
+		]
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+}
+
+@test "TPR091: Using the --json-output flag with functions that run in multiple repos" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list $SWUPD_OPTS --json-output"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		[
+		{ "type" : "start", "section" : "3rd-party-bundle-list" },
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		{ "type" : "info", "msg" : " 3rd-Party Repo: repo1" },
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		{ "type" : "info", "msg" : "Installed bundles:" },
+		{ "type" : "info", "msg" : " -" },
+		{ "type" : "info", "msg" : "os-core" },
+		{ "type" : "info", "msg" : " -" },
+		{ "type" : "info", "msg" : "test-bundle1" },
+		{ "type" : "info", "msg" : " Total: 2" },
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		{ "type" : "info", "msg" : " 3rd-Party Repo: repo2" },
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		{ "type" : "info", "msg" : "Installed bundles:" },
+		{ "type" : "info", "msg" : " -" },
+		{ "type" : "info", "msg" : "os-core" },
+		{ "type" : "info", "msg" : " Total: 1" },
+		{ "type" : "end", "section" : "3rd-party-bundle-list", "status" : 0 }
+		]
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+}
+
+@test "TPR092: Using the --json-output flag to show progress with functions that run in multiple repos" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list $SWUPD_OPTS_PROGRESS --json-output"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		[
+		{ "type" : "start", "section" : "3rd-party-bundle-list" },
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		{ "type" : "info", "msg" : " 3rd-Party Repo: repo1" },
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		{ "type" : "progress", "currentStep" : 1, "totalSteps" : 4, "stepCompletion" : -1, "stepDescription" : "load_manifests" },
+		{ "type" : "progress", "currentStep" : 1, "totalSteps" : 4, "stepCompletion" : 100, "stepDescription" : "load_manifests" },
+		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 4, "stepCompletion" : -1, "stepDescription" : "list_bundles" },
+		{ "type" : "info", "msg" : "Installed bundles:" },
+		{ "type" : "info", "msg" : " -" },
+		{ "type" : "info", "msg" : "os-core" },
+		{ "type" : "info", "msg" : " -" },
+		{ "type" : "info", "msg" : "test-bundle1" },
+		{ "type" : "info", "msg" : " Total: 2" },
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		{ "type" : "info", "msg" : " 3rd-Party Repo: repo2" },
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 4, "stepCompletion" : 100, "stepDescription" : "list_bundles" },
+		{ "type" : "progress", "currentStep" : 3, "totalSteps" : 4, "stepCompletion" : -1, "stepDescription" : "load_manifests" },
+		{ "type" : "progress", "currentStep" : 3, "totalSteps" : 4, "stepCompletion" : 100, "stepDescription" : "load_manifests" },
+		{ "type" : "progress", "currentStep" : 4, "totalSteps" : 4, "stepCompletion" : -1, "stepDescription" : "list_bundles" },
+		{ "type" : "info", "msg" : "Installed bundles:" },
+		{ "type" : "info", "msg" : " -" },
+		{ "type" : "info", "msg" : "os-core" },
+		{ "type" : "info", "msg" : " Total: 1" },
+		{ "type" : "progress", "currentStep" : 4, "totalSteps" : 4, "stepCompletion" : 100, "stepDescription" : "list_bundles" },
+		{ "type" : "end", "section" : "3rd-party-bundle-list", "status" : 0 }
+		]
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+}

--- a/test/functional/3rd-party/3rd-party-json-output.bats
+++ b/test/functional/3rd-party/3rd-party-json-output.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
+	create_bundle -n test-bundle1 -f /foo/file_1 -u repo1 "$TEST_NAME"
+
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
+	create_bundle -n test-bundle2 -f /foo/file_2 -u repo2 "$TEST_NAME"
+
+}
+
+@test "TPR087: Using the --json-output flag with functions that run in a single repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle1 --json-output"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		[
+		{ "type" : "start", "section" : "3rd-party-bundle-add" },
+		{ "type" : "info", "msg" : "Searching for bundle test-bundle1 in the 3rd-party repositories..." },
+		{ "type" : "info", "msg" : "Bundle test-bundle1 found in 3rd-party repository repo1" },
+		{ "type" : "info", "msg" : " Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons" },
+		{ "type" : "info", "msg" : "Loading required manifests..." },
+		{ "type" : "info", "msg" : " Validating 3rd-party bundle binaries..." },
+		{ "type" : "info", "msg" : "No packs need to be downloaded" },
+		{ "type" : "info", "msg" : "Validate downloaded files" },
+		{ "type" : "info", "msg" : "Starting download of remaining update content. This may take a while..." },
+		{ "type" : "info", "msg" : " Validating 3rd-party bundle file permissions..." },
+		{ "type" : "info", "msg" : "Installing files..." },
+		{ "type" : "warning", "msg" : "post-update helper scripts skipped due to --no-scripts argument" },
+		{ "type" : "info", "msg" : " Exporting 3rd-party bundle binaries..." },
+		{ "type" : "info", "msg" : "Successfully installed 1 bundle" },
+		{ "type" : "end", "section" : "3rd-party-bundle-add", "status" : 0 }
+		]
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "TPR088: Using the --json-output flag with functions that run in a single repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS_PROGRESS test-bundle1 --json-output"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		[
+		{ "type" : "start", "section" : "3rd-party-bundle-add" },
+		{ "type" : "info", "msg" : "Searching for bundle test-bundle1 in the 3rd-party repositories..." },
+		{ "type" : "info", "msg" : "Bundle test-bundle1 found in 3rd-party repository repo1" },
+		{ "type" : "info", "msg" : " Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons" },
+		{ "type" : "progress", "currentStep" : 1, "totalSteps" : 11, "stepCompletion" : -1, "stepDescription" : "load_manifests" },
+		{ "type" : "info", "msg" : "Loading required manifests..." },
+		{ "type" : "info", "msg" : " Validating 3rd-party bundle binaries..." },
+		{ "type" : "progress", "currentStep" : 1, "totalSteps" : 11, "stepCompletion" : 100, "stepDescription" : "load_manifests" },
+		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 11, "stepCompletion" : 0, "stepDescription" : "validate_binaries" },
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 11, "stepCompletion" : 100, "stepDescription" : "validate_binaries" },
+		{ "type" : "progress", "currentStep" : 3, "totalSteps" : 11, "stepCompletion" : 0, "stepDescription" : "download_packs" },
+		{ "type" : "info", "msg" : "No packs need to be downloaded" },
+		{ "type" : "progress", "currentStep" : 3, "totalSteps" : 11, "stepCompletion" : 100, "stepDescription" : "download_packs" },
+		{ "type" : "progress", "currentStep" : 4, "totalSteps" : 11, "stepCompletion" : -1, "stepDescription" : "extract_packs" },
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		{ "type" : "progress", "currentStep" : 4, "totalSteps" : 11, "stepCompletion" : 100, "stepDescription" : "extract_packs" },
+		{ "type" : "progress", "currentStep" : 5, "totalSteps" : 11, "stepCompletion" : 0, "stepDescription" : "validate_fullfiles" },
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		{ "type" : "progress", "currentStep" : 5, "totalSteps" : 11, "stepCompletion" : 100, "stepDescription" : "validate_fullfiles" },
+		{ "type" : "progress", "currentStep" : 6, "totalSteps" : 11, "stepCompletion" : 0, "stepDescription" : "download_fullfiles" },
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		{ "type" : "progress", "currentStep" : 6, "totalSteps" : 11, "stepCompletion" : 100, "stepDescription" : "download_fullfiles" },
+		{ "type" : "progress", "currentStep" : 7, "totalSteps" : 11, "stepCompletion" : -1, "stepDescription" : "extract_fullfiles" },
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		{ "type" : "progress", "currentStep" : 7, "totalSteps" : 11, "stepCompletion" : 100, "stepDescription" : "extract_fullfiles" },
+		{ "type" : "progress", "currentStep" : 8, "totalSteps" : 11, "stepCompletion" : 0, "stepDescription" : "validate_file_permissions" },
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		{ "type" : "progress", "currentStep" : 8, "totalSteps" : 11, "stepCompletion" : 100, "stepDescription" : "validate_file_permissions" },
+		{ "type" : "progress", "currentStep" : 9, "totalSteps" : 11, "stepCompletion" : 0, "stepDescription" : "install_files" },
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		{ "type" : "progress", "currentStep" : 9, "totalSteps" : 11, "stepCompletion" : 100, "stepDescription" : "install_files" },
+		{ "type" : "progress", "currentStep" : 10, "totalSteps" : 11, "stepCompletion" : -1, "stepDescription" : "run_postupdate_scripts" },
+		{ "type" : "warning", "msg" : "post-update helper scripts skipped due to --no-scripts argument" },
+		{ "type" : "info", "msg" : " Exporting 3rd-party bundle binaries..." },
+		{ "type" : "progress", "currentStep" : 10, "totalSteps" : 11, "stepCompletion" : 100, "stepDescription" : "run_postupdate_scripts" },
+		{ "type" : "progress", "currentStep" : 11, "totalSteps" : 11, "stepCompletion" : 0, "stepDescription" : "export_binaries" },
+	EOM
+	)
+	assert_in_output "$expected_output"
+	expected_output=$(cat <<-EOM
+		{ "type" : "info", "msg" : "Successfully installed 1 bundle" },
+		{ "type" : "end", "section" : "3rd-party-bundle-add", "status" : 0 }
+		]
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+}


### PR DESCRIPTION
Multi-repo operations can run in one or multiple repos, so that needs to
be taken in consideration when opening and closing progress steps.

Closes #1494 

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>