### PR TITLE
Separating cache from state files in statedir

### DIFF
--- a/src/swupd_lib/fullfile.c
+++ b/src/swupd_lib/fullfile.c
@@ -102,7 +102,7 @@ static int get_cached_fullfile(struct file *file)
 		ret = 1;
 
 		if (globals.state_dir_cache != NULL) {
-			string_or_die(&targetfile_cache, "%s/staged/%s", globals.state_dir_cache, file->hash);
+			targetfile_cache = statedir_dup_get_staged_file(file->hash);
 			if (lstat(targetfile_cache, &stat) == 0 && verify_file(file, targetfile_cache)) {
 				if (link_or_copy_all(targetfile_cache, targetfile) == 0) {
 					ret = 0;

--- a/src/swupd_lib/packs.c
+++ b/src/swupd_lib/packs.c
@@ -198,7 +198,7 @@ static int get_cached_packs(struct sub *sub)
 		ret = 1;
 
 		if (globals.state_dir_cache != NULL) {
-			string_or_die(&targetfile_cache, "%s/pack-%s-from-%i-to-%i.tar", globals.state_dir_cache, sub->component, sub->oldversion, sub->version);
+			targetfile_cache = statedir_dup_get_delta_pack(sub->component, sub->oldversion, sub->version);
 			if (lstat(targetfile_cache, &stat) == 0 && stat.st_size == 0) {
 				if (link_or_copy(targetfile_cache, targetfile) == 0) {
 					ret = 0;

--- a/src/swupd_lib/statedir.c
+++ b/src/swupd_lib/statedir.c
@@ -46,6 +46,13 @@
 /* Name of the version file */
 #define VERSION_FILE "version"
 
+/* Name of the directory that contains all the cache */
+#define CACHE_DIR "cache"
+
+
+/* ************* */
+/* State section */
+/* ************* */
 char *statedir_get_tracking_dir(void)
 {
 	return sys_path_join("%s/%s", globals.state_dir, TRACKING_DIR);
@@ -56,44 +63,73 @@ char *statedir_get_tracking_file(const char *bundle_name)
 	return sys_path_join("%s/%s/%s", globals.state_dir, TRACKING_DIR, bundle_name);
 }
 
+char *statedir_get_telemetry_record(char *record)
+{
+	return sys_path_join("%s/%s/%s", globals.state_dir, TELEMETRY_DIR, record);
+}
+
+char *statedir_get_swupd_lock(void)
+{
+	return sys_path_join("%s/%s", globals.state_dir, LOCK);
+}
+
+char *statedir_get_version(void)
+{
+	return sys_path_join("%s/%s", globals.state_dir, VERSION_FILE);
+}
+
+/* ************* */
+/* Cache section */
+/* ************* */
+
 char *statedir_get_staged_dir(void)
 {
-	return sys_path_join("%s/%s", globals.state_dir, STAGED_DIR);
+	return sys_path_join("%s/%s/%s", globals.state_dir, CACHE_DIR, STAGED_DIR);
+}
+
+static char *get_staged_file(char *state, char *file_hash)
+{
+	return sys_path_join("%s/%s/%s/%s", state, CACHE_DIR, STAGED_DIR, file_hash);
 }
 
 char *statedir_get_staged_file(char *file_hash)
 {
-	return sys_path_join("%s/%s/%s", globals.state_dir, STAGED_DIR, file_hash);
+	return get_staged_file(globals.state_dir, file_hash);
+}
+
+char *statedir_dup_get_staged_file(char *file_hash)
+{
+	return get_staged_file(globals.state_dir_cache, file_hash);
 }
 
 char *statedir_get_delta_dir(void)
 {
-	return sys_path_join("%s/%s", globals.state_dir, DELTA_DIR);
+	return sys_path_join("%s/%s/%s", globals.state_dir, CACHE_DIR, DELTA_DIR);
 }
 
 char *statedir_get_download_dir(void)
 {
-	return sys_path_join("%s/%s", globals.state_dir, DOWNLOAD_DIR);
+	return sys_path_join("%s/%s/%s", globals.state_dir, CACHE_DIR, DOWNLOAD_DIR);
 }
 
 char *statedir_get_fullfile_tar(char *file_hash)
 {
-	return sys_path_join("%s/%s/.%s.tar", globals.state_dir, DOWNLOAD_DIR, file_hash);
+	return sys_path_join("%s/%s/%s/.%s.tar", globals.state_dir, CACHE_DIR, DOWNLOAD_DIR, file_hash);
 }
 
 char *statedir_get_fullfile_renamed_tar(char *file_hash)
 {
-	return sys_path_join("%s/%s/%s.tar", globals.state_dir, DOWNLOAD_DIR, file_hash);
+	return sys_path_join("%s/%s/%s/%s.tar", globals.state_dir, CACHE_DIR, DOWNLOAD_DIR, file_hash);
 }
 
 char *statedir_get_manifest_root_dir(void)
 {
-	return sys_path_join("%s/%s", globals.state_dir, MANIFEST_DIR);
+	return sys_path_join("%s/%s/%s", globals.state_dir, CACHE_DIR, MANIFEST_DIR);
 }
 
 static char *get_manifest_dir(char *state, int version)
 {
-	return sys_path_join("%s/%s/%i", state, MANIFEST_DIR, version);
+	return sys_path_join("%s/%s/%s/%i", state, CACHE_DIR, MANIFEST_DIR, version);
 }
 
 char *statedir_get_manifest_dir(int version)
@@ -108,12 +144,12 @@ char *statedir_dup_get_manifest_dir(int version)
 
 char *statedir_get_manifest_tar(int version, char *component)
 {
-	return sys_path_join("%s/%s/%i/Manifest.%s.tar", globals.state_dir, MANIFEST_DIR, version, component);
+	return sys_path_join("%s/%s/%s/%i/Manifest.%s.tar", globals.state_dir, CACHE_DIR, MANIFEST_DIR, version, component);
 }
 
 static char *get_manifest(char *state, int version, char *component)
 {
-	return sys_path_join("%s/%s/%i/Manifest.%s", state, MANIFEST_DIR, version, component);
+	return sys_path_join("%s/%s/%s/%i/Manifest.%s", state, CACHE_DIR, MANIFEST_DIR, version, component);
 }
 
 char *statedir_get_manifest(int version, char *component)
@@ -128,63 +164,48 @@ char *statedir_dup_get_manifest(int version, char *component)
 
 char *statedir_get_hashed_manifest(int version, char *component, char *manifest_hash)
 {
-	return sys_path_join("%s/%s/%i/Manifest.%s.%s", globals.state_dir, MANIFEST_DIR, version, component, manifest_hash);
+	return sys_path_join("%s/%s/%s/%i/Manifest.%s.%s", globals.state_dir, CACHE_DIR, MANIFEST_DIR, version, component, manifest_hash);
 }
 
 char *statedir_get_manifest_delta_dir(void)
 {
-	return sys_path_join("%s/%s", globals.state_dir, MANIFEST_DIR);
+	return sys_path_join("%s/%s/%s", globals.state_dir, CACHE_DIR, MANIFEST_DIR);
 }
 
 char *statedir_get_manifest_delta(char *bundle, int from_version, int to_version)
 {
-	return sys_path_join("%s/%s/Manifest-%s-delta-from-%i-to-%i", globals.state_dir, MANIFEST_DIR, bundle, from_version, to_version);
-}
-
-char *statedir_get_telemetry_record(char *record)
-{
-	return sys_path_join("%s/%s/%s", globals.state_dir, TELEMETRY_DIR, record);
-}
-
-char *statedir_get_swupd_lock(void)
-{
-	return sys_path_join("%s/%s", globals.state_dir, LOCK);
+	return sys_path_join("%s/%s/%s/Manifest-%s-delta-from-%i-to-%i", globals.state_dir, CACHE_DIR, MANIFEST_DIR, bundle, from_version, to_version);
 }
 
 char *statedir_get_delta_pack_dir(void)
 {
-	return sys_path_join("%s", globals.state_dir);
+	return sys_path_join("%s/%s", globals.state_dir, CACHE_DIR);
+}
+
+static char *get_delta_pack(char *state, char *bundle, int from_version, int to_version)
+{
+	return sys_path_join("%s/%s/pack-%s-from-%i-to-%i.tar", state, CACHE_DIR, bundle, from_version, to_version);
 }
 
 char *statedir_get_delta_pack(char *bundle, int from_version, int to_version)
 {
-	return sys_path_join("%s/pack-%s-from-%i-to-%i.tar", globals.state_dir, bundle, from_version, to_version);
+	return get_delta_pack(globals.state_dir, bundle, from_version, to_version);
 }
 
-char *statedir_get_version(void)
+char *statedir_dup_get_delta_pack(char *bundle, int from_version, int to_version)
 {
-	return sys_path_join("%s/%s", globals.state_dir, VERSION_FILE);
+	return get_delta_pack(globals.state_dir_cache, bundle, from_version, to_version);
 }
 
-int statedir_create_dirs(const char *path)
+static int create_root_owned_dirs(const char *path, const char **dirs, unsigned int dir_count)
 {
 	int ret = 0;
 	unsigned int i;
-	char *dir;
-#define STATE_DIR_COUNT (sizeof(state_dirs) / sizeof(state_dirs[0]))
-	const char *state_dirs[] = { DELTA_DIR, STAGED_DIR, DOWNLOAD_DIR, TELEMETRY_DIR, TRACKING_DIR, MANIFEST_DIR, "3rd-party" };
+	char *dir = NULL;
 
-	// check for existence
-	if (ensure_root_owned_dir(path)) {
-		// state dir doesn't exist
-		if (mkdir_p(path) != 0 || chmod(path, S_IRWXU) != 0) {
-			error("failed to create %s\n", path);
-			return -1;
-		}
-	}
+	for (i = 0; i < dir_count; i++) {
 
-	for (i = 0; i < STATE_DIR_COUNT; i++) {
-		string_or_die(&dir, "%s/%s", path, state_dirs[i]);
+		dir = sys_path_join("%s/%s", path, dirs[i]);
 		ret = ensure_root_owned_dir(dir);
 		if (ret) {
 			ret = mkdir(dir, S_IRWXU);
@@ -196,6 +217,40 @@ int statedir_create_dirs(const char *path)
 		}
 		FREE(dir);
 	}
+
+	return 0;
+}
+
+int statedir_create_dirs(const char *path)
+{
+	int ret = 0;
+	char *sub_path = NULL;
+	const char *state_root_dirs[] = { CACHE_DIR, TRACKING_DIR, TELEMETRY_DIR, "3rd-party" };
+	const char *cache_dirs[] = { DELTA_DIR, STAGED_DIR, DOWNLOAD_DIR, MANIFEST_DIR};
+#define STATE_ROOT_DIR_COUNT (sizeof(state_root_dirs) / sizeof(state_root_dirs[0]))
+#define CACHE_DIR_COUNT (sizeof(cache_dirs) / sizeof(cache_dirs[0]))
+
+	// check for existence
+	if (ensure_root_owned_dir(path)) {
+		// state dir doesn't exist
+		if (mkdir_p(path) != 0 || chmod(path, S_IRWXU) != 0) {
+			error("failed to create %s\n", path);
+			return -1;
+		}
+	}
+
+	ret = create_root_owned_dirs(path, state_root_dirs, STATE_ROOT_DIR_COUNT);
+	if (ret) {
+		return ret;
+	}
+
+	sub_path = sys_path_join("%s/%s", path, CACHE_DIR);
+	ret = create_root_owned_dirs(sub_path, cache_dirs, CACHE_DIR_COUNT);
+	FREE(sub_path);
+	if (ret) {
+		return ret;
+	}
+
 	/* Do a final check to make sure that the top level dir wasn't
 	 * tampered with whilst we were creating the dirs */
 	if (ensure_root_owned_dir(path)) {

--- a/src/swupd_lib/statedir.h
+++ b/src/swupd_lib/statedir.h
@@ -35,6 +35,14 @@ char *statedir_get_staged_dir(void);
 char *statedir_get_staged_file(char *file_hash);
 
 /**
+ * @brief Gets the path to a file in the staged directory in the
+ * statedir duplicate (also known as statedir_cache).
+ *
+ * @param file_hash, the hash of the file
+ */
+char *statedir_dup_get_staged_file(char *file_hash);
+
+/**
   * @brief Gets the path to the delta directory in the statedir.
   */
 char *statedir_get_delta_dir(void);
@@ -158,6 +166,18 @@ char *statedir_get_delta_pack_dir(void);
  * @param to_version, the to version for the delta
  */
 char *statedir_get_delta_pack(char *bundle, int from_version, int to_version);
+
+/**
+ * @brief Gets the path to the delta pack tar of the specified bundle
+ * going from one version to another version in the statedir duplicate
+ * (also known as statedir_cache).
+ *
+ * @param bundle, the name of a bundle
+ * @param from_version, the from version for the delta
+ * @param to_version, the to version for the delta
+ */
+char *statedir_dup_get_delta_pack(char *bundle, int from_version, int to_version);
+
 /**
  * @brief Gets the path to the version file in the statedir.
  */

--- a/test/functional/api/api-3rd-party-clean.bats
+++ b/test/functional/api/api-3rd-party-clean.bats
@@ -9,13 +9,13 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME" 10 1
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
-	STATE1="$TPSTATEDIR"
-	sudo mkdir -p "$STATE1"/manifest/10
-	sudo touch "$STATE1"/manifest/10/Manifest.test{1..3}
-	sudo touch "$STATE1"/pack-test{1..2}-from-0.tar
+	STATE1="$TPSTATEDIR_ABS"
+	sudo mkdir -p "$TPSTATEDIR_MANIFEST"/10
+	sudo touch "$TPSTATEDIR_MANIFEST"/10/Manifest.test{1..3}
+	sudo touch "$TPSTATEDIR_CACHE"/pack-test{1..2}-from-0.tar
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
-	STATE2="$TPSTATEDIR"
-	sudo touch "$STATE2"/pack-test3-from-0.tar
+	STATE2="$TPSTATEDIR_ABS"
+	sudo touch "$TPSTATEDIR_CACHE"/pack-test3-from-0.tar
 
 }
 
@@ -41,13 +41,13 @@ test_setup() {
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		\\[repo1\\]
-		$TEST_ROOT_DIR/$STATE1/pack-test.-from-0.tar
-		$TEST_ROOT_DIR/$STATE1/pack-test.-from-0.tar
-		$TEST_ROOT_DIR/$STATE1/manifest/10/Manifest.test.
-		$TEST_ROOT_DIR/$STATE1/manifest/10/Manifest.test.
-		$TEST_ROOT_DIR/$STATE1/manifest/10/Manifest.test.
+		$STATE1/cache/pack-test.-from-0.tar
+		$STATE1/cache/pack-test.-from-0.tar
+		$STATE1/cache/manifest/10/Manifest.test.
+		$STATE1/cache/manifest/10/Manifest.test.
+		$STATE1/cache/manifest/10/Manifest.test.
 		\\[repo2\\]
-		$TEST_ROOT_DIR/$STATE2/pack-test3-from-0.tar
+		$STATE2/cache/pack-test3-from-0.tar
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
@@ -60,11 +60,11 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		$TEST_ROOT_DIR/$STATE1/pack-test.-from-0.tar
-		$TEST_ROOT_DIR/$STATE1/pack-test.-from-0.tar
-		$TEST_ROOT_DIR/$STATE1/manifest/10/Manifest.test.
-		$TEST_ROOT_DIR/$STATE1/manifest/10/Manifest.test.
-		$TEST_ROOT_DIR/$STATE1/manifest/10/Manifest.test.
+		$STATE1/cache/pack-test.-from-0.tar
+		$STATE1/cache/pack-test.-from-0.tar
+		$STATE1/cache/manifest/10/Manifest.test.
+		$STATE1/cache/manifest/10/Manifest.test.
+		$STATE1/cache/manifest/10/Manifest.test.
 	EOM
 	)
 	assert_regex_is_output "$expected_output"

--- a/test/functional/api/api-clean.bats
+++ b/test/functional/api/api-clean.bats
@@ -8,9 +8,9 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment "$TEST_NAME"
-	sudo mkdir "$STATEDIR"/manifest/10
-	sudo touch "$STATEDIR"/manifest/10/Manifest.test{1..3}
-	sudo touch "$STATEDIR"/pack-test{1..2}-from-0.tar
+	sudo mkdir "$STATEDIR_MANIFEST"/10
+	sudo touch "$STATEDIR_MANIFEST"/10/Manifest.test{1..3}
+	sudo touch "$STATEDIR_CACHE"/pack-test{1..2}-from-0.tar
 
 }
 
@@ -29,11 +29,11 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		$TEST_ROOT_DIR/$STATEDIR/pack-test.-from-0.tar
-		$TEST_ROOT_DIR/$STATEDIR/pack-test.-from-0.tar
-		$TEST_ROOT_DIR/$STATEDIR/manifest/10/Manifest.test.
-		$TEST_ROOT_DIR/$STATEDIR/manifest/10/Manifest.test.
-		$TEST_ROOT_DIR/$STATEDIR/manifest/10/Manifest.test.
+		$STATEDIR_CACHE/pack-test.-from-0.tar
+		$STATEDIR_CACHE/pack-test.-from-0.tar
+		$STATEDIR_MANIFEST/10/Manifest.test.
+		$STATEDIR_MANIFEST/10/Manifest.test.
+		$STATEDIR_MANIFEST/10/Manifest.test.
 	EOM
 	)
 	assert_regex_is_output "$expected_output"

--- a/test/functional/bundleadd/add-bad-hash-state.bats
+++ b/test/functional/bundleadd/add-bad-hash-state.bats
@@ -8,8 +8,8 @@ test_setup() {
 	create_bundle -n test-bundle -f /usr/bin/test-file "$TEST_NAME"
 	# set up state directory with bad hash file and pack hint
 	file_hash=$(get_hash_from_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle /usr/bin/test-file)
-	sudo sh -c "echo \"test file MODIFIED\" > $STATEDIR/staged/$file_hash"
-	sudo touch "$STATEDIR"/pack-test-bundle-from-0-to-10.tar
+	sudo sh -c "echo \"test file MODIFIED\" > $STATEDIR_STAGED/$file_hash"
+	sudo touch "$STATEDIR_CACHE"/pack-test-bundle-from-0-to-10.tar
 
 }
 
@@ -18,12 +18,12 @@ test_setup() {
 	# since one of the files needed to install the bundle is already in the state/staged
 	# directory, in theory this one should be used instead of downloading it again...
 	# however since the hash of this file is wrong it should be deleted and re-downloaded
-	hash_before=$(sudo "$SWUPD" hashdump "$STATEDIR"/staged/"$file_hash")
+	hash_before=$(sudo "$SWUPD" hashdump "$STATEDIR_STAGED"/"$file_hash")
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
 	assert_status_is 0
-	hash_after=$(sudo "$SWUPD" hashdump "$STATEDIR"/staged/"$file_hash")
+	hash_after=$(sudo "$SWUPD" hashdump "$STATEDIR_STAGED"/"$file_hash")
 	assert_file_exists "$TARGETDIR"/usr/bin/test-file
 	assert_not_equal "$hash_before" "$hash_after"
 	expected_output=$(cat <<-EOM

--- a/test/functional/bundleadd/add-bad-hash.bats
+++ b/test/functional/bundleadd/add-bad-hash.bats
@@ -31,7 +31,7 @@ test_setup() {
 		No packs need to be downloaded
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
-		Error: File content hash mismatch for $TEST_DIRNAME/testfs/state/staged/e6d85023c5e619eb43d5cfbfdbdec784afef5a82ffa54e8c93bda3e0883360a3 (bad server data?)
+		Error: File content hash mismatch for $STATEDIR_STAGED/e6d85023c5e619eb43d5cfbfdbdec784afef5a82ffa54e8c93bda3e0883360a3 (bad server data?)
 	EOM
 	)
 	assert_is_output "$expected_output"

--- a/test/functional/bundleadd/add-fall-back-to-fullfile.bats
+++ b/test/functional/bundleadd/add-fall-back-to-fullfile.bats
@@ -41,9 +41,9 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/file11
 	assert_file_exists "$TARGETDIR"/file12
 	# validate zero pack was downloaded
-	assert_file_exists "$STATEDIR"/pack-test-bundle1-from-0-to-10.tar
+	assert_file_exists "$STATEDIR_CACHE"/pack-test-bundle1-from-0-to-10.tar
 	# validate the file missing from the zero pack was downloaded
-	assert_file_exists "$STATEDIR"/staged/"$removed_file"
+	assert_file_exists "$STATEDIR_STAGED"/"$removed_file"
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		Downloading packs for:

--- a/test/functional/bundleadd/add-no-disk-space.bats
+++ b/test/functional/bundleadd/add-no-disk-space.bats
@@ -16,8 +16,8 @@ test_setup() {
 	bfiles="/file1,/file2,/file3,/file4,/file5,/file6,/file7,/file8,/file9,/file10"
 	create_bundle -n test-bundle -f "$bfiles","$file1" "$TEST_NAME"
 
-	# create the state version dirs ahead of time
-	sudo mkdir "$TEST_NAME"/testfs/state/manifest/10
+	# create the state dirs ahead of time
+	sudo mkdir -p "$STATEDIR_MANIFEST"/10
 
 }
 

--- a/test/functional/bundleadd/add-uses-zeropack.bats
+++ b/test/functional/bundleadd/add-uses-zeropack.bats
@@ -28,7 +28,7 @@ test_setup() {
 	assert_file_exists "$TARGETDIR"/file10
 	assert_file_exists "$TARGETDIR"/file11
 	# validate zero pack was downloaded
-	assert_file_exists "$STATEDIR"/pack-test-bundle1-from-0-to-10.tar
+	assert_file_exists "$STATEDIR_CACHE"/pack-test-bundle1-from-0-to-10.tar
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		Downloading packs for:

--- a/test/functional/bundlelist/list-experimental.bats
+++ b/test/functional/bundlelist/list-experimental.bats
@@ -61,7 +61,7 @@ global_setup() {
 	# bundle-list with no options should list only installed bundles, there should
 	# be a way to distinguish those that are experimental
 
-	sudo mv "$STATEDIR"/manifest/10/Manifest.MoM "$STATEDIR"/manifest/10/Manifest.MoM.temp
+	sudo mv "$STATEDIR_MANIFEST"/10/Manifest.MoM "$STATEDIR_MANIFEST"/10/Manifest.MoM.temp
 	sudo mv "$WEBDIR"/10/Manifest.MoM.tar "$WEBDIR"/10/Manifest.MoM.tar.temp
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS"
@@ -78,7 +78,7 @@ global_setup() {
 	)
 	assert_in_output "$expected_output"
 
-	sudo mv "$STATEDIR"/manifest/10/Manifest.MoM.temp "$STATEDIR"/manifest/10/Manifest.MoM
+	sudo mv "$STATEDIR_MANIFEST"/10/Manifest.MoM.temp "$STATEDIR_MANIFEST"/10/Manifest.MoM
 	sudo mv "$WEBDIR"/10/Manifest.MoM.tar.temp "$WEBDIR"/10/Manifest.MoM.tar
 
 }

--- a/test/functional/bundlelist/list-no-disk-space.bats
+++ b/test/functional/bundlelist/list-no-disk-space.bats
@@ -15,7 +15,7 @@ test_setup() {
 	create_bundle -n test-bundle2 -f /file_2 "$TEST_NAME"
 
 	# create the state version dirs ahead of time
-	sudo mkdir "$TEST_NAME"/testfs/state/manifest/10
+	sudo mkdir -p "$STATEDIR_MANIFEST"/10
 
 }
 

--- a/test/functional/bundleremove/remove-no-disk-space.bats
+++ b/test/functional/bundleremove/remove-no-disk-space.bats
@@ -14,7 +14,7 @@ test_setup() {
 	create_bundle -L -n test-bundle -f /file_1 "$TEST_NAME"
 
 	# create the state version dirs ahead of time
-	sudo mkdir "$TEST_NAME"/testfs/state/manifest/10
+	sudo mkdir -p "$STATEDIR_MANIFEST"/10
 
 }
 

--- a/test/functional/os-install/install-download.bats
+++ b/test/functional/os-install/install-download.bats
@@ -33,11 +33,11 @@ test_setup() {
 	assert_is_output "$expected_output"
 	assert_file_not_exists "$TARGETDIR"/core
 
-	assert_file_exists "$STATEDIR"/manifest/10/Manifest.MoM
-	assert_file_exists "$STATEDIR"/manifest/10/Manifest.os-core
+	assert_file_exists "$STATEDIR_MANIFEST"/10/Manifest.MoM
+	assert_file_exists "$STATEDIR_MANIFEST"/10/Manifest.os-core
 
-	core_hash=$(get_hash_from_manifest "$STATEDIR"/manifest/10/Manifest.os-core "/core")
-	assert_file_exists "$STATEDIR"/staged/"$core_hash"
+	core_hash=$(get_hash_from_manifest "$STATEDIR_MANIFEST"/10/Manifest.os-core "/core")
+	assert_file_exists "$STATEDIR_STAGED"/"$core_hash"
 
 }
 #WEIGHT=1

--- a/test/functional/os-install/install-statedir-cache-offline.bats
+++ b/test/functional/os-install/install-statedir-cache-offline.bats
@@ -14,13 +14,13 @@ test_setup() {
 
 	# Populate statedir-cache
 	sudo mkdir -m 700 -p "$statedir_cache_path"
-	sudo mkdir -m 700 "$statedir_cache_path"/staged
-	sudo mkdir -m 755 -p "$statedir_cache_path"/manifest/10
-	sudo cp "$WEBDIR"/10/Manifest.MoM "$statedir_cache_path"/manifest/10
-	sudo cp "$WEBDIR"/10/Manifest.MoM.sig "$statedir_cache_path"/manifest/10
-	sudo cp "$WEBDIR"/10/Manifest.os-core "$statedir_cache_path"/manifest/10
-	sudo touch "$statedir_cache_path"/pack-os-core-from-0-to-10.tar
-	sudo rsync -r "$WEBDIR"/10/files/* "$statedir_cache_path"/staged --exclude="*.tar"
+	sudo mkdir -m 700 -p "$statedir_cache_path"/cache/staged
+	sudo mkdir -m 755 -p "$statedir_cache_path"/cache/manifest/10
+	sudo cp "$WEBDIR"/10/Manifest.MoM "$statedir_cache_path"/cache/manifest/10
+	sudo cp "$WEBDIR"/10/Manifest.MoM.sig "$statedir_cache_path"/cache/manifest/10
+	sudo cp "$WEBDIR"/10/Manifest.os-core "$statedir_cache_path"/cache/manifest/10
+	sudo touch "$statedir_cache_path"/cache/pack-os-core-from-0-to-10.tar
+	sudo rsync -r "$WEBDIR"/10/files/* "$statedir_cache_path"/cache/staged --exclude="*.tar"
 
 }
 
@@ -58,7 +58,7 @@ test_setup() {
 
 	# Swupd should attempt to download the missing manifest and fail.
 
-	sudo rm "$statedir_cache_path"/manifest/10/Manifest.os-core
+	sudo rm "$statedir_cache_path"/cache/manifest/10/Manifest.os-core
 	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --url=https://localhost --statedir-cache $statedir_cache_path -V 10"
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MANIFEST"
@@ -86,7 +86,7 @@ test_setup() {
 
 	# Swupd should attempt to download the signature and fail.
 
-	sudo rm "$statedir_cache_path"/manifest/10/Manifest.MoM.sig
+	sudo rm "$statedir_cache_path"/cache/manifest/10/Manifest.MoM.sig
 	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --url=https://localhost --statedir-cache $statedir_cache_path -V 10"
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
@@ -114,7 +114,7 @@ test_setup() {
 
 	# Swupd should attempt to download the fullfiles and fail.
 
-	sudo rm -r "$statedir_cache_path"/staged
+	sudo rm -r "$statedir_cache_path"/cache/staged
 	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --url=https://localhost --statedir-cache $statedir_cache_path -V 10"
 
 	assert_status_is "$SWUPD_COULDNT_DOWNLOAD_FILE"
@@ -145,7 +145,7 @@ test_setup() {
 
 	# Swupd should fail to download the pack, but continue successfully.
 
-	sudo rm "$statedir_cache_path"/pack-os-core-from-0-to-10.tar
+	sudo rm "$statedir_cache_path"/cache/pack-os-core-from-0-to-10.tar
 	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --url=https://localhost --statedir-cache $statedir_cache_path -V 10"
 
 	assert_status_is "$SWUPD_OK"

--- a/test/functional/os-install/install-statedir-cache.bats
+++ b/test/functional/os-install/install-statedir-cache.bats
@@ -10,17 +10,17 @@ test_setup() {
 	create_test_environment -e "$TEST_NAME" 10
 	create_bundle -n os-core -f /core "$TEST_NAME"
 
-	statedir_cache_path="${TEST_DIRNAME}/testfs/statedir-cache"
+	statedir_cache_path="$TEST_DIRNAME"/testfs/statedir-cache
 
 	# Populate statedir-cache
 	sudo mkdir -m 700 -p "$statedir_cache_path"
-	sudo mkdir -m 700 "$statedir_cache_path"/staged
-	sudo mkdir -m 755 -p "$statedir_cache_path"/manifest/10
-	sudo cp "$WEBDIR"/10/Manifest.MoM "$statedir_cache_path"/manifest/10
-	sudo cp "$WEBDIR"/10/Manifest.MoM.sig "$statedir_cache_path"/manifest/10
-	sudo cp "$WEBDIR"/10/Manifest.os-core "$statedir_cache_path"/manifest/10
-	sudo touch "$statedir_cache_path"/pack-os-core-from-0-to-10.tar
-	sudo rsync -r "$WEBDIR"/10/files/* "$statedir_cache_path"/staged --exclude="*.tar"
+	sudo mkdir -m 700 -p "$statedir_cache_path"/cache/staged
+	sudo mkdir -m 755 -p "$statedir_cache_path"/cache/manifest/10
+	sudo cp "$WEBDIR"/10/Manifest.MoM "$statedir_cache_path"/cache/manifest/10
+	sudo cp "$WEBDIR"/10/Manifest.MoM.sig "$statedir_cache_path"/cache/manifest/10
+	sudo cp "$WEBDIR"/10/Manifest.os-core "$statedir_cache_path"/cache/manifest/10
+	sudo touch "$statedir_cache_path"/cache/pack-os-core-from-0-to-10.tar
+	sudo rsync -r "$WEBDIR"/10/files/* "$statedir_cache_path"/cache/staged --exclude="*.tar"
 
 }
 
@@ -59,9 +59,9 @@ test_setup() {
 	# The statedir-cache will have no update content, so the network must be used
 	# as a fallback.
 
-	sudo rm "$statedir_cache_path"/manifest/10/Manifest.os-core
-	sudo rm "$statedir_cache_path"/pack-os-core-from-0-to-10.tar
-	sudo rm -r "$statedir_cache_path"/staged
+	sudo rm "$statedir_cache_path"/cache/manifest/10/Manifest.os-core
+	sudo rm "$statedir_cache_path"/cache/pack-os-core-from-0-to-10.tar
+	sudo rm -r "$statedir_cache_path"/cache/staged
 	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --statedir-cache $statedir_cache_path"
 
 	assert_status_is "$SWUPD_OK"
@@ -96,7 +96,7 @@ test_setup() {
 	# missing fullfiles in the statedir-cache will fallback to network downloads, so packs
 	# must not be used to populate the staged directory with fullfiles.
 
-	sudo rm -r "$statedir_cache_path"/staged
+	sudo rm -r "$statedir_cache_path"/cache/staged
 	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --statedir-cache $statedir_cache_path"
 
 	assert_status_is "$SWUPD_OK"
@@ -127,7 +127,7 @@ test_setup() {
 	# Swupd should fallback to network downloads when the statedir-cache contains
 	# corrupt manifests.
 
-	sudo sh -c "echo invalid > ${statedir_cache_path}/manifest/10/Manifest.os-core"
+	sudo sh -c "echo invalid > ${statedir_cache_path}/cache/manifest/10/Manifest.os-core"
 	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --statedir-cache $statedir_cache_path"
 
 	assert_status_is "$SWUPD_OK"

--- a/test/functional/repair/repair-no-disk-space.bats
+++ b/test/functional/repair/repair-no-disk-space.bats
@@ -23,8 +23,8 @@ test_setup() {
 	update_bundle "$TEST_NAME" test-bundle --add "$file1"
 
 	# create the state version dirs ahead of time
-	sudo mkdir "$TEST_NAME"/testfs/state/manifest/10
-	sudo mkdir "$TEST_NAME"/testfs/state/manifest/20
+	sudo mkdir -p "$STATEDIR_MANIFEST"/10
+	sudo mkdir -p "$STATEDIR_MANIFEST"/20
 
 }
 

--- a/test/functional/search/search-no-disk-space.bats
+++ b/test/functional/search/search-no-disk-space.bats
@@ -15,8 +15,8 @@ test_setup() {
 	create_bundle -n test-bundle2 -f /file_2 "$TEST_NAME"
 
 	# create the state version dirs ahead of time
-	sudo mkdir "$TEST_NAME"/testfs/state/manifest/10
-	sudo chmod -R 0700 "$TEST_NAME"/testfs/state/manifest/10
+	sudo mkdir -p "$STATEDIR_MANIFEST"/10
+	sudo chmod -R 0700 "$STATEDIR_MANIFEST"/10
 
 }
 

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -622,16 +622,31 @@ set_env_variables() { # swupd_function
 	testfs_path="$path"/"$env_name"/testfs
 
 	debug_msg "Exporting environment variables for $env_name"
-	export TEST_DIRNAME="$path"/"$env_name"
-	debug_msg "TEST_DIRNAME: $TEST_DIRNAME"
+	# relevant relative paths
 	export WEBDIR="$env_name"/web-dir
 	debug_msg "WEBDIR: $WEBDIR"
 	export TARGETDIR="$env_name"/testfs/target-dir
 	debug_msg "TARGETDIR: $TARGETDIR"
 	export STATEDIR="$env_name"/testfs/state
 	debug_msg "STATEDIR: $STATEDIR"
+
+	# relevant absolute paths
+	export TEST_DIRNAME="$path"/"$env_name"
+	debug_msg "TEST_DIRNAME: $TEST_DIRNAME"
 	export PATH_PREFIX="$TEST_DIRNAME"/testfs/target-dir
 	debug_msg "PATH_PREFIX: $PATH_PREFIX"
+	export STATEDIR_TRACKING="$TEST_DIRNAME"/testfs/state/bundles
+	debug_msg "STATEDIR_TRACKING: $STATEDIR_TRACKING"
+	export STATEDIR_CACHE="$TEST_DIRNAME"/testfs/state/cache
+	debug_msg "STATEDIR_CACHE: $STATEDIR_CACHE"
+	export STATEDIR_DELTA="$TEST_DIRNAME"/testfs/state/cache/delta
+	debug_msg "STATEDIR_DELTA: $STATEDIR_DELTA"
+	export STATEDIR_DOWNLOAD="$TEST_DIRNAME"/testfs/state/cache/download
+	debug_msg "STATEDIR_DOWNLOAD: $STATEDIR_DOWNLOAD"
+	export STATEDIR_MANIFEST="$TEST_DIRNAME"/testfs/state/cache/manifest
+	debug_msg "STATEDIR_MANIFEST: $STATEDIR_MANIFEST"
+	export STATEDIR_STAGED="$TEST_DIRNAME"/testfs/state/cache/staged
+	debug_msg "STATEDIR_STAGED: $STATEDIR_STAGED"
 
 	# different options for swupd
 	export SWUPD_OPTS="-S $testfs_path/state -p $testfs_path/target-dir -F staging -C $TEST_DIRNAME/Swupd_Root.pem -I --no-progress"
@@ -1639,21 +1654,38 @@ create_third_party_repo() { #swupd_function
 	# create the state dir for the 3rd-party repo
 	TPSTATEDIR="$STATEDIR"/3rd-party/"$repo_name"
 	debug_msg "Creating a state directory for repo $repo_name at $TPSTATEDIR..."
-	sudo mkdir -p "$TPSTATEDIR"/{staged,download,delta,telemetry,bundles}
+	sudo mkdir -p "$TPSTATEDIR"/{bundles,cache}
+	sudo mkdir -p "$TPSTATEDIR"/cache/{staged,download,delta,manifest}
 	sudo chmod -R 0700 "$STATEDIR"
 
 	# create the basic content for the 3rd-party repo
 	create_version -r "$env_name" "$version" 0 "$format" "$repo_name"
 	debug_msg "3rd-party repo $repo_name created successfully"
 
-	export TPSTATEDIR
+	# relevant relative paths
 	export TPWEBDIR="$env_name"/3rd-party/"$repo_name"
-	export TPTARGETDIR="$env_name"/testfs/target-dir/"$THIRD_PARTY_BUNDLES_DIR"/"$repo_name"
-	export TPURL="$path"/"$env_name"/3rd-party/"$repo_name"
-	debug_msg "3rd-party repo state dir: $TPSTATEDIR"
 	debug_msg "3rd-party repo content dir: $TPWEBDIR"
+	export TPTARGETDIR="$env_name"/testfs/target-dir/"$THIRD_PARTY_BUNDLES_DIR"/"$repo_name"
 	debug_msg "3rd-party repo target dir: $TPTARGETDIR"
+	export TPSTATEDIR
+	debug_msg "3rd-party repo state dir: $TPSTATEDIR"
+
+	# relevant absolute paths
+	export TPURL="$path"/"$env_name"/3rd-party/"$repo_name"
 	debug_msg "3rd-party repo URL: $TPURL"
+	export TPSTATEDIR_ABS="$path"/"$TPSTATEDIR"
+	export TPSTATEDIR_TRACKING="$TPSTATEDIR_ABS"/bundles
+	debug_msg "3rd-party repo statedir tracking dir: $TPSTATEDIR_TRACKING"
+	export TPSTATEDIR_CACHE="$TPSTATEDIR_ABS"/cache
+	debug_msg "3rd-party repo statedir cache dir: $TPSTATEDIR_CACHE"
+	export TPSTATEDIR_DELTA="$TPSTATEDIR_ABS"/cache/delta
+	debug_msg "3rd-party repo statedir delta dir: $TPSTATEDIR_DELTA"
+	export TPSTATEDIR_DOWNLOAD="$TPSTATEDIR_ABS"/cache/download
+	debug_msg "3rd-party repo statedir download dir: $TPSTATEDIR_DOWNLOAD"
+	export TPSTATEDIR_MANIFEST="$TPSTATEDIR_ABS"/cache/manifest
+	debug_msg "3rd-party repo statedir manifest dir: $TPSTATEDIR_MANIFEST"
+	export TPSTATEDIR_STAGED="$TPSTATEDIR_ABS"/cache/staged
+	debug_msg "3rd-party repo statedir staged dir: $TPSTATEDIR_STAGED"
 
 	# if requested, add the new repo to the repo.ini file
 	# and the template file
@@ -1949,7 +1981,8 @@ create_test_environment() { # swupd_function
 
 	# state files & dirs
 	debug_msg "Creating a state dir"
-	sudo mkdir -p "$statedir"/{staged,download,delta,telemetry,bundles,manifest,3rd-party}
+	sudo mkdir -p "$statedir"/{telemetry,bundles,3rd-party,cache}
+	sudo mkdir -p "$statedir"/cache/{staged,download,delta,manifest}
 	sudo chmod -R 0700 "$statedir"
 
 	# every environment needs to have at least the os-core bundle so this should be

--- a/test/functional/update/update-no-disk-space.bats
+++ b/test/functional/update/update-no-disk-space.bats
@@ -21,8 +21,8 @@ test_setup() {
 	update_bundle "$TEST_NAME" test-bundle --add "$file1"
 
 	# create the state version dirs ahead of time
-	sudo mkdir "$TEST_NAME"/testfs/state/manifest/10
-	sudo mkdir "$TEST_NAME"/testfs/state/manifest/20
+	sudo mkdir -p "$STATEDIR_MANIFEST"/10
+	sudo mkdir -p "$STATEDIR_MANIFEST"/20
 
 }
 

--- a/test/functional/update/update-search-file-index.bats
+++ b/test/functional/update/update-search-file-index.bats
@@ -39,7 +39,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$STATEDIR"/manifest/10/Manifest.test-bundle1
+	assert_file_exists "$STATEDIR_MANIFEST"/10/Manifest.test-bundle1
 }
 
 @test "UPD060: Don't download search-file index on update" {
@@ -69,7 +69,7 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_not_exists "$STATEDIR"/manifest/10/Manifest.test-bundle1
+	assert_file_not_exists "$STATEDIR_MANIFEST"/10/Manifest.test-bundle1
 }
 
 #WEIGHT=5

--- a/test/functional/update/update-statedir-bad-hash.bats
+++ b/test/functional/update/update-statedir-bad-hash.bats
@@ -9,8 +9,8 @@ test_setup() {
 	update_bundle "$TEST_NAME" os-core --add /test-file
 	file_hash=$(get_hash_from_manifest "$TEST_NAME"/web-dir/100/Manifest.os-core /test-file)
 	# copy the file from the files directory to state/staged and modify it
-	sudo cp "$WEBDIR"/100/files/"$file_hash" "$STATEDIR"/staged/
-	write_to_protected_file -a "$STATEDIR"/staged/"$file_hash" "extra string"
+	sudo cp "$WEBDIR"/100/files/"$file_hash" "$STATEDIR_STAGED"
+	write_to_protected_file -a "$STATEDIR_STAGED"/"$file_hash" "extra string"
 
 }
 


### PR DESCRIPTION
This commit moves the cache directories and files into their own "cache"
directory in the statedir, that way it is separated from state files.

Related to #1539 

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>