### PR TITLE
Group manifest artifacts under the same directory in the statedir

### DIFF
--- a/src/cmds/clean.c
+++ b/src/cmds/clean.c
@@ -466,5 +466,9 @@ enum swupd_code clean_statedir(bool dry_run, bool all)
 	}
 
 	/* NOTE: do not clean the state_dir/bundles directory */
-	return clean_staged_manifests(globals.state_dir, dry_run, all);
+	path = statedir_get_manifest_root_dir();
+	ret = clean_staged_manifests(path, dry_run, all);
+	FREE(path);
+
+	return ret;
 }

--- a/src/swupd_lib/manifest.c
+++ b/src/swupd_lib/manifest.c
@@ -151,7 +151,7 @@ static int retrieve_manifest(int previous_version, int version, char *component,
 
 	/* Check statedir-cache */
 	if (globals.state_dir_cache != NULL) {
-		string_or_die(&filename_cache, "%s/%i/Manifest.%s", globals.state_dir_cache, version, component);
+		filename_cache = statedir_dup_get_manifest(version, component);
 		if (link_or_copy(filename_cache, filename) == 0) {
 			ret = 0;
 			goto out;
@@ -271,7 +271,7 @@ static bool mom_signature_verify(const char *data_url, const char *data_filename
 
 	// Check statedir-cache
 	if (globals.state_dir_cache != NULL) {
-		string_or_die(&sig_filename_cache, "%s/%i/Manifest.MoM.sig", globals.state_dir_cache, version);
+		sig_filename_cache = statedir_dup_get_manifest(version, "MoM.sig");
 		if (link_or_copy(sig_filename_cache, sig_filename) == 0) {
 			result = signature_verify(data_filename, sig_filename, SIGNATURE_DEFAULT);
 

--- a/src/swupd_lib/statedir.c
+++ b/src/swupd_lib/statedir.c
@@ -133,12 +133,12 @@ char *statedir_get_hashed_manifest(int version, char *component, char *manifest_
 
 char *statedir_get_manifest_delta_dir(void)
 {
-	return sys_path_join("%s", globals.state_dir);
+	return sys_path_join("%s/%s", globals.state_dir, MANIFEST_DIR);
 }
 
 char *statedir_get_manifest_delta(char *bundle, int from_version, int to_version)
 {
-	return sys_path_join("%s/Manifest-%s-delta-from-%i-to-%i", globals.state_dir, bundle, from_version, to_version);
+	return sys_path_join("%s/%s/Manifest-%s-delta-from-%i-to-%i", globals.state_dir, MANIFEST_DIR, bundle, from_version, to_version);
 }
 
 char *statedir_get_telemetry_record(char *record)

--- a/src/swupd_lib/statedir.c
+++ b/src/swupd_lib/statedir.c
@@ -37,6 +37,9 @@
 /* Name of the telemetry directory */
 #define TELEMETRY_DIR "telemetry"
 
+/* Name of the manifest directory */
+#define MANIFEST_DIR "manifest"
+
 /* Name of the swupd lock file */
 #define LOCK "swupd_lock"
 
@@ -83,9 +86,14 @@ char *statedir_get_fullfile_renamed_tar(char *file_hash)
 	return sys_path_join("%s/%s/%s.tar", globals.state_dir, DOWNLOAD_DIR, file_hash);
 }
 
+char *statedir_get_manifest_root_dir(void)
+{
+	return sys_path_join("%s/%s", globals.state_dir, MANIFEST_DIR);
+}
+
 static char *get_manifest_dir(char *state, int version)
 {
-	return sys_path_join("%s/%i", state, version);
+	return sys_path_join("%s/%s/%i", state, MANIFEST_DIR, version);
 }
 
 char *statedir_get_manifest_dir(int version)
@@ -100,17 +108,27 @@ char *statedir_dup_get_manifest_dir(int version)
 
 char *statedir_get_manifest_tar(int version, char *component)
 {
-	return sys_path_join("%s/%i/Manifest.%s.tar", globals.state_dir, version, component);
+	return sys_path_join("%s/%s/%i/Manifest.%s.tar", globals.state_dir, MANIFEST_DIR, version, component);
+}
+
+static char *get_manifest(char *state, int version, char *component)
+{
+	return sys_path_join("%s/%s/%i/Manifest.%s", state, MANIFEST_DIR, version, component);
 }
 
 char *statedir_get_manifest(int version, char *component)
 {
-	return sys_path_join("%s/%i/Manifest.%s", globals.state_dir, version, component);
+	return get_manifest(globals.state_dir, version, component);
+}
+
+char *statedir_dup_get_manifest(int version, char *component)
+{
+	return get_manifest(globals.state_dir_cache, version, component);
 }
 
 char *statedir_get_hashed_manifest(int version, char *component, char *manifest_hash)
 {
-	return sys_path_join("%s/%i/Manifest.%s.%s", globals.state_dir, version, component, manifest_hash);
+	return sys_path_join("%s/%s/%i/Manifest.%s.%s", globals.state_dir, MANIFEST_DIR, version, component, manifest_hash);
 }
 
 char *statedir_get_manifest_delta_dir(void)
@@ -154,7 +172,7 @@ int statedir_create_dirs(const char *path)
 	unsigned int i;
 	char *dir;
 #define STATE_DIR_COUNT (sizeof(state_dirs) / sizeof(state_dirs[0]))
-	const char *state_dirs[] = { "delta", "staged", "download", "telemetry", "bundles", "3rd-party" };
+	const char *state_dirs[] = { DELTA_DIR, STAGED_DIR, DOWNLOAD_DIR, TELEMETRY_DIR, TRACKING_DIR, MANIFEST_DIR, "3rd-party" };
 
 	// check for existence
 	if (ensure_root_owned_dir(path)) {

--- a/src/swupd_lib/statedir.h
+++ b/src/swupd_lib/statedir.h
@@ -53,14 +53,20 @@ char *statedir_get_fullfile_tar(char *file_hash);
 
 /**
  * @brief Gets the path to the directory where manifests are stored in the statedir.
+ */
+char *statedir_get_manifest_root_dir(void);
+
+/**
+ * @brief Gets the path to the directory where manifests for a specific version are
+ * stored in the statedir.
  *
  * @param version, the version of the manifests directory
  */
 char *statedir_get_manifest_dir(int version);
 
 /**
- * @brief Gets the path to the directory where manifests are stored in the statedir
- * duplicate (also known as statedir_cache).
+ * @brief Gets the path to the directory where manifests for a specific version are
+ * stored in the statedir duplicate (also known as statedir_cache).
  *
  * @param version, the version of the manifests directory
  */
@@ -83,6 +89,15 @@ char *statedir_get_manifest_tar(int version, char *component);
  * @param component, either MoM or the name of a bundle
  */
 char *statedir_get_manifest(int version, char *component);
+
+/**
+ * @brief Gets the path to the manifest of the specified component at a
+ * certain version in the statedir duplicate (also known as statedir_cache).
+ *
+ * @param version, the version of the manifest
+ * @param component, either MoM or the name of a bundle
+ */
+char *statedir_dup_get_manifest(int version, char *component);
 
 /**
  * @brief Gets the path to the manifest that contains its own hash

--- a/test/functional/api/api-3rd-party-clean.bats
+++ b/test/functional/api/api-3rd-party-clean.bats
@@ -10,8 +10,8 @@ test_setup() {
 	create_test_environment "$TEST_NAME" 10 1
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
 	STATE1="$TPSTATEDIR"
-	sudo mkdir "$STATE1"/10
-	sudo touch "$STATE1"/10/Manifest.test{1..3}
+	sudo mkdir -p "$STATE1"/manifest/10
+	sudo touch "$STATE1"/manifest/10/Manifest.test{1..3}
 	sudo touch "$STATE1"/pack-test{1..2}-from-0.tar
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
 	STATE2="$TPSTATEDIR"
@@ -43,9 +43,9 @@ test_setup() {
 		\\[repo1\\]
 		$TEST_ROOT_DIR/$STATE1/pack-test.-from-0.tar
 		$TEST_ROOT_DIR/$STATE1/pack-test.-from-0.tar
-		$TEST_ROOT_DIR/$STATE1/10/Manifest.test.
-		$TEST_ROOT_DIR/$STATE1/10/Manifest.test.
-		$TEST_ROOT_DIR/$STATE1/10/Manifest.test.
+		$TEST_ROOT_DIR/$STATE1/manifest/10/Manifest.test.
+		$TEST_ROOT_DIR/$STATE1/manifest/10/Manifest.test.
+		$TEST_ROOT_DIR/$STATE1/manifest/10/Manifest.test.
 		\\[repo2\\]
 		$TEST_ROOT_DIR/$STATE2/pack-test3-from-0.tar
 	EOM
@@ -62,9 +62,9 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		$TEST_ROOT_DIR/$STATE1/pack-test.-from-0.tar
 		$TEST_ROOT_DIR/$STATE1/pack-test.-from-0.tar
-		$TEST_ROOT_DIR/$STATE1/10/Manifest.test.
-		$TEST_ROOT_DIR/$STATE1/10/Manifest.test.
-		$TEST_ROOT_DIR/$STATE1/10/Manifest.test.
+		$TEST_ROOT_DIR/$STATE1/manifest/10/Manifest.test.
+		$TEST_ROOT_DIR/$STATE1/manifest/10/Manifest.test.
+		$TEST_ROOT_DIR/$STATE1/manifest/10/Manifest.test.
 	EOM
 	)
 	assert_regex_is_output "$expected_output"

--- a/test/functional/api/api-clean.bats
+++ b/test/functional/api/api-clean.bats
@@ -8,8 +8,8 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment "$TEST_NAME"
-	sudo mkdir "$STATEDIR"/10
-	sudo touch "$STATEDIR"/10/Manifest.test{1..3}
+	sudo mkdir "$STATEDIR"/manifest/10
+	sudo touch "$STATEDIR"/manifest/10/Manifest.test{1..3}
 	sudo touch "$STATEDIR"/pack-test{1..2}-from-0.tar
 
 }
@@ -31,9 +31,9 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		$TEST_ROOT_DIR/$STATEDIR/pack-test.-from-0.tar
 		$TEST_ROOT_DIR/$STATEDIR/pack-test.-from-0.tar
-		$TEST_ROOT_DIR/$STATEDIR/10/Manifest.test.
-		$TEST_ROOT_DIR/$STATEDIR/10/Manifest.test.
-		$TEST_ROOT_DIR/$STATEDIR/10/Manifest.test.
+		$TEST_ROOT_DIR/$STATEDIR/manifest/10/Manifest.test.
+		$TEST_ROOT_DIR/$STATEDIR/manifest/10/Manifest.test.
+		$TEST_ROOT_DIR/$STATEDIR/manifest/10/Manifest.test.
 	EOM
 	)
 	assert_regex_is_output "$expected_output"

--- a/test/functional/bundleadd/add-no-disk-space.bats
+++ b/test/functional/bundleadd/add-no-disk-space.bats
@@ -17,7 +17,7 @@ test_setup() {
 	create_bundle -n test-bundle -f "$bfiles","$file1" "$TEST_NAME"
 
 	# create the state version dirs ahead of time
-	sudo mkdir "$TEST_NAME"/testfs/state/10
+	sudo mkdir "$TEST_NAME"/testfs/state/manifest/10
 
 }
 

--- a/test/functional/bundlelist/list-experimental.bats
+++ b/test/functional/bundlelist/list-experimental.bats
@@ -61,7 +61,7 @@ global_setup() {
 	# bundle-list with no options should list only installed bundles, there should
 	# be a way to distinguish those that are experimental
 
-	sudo mv "$STATEDIR"/10/Manifest.MoM "$STATEDIR"/10/Manifest.MoM.temp
+	sudo mv "$STATEDIR"/manifest/10/Manifest.MoM "$STATEDIR"/manifest/10/Manifest.MoM.temp
 	sudo mv "$WEBDIR"/10/Manifest.MoM.tar "$WEBDIR"/10/Manifest.MoM.tar.temp
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS"
@@ -78,7 +78,7 @@ global_setup() {
 	)
 	assert_in_output "$expected_output"
 
-	sudo mv "$STATEDIR"/10/Manifest.MoM.temp "$STATEDIR"/10/Manifest.MoM
+	sudo mv "$STATEDIR"/manifest/10/Manifest.MoM.temp "$STATEDIR"/manifest/10/Manifest.MoM
 	sudo mv "$WEBDIR"/10/Manifest.MoM.tar.temp "$WEBDIR"/10/Manifest.MoM.tar
 
 }

--- a/test/functional/bundlelist/list-no-disk-space.bats
+++ b/test/functional/bundlelist/list-no-disk-space.bats
@@ -15,7 +15,7 @@ test_setup() {
 	create_bundle -n test-bundle2 -f /file_2 "$TEST_NAME"
 
 	# create the state version dirs ahead of time
-	sudo mkdir "$TEST_NAME"/testfs/state/10
+	sudo mkdir "$TEST_NAME"/testfs/state/manifest/10
 
 }
 

--- a/test/functional/bundleremove/remove-no-disk-space.bats
+++ b/test/functional/bundleremove/remove-no-disk-space.bats
@@ -14,7 +14,7 @@ test_setup() {
 	create_bundle -L -n test-bundle -f /file_1 "$TEST_NAME"
 
 	# create the state version dirs ahead of time
-	sudo mkdir "$TEST_NAME"/testfs/state/10
+	sudo mkdir "$TEST_NAME"/testfs/state/manifest/10
 
 }
 

--- a/test/functional/os-install/install-download.bats
+++ b/test/functional/os-install/install-download.bats
@@ -33,10 +33,10 @@ test_setup() {
 	assert_is_output "$expected_output"
 	assert_file_not_exists "$TARGETDIR"/core
 
-	assert_file_exists "$STATEDIR"/10/Manifest.MoM
-	assert_file_exists "$STATEDIR"/10/Manifest.os-core
+	assert_file_exists "$STATEDIR"/manifest/10/Manifest.MoM
+	assert_file_exists "$STATEDIR"/manifest/10/Manifest.os-core
 
-	core_hash=$(get_hash_from_manifest "$STATEDIR"/10/Manifest.os-core "/core")
+	core_hash=$(get_hash_from_manifest "$STATEDIR"/manifest/10/Manifest.os-core "/core")
 	assert_file_exists "$STATEDIR"/staged/"$core_hash"
 
 }

--- a/test/functional/os-install/install-statedir-cache-offline.bats
+++ b/test/functional/os-install/install-statedir-cache-offline.bats
@@ -15,10 +15,10 @@ test_setup() {
 	# Populate statedir-cache
 	sudo mkdir -m 700 -p "$statedir_cache_path"
 	sudo mkdir -m 700 "$statedir_cache_path"/staged
-	sudo mkdir -m 755 "$statedir_cache_path"/10
-	sudo cp "$WEBDIR"/10/Manifest.MoM "$statedir_cache_path"/10
-	sudo cp "$WEBDIR"/10/Manifest.MoM.sig "$statedir_cache_path"/10
-	sudo cp "$WEBDIR"/10/Manifest.os-core "$statedir_cache_path"/10
+	sudo mkdir -m 755 -p "$statedir_cache_path"/manifest/10
+	sudo cp "$WEBDIR"/10/Manifest.MoM "$statedir_cache_path"/manifest/10
+	sudo cp "$WEBDIR"/10/Manifest.MoM.sig "$statedir_cache_path"/manifest/10
+	sudo cp "$WEBDIR"/10/Manifest.os-core "$statedir_cache_path"/manifest/10
 	sudo touch "$statedir_cache_path"/pack-os-core-from-0-to-10.tar
 	sudo rsync -r "$WEBDIR"/10/files/* "$statedir_cache_path"/staged --exclude="*.tar"
 
@@ -58,7 +58,7 @@ test_setup() {
 
 	# Swupd should attempt to download the missing manifest and fail.
 
-	sudo rm "$statedir_cache_path"/10/Manifest.os-core
+	sudo rm "$statedir_cache_path"/manifest/10/Manifest.os-core
 	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --url=https://localhost --statedir-cache $statedir_cache_path -V 10"
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MANIFEST"
@@ -86,7 +86,7 @@ test_setup() {
 
 	# Swupd should attempt to download the signature and fail.
 
-	sudo rm "$statedir_cache_path"/10/Manifest.MoM.sig
+	sudo rm "$statedir_cache_path"/manifest/10/Manifest.MoM.sig
 	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --url=https://localhost --statedir-cache $statedir_cache_path -V 10"
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"

--- a/test/functional/os-install/install-statedir-cache.bats
+++ b/test/functional/os-install/install-statedir-cache.bats
@@ -15,10 +15,10 @@ test_setup() {
 	# Populate statedir-cache
 	sudo mkdir -m 700 -p "$statedir_cache_path"
 	sudo mkdir -m 700 "$statedir_cache_path"/staged
-	sudo mkdir -m 755 "$statedir_cache_path"/10
-	sudo cp "$WEBDIR"/10/Manifest.MoM "$statedir_cache_path"/10
-	sudo cp "$WEBDIR"/10/Manifest.MoM.sig "$statedir_cache_path"/10
-	sudo cp "$WEBDIR"/10/Manifest.os-core "$statedir_cache_path"/10
+	sudo mkdir -m 755 -p "$statedir_cache_path"/manifest/10
+	sudo cp "$WEBDIR"/10/Manifest.MoM "$statedir_cache_path"/manifest/10
+	sudo cp "$WEBDIR"/10/Manifest.MoM.sig "$statedir_cache_path"/manifest/10
+	sudo cp "$WEBDIR"/10/Manifest.os-core "$statedir_cache_path"/manifest/10
 	sudo touch "$statedir_cache_path"/pack-os-core-from-0-to-10.tar
 	sudo rsync -r "$WEBDIR"/10/files/* "$statedir_cache_path"/staged --exclude="*.tar"
 
@@ -59,7 +59,7 @@ test_setup() {
 	# The statedir-cache will have no update content, so the network must be used
 	# as a fallback.
 
-	sudo rm "$statedir_cache_path"/10/Manifest.os-core
+	sudo rm "$statedir_cache_path"/manifest/10/Manifest.os-core
 	sudo rm "$statedir_cache_path"/pack-os-core-from-0-to-10.tar
 	sudo rm -r "$statedir_cache_path"/staged
 	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --statedir-cache $statedir_cache_path"
@@ -127,7 +127,7 @@ test_setup() {
 	# Swupd should fallback to network downloads when the statedir-cache contains
 	# corrupt manifests.
 
-	sudo sh -c "echo invalid > ${statedir_cache_path}/10/Manifest.os-core"
+	sudo sh -c "echo invalid > ${statedir_cache_path}/manifest/10/Manifest.os-core"
 	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --statedir-cache $statedir_cache_path"
 
 	assert_status_is "$SWUPD_OK"

--- a/test/functional/repair/repair-no-disk-space.bats
+++ b/test/functional/repair/repair-no-disk-space.bats
@@ -23,8 +23,8 @@ test_setup() {
 	update_bundle "$TEST_NAME" test-bundle --add "$file1"
 
 	# create the state version dirs ahead of time
-	sudo mkdir "$TEST_NAME"/testfs/state/10
-	sudo mkdir "$TEST_NAME"/testfs/state/20
+	sudo mkdir "$TEST_NAME"/testfs/state/manifest/10
+	sudo mkdir "$TEST_NAME"/testfs/state/manifest/20
 
 }
 

--- a/test/functional/search/search-no-disk-space.bats
+++ b/test/functional/search/search-no-disk-space.bats
@@ -15,8 +15,8 @@ test_setup() {
 	create_bundle -n test-bundle2 -f /file_2 "$TEST_NAME"
 
 	# create the state version dirs ahead of time
-	sudo mkdir "$TEST_NAME"/testfs/state/10
-	sudo chmod -R 0700 "$TEST_NAME"/testfs/state/10
+	sudo mkdir "$TEST_NAME"/testfs/state/manifest/10
+	sudo chmod -R 0700 "$TEST_NAME"/testfs/state/manifest/10
 
 }
 

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1949,7 +1949,7 @@ create_test_environment() { # swupd_function
 
 	# state files & dirs
 	debug_msg "Creating a state dir"
-	sudo mkdir -p "$statedir"/{staged,download,delta,telemetry,bundles,3rd-party}
+	sudo mkdir -p "$statedir"/{staged,download,delta,telemetry,bundles,manifest,3rd-party}
 	sudo chmod -R 0700 "$statedir"
 
 	# every environment needs to have at least the os-core bundle so this should be
@@ -4064,10 +4064,10 @@ clean_state_dir() { # swupd_function
 	validate_path "$env_name"
 	if [ -z "$repo_name" ]; then
 		sudo rm -rf "$env_name"/testfs/state
-		sudo mkdir -p "$env_name"/testfs/state/{staged,download,delta,telemetry}
+		sudo mkdir -p "$env_name"/testfs/state/{staged,download,delta,telemetry,manifest}
 	else
 		sudo rm -rf "$env_name"/testfs/state/3rd-party/"$repo_name"
-		sudo mkdir -p "$env_name"/testfs/state/3rd-party/"$repo_name"/{staged,download,delta,telemetry,bundles}
+		sudo mkdir -p "$env_name"/testfs/state/3rd-party/"$repo_name"/{staged,download,delta,telemetry,bundles,manifest}
 	fi
 	sudo chmod -R 0700 "$env_name"/testfs/state
 

--- a/test/functional/update/update-no-disk-space.bats
+++ b/test/functional/update/update-no-disk-space.bats
@@ -21,8 +21,8 @@ test_setup() {
 	update_bundle "$TEST_NAME" test-bundle --add "$file1"
 
 	# create the state version dirs ahead of time
-	sudo mkdir "$TEST_NAME"/testfs/state/10
-	sudo mkdir "$TEST_NAME"/testfs/state/20
+	sudo mkdir "$TEST_NAME"/testfs/state/manifest/10
+	sudo mkdir "$TEST_NAME"/testfs/state/manifest/20
 
 }
 

--- a/test/functional/update/update-search-file-index.bats
+++ b/test/functional/update/update-search-file-index.bats
@@ -39,7 +39,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$STATEDIR"/10/Manifest.test-bundle1
+	assert_file_exists "$STATEDIR"/manifest/10/Manifest.test-bundle1
 }
 
 @test "UPD060: Don't download search-file index on update" {
@@ -69,7 +69,7 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_not_exists "$STATEDIR"/10/Manifest.test-bundle1
+	assert_file_not_exists "$STATEDIR"/manifest/10/Manifest.test-bundle1
 }
 
 #WEIGHT=5


### PR DESCRIPTION
This PR groups all the manifest-related artifacts that swupd downloads under the same "manifest" directory, so we keep a better consistency within the statedir.

This PR is built on top of #1567 and it needs to be merged first.

Related to #1539