### PR TITLE
sys: Fixing documentation of ls_sys

### DIFF
--- a/src/lib/sys.h
+++ b/src/lib/sys.h
@@ -94,7 +94,9 @@ int mkdir_p(const char *dir);
  */
 int rm_rf(const char *file);
 
-/* @brief Return a list of files in a directory */
+/**
+ * @brief Return a list of files in a directory
+ */
 struct list *sys_ls(char *path);
 
 /**


### PR DESCRIPTION
To be parsed doc commend should start with **

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>