### PR TITLE
Add `--orphans` flag for bundle-list

### DIFF
--- a/config
+++ b/config
@@ -203,6 +203,9 @@
 # Show the installation status of the listed bundles (boolean value)
 #status=<true/false>
 
+# List orphaned bundles (boolean value)
+#orphans=<true/false>
+
 
 [bundle-info]
 

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -268,6 +268,9 @@ bundle-list
 --deps=<bundle>     Lists all bundle dependencies of the passed BUNDLE,
         including recursively included bundles.
 
+--orphans    List orphaned bundles. Orphan bundles are those that are installed
+         but no longer required by any tracked bundle.
+
 bundle-info
 -----------
 

--- a/src/alias.c
+++ b/src/alias.c
@@ -162,14 +162,25 @@ struct list *get_alias_definitions(void)
 	struct list *iteru = NULL;
 	struct list *system_alias_files = NULL;
 	struct list *user_alias_files = NULL;
+	struct list *tmp_list = NULL;
 
 	/* get sorted system and user filenames */
-	string_or_die(&path, "%s/%s", globals.path_prefix, SYSTEM_ALIAS_PATH);
-	system_alias_files = get_dir_files_sorted(path);
+	path = sys_path_join("%s/%s", globals.path_prefix, SYSTEM_ALIAS_PATH);
+	tmp_list = sys_ls(path);
+	for (iters = tmp_list; iters; iters = iters->next) {
+		system_alias_files = list_prepend_data(system_alias_files, str_or_die("%s/%s", path, (char *)iters->data));
+	}
+	system_alias_files = list_sort(system_alias_files, str_cmp_wrapper);
+	list_free_list_and_data(tmp_list, free);
 	FREE(path);
 
-	string_or_die(&path, "%s/%s", globals.path_prefix, USER_ALIAS_PATH);
-	user_alias_files = get_dir_files_sorted(path);
+	path = sys_path_join("%s/%s", globals.path_prefix, USER_ALIAS_PATH);
+	tmp_list = sys_ls(path);
+	for (iters = tmp_list; iters; iters = iters->next) {
+		user_alias_files = list_prepend_data(user_alias_files, str_or_die("%s/%s", path, (char *)iters->data));
+	}
+	user_alias_files = list_sort(user_alias_files, str_cmp_wrapper);
+	list_free_list_and_data(tmp_list, free);
 	FREE(path);
 
 	/* get a combined list with user files overriding system files */

--- a/src/bundle.c
+++ b/src/bundle.c
@@ -238,3 +238,30 @@ void track_bundle(const char *bundle_name)
 {
 	track_bundle_in_statedir(bundle_name, globals.state_dir);
 }
+
+static char *get_bundles_dir(void)
+{
+	return sys_path_join("%s/%s", globals.path_prefix, BUNDLES_DIR);
+}
+
+struct list *bundle_list_tracked(void)
+{
+	struct list *bundles = NULL;
+	char *tracking_dir = get_tracking_dir();
+
+	bundles = sys_ls(tracking_dir);
+	FREE(tracking_dir);
+
+	return bundles;
+}
+
+struct list *bundle_list_installed(void)
+{
+	struct list *bundles = NULL;
+	char *bundles_dir = get_bundles_dir();
+
+	bundles = sys_ls(bundles_dir);
+	FREE(bundles_dir);
+
+	return bundles;
+}

--- a/src/bundle.h
+++ b/src/bundle.h
@@ -62,6 +62,16 @@ void track_bundle_in_statedir(const char *bundle_name, const char *state_dir);
  */
 void track_bundle(const char *bundle_name);
 
+/**
+ * @brief Returns the list of tracked bundles.
+ */
+struct list *bundle_list_tracked(void);
+
+/**
+ * @brief Returns the list of installed bundles.
+ */
+struct list *bundle_list_installed(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/bundle_list.c
+++ b/src/bundle_list.c
@@ -37,10 +37,14 @@ static bool cmdline_local = true;
 static bool cmdline_option_status = false;
 static bool cmdline_option_orphans = false;
 
+void bundle_list_set_option_local(bool opt)
+{
+	cmdline_local = opt;
+}
+
 void bundle_list_set_option_all(bool opt)
 {
 	cmdline_option_all = opt;
-	cmdline_local = !cmdline_option_all;
 }
 
 void bundle_list_set_option_has_dep(char *bundle)
@@ -50,7 +54,6 @@ void bundle_list_set_option_has_dep(char *bundle)
 	}
 	FREE(cmdline_option_has_dep);
 	cmdline_option_has_dep = bundle;
-	cmdline_local = false;
 }
 
 void bundle_list_set_option_deps(char *bundle)
@@ -60,7 +63,6 @@ void bundle_list_set_option_deps(char *bundle)
 	}
 	FREE(cmdline_option_deps);
 	cmdline_option_deps = bundle;
-	cmdline_local = false;
 }
 
 void bundle_list_set_option_status(bool opt)

--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -245,11 +245,7 @@ int rm_rf(const char *file)
 	return run_command_quiet("/bin/rm", "-rf", file, NULL);
 }
 
-/* Get a list of files in a directory sorted by filename
- * with their fullpath, returns NULL on error (errno set by
- * opendir).
- */
-struct list *get_dir_files_sorted(char *path)
+struct list *sys_ls(char *path)
 {
 	DIR *dir = NULL;
 	struct dirent *ent = NULL;
@@ -267,7 +263,7 @@ struct list *get_dir_files_sorted(char *path)
 		if (ent->d_name[0] == '.') {
 			continue;
 		}
-		string_or_die(&name, "%s/%s", path, ent->d_name);
+		string_or_die(&name, "%s", ent->d_name);
 		files = list_prepend_data(files, name);
 	}
 
@@ -277,7 +273,7 @@ struct list *get_dir_files_sorted(char *path)
 	}
 	(void)closedir(dir);
 
-	return list_sort(files, str_cmp_wrapper);
+	return files;
 }
 
 bool sys_file_exists(const char *filename)

--- a/src/lib/sys.h
+++ b/src/lib/sys.h
@@ -89,10 +89,8 @@ int mkdir_p(const char *dir);
  */
 int rm_rf(const char *file);
 
-/**
- * @brief Return a list of all files in a directory, sorted lexicographically
- */
-struct list *get_dir_files_sorted(char *path);
+/* @brief Return a list of files in a directory */
+struct list *sys_ls(char *path);
 
 /**
  * @brief Checks if a file exists in the filesystem.

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -364,10 +364,12 @@ extern regex_t *compile_whitelist(const char *whitelist_pattern);
 
 /* bundle_list.c*/
 extern enum swupd_code list_bundles(void);
+extern void bundle_list_set_option_local(bool opt);
 extern void bundle_list_set_option_all(bool opt);
 extern void bundle_list_set_option_has_dep(char *bundle);
 extern void bundle_list_set_option_deps(char *bundle);
 extern void bundle_list_set_option_status(bool opt);
+extern void bundle_list_set_option_orphans(bool opt);
 
 /* clean.c */
 extern int clean_get_stats(void);

--- a/src/swupd_comp_functions.c
+++ b/src/swupd_comp_functions.c
@@ -45,6 +45,11 @@ int cmp_string_filerecord_filename(const void *a, const void *b)
 	return str_cmp(*(const char **)a, ((struct filerecord *)b)->filename);
 }
 
+int cmp_string_sub_component(const void *a, const void *b)
+{
+	return str_cmp((const char *)a, ((struct sub *)b)->component);
+}
+
 int cmp_file_filename(const void *a, const void *b)
 {
 	return str_cmp(((struct file *)a)->filename, ((struct file *)b)->filename);

--- a/src/swupd_comp_functions.h
+++ b/src/swupd_comp_functions.h
@@ -40,6 +40,9 @@ int cmp_sub_component_string(const void *a, const void *b);
 /** @brief compare a string with filerecord->filename */
 int cmp_string_filerecord_filename(const void *a, const void *b);
 
+/** @brief compare a string with sub->component */
+int cmp_string_sub_component(const void *a, const void *b);
+
 /**
  * @brief compare file->filename with file->filename
  * @returns an inverse result

--- a/swupd.bash
+++ b/swupd.bash
@@ -100,7 +100,7 @@ _swupd() {
     return 1
   fi
 
-	# Ignore SC2207 because that's the standard way to fill COMPREPLY
+  # Ignore SC2207 because that's the standard way to fill COMPREPLY
   # shellcheck disable=SC2207
   COMPREPLY=($(compgen -W "$opts" -- "$cur"));
   # Ignore SC2128 because only when there's one candidate it's completed on `Tab`

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -223,6 +223,7 @@ local -a bundle_list=(
   '(help -a --all -D --has-dep --deps --status)'{-D,--has-dep=}'[List all bundles which have BUNDLE as a dependency]:has-dep: _swupd_installed_bundles -u'
   '(help -a --all -D --has-dep --deps --status)--deps=[List bundles included by BUNDLE]:deps: _swupd_installed_bundles -u'
   '(help -D --has-dep --deps)--status[Show the installation status of the listed bundles]'
+  '(help -a --all -D --has-dep --deps --status --orphans)--orphans[List orphaned bundles]'
 )
 
 local -a bundle_info=(

--- a/test/functional/3rd-party/3rd-party-bundle-list-orphans.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-list-orphans.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME" 10 1
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
+	WEBDIR="$TPWEBDIR"
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
+	create_bundle -L -t -n test-bundle1 -f /file_1 -u repo1 "$TEST_NAME"
+	create_bundle -L -t -n test-bundle2 -f /file_2 -u repo1 "$TEST_NAME"
+	create_bundle -L    -n test-bundle3 -f /file_3 -u repo1 "$TEST_NAME"
+	create_bundle -L -t -n test-bundle4 -f /file_4 -u repo2 "$TEST_NAME"
+	create_bundle       -n test-bundle5 -f /file_5 -u repo2 "$TEST_NAME"
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
+
+}
+
+@test "TPR093: List orphaned 3rd-party bundles" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list $SWUPD_OPTS --orphans"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
+		Loading required manifests...
+		Orphan bundles:
+		 - test-bundle3
+		Total: 1
+		Use "swupd 3rd-party bundle-add BUNDLE" to no longer list BUNDLE and its dependencies as orphaned
+		_____________________________
+		 3rd-Party Repository: repo2
+		_____________________________
+		Loading required manifests...
+		Orphan bundles:
+		Total: 0
+		Use "swupd 3rd-party bundle-add BUNDLE" to no longer list BUNDLE and its dependencies as orphaned
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "TPR094: List orphaned 3rd-party bundles with --repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list $SWUPD_OPTS --orphans --repo repo1"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Loading required manifests...
+		Orphan bundles:
+		 - test-bundle3
+		Total: 1
+		Use "swupd 3rd-party bundle-add BUNDLE" to no longer list BUNDLE and its dependencies as orphaned
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}

--- a/test/functional/api/api-3rd-party-bundle-list.bats
+++ b/test/functional/api/api-3rd-party-bundle-list.bats
@@ -9,13 +9,14 @@ global_setup() {
 
 	create_test_environment "$TEST_NAME" 10 1
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
-	WEBDIR="$TPWEBDIR"
+	REPO1="$TPWEBDIR"
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
 	create_bundle -L -t -n test-bundle1 -f /file_1 -u repo1 "$TEST_NAME"
 	create_bundle -L -t -n test-bundle2 -f /file_2 -u repo1 "$TEST_NAME"
 	create_bundle       -n test-bundle3 -f /file_3 -u repo1 "$TEST_NAME"
 	create_bundle -L -t -n test-bundle4 -f /file_4 -u repo2 "$TEST_NAME"
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
+	create_bundle -L    -n test-bundle5 -f /file_5 -u repo2 "$TEST_NAME"
+	add_dependency_to_manifest "$REPO1"/10/Manifest.test-bundle1 test-bundle2
 
 }
 
@@ -32,6 +33,7 @@ global_setup() {
 		[repo2]
 		os-core
 		test-bundle4
+		test-bundle5
 	EOM
 	)
 	assert_is_output "$expected_output"
@@ -67,6 +69,7 @@ global_setup() {
 		[repo2]
 		os-core
 		test-bundle4
+		test-bundle5
 	EOM
 	)
 	assert_is_output "$expected_output"
@@ -146,4 +149,33 @@ global_setup() {
 	assert_is_output "$expected_output"
 
 }
+
+@test "API078: 3rd-party bundle-list --orphans" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list $SWUPD_OPTS --orphans --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		[repo1]
+		[repo2]
+		test-bundle5
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API079: 3rd-party bundle-list --orphans --repo REPOSITORY" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-list $SWUPD_OPTS --orphans --repo repo2 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		test-bundle5
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
 #WEIGHT=10

--- a/test/functional/api/api-bundle-list.bats
+++ b/test/functional/api/api-bundle-list.bats
@@ -12,6 +12,7 @@ global_setup() {
 	create_bundle -n test-bundle2 -f /file_2 "$TEST_NAME"
 	create_bundle -L -t -n test-bundle3 -f /file_3 "$TEST_NAME"
 	create_bundle -L -e -n test-bundle4 -f /file_4 "$TEST_NAME"
+	create_bundle -L    -n test-bundle5 -f /file_5 "$TEST_NAME"
 	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle3 test-bundle4
 
 }
@@ -25,6 +26,7 @@ global_setup() {
 		os-core
 		test-bundle3
 		test-bundle4: experimental
+		test-bundle5
 	EOM
 	)
 	assert_is_output "$expected_output"
@@ -42,6 +44,7 @@ global_setup() {
 		test-bundle2
 		test-bundle3
 		test-bundle4: experimental
+		test-bundle5
 	EOM
 	)
 	assert_is_output "$expected_output"
@@ -84,6 +87,7 @@ global_setup() {
 		os-core: installed
 		test-bundle3: explicitly installed
 		test-bundle4: installed, experimental
+		test-bundle5: installed
 	EOM
 	)
 	assert_is_output "$expected_output"
@@ -101,6 +105,20 @@ global_setup() {
 		test-bundle2
 		test-bundle3: explicitly installed
 		test-bundle4: installed, experimental
+		test-bundle5: installed
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API077: bundle-list --orphans" {
+
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --orphans --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		test-bundle5
 	EOM
 	)
 	assert_is_output "$expected_output"

--- a/test/functional/bundlelist/list-flags.bats
+++ b/test/functional/bundlelist/list-flags.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+@test "LST029: List conflicting flags" {
+
+	# Some flags are mutually exclusive
+
+	# --orphans & --all
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --orphans --all"
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	assert_in_output "Error: --orphans and --all options are mutually exclusive"
+
+	# --orphans & --has-dep
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --orphans --has-dep os-core"
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	assert_in_output "Error: --orphans and --has-dep options are mutually exclusive"
+
+	# --orphans & --deps
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --orphans --deps 0s-core"
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	assert_in_output "Error: --orphans and --deps options are mutually exclusive"
+
+}

--- a/test/functional/bundlelist/list-orphans.bats
+++ b/test/functional/bundlelist/list-orphans.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+global_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle       -n test-bundle1 -f /file1 "$TEST_NAME"
+	create_bundle -L -t -n test-bundle2 -f /file2 "$TEST_NAME"
+	create_bundle -L -t -n test-bundle3 -f /file3 "$TEST_NAME"
+	create_bundle -L    -n test-bundle4 -f /file4 "$TEST_NAME"
+	create_bundle -L    -n test-bundle5 -f /file5 "$TEST_NAME"
+	create_bundle -L    -n test-bundle6 -f /file6 "$TEST_NAME"
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle3 test-bundle4
+
+}
+
+@test "LST027: List orphaned bundles" {
+
+	# list bundles that are orphans
+
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --orphans"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Loading required manifests...
+		Orphan bundles:
+		 - test-bundle5
+		 - test-bundle6
+		Total: 2
+		Use "swupd bundle-add BUNDLE" to no longer list BUNDLE and its dependencies as orphaned
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "LST028: List orphaned bundles with status" {
+
+	# list bundles that are orphans
+
+	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --orphans --status"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Loading required manifests...
+		Orphan bundles:
+		 - test-bundle5 (installed)
+		 - test-bundle6 (installed)
+		Total: 2
+		Use "swupd bundle-add BUNDLE" to no longer list BUNDLE and its dependencies as orphaned
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}


### PR DESCRIPTION
This commit adds the `--orphans` flag to `bundle-list` and `3rd-party bundle-list`. This flag will list the bundles that are no longer required by any tracked bundles.

Closes #1530 