### PR TITLE
Creating new module statedir, to group all functions related to handling of statedir (part 1)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -128,6 +128,8 @@ swupd_SOURCES = \
 	src/swupd_lib/search_file.c \
 	src/swupd_lib/signature.c \
 	src/swupd_lib/signature.h \
+	src/swupd_lib/statedir.c \
+	src/swupd_lib/statedir.h \
 	src/swupd_lib/stats.c \
 	src/swupd_lib/subscriptions.c \
 	src/swupd_lib/swupd_comp_functions.c \

--- a/src/3rd_party/3rd_party_bundle_add.c
+++ b/src/3rd_party/3rd_party_bundle_add.c
@@ -130,7 +130,7 @@ static enum swupd_code validate_permissions(struct file *file)
 		return ret_code;
 	}
 
-	string_or_die(&staged_file, "%s/staged/%s", globals.state_dir, file->hash);
+	staged_file = statedir_get_staged_file(file->hash);
 	if (lstat(staged_file, &file_stats) == 0) {
 		if ((file_stats.st_mode & S_ISUID) || (file_stats.st_mode & S_ISGID) || (file_stats.st_mode & S_ISVTX)) {
 			warn("File %s has dangerous permissions\n", file->filename);

--- a/src/3rd_party/3rd_party_repos.c
+++ b/src/3rd_party/3rd_party_repos.c
@@ -309,7 +309,7 @@ enum swupd_code third_party_set_repo(struct repo *repo, bool sigcheck)
 	/* make sure there are state directories for the 3rd-party
 	 * repo if not there already */
 	repo_state_dir = get_repo_state_dir(repo->name);
-	if (create_state_dirs(repo_state_dir)) {
+	if (statedir_create_dirs(repo_state_dir)) {
 		FREE(repo_state_dir);
 		error("Unable to create the state directories for repository %s\n\n", repo->name);
 		return SWUPD_COULDNT_CREATE_DIR;

--- a/src/3rd_party/3rd_party_update.c
+++ b/src/3rd_party/3rd_party_update.c
@@ -137,7 +137,7 @@ static enum swupd_code validate_permissions(struct file *file)
 		return ret_code;
 	}
 
-	string_or_die(&staged_file, "%s/staged/%s", globals.state_dir, file->hash);
+	staged_file = statedir_get_staged_file(file->hash);
 	if (lstat(staged_file, &file_stats) == 0) {
 		/* see if the file being updated has dangerous flags */
 		if ((file_stats.st_mode & S_ISUID) || (file_stats.st_mode & S_ISGID) || (file_stats.st_mode & S_ISVTX)) {

--- a/src/cmds/bundle_remove.c
+++ b/src/cmds/bundle_remove.c
@@ -165,9 +165,7 @@ static bool is_deletable_dependency(const void *dependency)
  */
 static void remove_tracked(const char *bundle)
 {
-	char *destdir = get_tracking_dir();
-	char *tracking_file = sys_path_join("%s/%s", destdir, bundle);
-	FREE(destdir);
+	char *tracking_file = statedir_get_tracking_file(bundle);
 	/* we don't care about failures here since any weird state in the tracking
 	 * dir MUST be handled gracefully */
 	sys_rm(tracking_file);

--- a/src/cmds/clean.c
+++ b/src/cmds/clean.c
@@ -441,7 +441,7 @@ enum swupd_code clean_statedir(bool dry_run, bool all)
 		}
 	}
 
-	staged_dir = sys_path_join("%s/%s", globals.state_dir, "staged");
+	staged_dir = statedir_get_staged_dir();
 	ret = remove_if(staged_dir, dry_run, is_fullfile);
 	FREE(staged_dir);
 	if (ret != SWUPD_OK) {

--- a/src/cmds/os_install.c
+++ b/src/cmds/os_install.c
@@ -166,7 +166,7 @@ enum swupd_code install_main(int argc, char **argv)
 
 	/* Initialize the default state dir of the system to be installed */
 	char *new_os_state = sys_path_join("%s/%s", globals.path_prefix, "/var/lib/swupd");
-	if (create_state_dirs(new_os_state)) {
+	if (statedir_create_dirs(new_os_state)) {
 		ret = SWUPD_COULDNT_CREATE_DIR;
 		FREE(new_os_state);
 		return ret;

--- a/src/cmds/verify.c
+++ b/src/cmds/verify.c
@@ -306,7 +306,7 @@ static int get_required_files(struct manifest *official_manifest, struct list *r
  * If a low-space warning has been printed, don't check again,
  * but just warn the user and return.
 */
-static void check_warn_freespace(const struct file *file)
+static void check_warn_freespace(struct file *file)
 {
 	long fs_free;
 	char *original = NULL;
@@ -324,7 +324,7 @@ static void check_warn_freespace(const struct file *file)
 		goto out;
 	}
 
-	string_or_die(&original, "%s/staged/%s", globals.state_dir, file->hash);
+	original = statedir_get_staged_file(file->hash);
 	fs_free = get_available_space(globals.path_prefix);
 	if (fs_free < 0 || stat(original, &st) != 0) {
 		warn("Unable to determine free space on filesystem\n");

--- a/src/cmds/verify.c
+++ b/src/cmds/verify.c
@@ -1278,7 +1278,14 @@ brick_the_system_and_clean_curl:
 			/* make sure the bundle was in fact valid and will
 			 * be installed before creating the tracking file */
 			if (list_search(bundles_subs, bundle, cmp_sub_component_string)) {
-				track_bundle_in_statedir(bundle, new_os_statedir);
+				char *tracking_file = sys_path_join("%s/bundles/%s", new_os_statedir, bundle);
+				int fd = open(tracking_file, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+				if (fd) {
+					close(fd);
+				} else {
+					debug("The tracking file %s failed to be created\n", tracking_file);
+				}
+				FREE(tracking_file);
 			}
 		}
 		FREE(new_os_statedir);

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -301,9 +301,11 @@ extern bool is_url_insecure(const char *url);
 extern void remove_trailing_slash(char *url);
 extern void print_header(const char *header);
 extern void prettify_size(long size_in_bytes, char **pretty_size);
-extern int create_state_dirs(const char *state_dir_path);
 extern bool confirm_action(void);
 extern bool is_binary(const char *filename);
+extern int ensure_root_owned_dir(const char *dirname);
+extern void unlink_all_staged_content(struct file *file);
+extern bool safeguard_tracking_dir(const char *state_dir);
 
 /* subscription.c */
 typedef bool (*subs_fn_t)(struct list **subs, const char *component, int recursion, bool is_optional);
@@ -391,8 +393,6 @@ extern int handle_mirror_if_stale(void);
 extern enum swupd_code clean_statedir(bool all, bool dry_run);
 
 extern void warn_nosigcheck(const char *file);
-
-extern void unlink_all_staged_content(struct file *file);
 
 /* Parameter parsing in global.c */
 extern struct global_const global;

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -27,6 +27,7 @@
 #include "swupd_lib/manifest.h"
 #include "swupd_lib/progress.h"
 #include "swupd_lib/scripts.h"
+#include "swupd_lib/statedir.h"
 #include "swupd_lib/swupd_comp_functions.h"
 #include "swupd_lib/swupd_curl.h"
 #include "swupd_lib/swupd_progress.h"
@@ -308,7 +309,6 @@ extern bool is_binary(const char *filename);
 typedef bool (*subs_fn_t)(struct list **subs, const char *component, int recursion, bool is_optional);
 struct list *free_list_file(struct list *item);
 extern void create_and_append_subscription(struct list **subs, const char *component);
-extern char *get_tracking_dir(void);
 extern int add_subscriptions(struct list *bundles, struct list **subs, struct manifest *mom, bool find_all, int recursion);
 extern int subscription_get_tree(struct list *bundles, struct list **subs, struct manifest *mom, bool find_all, int recursion);
 

--- a/src/swupd_lib/bundle.c
+++ b/src/swupd_lib/bundle.c
@@ -208,17 +208,14 @@ int required_by(struct list **reqd_by, const char *bundle_name, struct manifest 
 	return count;
 }
 
-void track_bundle_in_statedir(const char *bundle_name, const char *state_dir)
+void track_bundle(const char *bundle_name)
 {
 	int ret = 0;
 	int fd;
-	char *tracking_dir;
 	char *tracking_file;
 
-	tracking_dir = sys_path_join("%s/%s", state_dir, "bundles");
-	tracking_file = sys_path_join("%s/%s", tracking_dir, bundle_name);
-
 	/* touch a tracking file */
+	tracking_file = statedir_get_tracking_file(bundle_name);
 	fd = open(tracking_file, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
 	if (fd < 0) {
 		ret = -1;
@@ -228,15 +225,9 @@ void track_bundle_in_statedir(const char *bundle_name, const char *state_dir)
 
 out:
 	if (ret) {
-		debug("Issue creating tracking file in %s for %s\n", tracking_dir, bundle_name);
+		debug("Issue creating tracking file %s for %s\n", tracking_file, bundle_name);
 	}
-	FREE(tracking_dir);
 	FREE(tracking_file);
-}
-
-void track_bundle(const char *bundle_name)
-{
-	track_bundle_in_statedir(bundle_name, globals.state_dir);
 }
 
 static char *get_bundles_dir(void)

--- a/src/swupd_lib/bundle.c
+++ b/src/swupd_lib/bundle.c
@@ -54,7 +54,7 @@ bool is_tracked_bundle(const char *bundle_name)
 	char *filename = NULL;
 	bool ret;
 
-	filename = sys_path_join("%s/bundles/%s", globals.state_dir, bundle_name);
+	filename = statedir_get_tracking_file(bundle_name);
 	ret = sys_file_exists(filename);
 	FREE(filename);
 
@@ -247,7 +247,7 @@ static char *get_bundles_dir(void)
 struct list *bundle_list_tracked(void)
 {
 	struct list *bundles = NULL;
-	char *tracking_dir = get_tracking_dir();
+	char *tracking_dir = statedir_get_tracking_dir();
 
 	bundles = sys_ls(tracking_dir);
 	FREE(tracking_dir);

--- a/src/swupd_lib/bundle.h
+++ b/src/swupd_lib/bundle.h
@@ -43,21 +43,10 @@ bool is_tracked_bundle(const char *bundle_name);
 int required_by(struct list **reqd_by, const char *bundle_name, struct manifest *mom, int recursion, struct list *exclusions, char *msg, bool include_optional);
 
 /**
- * @brief Creates a tracking file in the tracking directory within the
- * specified state directory.
- * If there are no tracked files in that directory (directory is empty
- * or does not exist), copy the tracking directory at
- * path_prefix/usr/share/clear/bundles to the tracking directory to
- * initiate the tracking files.
+ * @brief Creates a tracking file in the tracking directory.
+
  * This function does not return an error code because weird state in this
  * directory must be handled gracefully whenever encountered.
- * @param bundle_name The name of the bundle.
- * @param state_dir The path to the state directory.
- */
-void track_bundle_in_statedir(const char *bundle_name, const char *state_dir);
-
-/**
- * @brief Similar to track_bundle_in_statedir() but uses the global state_dir.
  * @param bundle_name The name of the bundle.
  */
 void track_bundle(const char *bundle_name);

--- a/src/swupd_lib/delta.c
+++ b/src/swupd_lib/delta.c
@@ -139,7 +139,7 @@ void apply_deltas(struct manifest *current_manifest)
 			goto next;
 		}
 
-		string_or_die(&to_staged, "%s/staged/%s", globals.state_dir, to);
+		to_staged = statedir_get_staged_file(to);
 
 		/* If 'to' file already exists, no need to apply delta. */
 		struct stat stat;

--- a/src/swupd_lib/fullfile.c
+++ b/src/swupd_lib/fullfile.c
@@ -97,7 +97,7 @@ static int get_cached_fullfile(struct file *file)
 
 	/* Check the statedir and statedir-cache for the expected fullfile. When the
 	 * fullfile exists in the statedir-cache, it is copied to the statedir. */
-	string_or_die(&targetfile, "%s/staged/%s", globals.state_dir, file->hash);
+	targetfile = statedir_get_staged_file(file->hash);
 	if (lstat(targetfile, &stat) != 0 || !verify_file(file, targetfile)) {
 		ret = 1;
 

--- a/src/swupd_lib/helpers.c
+++ b/src/swupd_lib/helpers.c
@@ -117,7 +117,7 @@ void unlink_all_staged_content(struct file *file)
 	FREE(filename);
 
 	/* downloaded and un-tar'd file */
-	string_or_die(&filename, "%s/staged/%s", globals.state_dir, file->hash);
+	filename = statedir_get_staged_file(file->hash);
 	(void)remove(filename);
 	FREE(filename);
 }
@@ -756,7 +756,7 @@ int untar_full_download(void *data)
 
 	string_or_die(&tar_dotfile, "%s/download/.%s.tar", globals.state_dir, file->hash);
 	string_or_die(&tarfile, "%s/download/%s.tar", globals.state_dir, file->hash);
-	string_or_die(&targetfile, "%s/staged/%s", globals.state_dir, file->hash);
+	targetfile = statedir_get_staged_file(file->hash);
 
 	/* If valid target file already exists, we're done.
 	 * NOTE: this should NEVER happen given the checking that happens
@@ -786,8 +786,7 @@ int untar_full_download(void *data)
 	}
 
 	/* modern tar will automatically determine the compression type used */
-	char *outputdir;
-	string_or_die(&outputdir, "%s/staged", globals.state_dir);
+	char *outputdir = statedir_get_staged_dir();
 	err = archives_extract_to(tarfile, outputdir);
 	FREE(outputdir);
 	if (err) {

--- a/src/swupd_lib/helpers.c
+++ b/src/swupd_lib/helpers.c
@@ -997,11 +997,6 @@ void prettify_size(long size_in_bytes, char **pretty_size)
 	string_or_die(pretty_size, "%.2lf GB", size);
 }
 
-char *get_tracking_dir(void)
-{
-	return sys_path_join("%s/%s", globals.state_dir, "bundles");
-}
-
 bool confirm_action(void)
 {
 	int response;

--- a/src/swupd_lib/statedir.c
+++ b/src/swupd_lib/statedir.c
@@ -22,6 +22,9 @@
 /* Name of the tracking directory */
 #define TRACKING_DIR "bundles"
 
+/* Name of the staged directory */
+#define STAGED_DIR "staged"
+
 char *statedir_get_tracking_dir(void)
 {
 	return sys_path_join("%s/%s", globals.state_dir, TRACKING_DIR);
@@ -30,4 +33,14 @@ char *statedir_get_tracking_dir(void)
 char *statedir_get_tracking_file(const char *bundle_name)
 {
 	return sys_path_join("%s/%s/%s", globals.state_dir, TRACKING_DIR, bundle_name);
+}
+
+char *statedir_get_staged_dir(void)
+{
+	return sys_path_join("%s/%s", globals.state_dir, STAGED_DIR);
+}
+
+char *statedir_get_staged_file(char *file_hash)
+{
+	return sys_path_join("%s/%s/%s", globals.state_dir, STAGED_DIR, file_hash);
 }

--- a/src/swupd_lib/statedir.c
+++ b/src/swupd_lib/statedir.c
@@ -1,0 +1,33 @@
+/*
+ *   Software Updater - client side
+ *
+ *      Copyright © 2012-2020 Intel Corporation.
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, version 2 or later of the License.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "swupd.h"
+
+/* Name of the tracking directory */
+#define TRACKING_DIR "bundles"
+
+char *statedir_get_tracking_dir(void)
+{
+	return sys_path_join("%s/%s", globals.state_dir, TRACKING_DIR);
+}
+
+char *statedir_get_tracking_file(const char *bundle_name)
+{
+	return sys_path_join("%s/%s/%s", globals.state_dir, TRACKING_DIR, bundle_name);
+}

--- a/src/swupd_lib/statedir.h
+++ b/src/swupd_lib/statedir.h
@@ -34,6 +34,13 @@ char *statedir_get_staged_dir(void);
  */
 char *statedir_get_staged_file(char *file_hash);
 
+/**
+ * @brief Creates the required directories in the statedir.
+ *
+ * @param path The path of the statedir
+ */
+int statedir_create_dirs(const char *path);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/swupd_lib/statedir.h
+++ b/src/swupd_lib/statedir.h
@@ -22,6 +22,18 @@ char *statedir_get_tracking_dir(void);
  */
 char *statedir_get_tracking_file(const char *bundle_name);
 
+/**
+  * @brief Gets the path to the staged directory in the statedir.
+  */
+char *statedir_get_staged_dir(void);
+
+/**
+ * @brief Gets the path to a file in the staged directory in the statedir.
+ *
+ * @param file_hash, the hash of the file
+ */
+char *statedir_get_staged_file(char *file_hash);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/swupd_lib/statedir.h
+++ b/src/swupd_lib/statedir.h
@@ -1,0 +1,29 @@
+#ifndef __STATEDIR__
+#define __STATEDIR__
+
+/**
+ * @file
+ * @brief Module that handles the statedir
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+  * @brief Gets the path to the bundle tracking directory in the statedir.
+  */
+char *statedir_get_tracking_dir(void);
+
+/**
+ * @brief Gets the path to the tracking file of the specified bundle in the statedir.
+ *
+ * @param bundle_name, the name of the bundle
+ */
+char *statedir_get_tracking_file(const char *bundle_name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/swupd_lib/target_root.c
+++ b/src/swupd_lib/target_root.c
@@ -232,7 +232,7 @@ static enum swupd_code install_file_using_tar(const char *fullfile_path, const c
 		goto out;
 	}
 
-	stage_dir = sys_path_join("%s/staged", globals.state_dir);
+	stage_dir = statedir_get_staged_dir();
 	staged_file = str_or_die("%s%s", STAGE_FILE_PREFIX, target_basename);
 	err = tartar(stage_dir, staged_file, target_path);
 	if (err) {
@@ -345,7 +345,7 @@ static enum swupd_code stage_single_file(struct file *file, struct manifest *mom
 	dir = sys_dirname(file->filename);
 	target_basename = sys_basename(file->filename);
 
-	fullfile_path = sys_path_join("%s/staged/%s", globals.state_dir, file->hash);
+	fullfile_path = statedir_get_staged_file(file->hash);
 	target_path = sys_path_join("%s/%s", globals.path_prefix, dir);
 	target_file = sys_path_join("%s/%s", globals.path_prefix, file->filename);
 	staged_file = sys_path_join("%s/%s%s", target_path, STAGE_FILE_PREFIX, target_basename);


### PR DESCRIPTION
Create a statedir module with functions related operations exclusive to statedir, like cleaning staged dir, other cleaning operations and functions to build specific directories.

This is the first of a series of PRs aimed to complete that goal.

Relates #1538 