### PR TITLE
swupd.bash: Make swupd.bash sh compliant

### DIFF
--- a/swupd.bash
+++ b/swupd.bash
@@ -35,7 +35,7 @@ _swupd() {
           }')
 
   if [[ ${words[1]} == "3rd-party" ]]; then
-    grep -q 3rd-party <(swupd -h) || return 1
+    swupd -h | grep -q 3rd-party || return 1
 
     third_subcmds=$(swupd 3rd-party -h | sed -n -E \
                                              -e '

--- a/test/functional/usability/usa-completion-basic.bats
+++ b/test/functional/usability/usa-completion-basic.bats
@@ -10,7 +10,7 @@ load "../testlib"
 
 @test "USA002: Verify the autocomplete syntax" {
 
-	bash "$SWUPD_DIR"/swupd.bash
+	bash --posix "$SWUPD_DIR"/swupd.bash
 
 }
 


### PR DESCRIPTION
Clear requires that bash autocomplete scripts to be executable by sh
shell

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>