### PR TITLE
target_root: Use run_commmand to execute tar|tar command

### DIFF
--- a/scripts/build_and_run_tests.bash
+++ b/scripts/build_and_run_tests.bash
@@ -42,7 +42,7 @@ run_checks_tartar() {
 
 	# Tar tar doasnt support hardlinks
 	# There's a known bug in tar tar code that doesn't support unusual file names
-	FILES="$(find test/functional  -name "*.bats" \( ! -path "*only_in_ci_system*" \) | sort | grep -v install-hardlink-symlink.bats | grep -v update-unusual-file-names.bats)"
+	FILES="$(find test/functional  -name "*.bats" \( ! -path "*only_in_ci_system*" \) | sort | grep -v install-hardlink-symlink.bats)"
 
 	env TESTS="$FILES"  make -j "$JOB_COUNT" -e check
 	env TESTS="$(find ./test/functional/only_in_ci_system  -name "*.bats" | sort)" make -e -j1 check

--- a/src/lib/sys.h
+++ b/src/lib/sys.h
@@ -44,6 +44,11 @@ long get_available_space(const char *path);
 #define run_command_params(_params) run_command_full_params(NULL, NULL, _params)
 
 /**
+ * @brief runs a command from params with standard and error output redirected to /dev/null.
+ */
+#define run_command_params_quiet(_params) run_command_full_params("/dev/null", "/dev/null", _params)
+
+/**
  * @brief Run command cmd with parameters informed in a NULL terminated list of strings.
  *
  * Return a negative number (-errno) if we are unable to create a new thread to
@@ -51,7 +56,7 @@ long get_available_space(const char *path);
  * If there's an error in the execution of the program 255 may also be returned
  *
  * Notes:
- * - This function doesn't execute on a shell like system() so we won't have any
+ * - This function doesn't execute on a shell like system () so we won't have any
  *   issue with parameters globbing.
  * - The full path to cmd is required.
  *

--- a/src/swupd_build_variant.h
+++ b/src/swupd_build_variant.h
@@ -13,27 +13,27 @@
  * for it. This has been tested in Ostro OS in combination with IMA
  * and Smack, but not with SELinux.
  */
-#define TAR_COMMAND "bsdtar"
-#define TAR_XATTR_ARGS ""
+#define TAR_COMMAND "/usr/bin/bsdtar"
 
 #else /* SWUPD_WITH_BSDTAR */
 
 /* GNU tar requires special options, depending on how the OS uses xattrs.
  * This has been tested in Clear Linux OS in combination with SELinux.
  */
-#define TAR_COMMAND "tar"
+#define TAR_COMMAND "/usr/bin/tar"
+
+#ifdef SWUPD_WITH_XATTRS
+
 #ifdef SWUPD_TAR_SELINUX
 #define TAR_XATTR_ARGS "--xattrs --xattrs-include='*' --selinux"
-#else
+#else /* SWUPD_TAR_SELINUX */
 #define TAR_XATTR_ARGS "--xattrs --xattrs-include='*'"
-#endif
+#endif /* SWUPD_TAR_SELINUX */
+
+#endif /* SWUPD_WITH_XATTRS */
 
 #endif /* SWUPD_WITH_BSDTAR */
 
-#ifdef SWUPD_WITH_XATTRS
-#define TAR_PERM_ATTR_ARGS "--preserve-permissions " TAR_XATTR_ARGS
-#else /* SWUPD_WITHOUT_XATTRS */
-#define TAR_PERM_ATTR_ARGS "--preserve-permissions "
-#endif
+#define TAR_PERM_ATTR_ARGS "--preserve-permissions"
 
-#endif
+#endif /* __INCLUDE_GUARD_SWUPD_BUILD_VARIANT_H */

--- a/test/code_analysis/warning_functions.bats
+++ b/test/code_analysis/warning_functions.bats
@@ -7,7 +7,7 @@
 	# There are some C functions that are tricky to use and it's prefered to
 	# avoid using them in swupd. If any function in this list is really needed
 	# we need to review the usage and add an exception here.
-	local functions="strcpy wcscpy strcat wcscat sprintf vsprintf strtok ato strlen strcmp wcslen alloca vscanf vsscanf vfscanf scanf sscanf fscanf strncat strsep toa memmove asctime getwd gets basename dirname free"
+	local functions="strcpy wcscpy strcat wcscat sprintf vsprintf strtok ato strlen strcmp wcslen alloca vscanf vsscanf vfscanf scanf sscanf fscanf strncat strsep toa memmove asctime getwd gets basename dirname free system"
 
 	local exceptions
 	declare -A exceptions


### PR DESCRIPTION
Porting code to better way on interacting with system commands using the
run_command function. As run_command don't support multi-thread for
performance reasons, we are now using a file instead of a pipe. As tar|tar
is now a fallback, this won't have any performance impacts on any case
where with no problems and errors.

Fixes #640 and #671

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>