### PR TITLE
Grouping functions related to handling of statedir (part 3)

### DIFF
--- a/src/3rd_party/3rd_party_repos.c
+++ b/src/3rd_party/3rd_party_repos.c
@@ -314,7 +314,7 @@ enum swupd_code third_party_set_repo(struct repo *repo, bool sigcheck)
 		error("Unable to create the state directories for repository %s\n\n", repo->name);
 		return SWUPD_COULDNT_CREATE_DIR;
 	}
-	set_state_dir(repo_state_dir);
+	statedir_set_path(repo_state_dir);
 	FREE(repo_state_dir);
 
 	return SWUPD_OK;
@@ -379,7 +379,7 @@ static enum swupd_code third_party_find_bundle(const char *bundle, struct list *
 
 clean_and_exit:
 	set_path_prefix(globals_bkp.path_prefix);
-	set_state_dir(globals_bkp.state_dir);
+	statedir_set_path(globals_bkp.state_dir);
 	set_content_url(globals_bkp.content_url);
 	set_version_url(globals_bkp.version_url);
 
@@ -444,7 +444,7 @@ enum swupd_code third_party_run_operation(struct list *bundles, const char *repo
 			/* return the global variables to the original values */
 		next:
 			set_path_prefix(globals_bkp.path_prefix);
-			set_state_dir(globals_bkp.state_dir);
+			statedir_set_path(globals_bkp.state_dir);
 			set_content_url(globals_bkp.content_url);
 			set_version_url(globals_bkp.version_url);
 		}

--- a/src/cmds/bundle_add.c
+++ b/src/cmds/bundle_add.c
@@ -285,9 +285,11 @@ static enum swupd_code download_content(struct manifest *mom, struct list *to_in
 	/* download necessary packs */
 	timelist_timer_start(globals.global_times, "Download packs");
 
-	if (rm_staging_dir_contents("download") < 0) {
-		debug("rm_staging_dir_contents failed - resuming operation\n");
+	char *download_dir = statedir_get_download_dir();
+	if (sys_rm_dir_contents(download_dir) < 0) {
+		debug("removing the contents from download in statedir failed - resuming operation\n");
 	}
+	FREE(download_dir);
 
 	if (list_longer_than(to_install_files, 10 * list_len(to_install_bundles))) {
 		download_zero_packs(to_install_bundles, mom);

--- a/src/cmds/update.c
+++ b/src/cmds/update.c
@@ -306,11 +306,14 @@ enum swupd_code execute_update_extra(extra_proc_fn_t post_update_fn, extra_proc_
 
 	/* housekeeping */
 	timelist_timer_start(globals.global_times, "Clean up download directory");
-	if (rm_staging_dir_contents("download")) {
+	char *download_dir = statedir_get_download_dir();
+	if (sys_rm_dir_contents(download_dir)) {
+		FREE(download_dir);
 		error("There was a problem cleaning download directory\n");
 		ret = SWUPD_COULDNT_REMOVE_FILE;
 		goto clean_curl;
 	}
+	FREE(download_dir);
 	timelist_timer_stop(globals.global_times); // closing: Clean up download directory
 
 	/* setup manifests */

--- a/src/cmds/verify.c
+++ b/src/cmds/verify.c
@@ -978,7 +978,9 @@ enum swupd_code execute_verify_extra(extra_proc_fn_t post_verify_fn)
 	 * certificate is hosed and the admin knows it and wants to recover.
 	 */
 	timelist_timer_start(globals.global_times, "Clean up download directory");
-	ret = rm_staging_dir_contents("download");
+	char *download_dir = statedir_get_download_dir();
+	ret = sys_rm_dir_contents(download_dir);
+	FREE(download_dir);
 	if (ret != 0) {
 		warn("Failed to remove prior downloads, carrying on anyway\n");
 	}

--- a/src/cmds/verify.c
+++ b/src/cmds/verify.c
@@ -929,7 +929,7 @@ enum swupd_code execute_verify_extra(extra_proc_fn_t post_verify_fn)
 	bool invalid_bundle = false;
 
 	if (cmdline_option_statedir_cache != NULL) {
-		ret = set_state_dir_cache(cmdline_option_statedir_cache);
+		ret = statedir_dup_set_path(cmdline_option_statedir_cache);
 		if (ret != true) {
 			error("Failed to set statedir-cache\n");
 			goto clean_args_and_exit;

--- a/src/lib/sys.h
+++ b/src/lib/sys.h
@@ -215,6 +215,13 @@ bool sys_is_dir(const char *path);
 bool sys_filelink_is_dir(const char *path);
 
 /**
+ * @brief Remove the content of a directory without removing the directory itself.
+ *
+ * @return 0 on success, negative value on errors
+ */
+int sys_rm_dir_contents(const char *path);
+
+/**
  * @brief Remove file or directory.
  *
  * If filename is a directory, removes all files and directories recursively.

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -261,7 +261,6 @@ extern void populate_file_struct(struct file *file, char *filename);
 extern bool verify_file(struct file *file, char *filename);
 extern bool verify_file_lazy(char *filename);
 extern int verify_bundle_hash(struct manifest *manifest, struct file *bundle);
-extern int rm_staging_dir_contents(const char *rel_path);
 void free_file_data(void *data);
 void remove_files_in_manifest_from_fs(struct manifest *m);
 void deduplicate_files_from_manifest(struct manifest **m1, struct manifest *m2);

--- a/src/swupd_lib/globals.c
+++ b/src/swupd_lib/globals.c
@@ -193,65 +193,6 @@ static bool is_valid_integer_format(char *str)
 	return true;
 }
 
-/* Initializes the state_dir global variable. If the path parameter is not
- * NULL, state_dir will be set to its value. Otherwise, the value is the
- * build-time default (STATE_DIR).
- */
-bool set_state_dir(char *path)
-{
-	if (!path) {
-		error("Statedir shouldn't be NULL\n");
-		return false;
-	}
-
-	if (path[0] != '/') {
-		error("State dir must be a full path starting with '/', not '%c'\n", path[0]);
-		return false;
-	}
-
-	/* Prevent some disasters: since the state dir can be destroyed and
-	 * reconstructed, make sure we never set those by accident and nuke the
-	 * system. */
-	if (!str_cmp(path, "/") || !str_cmp(path, "/var") || !str_cmp(path, "/usr")) {
-		error("Refusing to use '%s' as a state dir because it might be erased first\n", path);
-		return false;
-	}
-
-	FREE(globals.state_dir);
-	string_or_die(&globals.state_dir, "%s", path);
-
-	return true;
-}
-
-/* Sets the state_dir_cache global variable. If the path parameter is not
- * NULL, state_dir_cache will be set to its value.
- */
-bool set_state_dir_cache(char *path)
-{
-	if (!path) {
-		error("Statedir-cache shouldn't be set to NULL\n");
-		return false;
-	}
-
-	if (path[0] != '/') {
-		error("Statedir-cache must be a full path starting with '/', not '%c'\n", path[0]);
-		return false;
-	}
-
-	/* Prevent some disasters: since the statedir-cache can be destroyed and
-	 * reconstructed, make sure we never set those by accident and nuke the
-	 * system. */
-	if (!str_cmp(path, "/") || !str_cmp(path, "/var") || !str_cmp(path, "/usr")) {
-		error("Refusing to use '%s' as a statedir-cache because it might be erased first\n", path);
-		return false;
-	}
-
-	FREE(globals.state_dir_cache);
-	string_or_die(&globals.state_dir_cache, "%s", path);
-
-	return true;
-}
-
 static void set_default_state_dir(void)
 {
 	string_or_die(&globals.state_dir, "%s", STATE_DIR);
@@ -595,7 +536,7 @@ static bool global_parse_opt(int opt, char *optarg)
 		}
 		return true;
 	case 'S':
-		if (!set_state_dir(optarg)) {
+		if (!statedir_set_path(optarg)) {
 			error("Invalid --statedir argument\n\n");
 			return false;
 		}

--- a/src/swupd_lib/globals.h
+++ b/src/swupd_lib/globals.h
@@ -95,10 +95,8 @@ void save_cmd(char **argv);
 
 bool set_path_prefix(char *path);
 bool set_default_urls(void);
-bool set_state_dir_cache(char *path);
 void set_default_path_prefix(void);
 void set_content_url(char *url);
-bool set_state_dir(char *path);
 void set_version_url(char *url);
 void set_cert_path(char *path);
 

--- a/src/swupd_lib/helpers.c
+++ b/src/swupd_lib/helpers.c
@@ -570,7 +570,7 @@ bool version_files_consistent(void)
 	int state_v = -1;
 	char *state_v_path;
 
-	string_or_die(&state_v_path, "%s/version", globals.state_dir);
+	state_v_path = statedir_get_version();
 	os_release_v = get_current_version(globals.path_prefix);
 	state_v = get_version_from_path(state_v_path);
 	FREE(state_v_path);

--- a/src/swupd_lib/lock.c
+++ b/src/swupd_lib/lock.c
@@ -59,7 +59,7 @@ int p_lockfile(void)
 	};
 	char *lockfile;
 
-	string_or_die(&lockfile, "%s/swupd_lock", globals.state_dir);
+	lockfile = statedir_get_swupd_lock();
 
 	/* open lock file */
 	lock_fd = open(lockfile, O_RDWR | O_CREAT | O_CLOEXEC, 0600);

--- a/src/swupd_lib/manifest.c
+++ b/src/swupd_lib/manifest.c
@@ -91,8 +91,8 @@ static int try_manifest_delta_download(int from, int to, char *component)
 	from_manifest = statedir_get_manifest(from, component);
 	to_manifest = statedir_get_manifest(to, component);
 
-	string_or_die(&manifest_delta, "%s/Manifest-%s-delta-from-%i-to-%i", globals.state_dir, component, from, to);
-	string_or_die(&to_dir, "%s/%i", globals.state_dir, to);
+	manifest_delta = statedir_get_manifest_delta(component, from, to);
+	to_dir = statedir_get_manifest_dir(to);
 
 	if (!sys_file_exists(manifest_delta)) {
 		string_or_die(&url, "%s/%i/Manifest-%s-delta-from-%i", globals.content_url, to, component, from);
@@ -143,7 +143,7 @@ static int retrieve_manifest(int previous_version, int version, char *component,
 		goto out;
 	}
 
-	string_or_die(&dir, "%s/%i", globals.state_dir, version);
+	dir = statedir_get_manifest_dir(version);
 	ret = mkdir(dir, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 	if ((ret != 0) && (errno != EEXIST)) {
 		goto out;

--- a/src/swupd_lib/packs.c
+++ b/src/swupd_lib/packs.c
@@ -124,7 +124,7 @@ static int download_pack(struct swupd_curl_parallel_handle *download_handle, int
 	char *url = NULL;
 	char *filename;
 
-	string_or_die(&filename, "%s/pack-%s-from-%i-to-%i.tar", globals.state_dir, module, oldversion, newversion);
+	filename = statedir_get_delta_pack(module, oldversion, newversion);
 
 	struct pack_data *pack_data;
 
@@ -189,7 +189,7 @@ static int get_cached_packs(struct sub *sub)
 
 	/* Check the statedir and statedir-cache for the expected pack. When the
 	 * pack exists in the statedir-cache, it is copied to the statedir. */
-	string_or_die(&targetfile, "%s/pack-%s-from-%i-to-%i.tar", globals.state_dir, sub->component, sub->oldversion, sub->version);
+	targetfile = statedir_get_delta_pack(sub->component, sub->oldversion, sub->version);
 	if (lstat(targetfile, &stat) != 0 || stat.st_size != 0) {
 		ret = 1;
 

--- a/src/swupd_lib/statedir.c
+++ b/src/swupd_lib/statedir.c
@@ -172,3 +172,39 @@ int statedir_create_dirs(const char *path)
 
 	return ret;
 }
+
+static bool set_state_path(char** state, char *path)
+{
+	if (!path) {
+		error("Statedir shouldn't be NULL\n");
+		return false;
+	}
+
+	if (path[0] != '/') {
+		error("State dir must be a full path starting with '/', not '%c'\n", path[0]);
+		return false;
+	}
+
+	/* Prevent some disasters: since the state dir can be destroyed and
+	 * reconstructed, make sure we never set those by accident and nuke the
+	 * system. */
+	if (!str_cmp(path, "/") || !str_cmp(path, "/var") || !str_cmp(path, "/usr")) {
+		error("Refusing to use '%s' as a state dir because it might be erased first\n", path);
+		return false;
+	}
+
+	FREE(*state);
+	*state = sys_path_join("%s", path);
+
+	return true;
+}
+
+bool statedir_set_path(char *path)
+{
+	return set_state_path(&globals.state_dir, path);
+}
+
+bool statedir_dup_set_path(char *path)
+{
+	return set_state_path(&globals.state_dir_cache, path);
+}

--- a/src/swupd_lib/statedir.c
+++ b/src/swupd_lib/statedir.c
@@ -80,6 +80,11 @@ char *statedir_get_fullfile_renamed_tar(char *file_hash)
 	return sys_path_join("%s/%s/%s.tar", globals.state_dir, DOWNLOAD_DIR, file_hash);
 }
 
+char *statedir_get_manifest_dir(int version)
+{
+	return sys_path_join("%s/%i", globals.state_dir, version);
+}
+
 char *statedir_get_manifest_tar(int version, char *component)
 {
 	return sys_path_join("%s/%i/Manifest.%s.tar", globals.state_dir, version, component);
@@ -93,6 +98,11 @@ char *statedir_get_manifest(int version, char *component)
 char *statedir_get_hashed_manifest(int version, char *component, char *manifest_hash)
 {
 	return sys_path_join("%s/%i/Manifest.%s.%s", globals.state_dir, version, component, manifest_hash);
+}
+
+char *statedir_get_manifest_delta(char *bundle, int from_version, int to_version)
+{
+	return sys_path_join("%s/Manifest-%s-delta-from-%i-to-%i", globals.state_dir, bundle, from_version, to_version);
 }
 
 char *statedir_get_telemetry_record(char *record)

--- a/src/swupd_lib/statedir.c
+++ b/src/swupd_lib/statedir.c
@@ -37,6 +37,9 @@
 /* Name of the telemetry directory */
 #define TELEMETRY_DIR "telemetry"
 
+/* Name of the swupd lock file */
+#define LOCK "swupd_lock"
+
 char *statedir_get_tracking_dir(void)
 {
 	return sys_path_join("%s/%s", globals.state_dir, TRACKING_DIR);
@@ -95,6 +98,11 @@ char *statedir_get_hashed_manifest(int version, char *component, char *manifest_
 char *statedir_get_telemetry_record(char *record)
 {
 	return sys_path_join("%s/%s/%s", globals.state_dir, TELEMETRY_DIR, record);
+}
+
+char *statedir_get_swupd_lock(void)
+{
+	return sys_path_join("%s/%s", globals.state_dir, LOCK);
 }
 
 int statedir_create_dirs(const char *path)

--- a/src/swupd_lib/statedir.c
+++ b/src/swupd_lib/statedir.c
@@ -115,6 +115,11 @@ char *statedir_get_swupd_lock(void)
 	return sys_path_join("%s/%s", globals.state_dir, LOCK);
 }
 
+char *statedir_get_delta_pack(char *bundle, int from_version, int to_version)
+{
+	return sys_path_join("%s/pack-%s-from-%i-to-%i.tar", globals.state_dir, bundle, from_version, to_version);
+}
+
 int statedir_create_dirs(const char *path)
 {
 	int ret = 0;

--- a/src/swupd_lib/statedir.c
+++ b/src/swupd_lib/statedir.c
@@ -40,6 +40,9 @@
 /* Name of the swupd lock file */
 #define LOCK "swupd_lock"
 
+/* Name of the version file */
+#define VERSION_FILE "version"
+
 char *statedir_get_tracking_dir(void)
 {
 	return sys_path_join("%s/%s", globals.state_dir, TRACKING_DIR);
@@ -118,6 +121,11 @@ char *statedir_get_swupd_lock(void)
 char *statedir_get_delta_pack(char *bundle, int from_version, int to_version)
 {
 	return sys_path_join("%s/pack-%s-from-%i-to-%i.tar", globals.state_dir, bundle, from_version, to_version);
+}
+
+char *statedir_get_version(void)
+{
+	return sys_path_join("%s/%s", globals.state_dir, VERSION_FILE);
 }
 
 int statedir_create_dirs(const char *path)

--- a/src/swupd_lib/statedir.c
+++ b/src/swupd_lib/statedir.c
@@ -34,6 +34,9 @@
 /* Name of the download directory */
 #define DOWNLOAD_DIR "download"
 
+/* Name of the telemetry directory */
+#define TELEMETRY_DIR "telemetry"
+
 char *statedir_get_tracking_dir(void)
 {
 	return sys_path_join("%s/%s", globals.state_dir, TRACKING_DIR);
@@ -87,6 +90,11 @@ char *statedir_get_manifest(int version, char *component)
 char *statedir_get_hashed_manifest(int version, char *component, char *manifest_hash)
 {
 	return sys_path_join("%s/%i/Manifest.%s.%s", globals.state_dir, version, component, manifest_hash);
+}
+
+char *statedir_get_telemetry_record(char *record)
+{
+	return sys_path_join("%s/%s/%s", globals.state_dir, TELEMETRY_DIR, record);
 }
 
 int statedir_create_dirs(const char *path)

--- a/src/swupd_lib/statedir.h
+++ b/src/swupd_lib/statedir.h
@@ -125,6 +125,10 @@ char *statedir_get_swupd_lock(void);
  * @param to_version, the to version for the delta
  */
 char *statedir_get_delta_pack(char *bundle, int from_version, int to_version);
+/**
+ * @brief Gets the path to the version file in the statedir.
+ */
+char *statedir_get_version(void);
 
 /**
  * @brief Creates the required directories in the statedir.

--- a/src/swupd_lib/statedir.h
+++ b/src/swupd_lib/statedir.h
@@ -137,6 +137,20 @@ char *statedir_get_version(void);
  */
 int statedir_create_dirs(const char *path);
 
+/**
+ * @brief Sets the path to the statedir.
+ *
+ * @param path The path of the statedir
+ */
+bool statedir_set_path(char *path);
+
+/**
+ * @brief Sets the path to the duplicate (cache) of the statedir.
+ *
+ * @param path The path of the statedir duplicate
+ */
+bool statedir_dup_set_path(char *path);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/swupd_lib/statedir.h
+++ b/src/swupd_lib/statedir.h
@@ -88,6 +88,13 @@ char *statedir_get_hashed_manifest(int version, char *component, char *manifest_
 char *statedir_get_fullfile_renamed_tar(char *file_hash);
 
 /**
+ * @brief Gets the path to the telemetry record in the statedir.
+ *
+ * @param record, the name of the telemetry record
+ */
+char *statedir_get_telemetry_record(char *record);
+
+/**
  * @brief Creates the required directories in the statedir.
  *
  * @param path The path of the statedir

--- a/src/swupd_lib/statedir.h
+++ b/src/swupd_lib/statedir.h
@@ -117,6 +117,16 @@ char *statedir_get_telemetry_record(char *record);
 char *statedir_get_swupd_lock(void);
 
 /**
+ * @brief Gets the path to the delta pack tar of the specified bundle
+ * going from one version to another version in the statedir.
+ *
+ * @param bundle, the name of a bundle
+ * @param from_version, the from version for the delta
+ * @param to_version, the to version for the delta
+ */
+char *statedir_get_delta_pack(char *bundle, int from_version, int to_version);
+
+/**
  * @brief Creates the required directories in the statedir.
  *
  * @param path The path of the statedir

--- a/src/swupd_lib/statedir.h
+++ b/src/swupd_lib/statedir.h
@@ -95,6 +95,11 @@ char *statedir_get_fullfile_renamed_tar(char *file_hash);
 char *statedir_get_telemetry_record(char *record);
 
 /**
+ * @brief Gets the path to the swupd lock file in the statedir.
+ */
+char *statedir_get_swupd_lock(void);
+
+/**
  * @brief Creates the required directories in the statedir.
  *
  * @param path The path of the statedir

--- a/src/swupd_lib/statedir.h
+++ b/src/swupd_lib/statedir.h
@@ -52,6 +52,13 @@ char *statedir_get_download_dir(void);
 char *statedir_get_fullfile_tar(char *file_hash);
 
 /**
+ * @brief Gets the path to the directory where manifests are stored in the statedir.
+ *
+ * @param version, the version of the manifests directory
+ */
+char *statedir_get_manifest_dir(int version);
+
+/**
  * @brief Gets the path to the downloaded manifest tar of the specified
  * component at a certain version in the statedir.
  *
@@ -78,6 +85,16 @@ char *statedir_get_manifest(int version, char *component);
  * @param manifest_hash, the hash of the manifest
  */
 char *statedir_get_hashed_manifest(int version, char *component, char *manifest_hash);
+
+/**
+ * @brief Gets the path to the manifest delta of the specified bundle
+ * going from one version to another version in the statedir.
+ *
+ * @param bundle, the name of a bundle
+ * @param from_version, the from version for the delta
+ * @param to_version, the to version for the delta
+ */
+char *statedir_get_manifest_delta(char *bundle, int from_version, int to_version);
 
 /**
  * @brief Gets the path to the temporary name given to a downloaded

--- a/src/swupd_lib/telemetry.c
+++ b/src/swupd_lib/telemetry.c
@@ -83,7 +83,7 @@ void telemetry(enum telemetry_severity level, const char *class, const char *fmt
 		goto error;
 	}
 
-	string_or_die(&newname, "%s/telemetry/%s", globals.state_dir, filename_n);
+	newname = statedir_get_telemetry_record(filename_n);
 
 	ret = rename(filename, newname);
 	FREE(filename);

--- a/src/swupd_lib/version.c
+++ b/src/swupd_lib/version.c
@@ -355,7 +355,7 @@ int update_device_latest_version(int version)
 	FILE *file = NULL;
 	char *path = NULL;
 
-	string_or_die(&path, "%s/version", globals.state_dir);
+	path = statedir_get_version();
 	file = fopen(path, "w");
 	if (!file) {
 		FREE(path);


### PR DESCRIPTION
This PR adds functions to get manifest files from the statedir.

This PR is built on top of #1552 and #1557 so they need to be reviewed first.

Closes #1538