### PR TITLE
3rd-party: using "repository" for headers

### DIFF
--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -537,7 +537,7 @@ void third_party_repo_header(const char *repo_name)
 {
 	char *header = NULL;
 
-	string_or_die(&header, " 3rd-Party Repo: %s", repo_name);
+	string_or_die(&header, " 3rd-Party Repository: %s", repo_name);
 	print_header(header);
 	if (log_is_quiet()) {
 		print("[%s]\n", repo_name);

--- a/test/functional/3rd-party/3rd-party-bundle-list-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-list-basic.bats
@@ -30,9 +30,9 @@ global_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 
 		Installed bundles:
 		 - os-core
@@ -41,9 +41,9 @@ global_setup() {
 		Total: 2
 
 
-		_______________________
-		 3rd-Party Repo: repo2
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo2
+		_____________________________
 
 		Installed bundles:
 		 - os-core
@@ -65,9 +65,9 @@ global_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 
 		All available bundles:
 		 - os-core
@@ -77,9 +77,9 @@ global_setup() {
 		Total: 3
 
 
-		_______________________
-		 3rd-Party Repo: repo2
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo2
+		_____________________________
 
 		All available bundles:
 		 - os-core

--- a/test/functional/3rd-party/3rd-party-bundle-list-deps.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-list-deps.bats
@@ -28,9 +28,9 @@ global_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 
 		Loading required manifests...
 
@@ -53,9 +53,9 @@ global_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 
 		Loading required manifests...
 

--- a/test/functional/3rd-party/3rd-party-check-update-basic.bats
+++ b/test/functional/3rd-party/3rd-party-check-update-basic.bats
@@ -26,18 +26,18 @@ global_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		____________________________
-		 3rd-Party Repo: test-repo1
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo1
+		__________________________________
 
 		Current OS version: 10
 		Latest server version: 20
 		There is a new OS version available: 20
 
 
-		____________________________
-		 3rd-Party Repo: test-repo2
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo2
+		__________________________________
 
 		Current OS version: 10
 		Latest server version: 10

--- a/test/functional/3rd-party/3rd-party-diagnose-basic.bats
+++ b/test/functional/3rd-party/3rd-party-diagnose-basic.bats
@@ -38,9 +38,9 @@ global_setup() {
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
-		____________________________
-		 3rd-Party Repo: test-repo1
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo1
+		__________________________________
 		Diagnosing version 20
 		Downloading missing manifests...
 		Checking for missing files
@@ -57,9 +57,9 @@ global_setup() {
 		  1 file found which should be deleted
 		Use "swupd repair" to correct the problems in the system
 		Diagnose successful
-		____________________________
-		 3rd-Party Repo: test-repo2
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo2
+		__________________________________
 		Diagnosing version 10
 		Downloading missing manifests...
 		Checking for missing files
@@ -133,9 +133,9 @@ global_setup() {
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
-		____________________________
-		 3rd-Party Repo: test-repo1
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo1
+		__________________________________
 		Diagnosing version 20
 		Downloading missing manifests...
 		Checking for missing files
@@ -153,9 +153,9 @@ global_setup() {
 		  1 file found which should be deleted
 		Use "swupd repair" to correct the problems in the system
 		Diagnose successful
-		____________________________
-		 3rd-Party Repo: test-repo2
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo2
+		__________________________________
 		Diagnosing version 10
 		Downloading missing manifests...
 		Checking for missing files
@@ -179,9 +179,9 @@ global_setup() {
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
-		____________________________
-		 3rd-Party Repo: test-repo1
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo1
+		__________________________________
 		Diagnosing version 20
 		Downloading missing manifests...
 		Checking for missing files
@@ -201,9 +201,9 @@ global_setup() {
 		  3 files found which should be deleted
 		Use "swupd repair --picky" to correct the problems in the system
 		Diagnose successful
-		____________________________
-		 3rd-Party Repo: test-repo2
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo2
+		__________________________________
 		Diagnosing version 10
 		Downloading missing manifests...
 		Checking for missing files

--- a/test/functional/3rd-party/3rd-party-info.bats
+++ b/test/functional/3rd-party/3rd-party-info.bats
@@ -25,16 +25,16 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Distribution:      Swupd Test Distro
 		Installed version: 10 (format 1)
 		Version URL:       file://$URL1
 		Content URL:       file://$URL1
-		_______________________
-		 3rd-Party Repo: repo2
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo2
+		_____________________________
 		Distribution:      Swupd Test Distro
 		Installed version: 20 (format 5)
 		Version URL:       file://$URL2

--- a/test/functional/3rd-party/3rd-party-json-output-multirepo.bats
+++ b/test/functional/3rd-party/3rd-party-json-output-multirepo.bats
@@ -72,30 +72,18 @@ global_setup() {
 	expected_output=$(cat <<-EOM
 		[
 		{ "type" : "start", "section" : "3rd-party-bundle-list" },
-	EOM
-	)
-	assert_in_output "$expected_output"
-	expected_output=$(cat <<-EOM
-		{ "type" : "info", "msg" : " 3rd-Party Repo: repo1" },
-	EOM
-	)
-	assert_in_output "$expected_output"
-	expected_output=$(cat <<-EOM
+		{ "type" : "info", "msg" : "_____________________________" },
+		{ "type" : "info", "msg" : " 3rd-Party Repository: repo1" },
+		{ "type" : "info", "msg" : "_____________________________" },
 		{ "type" : "info", "msg" : "Installed bundles:" },
 		{ "type" : "info", "msg" : " -" },
 		{ "type" : "info", "msg" : "os-core" },
 		{ "type" : "info", "msg" : " -" },
 		{ "type" : "info", "msg" : "test-bundle1" },
 		{ "type" : "info", "msg" : " Total: 2" },
-	EOM
-	)
-	assert_in_output "$expected_output"
-	expected_output=$(cat <<-EOM
-		{ "type" : "info", "msg" : " 3rd-Party Repo: repo2" },
-	EOM
-	)
-	assert_in_output "$expected_output"
-	expected_output=$(cat <<-EOM
+		{ "type" : "info", "msg" : "_____________________________" },
+		{ "type" : "info", "msg" : " 3rd-Party Repository: repo2" },
+		{ "type" : "info", "msg" : "_____________________________" },
 		{ "type" : "info", "msg" : "Installed bundles:" },
 		{ "type" : "info", "msg" : " -" },
 		{ "type" : "info", "msg" : "os-core" },
@@ -116,15 +104,9 @@ global_setup() {
 	expected_output=$(cat <<-EOM
 		[
 		{ "type" : "start", "section" : "3rd-party-bundle-list" },
-	EOM
-	)
-	assert_in_output "$expected_output"
-	expected_output=$(cat <<-EOM
-		{ "type" : "info", "msg" : " 3rd-Party Repo: repo1" },
-	EOM
-	)
-	assert_in_output "$expected_output"
-	expected_output=$(cat <<-EOM
+		{ "type" : "info", "msg" : "_____________________________" },
+		{ "type" : "info", "msg" : " 3rd-Party Repository: repo1" },
+		{ "type" : "info", "msg" : "_____________________________" },
 		{ "type" : "progress", "currentStep" : 1, "totalSteps" : 4, "stepCompletion" : -1, "stepDescription" : "load_manifests" },
 		{ "type" : "progress", "currentStep" : 1, "totalSteps" : 4, "stepCompletion" : 100, "stepDescription" : "load_manifests" },
 		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 4, "stepCompletion" : -1, "stepDescription" : "list_bundles" },
@@ -134,15 +116,9 @@ global_setup() {
 		{ "type" : "info", "msg" : " -" },
 		{ "type" : "info", "msg" : "test-bundle1" },
 		{ "type" : "info", "msg" : " Total: 2" },
-	EOM
-	)
-	assert_in_output "$expected_output"
-	expected_output=$(cat <<-EOM
-		{ "type" : "info", "msg" : " 3rd-Party Repo: repo2" },
-	EOM
-	)
-	assert_in_output "$expected_output"
-	expected_output=$(cat <<-EOM
+		{ "type" : "info", "msg" : "_____________________________" },
+		{ "type" : "info", "msg" : " 3rd-Party Repository: repo2" },
+		{ "type" : "info", "msg" : "_____________________________" },
 		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 4, "stepCompletion" : 100, "stepDescription" : "list_bundles" },
 		{ "type" : "progress", "currentStep" : 3, "totalSteps" : 4, "stepCompletion" : -1, "stepDescription" : "load_manifests" },
 		{ "type" : "progress", "currentStep" : 3, "totalSteps" : 4, "stepCompletion" : 100, "stepDescription" : "load_manifests" },

--- a/test/functional/3rd-party/3rd-party-repair-basic.bats
+++ b/test/functional/3rd-party/3rd-party-repair-basic.bats
@@ -38,9 +38,9 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		____________________________
-		 3rd-Party Repo: test-repo1
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo1
+		__________________________________
 		Diagnosing version 20
 		Downloading missing manifests...
 		Checking for corrupt files
@@ -67,9 +67,9 @@ test_setup() {
 		Calling post-update helper scripts
 		Regenerating 3rd-party bundle binaries...
 		Repair successful
-		____________________________
-		 3rd-Party Repo: test-repo2
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo2
+		__________________________________
 		Diagnosing version 10
 		Downloading missing manifests...
 		Checking for corrupt files
@@ -143,9 +143,9 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		____________________________
-		 3rd-Party Repo: test-repo1
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo1
+		__________________________________
 		Diagnosing version 20
 		Downloading missing manifests...
 		Checking for corrupt files
@@ -173,9 +173,9 @@ test_setup() {
 		Calling post-update helper scripts
 		Regenerating 3rd-party bundle binaries...
 		Repair successful
-		____________________________
-		 3rd-Party Repo: test-repo2
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo2
+		__________________________________
 		Diagnosing version 10
 		Downloading missing manifests...
 		Checking for corrupt files
@@ -203,9 +203,9 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		____________________________
-		 3rd-Party Repo: test-repo1
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo1
+		__________________________________
 		Diagnosing version 20
 		Downloading missing manifests...
 		Checking for corrupt files
@@ -235,9 +235,9 @@ test_setup() {
 		Calling post-update helper scripts
 		Regenerating 3rd-party bundle binaries...
 		Repair successful
-		____________________________
-		 3rd-Party Repo: test-repo2
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo2
+		__________________________________
 		Diagnosing version 10
 		Downloading missing manifests...
 		Checking for corrupt files

--- a/test/functional/3rd-party/3rd-party-repair-exported-bin.bats
+++ b/test/functional/3rd-party/3rd-party-repair-exported-bin.bats
@@ -40,9 +40,9 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Diagnosing version 10
 		Downloading missing manifests...
 		Checking for corrupt files

--- a/test/functional/3rd-party/3rd-party-update-basic.bats
+++ b/test/functional/3rd-party/3rd-party-update-basic.bats
@@ -82,9 +82,9 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		____________________________
-		 3rd-Party Repo: test-repo1
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo1
+		__________________________________
 		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Preparing to update from 10 to 20
@@ -106,9 +106,9 @@ test_setup() {
 		Updating 3rd-party bundle binaries...
 		Warning: post-update helper scripts skipped due to --no-scripts argument
 		Update successful - System updated from version 10 to version 20
-		____________________________
-		 3rd-Party Repo: test-repo2
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo2
+		__________________________________
 		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Version on server (10) is not newer than system version (10)
@@ -126,15 +126,15 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		____________________________
-		 3rd-Party Repo: test-repo1
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo1
+		__________________________________
 		Current OS version: 10
 		Latest server version: 20
 		There is a new OS version available: 20
-		____________________________
-		 3rd-Party Repo: test-repo2
-		____________________________
+		__________________________________
+		 3rd-Party Repository: test-repo2
+		__________________________________
 		Current OS version: 10
 		Latest server version: 10
 		There are no updates available

--- a/test/functional/3rd-party/3rd-party-update-dangerous-flags.bats
+++ b/test/functional/3rd-party/3rd-party-update-dangerous-flags.bats
@@ -46,9 +46,9 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Preparing to update from 10 to 20
@@ -88,9 +88,9 @@ test_setup() {
 
 	assert_status_is "$SWUPD_INVALID_FILE"
 	expected_output=$(cat <<-EOM
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Preparing to update from 10 to 20
@@ -128,9 +128,9 @@ test_setup() {
 
 	assert_status_is "$SWUPD_INVALID_FILE"
 	expected_output=$(cat <<-EOM
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Preparing to update from 10 to 20
@@ -162,9 +162,9 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Preparing to update from 10 to 20

--- a/test/functional/3rd-party/3rd-party-update-export-template-multi-repo.bats
+++ b/test/functional/3rd-party/3rd-party-update-export-template-multi-repo.bats
@@ -51,9 +51,9 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Preparing to update from 10 to 20
@@ -76,22 +76,22 @@ test_setup() {
 		Updating 3rd-party bundle binaries...
 		Warning: post-update helper scripts skipped due to --no-scripts argument
 		Update successful - System updated from version 10 to version 20
-		_______________________
-		 3rd-Party Repo: repo2
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo2
+		_____________________________
 		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Version on server (10) is not newer than system version (10)
 		Update complete - System already up-to-date at version 10
 		The scripts that export binaries from 3rd-party repositories need to be regenerated
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Regenerating scripts...
 		Scripts regenerated successfully
-		_______________________
-		 3rd-Party Repo: repo2
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo2
+		_____________________________
 		Regenerating scripts...
 		Scripts regenerated successfully
 	EOM
@@ -173,14 +173,14 @@ test_setup() {
 		Warning: post-update helper scripts skipped due to --no-scripts argument
 		Update successful - System updated from version 10 to version 20
 		The scripts that export binaries from 3rd-party repositories need to be regenerated
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Regenerating scripts...
 		Scripts regenerated successfully
-		_______________________
-		 3rd-Party Repo: repo2
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo2
+		_____________________________
 		Regenerating scripts...
 		Scripts regenerated successfully
 	EOM

--- a/test/functional/3rd-party/3rd-party-update-export-template.bats
+++ b/test/functional/3rd-party/3rd-party-update-export-template.bats
@@ -39,9 +39,9 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Preparing to update from 10 to 20
@@ -107,9 +107,9 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Preparing to update from 10 to 20
@@ -133,9 +133,9 @@ test_setup() {
 		Warning: post-update helper scripts skipped due to --no-scripts argument
 		Update successful - System updated from version 10 to version 20
 		The scripts that export binaries from 3rd-party repositories need to be regenerated
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Regenerating scripts...
 		Scripts regenerated successfully
 	EOM
@@ -181,9 +181,9 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Preparing to update from 10 to 20
@@ -207,9 +207,9 @@ test_setup() {
 		Warning: post-update helper scripts skipped due to --no-scripts argument
 		Update successful - System updated from version 10 to version 20
 		The scripts that export binaries from 3rd-party repositories need to be regenerated
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Regenerating scripts...
 		Scripts regenerated successfully
 	EOM

--- a/test/functional/3rd-party/3rd-party-update-exported-bin.bats
+++ b/test/functional/3rd-party/3rd-party-update-exported-bin.bats
@@ -45,9 +45,9 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Preparing to update from 10 to 20

--- a/test/functional/update/update-3rd-party.bats
+++ b/test/functional/update/update-3rd-party.bats
@@ -49,9 +49,9 @@ test_setup() {
 		Calling post-update helper scripts
 		Update successful - System updated from version 10 to version 20
 		Updating content from 3rd-party repositories
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Preparing to update from 10 to 20
@@ -100,11 +100,9 @@ test_setup() {
 		]
 		[
 		{ "type" : "start", "section" : "3rd-party-update" },
-	EOM
-	)
-	assert_in_output "$expected_output"
-	expected_output=$(cat <<-EOM
-		{ "type" : "info", "msg" : " 3rd-Party Repo: repo1" },
+		{ "type" : "info", "msg" : "_____________________________" },
+		{ "type" : "info", "msg" : " 3rd-Party Repository: repo1" },
+		{ "type" : "info", "msg" : "_____________________________" },
 	EOM
 	)
 	assert_in_output "$expected_output"
@@ -128,9 +126,9 @@ test_setup() {
 		Latest server version: 20
 		There is a new OS version available: 20
 		Checking update status of content from 3rd-party repositories
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Current OS version: 10
 		Latest server version: 20
 		There is a new OS version available: 20
@@ -170,9 +168,9 @@ test_setup() {
 		Downloading all Clear Linux manifests...
 		Update successful - System updated from version 10 to version 20
 		Updating content from 3rd-party repositories
-		_______________________
-		 3rd-Party Repo: repo1
-		_______________________
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
 		Updates from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Update started
 		Preparing to update from 10 to 20


### PR DESCRIPTION
Headers are printed at the beginning of the output for every repository
in operations that run in multipl repos. This header was using the word
"repo" but we are trying to use the whole "repository" word every time
we printed it to the user. This commit changes that.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>