### PR TITLE
helpers: Add check for allocation errors

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -920,6 +920,8 @@ static void print_char(const char c, int times)
 	char *str;
 
 	str = calloc(1, times + 1);
+	ON_NULL_ABORT(str);
+
 	memset(str, c, times);
 	info("%s\n", str);
 	free(str);


### PR DESCRIPTION
Forgot to add the check after calloc

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>