### PR TITLE
sys: sys_path_join() removes trailing '/' from "/"

### DIFF
--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -444,8 +444,11 @@ char *sys_path_join(const char *fmt, ...)
 
 	/* remove all duplicated PATH_SEPARATOR from the path */
 	for (i = j = 0; i < len; i++) {
-		if (path[i] == PATH_SEPARATOR &&
-		    (path[i + 1] == PATH_SEPARATOR || path[i + 1] == '\0')) {
+		if (path[i] == PATH_SEPARATOR && // Is separator and
+		    // Next is also a separator or
+		    (path[i + 1] == PATH_SEPARATOR ||
+		     // Is a trailing separator, but not root
+		     (path[i + 1] == '\0' && i != 0))) {
 			/* duplicated PATH_SEPARATOR, throw it away */
 			continue;
 		}


### PR DESCRIPTION
Sys_path_join is removing trailing '/', but we shouldn't remove the last
'/' if path is "/". Right now sys_path_join("/") == "" and should be "/".

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>