### PR TITLE
Makefile: Adding -Wshadow to prevent accident shadowing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,7 @@ AM_CFLAGS = -fPIE -fPIC -g -fno-common -std=gnu99 \
 	-Wunreachable-code \
 	-Wswitch-default \
 	-Wcast-align \
+	-Wshadow \
 	-Wbad-function-cast \
 	-Winline \
 	-Wundef \

--- a/src/bundle_info.c
+++ b/src/bundle_info.c
@@ -30,7 +30,7 @@
 static bool cmdline_option_dependencies = false;
 static bool cmdline_option_files = false;
 static int cmdline_option_version = 0;
-static char *bundle;
+static char *param_bundle;
 
 void bundle_info_set_option_version(int opt)
 {
@@ -121,7 +121,7 @@ static bool parse_options(int argc, char **argv)
 		return false;
 	}
 
-	bundle = *(argv + optind);
+	param_bundle = *(argv + optind);
 
 	return true;
 }
@@ -489,7 +489,7 @@ enum swupd_code bundle_info_main(int argc, char **argv)
 
 	progress_init_steps("bundle-info", steps_in_bundleinfo);
 
-	ret = bundle_info(bundle);
+	ret = bundle_info(param_bundle);
 
 	swupd_deinit();
 	progress_finish_steps(ret);

--- a/src/bundle_remove.c
+++ b/src/bundle_remove.c
@@ -35,7 +35,7 @@
 
 #define VERIFY_PICKY 1
 
-static char **bundles;
+static char **param_bundles;
 static bool cmdline_option_force = false;
 static bool cmdline_option_recursive = false;
 
@@ -103,7 +103,7 @@ static bool parse_options(int argc, char **argv)
 		return false;
 	}
 
-	bundles = argv + ind;
+	param_bundles = argv + ind;
 
 	return true;
 }
@@ -485,8 +485,8 @@ enum swupd_code bundle_remove_main(int argc, char **argv)
 
 	/* move the bundles provided in the command line into a
 	 * list so it is easier to handle them */
-	for (; *bundles; ++bundles) {
-		char *bundle = *bundles;
+	for (; *param_bundles; ++param_bundles) {
+		char *bundle = *param_bundles;
 		bundles_list = list_append_data(bundles_list, bundle);
 	}
 	bundles_list = list_head(bundles_list);

--- a/src/curl_async.c
+++ b/src/curl_async.c
@@ -617,7 +617,7 @@ int swupd_curl_parallel_download_end(struct swupd_curl_parallel_handle *h, int *
 
 		//Retry failed downloads
 		for (l = h->failed; l;) {
-			struct multi_curl_file *file = l->data;
+			file = l->data;
 
 			if (file->retries < globals.max_retries &&
 			    file->status != DOWNLOAD_STATUS_WRITE_ERROR) {

--- a/src/progress.c
+++ b/src/progress.c
@@ -30,7 +30,7 @@
 #define PERCENTAGE_OFF -2
 #define PERCENTAGE_ON -3
 
-static void default_progress_function(const char *step_description, int current_step, int total_steps, int percentage);
+static void default_progress_function(const char *step_description, int local_current_step, int local_total_steps, int percentage);
 
 static const char *title = NULL;
 static int total_steps = 0;
@@ -93,7 +93,7 @@ static void progress_spinner_start(void)
 	swupd_curl_download_set_progress_callback(progress_spinner_callback, &spinner_data);
 }
 
-static void default_progress_function(const char UNUSED_PARAM *step_description, int UNUSED_PARAM current_step, int UNUSED_PARAM total_steps, int percentage)
+static void default_progress_function(const char UNUSED_PARAM *step_description, int UNUSED_PARAM local_current_step, int UNUSED_PARAM local_total_steps, int percentage)
 {
 	if (percentage != PERCENTAGE_UNDEFINED &&
 	    (percentage < 0 || percentage > 100)) {

--- a/src/signature.c
+++ b/src/signature.c
@@ -50,12 +50,12 @@ static X509 *get_cert_from_path(const char *certificate_path);
 static X509_STORE *store = NULL;
 static STACK_OF(X509) *x509_stack = NULL;
 
-static int verify_callback_ignore_expiration(int ok, X509_STORE_CTX *store)
+static int verify_callback_ignore_expiration(int ok, X509_STORE_CTX *local_store)
 {
 	int error;
 
 	if (!ok) {
-		error = X509_STORE_CTX_get_error(store);
+		error = X509_STORE_CTX_get_error(local_store);
 		debug("Certificate verification error - %s\n",
 		      X509_verify_cert_error_string(error));
 		if (error == X509_V_ERR_CERT_HAS_EXPIRED) {
@@ -67,12 +67,12 @@ static int verify_callback_ignore_expiration(int ok, X509_STORE_CTX *store)
 	return ok;
 }
 
-static int verify_callback(int ok, X509_STORE_CTX *store)
+static int verify_callback(int ok, X509_STORE_CTX *local_store)
 {
 	int error;
 
 	if (!ok) {
-		error = X509_STORE_CTX_get_error(store);
+		error = X509_STORE_CTX_get_error(local_store);
 		debug("Certificate verification error - %s\n",
 		      X509_verify_cert_error_string(error));
 	}

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -30,8 +30,6 @@
 
 #include "swupd.h"
 
-struct list *subs;
-
 static void free_subscription_data(void *data)
 {
 	struct sub *sub = (struct sub *)data;

--- a/src/update.c
+++ b/src/update.c
@@ -141,7 +141,7 @@ int add_included_manifests(struct manifest *mom, struct list **subs)
 	return 0;
 }
 
-static enum swupd_code check_versions(int *current_version, int *server_version, int requested_version, char *path_prefix)
+static enum swupd_code check_versions(int *current_version, int *server_version, int req_version, char *path_prefix)
 {
 	int ret;
 
@@ -153,14 +153,14 @@ static enum swupd_code check_versions(int *current_version, int *server_version,
 		error("Update from version 0 not supported yet\n");
 		return SWUPD_INVALID_OPTION;
 	}
-	if (requested_version != -1) {
-		if (requested_version < *current_version) {
+	if (req_version != -1) {
+		if (req_version < *current_version) {
 			error("Requested version for update (%d) must be greater than current version (%d)\n",
-			      requested_version, *current_version);
+			      req_version, *current_version);
 			return SWUPD_INVALID_OPTION;
 		}
-		if (requested_version < *server_version) {
-			*server_version = requested_version;
+		if (req_version < *server_version) {
+			*server_version = req_version;
 		}
 	}
 


### PR DESCRIPTION
Make sure we are not accidently using the incorrect variable
by not allowing 2 variables with the same name.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>