### PR TITLE
verifytime: Missed a return on ENOENT error

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -483,6 +483,7 @@ static bool adjust_system_time()
 
 	if (err == -ENOENT) {
 		error("Failed to read system timestamp file\n");
+		return false;
 	}
 
 	system_time_str = time_to_string(system_time);

--- a/src/verifytime_main.c
+++ b/src/verifytime_main.c
@@ -36,6 +36,7 @@ int main()
 
 	if (err == -ENOENT) {
 		fprintf(stderr, "Failed to read system timestamp file\n");
+		return 1; // Error
 	}
 
 	system_time_str = time_to_string(system_time);


### PR DESCRIPTION
If the file doesn't exist in system, we can't proceed.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>