### PR TITLE
Add command to remove orphan bundles

### DIFF
--- a/config
+++ b/config
@@ -182,6 +182,9 @@
 # Removes a bundle and its dependencies recursively (boolean value)
 #recursive=<true/false>
 
+# Removes all orphaned bundles
+#orphans=<true/false>
+
 
 [bundle-list]
 

--- a/docs/swupd.1.rst
+++ b/docs/swupd.1.rst
@@ -245,6 +245,12 @@ bundle-remove <bundles>
         ``Warning``: This operation is dangerous and must be used with care since
         it can remove many unexpected bundles.
 
+--orphans       Removes all orphaned bundles. Orphan bundles are those that are no
+        longer required by any of the tracked bundles.
+
+        ``Warning``: This operation is dangerous and must be used with care since
+        it can remove many unexpected bundles.
+
 bundle-list
 -----------
 

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -325,6 +325,7 @@ extern enum swupd_code execute_remove_bundles(struct list *bundles);
 extern enum swupd_code execute_remove_bundles_extra(struct list *bundles, remove_extra_proc_fn_t post_remove_fn);
 extern void bundle_remove_set_option_force(bool opt);
 extern void bundle_remove_set_option_recursive(bool opt);
+extern void bundle_remove_set_option_orphans(bool opt);
 
 /* bundle_info.c */
 extern enum swupd_code bundle_info(char *bundle);

--- a/src/swupd_lib/bundle.h
+++ b/src/swupd_lib/bundle.h
@@ -72,6 +72,15 @@ struct list *bundle_list_tracked(void);
  */
 struct list *bundle_list_installed(void);
 
+/**
+ * @brief Creates a list of orphaned bundles.
+ * @param mom The MoM manifest
+ * @bundles A list struct where the orphaned bundles will be added
+ *
+ * @return SWUPD_Ok if the list was created successfully, and an error code otherwise
+ */
+enum swupd_code bundle_list_orphans(struct manifest *mom, struct list **bundles);
+
 #ifdef __cplusplus
 }
 #endif

--- a/swupd.zsh
+++ b/swupd.zsh
@@ -212,6 +212,7 @@ local -a bundle_add=(
 local -a bundle_remove=(
   '(help -x --force)'{-x,--force}'[Removes a bundle along with all the bundles that depend on it]'
   '(help -R --recursive)'{-R,--recursive}'[Removes a bundle and its dependencies recursively]'
+  '(help --orphans)--orphans[Removes all orphaned bundles]'
   '*:bundle-remove: _swupd_installed_bundles'
 )
 local -a bundle_remove_thirdparty=(

--- a/test/functional/3rd-party/3rd-party-bundle-remove-orphans.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-orphans.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME" 10 1
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
+	WEBDIR="$TPWEBDIR"
+	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
+	create_bundle -L -t -n test-bundle1 -f /file_1 -u repo1 "$TEST_NAME"
+	create_bundle -L    -n test-bundle2 -f /file_2 -u repo1 "$TEST_NAME"
+	create_bundle -L    -n test-bundle3 -f /file_3 -u repo1 "$TEST_NAME"
+	create_bundle -L    -n test-bundle4 -f /file_4 -u repo1 "$TEST_NAME"
+	create_bundle -L    -n test-bundle5 -f /file_5 -u repo2 "$TEST_NAME"
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle3 test-bundle4
+
+}
+
+@test "TPR095: Remove orphaned bundles from 3rd-party repositories" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS --orphans"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		_____________________________
+		 3rd-Party Repository: repo1
+		_____________________________
+		The following bundles are being removed:
+		 - test-bundle4
+		 - test-bundle3
+		Deleting bundle files...
+		Total deleted files: 4
+		Removing 3rd-party bundle binaries...
+		Successfully removed 2 bundles
+		_____________________________
+		 3rd-Party Repository: repo2
+		_____________________________
+		Removing 3rd-party bundle binaries...
+		No orphaned bundles found, nothing was removed
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "TPR096: Remove orphaned bundles from 3rd-party repositories using --repo" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS --orphans --repo repo1"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		The following bundles are being removed:
+		 - test-bundle4
+		 - test-bundle3
+		Deleting bundle files...
+		Total deleted files: 4
+		Removing 3rd-party bundle binaries...
+		Successfully removed 2 bundles
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "TPR097: Try removing orphaned bundles using invalid options" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS --orphans --force"
+
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	expected_output=$(cat <<-EOM
+		Error: --orphans and --force options are mutually exclusive
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS --orphans --recursive"
+
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	expected_output=$(cat <<-EOM
+		Error: --orphans and --recursive options are mutually exclusive
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS --orphans test-bundle1"
+
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	expected_output=$(cat <<-EOM
+		Error: you cannot specify bundles to remove when using --orphans
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+}

--- a/test/functional/api/api-3rd-party-bundle-remove.bats
+++ b/test/functional/api/api-3rd-party-bundle-remove.bats
@@ -11,6 +11,7 @@ test_setup() {
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
 	create_bundle -L -t -n test-bundle1 -f /file_1 -u repo1 "$TEST_NAME"
+	create_bundle -L    -n test-bundle2 -f /file_2 -u repo1 "$TEST_NAME"
 
 }
 
@@ -31,4 +32,28 @@ test_setup() {
 	assert_output_is_empty
 
 }
+
+@test "API081: 3rd-party bundle-remove --orphans" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS --orphans --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		[repo1]
+		[repo2]
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "API082: 3rd-party bundle-remove --orphans --repo REPOSITORY" {
+
+	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS --orphans --repo repo1 --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	assert_output_is_empty
+
+}
+
 #WEIGHT=10

--- a/test/functional/api/api-bundle-remove.bats
+++ b/test/functional/api/api-bundle-remove.bats
@@ -9,6 +9,7 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -t -n test-bundle1 -f /file_1 "$TEST_NAME"
+	create_bundle -L    -n test-bundle2 -f /file_2 "$TEST_NAME"
 
 }
 
@@ -20,4 +21,14 @@ test_setup() {
 	assert_output_is_empty
 
 }
+
+@test "API080: bundle-remove --orphans" {
+
+	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS --orphans --quiet"
+
+	assert_status_is "$SWUPD_OK"
+	assert_output_is_empty
+
+}
+
 #WEIGHT=2

--- a/test/functional/bundleremove/remove-flags.bats
+++ b/test/functional/bundleremove/remove-flags.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+@test "REM032: Bundle remove conflicting flags" {
+
+	# some flags are mutually exclusive
+
+	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS --orphans --force"
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	assert_in_output "Error: --orphans and --force options are mutually exclusive"
+
+	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS --orphans --recursive"
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	assert_in_output "Error: --orphans and --recursive options are mutually exclusive"
+
+}

--- a/test/functional/bundleremove/remove-orphans.bats
+++ b/test/functional/bundleremove/remove-orphans.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+	create_bundle -L -t -n test-bundle1 -f /file1 "$TEST_NAME"
+	create_bundle -L    -n test-bundle2 -f /file2 "$TEST_NAME"
+	create_bundle -L    -n test-bundle3 -f /file3 "$TEST_NAME"
+	create_bundle -L    -n test-bundle4 -f /file4 "$TEST_NAME"
+	create_bundle -L    -n test-bundle5 -f /file5 "$TEST_NAME"
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle4 test-bundle5
+
+}
+
+@test "REM030: Remove orphan bundles" {
+
+	# User can remove all bundles that are no longer required by
+	# tracked bundles
+
+	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS --orphans"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		The following bundles are being removed:
+		 - test-bundle5
+		 - test-bundle4
+		 - test-bundle3
+		Deleting bundle files...
+		Total deleted files: 6
+		Successfully removed 3 bundles
+	EOM
+	)
+	assert_is_output "$expected_output"
+
+}
+
+@test "REM031: Try removing orphan bundles along with other bundles" {
+
+	# User cannot provide other bundles to be removed when using the
+	# --orphans flag since this could potentially change the list of
+	# orphans
+
+	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle1 --orphans"
+
+	assert_status_is "$SWUPD_INVALID_OPTION"
+	expected_output=$(cat <<-EOM
+		Error: you cannot specify bundles to remove when using --orphans
+	EOM
+	)
+	assert_in_output "$expected_output"
+
+}


### PR DESCRIPTION
Dependencies of orphaned bundles can cause bloat and unexpected content to be on disk.
We need to remove all bundles that are not tracked or dependency of a tracked bundle.
This option should also be available for 3rd-party.

Closes #1529 