### PR TITLE
Test: Use global_setup for bundle-list tests

### DIFF
--- a/test/functional/bundlelist/list-all.bats
+++ b/test/functional/bundlelist/list-all.bats
@@ -2,7 +2,7 @@
 
 load "../testlib"
 
-test_setup() {
+global_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle       -n test-bundle1 -f /foo "$TEST_NAME"

--- a/test/functional/bundlelist/list-deps-flat.bats
+++ b/test/functional/bundlelist/list-deps-flat.bats
@@ -2,7 +2,7 @@
 
 load "../testlib"
 
-test_setup() {
+global_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle -n test-bundle1 -f /foo "$TEST_NAME"

--- a/test/functional/bundlelist/list-deps-invalid-bundle.bats
+++ b/test/functional/bundlelist/list-deps-invalid-bundle.bats
@@ -2,7 +2,7 @@
 
 load "../testlib"
 
-test_setup() {
+global_setup() {
 
 	create_test_environment "$TEST_NAME"
 

--- a/test/functional/bundlelist/list-deps-nested.bats
+++ b/test/functional/bundlelist/list-deps-nested.bats
@@ -2,7 +2,7 @@
 
 load "../testlib"
 
-test_setup() {
+global_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle -n test-bundle1 -f /foo "$TEST_NAME"

--- a/test/functional/bundlelist/list-has-dep-nested-not-installed.bats
+++ b/test/functional/bundlelist/list-has-dep-nested-not-installed.bats
@@ -2,7 +2,7 @@
 
 load "../testlib"
 
-test_setup() {
+global_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle -n test-bundle1 -f /foo "$TEST_NAME"

--- a/test/functional/bundlelist/list-has-dep-nested-server.bats
+++ b/test/functional/bundlelist/list-has-dep-nested-server.bats
@@ -2,7 +2,7 @@
 
 load "../testlib"
 
-test_setup() {
+global_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle -n test-bundle1 -f /foo "$TEST_NAME"

--- a/test/functional/bundlelist/list-has-dep-nested.bats
+++ b/test/functional/bundlelist/list-has-dep-nested.bats
@@ -2,7 +2,7 @@
 
 load "../testlib"
 
-test_setup() {
+global_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle1 -f /foo "$TEST_NAME"

--- a/test/functional/bundlelist/list-installed.bats
+++ b/test/functional/bundlelist/list-installed.bats
@@ -5,7 +5,7 @@
 
 load "../testlib"
 
-test_setup() {
+global_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle -L    -n test-bundle1 -f /file_1 "$TEST_NAME"

--- a/test/functional/bundlelist/list-json.bats
+++ b/test/functional/bundlelist/list-json.bats
@@ -5,7 +5,7 @@
 
 load "../testlib"
 
-test_setup() {
+global_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle -f /file_1 "$TEST_NAME"

--- a/test/functional/bundlelist/list-no-deps.bats
+++ b/test/functional/bundlelist/list-no-deps.bats
@@ -2,7 +2,7 @@
 
 load "../testlib"
 
-test_setup() {
+global_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle -n test-bundle1 -f /foo "$TEST_NAME"

--- a/test/functional/bundlelist/list-none-has-deps.bats
+++ b/test/functional/bundlelist/list-none-has-deps.bats
@@ -2,7 +2,7 @@
 
 load "../testlib"
 
-test_setup() {
+global_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle1 -f /foo "$TEST_NAME"

--- a/test/functional/bundlelist/list-quiet.bats
+++ b/test/functional/bundlelist/list-quiet.bats
@@ -5,7 +5,7 @@
 
 load "../testlib"
 
-test_setup() {
+global_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle1 -f /file_1 "$TEST_NAME"


### PR DESCRIPTION
Use global_setup in all bundle-list tests so we can only generate the
test environment once and use it for multiple tests. The one exception
is if we need to modify the env for a specific test.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>