### PR TITLE
motd: Remove motd code that was not being used

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -391,7 +391,6 @@ AH_TEMPLATE([STATE_DIR], [The state directory for swupd content])
 AH_TEMPLATE([LOG_DIR], [Directory for swupd log files])
 AH_TEMPLATE([BUNDLES_DIR], [Directory to use for bundles])
 AH_TEMPLATE([CERT_PATH], [Location of update certificate])
-AH_TEMPLATE([MOTD_FILE], [motd file path])
 
 AS_IF(
   [test "$enable_linux_rootfs_build" = "yes"],
@@ -400,8 +399,7 @@ AS_IF(
      AC_DEFINE([STATE_DIR], ["/var/lib/swupd"])
      AC_DEFINE([LOG_DIR], ["/var/log/swupd"])
      AC_DEFINE([BUNDLES_DIR], ["/usr/share/clear/bundles"])
-     AC_DEFINE_UNQUOTED([CERT_PATH], ["$cert_path"])
-     AC_DEFINE([MOTD_FILE], ["/usr/lib/motd.d/001-new-release"])],
+     AC_DEFINE_UNQUOTED([CERT_PATH], ["$cert_path"])],
   [AC_MSG_ERROR([Unknown build variant])]
 )
 

--- a/src/cmds/check_update.c
+++ b/src/cmds/check_update.c
@@ -121,7 +121,6 @@ enum swupd_code check_update(void)
 	if (current_version < server_version) {
 		info("There is a new OS version available: ");
 		print("%d\n", server_version);
-		update_motd(server_version);
 		return SWUPD_OK; /* update available */
 	} else if (current_version >= server_version) {
 		info("There are no updates available\n");

--- a/src/cmds/update.c
+++ b/src/cmds/update.c
@@ -432,7 +432,6 @@ enum swupd_code execute_update_extra(extra_proc_fn_t post_update_fn, extra_proc_
 		goto clean_exit;
 	}
 
-	delete_motd();
 	timelist_timer_stop(globals.global_times); // closing: Update loop
 
 	if (!download_only) {

--- a/src/swupd.h
+++ b/src/swupd.h
@@ -282,8 +282,6 @@ void v_lockfile(void);
 extern void print_manifest_files(struct manifest *m);
 extern void swupd_deinit(void);
 enum swupd_code swupd_init(enum swupd_init_config config);
-void update_motd(int new_release);
-void delete_motd(void);
 extern struct list *consolidate_files_from_bundles(struct list *bundles);
 extern struct list *files_from_bundles(struct list *bundles);
 extern bool version_files_consistent(void);

--- a/src/swupd_lib/helpers.c
+++ b/src/swupd_lib/helpers.c
@@ -526,24 +526,6 @@ out_fds:
 	return ret;
 }
 
-void update_motd(int new_release)
-{
-	FILE *motd_fp = NULL;
-
-	motd_fp = fopen(MOTD_FILE, "w");
-
-	if (motd_fp != NULL) {
-		fprintf(motd_fp, "There is a new OS version available: %d\n", new_release);
-		fprintf(motd_fp, "Upgrade to the latest version using 'swupd update'\n");
-		fclose(motd_fp);
-	}
-}
-
-void delete_motd(void)
-{
-	unlink(MOTD_FILE);
-}
-
 struct list *consolidate_files_from_bundles(struct list *bundles)
 {
 	/* bundles is a pointer to a list of manifests */


### PR DESCRIPTION
check-update was trying to create a motd in a deprecated directory and
it was always failing.

Removing code for now.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>