### PR TITLE
sys: sys_path_join was wrong for string "//"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -197,7 +197,8 @@ TESTS = \
 	test/unit/test_list.test \
 	test/unit/test_manifest.test \
 	test/unit/test_signature.test \
-	test/unit/test_strings.test
+	test/unit/test_strings.test \
+	test/unit/test_sys.test
 
 EXTRA_DIST += test/unit/test_helper.h test/unit/data
 

--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -454,7 +454,7 @@ char *sys_path_join(const char *fmt, ...)
 		    // Next is also a separator or
 		    (path[i + 1] == PATH_SEPARATOR ||
 		     // Is a trailing separator, but not root
-		     (path[i + 1] == '\0' && i != 0))) {
+		     (path[i + 1] == '\0' && j != 0))) {
 			/* duplicated PATH_SEPARATOR, throw it away */
 			continue;
 		}

--- a/test/unit/test_sys.c
+++ b/test/unit/test_sys.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+
+#include "../../src/lib/sys.h"
+#include "../../src/lib/strings.h"
+#include "test_helper.h"
+
+static void test_sys_path_join()
+{
+	char *path;
+	size_t i;
+
+	path = sys_path_join("%s/%s/%s", "/123", "456", "789");
+	check(str_cmp(path, "/123/456/789") == 0);
+	free(path);
+
+	const char *tests[][2] = {{"", ""},
+				  {"/", "/"},
+				  {"/usr/", "/usr"},
+				  {"/usr//", "/usr"},
+				  {"/usr///", "/usr"},
+				  {"//usr", "/usr"},
+				  {"///////usr///////", "/usr"},
+				  {"//usr//lib//test//////", "/usr/lib/test"},
+				  {"//////", "/"},
+				  {"",""}};
+
+	for (i = 0; i < sizeof(tests)/(sizeof(char *) * 2); i++) {
+		path = sys_path_join(tests[i][0]);
+		printf("test %s -> %s\n", tests[i][0], path);
+		check(str_cmp(path, tests[i][1]) == 0);
+		free(path);
+	}
+}
+
+int main() {
+	test_sys_path_join();
+
+	return 0;
+}


### PR DESCRIPTION
When sys_path_join("//") was used, the result was "" instead of "/"

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>