### PR TITLE
Test: show_target shellcheck warning

### DIFF
--- a/test/functional/update/update-attr-change.bats
+++ b/test/functional/update/update-attr-change.bats
@@ -119,6 +119,7 @@ test_setup() {
 	run stat --printf  "%a" "$TARGETDIR"/dir_sticky
 	[ "$output" -eq "1755" ]
 
+	# shellcheck disable=SC2119
 	show_target
 
 }

--- a/test/functional/update/update-boot-manager.bats
+++ b/test/functional/update/update-boot-manager.bats
@@ -59,6 +59,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
+	# shellcheck disable=SC2119
 	show_target
 
 }

--- a/test/functional/update/update-type-changes-dir-to-file.bats
+++ b/test/functional/update/update-type-changes-dir-to-file.bats
@@ -76,6 +76,7 @@ test_setup() {
 	assert_dir_not_exists "$TARGETDIR"/dir1
 	assert_file_exists "$TARGETDIR"/dir1
 	assert_file_exists "$TARGETDIR"/common_file
+	# shellcheck disable=SC2119
 	show_target
 
 }

--- a/test/functional/update/update-type-changes-file-to-symlink.bats
+++ b/test/functional/update/update-type-changes-file-to-symlink.bats
@@ -80,6 +80,7 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/dir1/dir2/file2
 	assert_file_exists "$TARGETDIR"/file3
 	assert_file_exists "$TARGETDIR"/file4
+	# shellcheck disable=SC2119
 	show_target
 
 }


### PR DESCRIPTION
The show_target function shows a warning that is not applicable so this
commit ignores that warning wherever show_target is used.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>