### PR TITLE
curl: exit if the file cannot be created/appended

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -540,6 +540,9 @@ restart_download:
 		} else {
 			curl_ret = swupd_download_file_create(&local);
 		}
+		if (curl_ret != CURLE_OK) {
+			goto exit;
+		}
 
 		curl_ret = curl_easy_setopt(curl, CURLOPT_PRIVATE, (void *)local_ptr);
 		if (curl_ret != CURLE_OK) {


### PR DESCRIPTION
If for some reason swupd fails to create or append the file it will
cause a segmentation fault. This, commit prevents this from happening.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>