### PR TITLE
API: Do not validate error messages in API tests

### DIFF
--- a/test/functional/api/api-mirror.bats
+++ b/test/functional/api/api-mirror.bats
@@ -49,7 +49,7 @@ global_setup() {
 
 }
 
-@test "API077: mirror --unset" {
+@test "API059: mirror --unset" {
 
 	run sudo sh -c "$SWUPD mirror $SWUPD_OPTS --unset --quiet"
 

--- a/test/functional/api/api-repair.bats
+++ b/test/functional/api/api-repair.bats
@@ -60,34 +60,4 @@ test_teardown() {
 	assert_is_output --identical "$expected_output"
 
 }
-
-@test "API059: repair (failure to repair)" {
-
-	# force some repairs in the target system
-	set_current_version "$TEST_NAME" 20
-	sudo touch "$TARGETDIR"/usr/untracked_file
-
-	# force failures while repairing
-	sudo touch "$TARGETDIR"/baz
-	sudo chattr +i "$TARGETDIR"/usr/untracked_file
-	sudo chattr +i "$TARGETDIR"/baz
-
-	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --picky --quiet"
-
-	assert_status_is_not "$SWUPD_OK"
-	expected_output=$(cat <<-EOM
-		Error: Target exists but is not a directory: $PATH_PREFIX/baz
-		$PATH_PREFIX/baz/bat
-		Error: Target has different file type but could not be removed: $PATH_PREFIX/baz
-		$PATH_PREFIX/baz/bat/file_3
-		Error: Target has different file type but could not be removed: $PATH_PREFIX/baz
-		$PATH_PREFIX/baz
-		$PATH_PREFIX/foo/file_1
-		$PATH_PREFIX/usr/lib/os-release
-		$PATH_PREFIX/usr/untracked_file
-	EOM
-	)
-	assert_is_output "$expected_output"
-
-}
 #WEIGHT=17

--- a/test/functional/repair/repair-error.bats
+++ b/test/functional/repair/repair-error.bats
@@ -76,4 +76,26 @@ test_teardown() {
 	assert_is_output "$expected_output"
 
 }
+
+@test "REP046: repair failure using --quiet" {
+
+	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --picky --quiet"
+
+	assert_status_is_not "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Error: Target exists but is not a directory: $PATH_PREFIX/baz
+		$PATH_PREFIX/baz/bat
+		Error: Target has different file type but could not be removed: $PATH_PREFIX/baz
+		$PATH_PREFIX/baz/bat/file_3
+		Error: Target has different file type but could not be removed: $PATH_PREFIX/baz
+		$PATH_PREFIX/baz
+		$PATH_PREFIX/foo/file_1
+		$PATH_PREFIX/usr/lib/os-release
+		$PATH_PREFIX/usr/untracked_file
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
 #WEIGHT=6


### PR DESCRIPTION
The tests in test/functional/api are going to validate the --quiet
output is rarely changed, therefore only expected output should be
validated and not warnings or error messages.

Closes #1502

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>