### PR TITLE
delta: Improve message on delta errors

### DIFF
--- a/src/swupd_lib/delta.c
+++ b/src/swupd_lib/delta.c
@@ -153,7 +153,6 @@ void apply_deltas(struct manifest *current_manifest)
 
 		struct list *ll = list_head(current_manifest->files);
 		char *found = NULL;
-		bool bad_on_sys = false;
 
 		for (; ll && !found; ll = ll->next) {
 			struct file *file = ll->data;
@@ -168,7 +167,7 @@ void apply_deltas(struct manifest *current_manifest)
 
 			if (!compute_hash_from_file(filename, hash) || !hash_equal(file->hash, hash)) {
 				FREE(filename);
-				bad_on_sys = true;
+				warn("File \"%s\" is missing or corrupted\n", file->filename);
 				continue;
 			}
 
@@ -176,12 +175,8 @@ void apply_deltas(struct manifest *current_manifest)
 		}
 
 		if (!found) {
-			warn("Couldn't use delta file %s\n", delta_file);
-			if (bad_on_sys) {
-				info("'from' file corrupted on system, consider running 'swupd verify --fix'\n");
-			} else {
-				info("no 'from' file to apply was found\n");
-			}
+			warn("Couldn't use delta file because original file is corrupted or missing\n");
+			info("Consider running \"swupd repair\" to fix the issue\n");
 			goto next;
 		}
 

--- a/test/functional/update/update-verify-fix-path-hash-mismatch.bats
+++ b/test/functional/update/update-verify-fix-path-hash-mismatch.bats
@@ -33,7 +33,9 @@ test_setup() {
 		Downloading packs for:
 		 - test-bundle
 		Finishing packs extraction...
-		Warning: Couldn.t use delta file .*
+		Warning: File "/usr/foo/test-file" is missing or corrupted
+		Warning: Couldn't use delta file because original file is corrupted or missing
+		Consider running "swupd repair" to fix the issue
 		Statistics for going from version 10 to version 100:
 		    changed bundles   : 1
 		    new bundles       : 0
@@ -50,7 +52,7 @@ test_setup() {
 		Update successful - System updated from version 10 to version 100
 	EOM
 	)
-	assert_regex_is_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_dir_exists "$TARGETDIR"/usr/foo
 	assert_file_exists "$TARGETDIR"/usr/foo/test-file
 

--- a/test/functional/update/update-verify-fix-path-missing-dir.bats
+++ b/test/functional/update/update-verify-fix-path-missing-dir.bats
@@ -26,7 +26,9 @@ test_setup() {
 		Downloading packs for:
 		 - test-bundle
 		Finishing packs extraction...
-		Warning: Couldn.t use delta file .*
+		Warning: File "/foo/bar/baz/test-file" is missing or corrupted
+		Warning: Couldn't use delta file because original file is corrupted or missing
+		Consider running "swupd repair" to fix the issue
 		Statistics for going from version 10 to version 100:
 		    changed bundles   : 1
 		    new bundles       : 0
@@ -43,7 +45,7 @@ test_setup() {
 		Update successful - System updated from version 10 to version 100
 	EOM
 	)
-	assert_regex_is_output "$expected_output"
+	assert_is_output "$expected_output"
 	assert_dir_exists "$TARGETDIR"/foo/bar/baz
 	assert_file_exists "$TARGETDIR"/foo/bar/baz/test-file
 


### PR DESCRIPTION
Print a more useful error when we fail to locate a file to apply a
delta. Add a suggestion for the user to run `swupd repair` and make
it clear that the problem is in their system and not in the update
content.

Fixes #1425

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>