### PR TITLE
clean: Clean manifests in deprecated location

### DIFF
--- a/src/cmds/clean.c
+++ b/src/cmds/clean.c
@@ -469,6 +469,13 @@ enum swupd_code clean_statedir(bool dry_run, bool all)
 	path = statedir_get_manifest_root_dir();
 	ret = clean_staged_manifests(path, dry_run, all);
 	FREE(path);
+	if (ret != SWUPD_OK) {
+		return ret;
+	}
+
+	// TODO: Remove after format bump to format 31
+	// Clean all manifests outside of the new manifests folder
+	ret = clean_staged_manifests(globals.state_dir, dry_run, true);
 
 	return ret;
 }


### PR DESCRIPTION
Manifest directory has moved and we need to clean manifests in previous location.

Signed-off-by: Otavio Pontes <otavio.pontes@intel.com>