### PR TITLE
thread_pool: Number of threads can be zero

### DIFF
--- a/src/lib/thread_pool.c
+++ b/src/lib/thread_pool.c
@@ -85,8 +85,8 @@ struct tp *tp_start(int num_threads)
 	int i;
 	struct tp *tp;
 
-	if (num_threads <= 0) {
-		error("Number of threads (%d) should be a positive integer\n", num_threads);
+	if (num_threads < 0) {
+		error("Number of threads (%d) shouldn't be negative\n", num_threads);
 		return NULL;
 	}
 


### PR DESCRIPTION
Actually thread_pool supports zero threads, that means exactly running in
serial. So rolling back to what it was before the integer conversion fix of
commit 2a7f181e0093f947008f777c11f663a195e256f2.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>