### PR TITLE
Fail to be compliant if --quiet tests change

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -241,6 +241,7 @@ compliant:
 	test/code_analysis/compliant.bats
 	test/functional/check_ids.bash
 	test/code_analysis/warning_functions.bats
+	test/code_analysis/quiet_output.bats
 	scripts/flag_validator.bash
 
 # Ignore SC1008 because scripts are using an unsupported shebang

--- a/test/code_analysis/quiet_output.bats
+++ b/test/code_analysis/quiet_output.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+@test "ANL005: swupd --quiet output has not changed" {
+
+	run git diff --name-only --exit-code origin/master HEAD test/functional/api/
+
+	# shellcheck disable=SC2154
+	# SC2154: var is referenced but not assigned
+	if [ "$status" -ne 0 ]; then
+		echo "The following --quiet tests changed:"
+		echo "$output"
+		return 1
+	fi
+
+}


### PR DESCRIPTION
We are aiming to provide a stable --quiet output, so forcing "make
compliant" to fail if there are changes in the test/functional/api
tests, which cover these scenarios will prevent us from unadvertedly
changing those tests.

Closes #1501

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>