### PR TITLE
verify: Don't apply heuristic to os-install

### DIFF
--- a/src/cmds/verify.c
+++ b/src/cmds/verify.c
@@ -1182,7 +1182,6 @@ enum swupd_code execute_verify_extra(extra_proc_fn_t post_verify_fn)
 			goto extra_files;
 		}
 	}
-	apply_heuristics_for_files(files_to_verify);
 
 	if (cmdline_option_extra_files_only) {
 		/* user wants to deal only with the extra files, so skip everything else */
@@ -1241,6 +1240,9 @@ enum swupd_code execute_verify_extra(extra_proc_fn_t post_verify_fn)
 		/* quick only replaces missing files, so it is done here */
 		goto brick_the_system_and_clean_curl;
 	}
+
+	/* Apply heuristics to list of files */
+	apply_heuristics_for_files(files_to_verify);
 
 	/* repair corrupt files */
 	timelist_timer_start(globals.global_times, "Fixing modified files");

--- a/test/functional/os-install/install-var.bats
+++ b/test/functional/os-install/install-var.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+# Author: Otavio Pontes
+# Email: otavio.pontes@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment -e "$TEST_NAME" 10
+	create_bundle -n os-core -f /var/file "$TEST_NAME"
+
+}
+
+@test "INS029: Install files on /var" {
+
+	# Making sure os-install is installing files on /var.
+	# /var is filtered by heuristics, but on install time we want
+	# to create them.
+
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR"
+
+	assert_status_is "$SWUPD_OK"
+	expected_output=$(cat <<-EOM
+		Installing OS version 10 (latest)
+		Downloading missing manifests...
+		Downloading packs for:
+		 - os-core
+		Finishing packs extraction...
+		Checking for corrupt files
+		Validate downloaded files
+		No extra files need to be downloaded
+		Installing base OS and selected bundles
+		Inspected 3 files
+		  2 files were missing
+		    2 of 2 missing files were installed
+		    0 of 2 missing files were not installed
+		Calling post-update helper scripts
+		Installation successful
+	EOM
+	)
+	assert_is_output "$expected_output"
+	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGETDIR"/var/file
+
+}


### PR DESCRIPTION
Don't run heuristics for os-install or repair --quick.
On os-install we want all files to be always installed. On repair --quick
we don't process any do_not_update files

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>