### PR TITLE
Fixing memory leak in delta.c

### DIFF
--- a/src/swupd_lib/delta.c
+++ b/src/swupd_lib/delta.c
@@ -117,6 +117,7 @@ void apply_deltas(struct manifest *current_manifest)
 	DIR *dir = opendir(delta_dir);
 	if (!dir) {
 		/* No deltas available to apply. */
+		FREE(delta_dir);
 		return;
 	}
 


### PR DESCRIPTION
Fixing:
- Memory leak delta.c
- Dead code in thread_pool.c

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>