### PR TITLE
Bug_fix: Fixing bug in diagnose/repair using the `--file` option

### DIFF
--- a/test/functional/api/api-diagnose.bats
+++ b/test/functional/api/api-diagnose.bats
@@ -8,13 +8,7 @@ load "../testlib"
 global_setup() {
 
 	create_test_environment -r "$TEST_NAME" 10 1
-	versionurl_hash=$(sudo "$SWUPD" hashdump --quiet "$TARGETDIR"/usr/share/defaults/swupd/versionurl)
-	sudo cp "$TARGETDIR"/usr/share/defaults/swupd/versionurl "$WEBDIR"/10/files/"$versionurl_hash"
-	versionurl="$WEBDIR"/10/files/"$versionurl_hash"
-	contenturl_hash=$(sudo "$SWUPD" hashdump --quiet "$TARGETDIR"/usr/share/defaults/swupd/contenturl)
-	sudo cp "$TARGETDIR"/usr/share/defaults/swupd/contenturl "$WEBDIR"/10/files/"$contenturl_hash"
-	contenturl="$WEBDIR"/10/files/"$contenturl_hash"
-	create_bundle -L -n os-core-update -f /usr/share/defaults/swupd/versionurl:"$versionurl",/usr/share/defaults/swupd/contenturl:"$contenturl" "$TEST_NAME"
+	add_os_core_update_bundle "$TEST_NAME"
 	create_bundle -L -n test-bundle1 -f /foo/file_1,/bar/file_2 "$TEST_NAME"
 	create_version "$TEST_NAME" 20 10 1
 	update_bundle -p "$TEST_NAME" test-bundle1 --update /foo/file_1

--- a/test/functional/api/api-repair.bats
+++ b/test/functional/api/api-repair.bats
@@ -8,13 +8,7 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment -r "$TEST_NAME" 10 1
-	versionurl_hash=$(sudo "$SWUPD" hashdump --quiet "$TARGETDIR"/usr/share/defaults/swupd/versionurl)
-	sudo cp "$TARGETDIR"/usr/share/defaults/swupd/versionurl "$WEBDIR"/10/files/"$versionurl_hash"
-	versionurl="$WEBDIR"/10/files/"$versionurl_hash"
-	contenturl_hash=$(sudo "$SWUPD" hashdump --quiet "$TARGETDIR"/usr/share/defaults/swupd/contenturl)
-	sudo cp "$TARGETDIR"/usr/share/defaults/swupd/contenturl "$WEBDIR"/10/files/"$contenturl_hash"
-	contenturl="$WEBDIR"/10/files/"$contenturl_hash"
-	create_bundle -L -n os-core-update -f /usr/share/defaults/swupd/versionurl:"$versionurl",/usr/share/defaults/swupd/contenturl:"$contenturl" "$TEST_NAME"
+	add_os_core_update_bundle "$TEST_NAME"
 	create_bundle -L -n test-bundle1 -f /foo/file_1,/bar/file_2 "$TEST_NAME"
 	create_version "$TEST_NAME" 20 10 1
 	update_bundle -p "$TEST_NAME" test-bundle1 --update /foo/file_1

--- a/test/functional/diagnose/diagnose-path.bats
+++ b/test/functional/diagnose/diagnose-path.bats
@@ -8,6 +8,7 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment -r "$TEST_NAME" 10 1
+	add_os_core_update_bundle "$TEST_NAME"
 	create_bundle -L -n test-bundle1 -f /foo/file_1,/bar/file_2 "$TEST_NAME"
 	create_version "$TEST_NAME" 20 10 1
 	update_bundle -p "$TEST_NAME" test-bundle1 --update /foo/file_1
@@ -161,11 +162,9 @@ test_setup() {
 		 -> File that should be deleted: $PATH_PREFIX/bar/file_2
 		Checking for extra files under $PATH_PREFIX/usr
 		 -> Extra file: $PATH_PREFIX/usr/untracked_file3
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/versionurl
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/contenturl
-		Inspected 8 files
+		Inspected 6 files
 		  3 files were missing
-		  4 files found which should be deleted
+		  2 files found which should be deleted
 		Use "swupd repair --picky" to correct the problems in the system
 		Diagnose successful
 	EOM
@@ -220,7 +219,31 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Diagnosing version 20
 		Downloading missing manifests...
+		Limiting diagnose to the following file:
+		 - /ba
 		Inspected 0 files
+		Diagnose successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "DIA029: Diagnosing extra files only specifying an untracked file or directory" {
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --extra-files-only --file /usr/untracked_file3"
+
+	assert_status_is "$SWUPD_NO"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 20
+		Downloading missing manifests...
+		Limiting diagnose to the following file:
+		 - /usr/untracked_file3
+		Checking for extra files under $PATH_PREFIX/usr/untracked_file3
+		 -> Extra file: $PATH_PREFIX/usr/untracked_file3
+		Inspected 1 file
+		  1 file found which should be deleted
+		Use "swupd repair --picky" to correct the problems in the system
 		Diagnose successful
 	EOM
 	)

--- a/test/functional/diagnose/diagnose-path.bats
+++ b/test/functional/diagnose/diagnose-path.bats
@@ -207,4 +207,25 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 }
+
+@test "DIA028: Diagnose with --file doesn't consider partial matches" {
+
+	# when using "diagnose --file <ITEM>", swupd will match the ITEM with
+	# either the full name of a file or a directory (recursively), but won't
+	# use partial matches
+
+	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --file /ba"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Diagnosing version 20
+		Downloading missing manifests...
+		Inspected 0 files
+		Diagnose successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
 #WEIGHT=36

--- a/test/functional/repair/repair-error.bats
+++ b/test/functional/repair/repair-error.bats
@@ -8,13 +8,7 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment -r "$TEST_NAME" 10 1
-	versionurl_hash=$(sudo "$SWUPD" hashdump --quiet "$TARGETDIR"/usr/share/defaults/swupd/versionurl)
-	sudo cp "$TARGETDIR"/usr/share/defaults/swupd/versionurl "$WEBDIR"/10/files/"$versionurl_hash"
-	versionurl="$WEBDIR"/10/files/"$versionurl_hash"
-	contenturl_hash=$(sudo "$SWUPD" hashdump --quiet "$TARGETDIR"/usr/share/defaults/swupd/contenturl)
-	sudo cp "$TARGETDIR"/usr/share/defaults/swupd/contenturl "$WEBDIR"/10/files/"$contenturl_hash"
-	contenturl="$WEBDIR"/10/files/"$contenturl_hash"
-	create_bundle -L -n os-core-update -f /usr/share/defaults/swupd/versionurl:"$versionurl",/usr/share/defaults/swupd/contenturl:"$contenturl" "$TEST_NAME"
+	add_os_core_update_bundle "$TEST_NAME"
 	create_bundle -L -n test-bundle1 -f /foo/file_1,/bar/file_2 "$TEST_NAME"
 	create_version "$TEST_NAME" 20 10 1
 	update_bundle -p "$TEST_NAME" test-bundle1 --update /foo/file_1

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1966,6 +1966,34 @@ destroy_test_environment() { # swupd_function
 
 }
 
+add_os_core_update_bundle() { # swupd_function
+
+	local env_name=$1
+	# If no parameters are received show usage
+	if [ $# -eq 0 ]; then
+		cat <<-EOM
+			Usage:
+			    add_os_core_update_bundle <environment_name>
+			EOM
+		return
+	fi
+	validate_path "$env_name"
+
+	# move the versionurl file to the content directory
+	versionurl_hash=$(sudo "$SWUPD" hashdump --quiet "$TARGETDIR"/usr/share/defaults/swupd/versionurl)
+	sudo cp "$TARGETDIR"/usr/share/defaults/swupd/versionurl "$WEBDIR"/10/files/"$versionurl_hash"
+	versionurl="$WEBDIR"/10/files/"$versionurl_hash"
+
+	# move the contenturl file to the content directory
+	contenturl_hash=$(sudo "$SWUPD" hashdump --quiet "$TARGETDIR"/usr/share/defaults/swupd/contenturl)
+	sudo cp "$TARGETDIR"/usr/share/defaults/swupd/contenturl "$WEBDIR"/10/files/"$contenturl_hash"
+	contenturl="$WEBDIR"/10/files/"$contenturl_hash"
+
+	# create the os-core-update bundle
+	create_bundle -L -n os-core-update -f /usr/share/defaults/swupd/versionurl:"$versionurl",/usr/share/defaults/swupd/contenturl:"$contenturl" "$env_name"
+
+}
+
 # Creates a test fiile system of a given size
 create_test_fs() { # swupd_function
 


### PR DESCRIPTION
This PR fixes a couple of bugs found in the diagnose/repair functionality:
- Diagnose should not use partial matches for the `--file` option
- Swupd should still check for extra files even in no tracked files are found in the path specified by the user with the `--file` flag.

Closes #1472 