### PR TITLE
Reporting if a file was fixed or not with --quiet

### DIFF
--- a/src/extra_files.c
+++ b/src/extra_files.c
@@ -87,12 +87,11 @@ static bool handle(const char *filename, bool is_dir, bool fix)
 		info(" -> Extra file: ");
 		print("%s%s", temp, is_dir ? "/" : "");
 		if (remove(temp)) {
-			info(" -> not deleted (%s)", strerror(errno));
+			print(" -> not deleted (%s)\n", strerror(errno));
 			ret = false;
 		} else {
-			info(" -> deleted");
+			print(" -> deleted\n");
 		}
-		print("\n");
 	} else {
 		info(" -> Extra file: ");
 		print("%s%s\n", temp, is_dir ? "/" : "");

--- a/src/verify.c
+++ b/src/verify.c
@@ -414,8 +414,7 @@ static void add_missing_files(struct manifest *official_manifest, struct list *f
 		}
 		if ((ret != 0) || hash_needs_work(file, local.hash)) {
 			counts.not_replaced++;
-			info(" -> not fixed");
-			print("\n");
+			print(" -> not fixed\n");
 
 			check_warn_freespace(file);
 
@@ -423,8 +422,7 @@ static void add_missing_files(struct manifest *official_manifest, struct list *f
 			counts.replaced++;
 			file->do_not_update = 1;
 			if (cmdline_option_install == false) {
-				info(" -> fixed");
-				print("\n");
+				print(" -> fixed\n");
 			}
 		}
 	out:
@@ -470,12 +468,11 @@ static void check_and_fix_one(struct file *file, struct manifest *official_manif
 	/* at the end of all this, verify the hash again to judge success */
 	if (verify_file(file, fullname)) {
 		counts.fixed++;
-		info(" -> fixed");
+		print(" -> fixed\n");
 	} else {
 		counts.not_fixed++;
-		info(" -> not fixed");
+		print(" -> not fixed\n");
 	}
-	print("\n");
 end:
 	free_and_clear_pointer(&fullname);
 }
@@ -608,28 +605,26 @@ static void remove_orphaned_files(struct list *files_to_verify, bool repair)
 		if (!sys_is_dir(fullname)) {
 			ret = unlinkat(fd, base, 0);
 			if (ret && errno != ENOENT) {
-				info(" -> not deleted (%s)", strerror(errno));
+				print(" -> not deleted (%s)\n", strerror(errno));
 				counts.not_deleted++;
 			} else {
-				info(" -> deleted");
+				print(" -> deleted\n");
 				counts.deleted++;
 			}
-			print("\n");
 		} else {
 			ret = unlinkat(fd, base, AT_REMOVEDIR);
 			if (ret) {
 				counts.not_deleted++;
 				if (errno != ENOTEMPTY) {
-					info(" -> not deleted (%s)", strerror(errno));
+					print(" -> not deleted (%s)\n", strerror(errno));
 				} else {
 					//FIXME: Add force removal option?
-					info(" -> not deleted (not empty)");
+					print(" -> not deleted (not empty)\n");
 				}
 			} else {
-				info(" -> deleted");
+				print(" -> deleted\n");
 				counts.deleted++;
 			}
-			print("\n");
 		}
 		close(fd);
 	out:

--- a/test/functional/api/api-3rd-party-repair.bats
+++ b/test/functional/api/api-3rd-party-repair.bats
@@ -32,12 +32,12 @@ test_setup() {
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		[repo1]
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/baz
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/baz/file_3
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/foo/file_1
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/usr/lib/os-release
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/bar/file_2
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/usr/untracked_file
+		$PATH_PREFIX/opt/3rd-party/bundles/repo1/baz -> fixed
+		$PATH_PREFIX/opt/3rd-party/bundles/repo1/baz/file_3 -> fixed
+		$PATH_PREFIX/opt/3rd-party/bundles/repo1/foo/file_1 -> fixed
+		$PATH_PREFIX/opt/3rd-party/bundles/repo1/usr/lib/os-release -> fixed
+		$PATH_PREFIX/opt/3rd-party/bundles/repo1/bar/file_2 -> deleted
+		$PATH_PREFIX/opt/3rd-party/bundles/repo1/usr/untracked_file -> deleted
 		[repo2]
 	EOM
 	)
@@ -51,12 +51,12 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/baz
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/baz/file_3
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/foo/file_1
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/usr/lib/os-release
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/bar/file_2
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/usr/untracked_file
+		$PATH_PREFIX/opt/3rd-party/bundles/repo1/baz -> fixed
+		$PATH_PREFIX/opt/3rd-party/bundles/repo1/baz/file_3 -> fixed
+		$PATH_PREFIX/opt/3rd-party/bundles/repo1/foo/file_1 -> fixed
+		$PATH_PREFIX/opt/3rd-party/bundles/repo1/usr/lib/os-release -> fixed
+		$PATH_PREFIX/opt/3rd-party/bundles/repo1/bar/file_2 -> deleted
+		$PATH_PREFIX/opt/3rd-party/bundles/repo1/usr/untracked_file -> deleted
 	EOM
 	)
 	assert_is_output "$expected_output"

--- a/test/functional/api/api-repair.bats
+++ b/test/functional/api/api-repair.bats
@@ -48,13 +48,13 @@ test_teardown() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		$PATH_PREFIX/baz
-		$PATH_PREFIX/baz/bat
-		$PATH_PREFIX/baz/bat/file_3
-		$PATH_PREFIX/foo/file_1
-		$PATH_PREFIX/usr/lib/os-release
-		$PATH_PREFIX/bar/file_2
-		$PATH_PREFIX/usr/untracked_file
+		$PATH_PREFIX/baz -> fixed
+		$PATH_PREFIX/baz/bat -> fixed
+		$PATH_PREFIX/baz/bat/file_3 -> fixed
+		$PATH_PREFIX/foo/file_1 -> fixed
+		$PATH_PREFIX/usr/lib/os-release -> fixed
+		$PATH_PREFIX/bar/file_2 -> deleted
+		$PATH_PREFIX/usr/untracked_file -> deleted
 	EOM
 	)
 	assert_is_output --identical "$expected_output"

--- a/test/functional/repair/repair-error.bats
+++ b/test/functional/repair/repair-error.bats
@@ -84,14 +84,14 @@ test_teardown() {
 	assert_status_is_not "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Error: Target exists but is not a directory: $PATH_PREFIX/baz
-		$PATH_PREFIX/baz/bat
+		$PATH_PREFIX/baz/bat -> not fixed
 		Error: Target has different file type but could not be removed: $PATH_PREFIX/baz
-		$PATH_PREFIX/baz/bat/file_3
+		$PATH_PREFIX/baz/bat/file_3 -> not fixed
 		Error: Target has different file type but could not be removed: $PATH_PREFIX/baz
-		$PATH_PREFIX/baz
-		$PATH_PREFIX/foo/file_1
-		$PATH_PREFIX/usr/lib/os-release
-		$PATH_PREFIX/usr/untracked_file
+		$PATH_PREFIX/baz -> not fixed
+		$PATH_PREFIX/foo/file_1 -> fixed
+		$PATH_PREFIX/usr/lib/os-release -> fixed
+		$PATH_PREFIX/usr/untracked_file -> not deleted (Operation not permitted)
 	EOM
 	)
 	assert_is_output "$expected_output"


### PR DESCRIPTION
When using --quiet, there was no way of knowing if a file had been
successfully repaired or not. This commit fixes that.

Closes #1504

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>