### PR TITLE
Moving some remaining functions to statedir.c

### DIFF
--- a/src/cmds/clean.c
+++ b/src/cmds/clean.c
@@ -345,7 +345,7 @@ static enum swupd_code clean_staged_manifests(const char *path, bool dry_run, bo
 			continue;
 		}
 
-		char *version_dir = sys_path_join("%s/%s", globals.state_dir, name);
+		char *version_dir = sys_path_join("%s/%s", path, name);
 
 		/* This is not precise: it may keep Manifest files that we don't use, and
 		 * also will keep the previous version. If that extra precision is
@@ -433,7 +433,7 @@ enum swupd_code clean_main(int argc, char **argv)
 enum swupd_code clean_statedir(bool dry_run, bool all)
 {
 	enum swupd_code ret;
-	char *staged_dir = NULL;
+	char *path = NULL;
 
 	if (!all) {
 		if (clock_gettime(CLOCK_REALTIME, &now)) {
@@ -442,21 +442,25 @@ enum swupd_code clean_statedir(bool dry_run, bool all)
 		}
 	}
 
-	staged_dir = statedir_get_staged_dir();
-	ret = remove_if(staged_dir, dry_run, is_fullfile);
-	FREE(staged_dir);
+	path = statedir_get_staged_dir();
+	ret = remove_if(path, dry_run, is_fullfile);
+	FREE(path);
 	if (ret != SWUPD_OK) {
 		return ret;
 	}
 
 	/* Pack presence indicator files. */
-	ret = remove_if(globals.state_dir, dry_run, is_pack_indicator);
+	path = statedir_get_delta_pack_dir();
+	ret = remove_if(path, dry_run, is_pack_indicator);
+	FREE(path);
 	if (ret != SWUPD_OK) {
 		return ret;
 	}
 
 	/* Manifest delta files. */
-	ret = remove_if(globals.state_dir, dry_run, is_manifest_delta);
+	path = statedir_get_manifest_delta_dir();
+	ret = remove_if(path, dry_run, is_manifest_delta);
+	FREE(path);
 	if (ret != SWUPD_OK) {
 		return ret;
 	}

--- a/src/swupd_lib/globals.c
+++ b/src/swupd_lib/globals.c
@@ -195,7 +195,7 @@ static bool is_valid_integer_format(char *str)
 
 static void set_default_state_dir(void)
 {
-	string_or_die(&globals.state_dir, "%s", STATE_DIR);
+	(void)statedir_set_path(STATE_DIR);
 }
 
 static void set_default_state_dir_cache(void)

--- a/src/swupd_lib/packs.c
+++ b/src/swupd_lib/packs.c
@@ -54,10 +54,12 @@ struct pack_data {
 static int finalize_pack_download(const char *module, int newversion, const char *filename)
 {
 	FILE *tarfile = NULL;
+	char *delta_pack_dir = NULL;
 	int err;
 
+	delta_pack_dir = statedir_get_delta_pack_dir();
 	debug("\nExtracting %s pack for version %i\n", module, newversion);
-	err = archives_extract_to(filename, globals.state_dir);
+	err = archives_extract_to(filename, delta_pack_dir);
 
 	unlink(filename);
 
@@ -68,6 +70,8 @@ static int finalize_pack_download(const char *module, int newversion, const char
 			fclose(tarfile);
 		}
 	}
+
+	FREE(delta_pack_dir);
 
 	return err;
 }

--- a/src/swupd_lib/statedir.c
+++ b/src/swupd_lib/statedir.c
@@ -83,9 +83,19 @@ char *statedir_get_fullfile_renamed_tar(char *file_hash)
 	return sys_path_join("%s/%s/%s.tar", globals.state_dir, DOWNLOAD_DIR, file_hash);
 }
 
+static char *get_manifest_dir(char *state, int version)
+{
+	return sys_path_join("%s/%i", state, version);
+}
+
 char *statedir_get_manifest_dir(int version)
 {
-	return sys_path_join("%s/%i", globals.state_dir, version);
+	return get_manifest_dir(globals.state_dir, version);
+}
+
+char *statedir_dup_get_manifest_dir(int version)
+{
+	return get_manifest_dir(globals.state_dir_cache, version);
 }
 
 char *statedir_get_manifest_tar(int version, char *component)
@@ -103,6 +113,11 @@ char *statedir_get_hashed_manifest(int version, char *component, char *manifest_
 	return sys_path_join("%s/%i/Manifest.%s.%s", globals.state_dir, version, component, manifest_hash);
 }
 
+char *statedir_get_manifest_delta_dir(void)
+{
+	return sys_path_join("%s", globals.state_dir);
+}
+
 char *statedir_get_manifest_delta(char *bundle, int from_version, int to_version)
 {
 	return sys_path_join("%s/Manifest-%s-delta-from-%i-to-%i", globals.state_dir, bundle, from_version, to_version);
@@ -116,6 +131,11 @@ char *statedir_get_telemetry_record(char *record)
 char *statedir_get_swupd_lock(void)
 {
 	return sys_path_join("%s/%s", globals.state_dir, LOCK);
+}
+
+char *statedir_get_delta_pack_dir(void)
+{
+	return sys_path_join("%s", globals.state_dir);
 }
 
 char *statedir_get_delta_pack(char *bundle, int from_version, int to_version)

--- a/src/swupd_lib/statedir.h
+++ b/src/swupd_lib/statedir.h
@@ -59,6 +59,14 @@ char *statedir_get_fullfile_tar(char *file_hash);
 char *statedir_get_manifest_dir(int version);
 
 /**
+ * @brief Gets the path to the directory where manifests are stored in the statedir
+ * duplicate (also known as statedir_cache).
+ *
+ * @param version, the version of the manifests directory
+ */
+char *statedir_dup_get_manifest_dir(int version);
+
+/**
  * @brief Gets the path to the downloaded manifest tar of the specified
  * component at a certain version in the statedir.
  *
@@ -85,6 +93,11 @@ char *statedir_get_manifest(int version, char *component);
  * @param manifest_hash, the hash of the manifest
  */
 char *statedir_get_hashed_manifest(int version, char *component, char *manifest_hash);
+
+/**
+  * @brief Gets the path to the manifest delta directory in the statedir.
+  */
+char *statedir_get_manifest_delta_dir(void);
 
 /**
  * @brief Gets the path to the manifest delta of the specified bundle
@@ -115,6 +128,11 @@ char *statedir_get_telemetry_record(char *record);
  * @brief Gets the path to the swupd lock file in the statedir.
  */
 char *statedir_get_swupd_lock(void);
+
+/**
+ * @brief Gets the path to the directory where delta-packs are stored in the statedir.
+ */
+char *statedir_get_delta_pack_dir(void);
 
 /**
  * @brief Gets the path to the delta pack tar of the specified bundle

--- a/src/swupd_lib/target_root.c
+++ b/src/swupd_lib/target_root.c
@@ -218,7 +218,7 @@ static enum swupd_code install_file_using_tar(const char *fullfile_path, const c
 	enum swupd_code ret = SWUPD_OK;
 	char *rename_tmpdir = NULL;
 	char *rename_target = NULL;
-	char *stage_dir = NULL;
+	char *staged_dir = NULL;
 	char *staged_file = NULL;
 	char *target_basename = NULL;
 	char *target_path = NULL;
@@ -226,15 +226,16 @@ static enum swupd_code install_file_using_tar(const char *fullfile_path, const c
 	target_basename = sys_basename(target_file);
 	target_path = sys_dirname(target_file);
 
-	rename_target = sys_path_join("%s/staged/%s%s", globals.state_dir, STAGE_FILE_PREFIX, target_basename);
+	staged_dir = statedir_get_staged_dir();
+	staged_file = str_or_die("%s%s", STAGE_FILE_PREFIX, target_basename);
+
+	rename_target = sys_path_join("%s/%s", staged_dir, staged_file);
 	if (rename(fullfile_path, rename_target) != 0) {
 		ret = SWUPD_COULDNT_RENAME_FILE;
 		goto out;
 	}
 
-	stage_dir = statedir_get_staged_dir();
-	staged_file = str_or_die("%s%s", STAGE_FILE_PREFIX, target_basename);
-	err = tartar(stage_dir, staged_file, target_path);
+	err = tartar(staged_dir, staged_file, target_path);
 	if (err) {
 		ret = SWUPD_SUBPROCESS_ERROR;
 	}
@@ -247,7 +248,7 @@ out:
 	FREE(rename_tmpdir);
 	FREE(rename_target);
 	FREE(staged_file);
-	FREE(stage_dir);
+	FREE(staged_dir);
 	FREE(target_path);
 	return ret;
 }


### PR DESCRIPTION
Some of these references to statedir where left in the code, this commit
moves them to the statedir.c module so references to content of the
statedir are not hardcoded. Files in the statedir can move to different
locations freely this way.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>