### PR TITLE
header: Print the header decoration all at once

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -915,13 +915,14 @@ fail:
 	return ret;
 }
 
-void print_pattern(const char *pattern, int times)
+static void print_char(const char c, int times)
 {
-	while (times > 0) {
-		info("%s", pattern);
-		times--;
-	}
-	info("\n");
+	char *str;
+
+	str = calloc(1, times + 1);
+	memset(str, c, times);
+	info("%s\n", str);
+	free(str);
 }
 
 void print_header(const char *header)
@@ -929,9 +930,9 @@ void print_header(const char *header)
 	int header_length;
 
 	header_length = str_len(header);
-	print_pattern("_", header_length + 1);
+	print_char('_', header_length + 1);
 	info("%s\n", header);
-	print_pattern("_", header_length + 1);
+	print_char('_', header_length + 1);
 	info("\n");
 }
 

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -298,7 +298,6 @@ extern void print_regexp_error(int errcode, regex_t *regexp);
 extern bool is_url_allowed(const char *url);
 extern bool is_url_insecure(const char *url);
 extern void remove_trailing_slash(char *url);
-extern void print_pattern(const char *pattern, int times);
 extern void print_header(const char *header);
 extern void prettify_size(long size_in_bytes, char **pretty_size);
 extern int create_state_dirs(const char *state_dir_path);


### PR DESCRIPTION
When printing the header, print all '_' chars at once to prevent
json-output and --debug to print that in multiple lines.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>