### PR TITLE
macros: Create wrapper for malloc and calloc functions

### DIFF
--- a/src/3rd_party_repos.c
+++ b/src/3rd_party_repos.c
@@ -73,8 +73,7 @@ static bool parse_key_values(char *section, char *key, char *value, void *data)
 
 	repo = list_search(*repos, section, cmp_repo_name_string);
 	if (!repo) {
-		repo = calloc(1, sizeof(struct repo));
-		ON_NULL_ABORT(repo);
+		repo = malloc_or_die(sizeof(struct repo));
 		repo->name = strdup_or_die(section);
 		*repos = list_append_data(*repos, repo);
 	}

--- a/src/alias.c
+++ b/src/alias.c
@@ -101,8 +101,7 @@ static struct list *parse_alias_file(char *fullpath)
 		*c = 0;
 		c++;
 
-		l = calloc(1, sizeof(struct alias_lookup));
-		ON_NULL_ABORT(l);
+		l = malloc_or_die(sizeof(struct alias_lookup));
 
 		/* get the bundles associated with the alias
 		 * note a file with multiple copies of the same

--- a/src/binary_loader.c
+++ b/src/binary_loader.c
@@ -36,9 +36,7 @@ static char **create_params_list(char *binary_name, int argc, char **argv)
 	char **params;
 	int i;
 
-	params = malloc(sizeof(char *) * (argc + 2));
-	ON_NULL_ABORT(params);
-
+	params = malloc_or_die(sizeof(char *) * (argc + 2));
 	params[0] = binary_name;
 	for (i = 0; i < argc; i++) {
 		params[i + 1] = argv[i];

--- a/src/clean.c
+++ b/src/clean.c
@@ -283,8 +283,7 @@ static char *read_mom_contents(int version)
 		goto end;
 	}
 
-	contents = malloc(stat.st_size + 1);
-	ON_NULL_ABORT(contents);
+	contents = malloc_or_die(stat.st_size + 1);
 
 	ret = fread(contents, stat.st_size, 1, f);
 	if (ret != 1) {

--- a/src/curl_async.c
+++ b/src/curl_async.c
@@ -199,9 +199,7 @@ struct swupd_curl_parallel_handle *swupd_curl_parallel_download_start(size_t max
 		return NULL;
 	}
 
-	h = calloc(1, sizeof(struct swupd_curl_parallel_handle));
-	ON_NULL_ABORT(h);
-
+	h = malloc_or_die(sizeof(struct swupd_curl_parallel_handle));
 	h->mcurl = curl_multi_init();
 	if (h->mcurl == NULL) {
 		goto error;
@@ -558,9 +556,7 @@ int swupd_curl_parallel_download_enqueue(struct swupd_curl_parallel_handle *h, c
 		return -EINVAL;
 	}
 
-	file = calloc(1, sizeof(struct multi_curl_file));
-	ON_NULL_ABORT(file);
-
+	file = malloc_or_die(sizeof(struct multi_curl_file));
 	file->file.path = strdup_or_die(filename);
 	file->url = strdup_or_die(url);
 	file->data = data;
@@ -579,8 +575,7 @@ int swupd_curl_parallel_download_enqueue(struct swupd_curl_parallel_handle *h, c
 
 	unlink(file->file.path);
 
-	progress = calloc(1, sizeof(struct file_progress));
-	ON_NULL_ABORT(progress);
+	progress = malloc_or_die(sizeof(struct file_progress));
 	progress->overall_progress = h->data;
 	file->progress = progress;
 

--- a/src/globals.c
+++ b/src/globals.c
@@ -678,8 +678,7 @@ static bool global_parse_opt(int opt, char *optarg)
 static char *generate_optstring(struct option *opts, int num_opts)
 {
 	int i = 0;
-	char *optstring = malloc(num_opts * 2 + 1); // Space for each opt + ':'
-	ON_NULL_ABORT(optstring);
+	char *optstring = malloc_or_die(num_opts * 2 + 1); // Space for each opt + ':'
 
 	while (opts->name) {
 		if (isalpha(opts->val)) {
@@ -793,8 +792,7 @@ int global_parse_options(int argc, char **argv, const struct global_options *opt
 
 	// If there's extra options
 	num_global_opts = (sizeof(global_opts) / sizeof(struct option));
-	opts_array = malloc(sizeof(struct option) * (opts->longopts_len + num_global_opts));
-	ON_NULL_ABORT(opts_array);
+	opts_array = malloc_or_die(sizeof(struct option) * (opts->longopts_len + num_global_opts));
 
 	// Copy local and global options to opts
 	memcpy(opts_array, opts->longopts,

--- a/src/hash.c
+++ b/src/hash.c
@@ -86,8 +86,7 @@ static void hmac_sha256_for_data(char *hash,
 	}
 
 	digest_str_len = MAX((digest_len * 2) + 1, SWUPD_HASH_LEN);
-	digest_str = calloc(digest_str_len, sizeof(char));
-	ON_NULL_ABORT(digest_str);
+	digest_str = malloc_or_die(digest_str_len * sizeof(char));
 
 	for (i = 0; i < digest_len; i++) {
 		snprintf(&digest_str[i * 2], digest_str_len, "%02x", (unsigned int)digest[i]);

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -862,8 +862,7 @@ void print_regexp_error(int errcode, regex_t *regexp)
 	char *error_buffer = NULL;
 
 	len = regerror(errcode, regexp, NULL, 0);
-	error_buffer = malloc(len);
-	ON_NULL_ABORT(error_buffer);
+	error_buffer = malloc_or_die(len);
 
 	regerror(errcode, regexp, error_buffer, len);
 	error("Invalid regular expression: %s\n", error_buffer)
@@ -956,9 +955,7 @@ static void print_char(const char c, int times)
 {
 	char *str;
 
-	str = calloc(1, times + 1);
-	ON_NULL_ABORT(str);
-
+	str = malloc_or_die(times + 1);
 	memset(str, c, times);
 	info("%s\n", str);
 	FREE(str);

--- a/src/lib/hashmap.c
+++ b/src/lib/hashmap.c
@@ -72,9 +72,7 @@ struct hashmap *hashmap_new(size_t capacity, hash_equal_fn_t equal, hash_fn_t ha
 	unsigned int mask_bits = calc_bits(capacity);
 	size_t real_capacity = HASH_SIZE(mask_bits);
 
-	hashmap = calloc(1, sizeof(struct hashmap) + real_capacity * sizeof(struct list *));
-	ON_NULL_ABORT(hashmap);
-
+	hashmap = malloc_or_die(sizeof(struct hashmap) + real_capacity * sizeof(struct list *));
 	hashmap->mask_bits = mask_bits;
 	hashmap->hash = hash;
 	hashmap->equal = equal;

--- a/src/lib/list.c
+++ b/src/lib/list.c
@@ -56,8 +56,7 @@ static struct list *list_alloc_item(void *data)
 {
 	struct list *item;
 
-	item = (struct list *)malloc(sizeof(struct list));
-	ON_NULL_ABORT(item);
+	item = malloc_or_die(sizeof(struct list));
 
 	item->data = data;
 	item->next = NULL;

--- a/src/lib/macros.h
+++ b/src/lib/macros.h
@@ -1,6 +1,8 @@
 #ifndef __INCLUDE_GUARD_MACROS_H
 #define __INCLUDE_GUARD_MACROS_H
 
+#include <stdio.h>
+#include <stdlib.h>
 /**
  * @file
  * @brief General use macros
@@ -45,5 +47,20 @@
 		free(_ptr);  \
 		_ptr = NULL; \
 	} while (0)
+
+/**
+ * @brief allocate memory of indicated size and zero it.
+ *
+ * Abort on out of memory errors.
+ */
+static inline void *malloc_or_die(size_t size)
+{
+	void *ptr;
+
+	ptr = calloc(1, (size_t)size);
+	ON_NULL_ABORT(ptr);
+
+	return ptr;
+}
 
 #endif

--- a/src/lib/strings.c
+++ b/src/lib/strings.c
@@ -92,8 +92,7 @@ char *str_join(const char *separator, struct list *strings)
 		str_size += sep_size;
 	}
 
-	ret = str = malloc(str_size);
-	ON_NULL_ABORT(str);
+	ret = str = malloc_or_die(str_size);
 	str[0] = '\0';
 
 	for (i = strings; i; i = i->next) {
@@ -168,9 +167,7 @@ int str_to_int(const char *str, int *value)
 
 char *str_to_lower(const char *str)
 {
-	char *str_lower = malloc(str_len(str) + 1);
-
-	ON_NULL_ABORT(str_lower);
+	char *str_lower = malloc_or_die(str_len(str) + 1);
 
 	for (int i = 0; str[i]; i++) {
 		str_lower[i] = tolower(str[i]);

--- a/src/lib/sys.c
+++ b/src/lib/sys.c
@@ -195,9 +195,7 @@ int run_command_full(const char *stdout_file, const char *stderr_file, const cha
 
 	// Create params array with space for all parameters,
 	// command basename and NULL terminator
-	params = malloc(sizeof(char *) * (args_count + 2));
-	ON_NULL_ABORT(params);
-
+	params = malloc_or_die(sizeof(char *) * (args_count + 2));
 	params[i++] = (char *)cmd;
 
 	va_start(ap, cmd);
@@ -441,8 +439,7 @@ char *sys_path_join(const char *fmt, ...)
 	va_end(ap);
 
 	len = str_len(path);
-	char *pretty_path = malloc(str_len(path) + 1);
-	ON_NULL_ABORT(pretty_path);
+	char *pretty_path = malloc_or_die(str_len(path) + 1);
 
 	/* remove all duplicated PATH_SEPARATOR from the path */
 	for (i = j = 0; i < len; i++) {

--- a/src/lib/thread_pool.c
+++ b/src/lib/thread_pool.c
@@ -89,8 +89,7 @@ struct tp *tp_start(int num_threads)
 		return NULL;
 	}
 
-	tp = calloc(1, sizeof(struct tp) + num_threads * sizeof(pthread_t *));
-	ON_NULL_ABORT(tp);
+	tp = malloc_or_die(sizeof(struct tp) + num_threads * sizeof(pthread_t *));
 
 	tp->num_threads = num_threads;
 	if (num_threads == 0) {

--- a/src/lib/timelist.c
+++ b/src/lib/timelist.c
@@ -40,8 +40,7 @@ struct time {
 
 timelist *timelist_new(void)
 {
-	timelist *head = malloc(sizeof(timelist));
-	ON_NULL_ABORT(head);
+	timelist *head = malloc_or_die(sizeof(timelist));
 	TAILQ_INIT(head);
 
 	timelist_timer_start(head, "Total execution time");
@@ -51,10 +50,7 @@ timelist *timelist_new(void)
 
 static struct time *alloc_time()
 {
-	struct time *t = calloc(1, sizeof(struct time));
-	ON_NULL_ABORT(t);
-
-	return t;
+	return malloc_or_die(sizeof(struct time));
 }
 
 static bool timer_stop(struct time *t)

--- a/src/manifest.c
+++ b/src/manifest.c
@@ -967,9 +967,7 @@ struct file **manifest_files_to_array(struct manifest *manifest)
 
 	numfiles = manifest->filecount;
 
-	array = malloc(sizeof(struct file *) * numfiles);
-	ON_NULL_ABORT(array);
-
+	array = malloc_or_die(sizeof(struct file *) * numfiles);
 	iter = list_head(manifest->files);
 	while (iter) {
 		file = iter->data;

--- a/src/manifest_parser.c
+++ b/src/manifest_parser.c
@@ -44,8 +44,7 @@ struct manifest *manifest_parse(const char *component, const char *filename, boo
 		return NULL;
 	}
 
-	manifest = calloc(1, sizeof(struct manifest));
-	ON_NULL_ABORT(manifest);
+	manifest = malloc_or_die(sizeof(struct manifest));
 
 	/* line 1: MANIFEST\t<version> */
 	line[0] = 0;
@@ -171,8 +170,7 @@ struct manifest *manifest_parse(const char *component, const char *filename, boo
 			goto err_close;
 		}
 
-		file = calloc(1, sizeof(struct file));
-		ON_NULL_ABORT(file);
+		file = malloc_or_die(sizeof(struct file));
 
 		if (line[0] == 'F') {
 			file->is_file = 1;

--- a/src/packs.c
+++ b/src/packs.c
@@ -130,8 +130,7 @@ static int download_pack(struct swupd_curl_parallel_handle *download_handle, int
 
 	string_or_die(&url, "%s/%i/pack-%s-from-%i.tar", globals.content_url, newversion, module, oldversion);
 
-	pack_data = calloc(1, sizeof(struct pack_data));
-	ON_NULL_ABORT(pack_data);
+	pack_data = malloc_or_die(sizeof(struct pack_data));
 
 	pack_data->url = url;
 	pack_data->filename = filename;
@@ -335,8 +334,7 @@ int download_zero_packs(struct list *bundles, struct manifest *mom)
 		struct manifest *m = iter->data;
 		struct sub *sub;
 
-		sub = calloc(1, sizeof(struct sub));
-		ON_NULL_ABORT(sub);
+		sub = malloc_or_die(sizeof(struct sub));
 		sub->component = m->component;
 		sub->version = m->version;
 

--- a/src/search_file.c
+++ b/src/search_file.c
@@ -157,8 +157,7 @@ static long get_bundle_size(const char *bundle)
 		return b->size;
 	}
 
-	b = calloc(1, sizeof(struct bundle_size));
-	ON_NULL_ABORT(b);
+	b = malloc_or_die(sizeof(struct bundle_size));
 	b->bundle_name = bundle;
 	b->size = compute_bundle_size(bundle);
 	bundle_size_cache = list_prepend_data(bundle_size_cache, b);

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -167,11 +167,9 @@ static void create_new_subscription(struct list **subs, const char *component, b
 {
 	struct sub *sub;
 
-	sub = calloc(1, sizeof(struct sub));
-	ON_NULL_ABORT(sub);
+	sub = malloc_or_die(sizeof(struct sub));
 
 	sub->component = strdup_or_die(component);
-
 	sub->version = 0;
 	sub->oldversion = 0;
 	sub->is_optional = is_optional;

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -76,7 +76,7 @@ struct sub {
 	 *   -1       -> error, local bundle do not match any bundle on MoM */
 	int version;
 
-	/* oldversion: set to 0 by calloc(), possibly overridden by MoM read */
+	/* oldversion: set to 0 by calloc, possibly overridden by MoM read */
 	int oldversion;
 
 	/* is_optional: true if the subscription referred to by this struct is optional,

--- a/src/verifytime.c
+++ b/src/verifytime.c
@@ -52,7 +52,7 @@ static char *sys_path_join(const char *fmt, ...)
 	va_end(ap);
 
 	len = str_len(path);
-	char *pretty_path = malloc(str_len(path) + 1);
+	char *pretty_path = calloc(1, str_len(path) + 1);
 	if (!pretty_path) {
 		abort();
 	}

--- a/src/version.c
+++ b/src/version.c
@@ -104,8 +104,7 @@ static int get_sig_inmemory(char *url, struct curl_file_data *tmp_version_sig)
 
 	tmp_version_sig->capacity = ret;
 
-	tmp_version_sig->data = (char *)malloc(ret * sizeof(char));
-	ON_NULL_ABORT(tmp_version_sig->data);
+	tmp_version_sig->data = malloc_or_die(ret * sizeof(char));
 
 	ret = swupd_curl_get_file_memory(sig_fname, tmp_version_sig);
 	if (ret != 0) {

--- a/src/xattrs.c
+++ b/src/xattrs.c
@@ -113,8 +113,7 @@ static const char **get_sorted_xattr_name_table(const char *names, int n)
 	const char **table;
 	int i;
 
-	table = calloc(1, n * sizeof(char *));
-	ON_NULL_ABORT(table);
+	table = malloc_or_die(n * sizeof(char *));
 
 	for (i = 0; i < n; i++) {
 		table[i] = names;
@@ -157,8 +156,7 @@ static void xattrs_do_action(xattrs_action_type_t action,
 		return; // no xattrs, this is OK
 	}
 
-	list = calloc(1, len);
-	ON_NULL_ABORT(list);
+	list = malloc_or_die(len);
 
 	len = llistxattr(src_filename, list, len);
 	if (len <= 0) {
@@ -174,8 +172,7 @@ static void xattrs_do_action(xattrs_action_type_t action,
 	sorted_list = get_sorted_xattr_name_table(list, count);
 
 	if (action == XATTRS_ACTION_GET_BLOB) {
-		value = calloc(1, len);
-		ON_NULL_ABORT(value);
+		value = malloc_or_die(len);
 
 		value_len = len;
 

--- a/test/code_analysis/warning_functions.bats
+++ b/test/code_analysis/warning_functions.bats
@@ -7,13 +7,14 @@
 	# There are some C functions that are tricky to use and it's prefered to
 	# avoid using them in swupd. If any function in this list is really needed
 	# we need to review the usage and add an exception here.
-	local functions="strcpy wcscpy strcat wcscat sprintf vsprintf strtok ato strlen strcmp wcslen alloca vscanf vsscanf vfscanf scanf sscanf fscanf strncat strsep toa memmove asctime getwd gets basename dirname free system"
+	local functions="strcpy wcscpy strcat wcscat sprintf vsprintf strtok ato strlen strcmp wcslen alloca vscanf vsscanf vfscanf scanf sscanf fscanf strncat strsep toa memmove asctime getwd gets basename dirname free system malloc calloc"
 
 	local exceptions
 	declare -A exceptions
 	exceptions["basename"]="sys.*"
 	exceptions["dirname"]="sys.*"
 	exceptions["free"]="macros.h,verifytime.c,verifytime_main.c"
+	exceptions["calloc"]="macros.h,verifytime.c"
 
 	local error=0
 	for func in $functions; do


### PR DESCRIPTION
Use always calloc to allocate memory and abort on errors

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>