### PR TITLE
swupd.bash: Multiple improvements

### DIFF
--- a/test/functional/usability/usa-completion-basic.bats
+++ b/test/functional/usability/usa-completion-basic.bats
@@ -16,13 +16,13 @@ load "../testlib"
 
 @test "USA003: Autocomplete has autoupdate" {
 
-	grep -q  '("autoupdate")' "$SWUPD_DIR"/swupd.bash
+	grep -q  '("bundle-add")' "$SWUPD_DIR"/swupd.bash
 
 }
 
-@test "USA004: Autocomplete has expected hashdump opts" {
+@test "USA004: Autocomplete has expected hashdump" {
 
-	grep -q  'opts="--help --no-xattrs --path --debug --quiet "' "$SWUPD_DIR"/swupd.bash
+	grep -q  '("hashdump")' "$SWUPD_DIR"/swupd.bash
 
 }
 #WEIGHT=1


### PR DESCRIPTION
- All options and subcommands are automatically generated from help messages.
- Used `_init_completion` to set $cur, $prev, $words variables, which are
  equivalent to $2, $3, $COMP_WORD, but far more readable.
  - It also allows possibility to use other functions provided in
    `/usr/share/bash-completion/bash_completion`, for future
- A minor change on getting current OS version via `swupd info --quiet` from
  reading `/var/lib/swupd/version`, which is non-readable to non-root users
  - Though MoM file is still non-readable to non-root users
- We only ship modern Bash, so the test on Bash version near the end of the
  script is removed

This also closes #1520 