### PR TITLE
Fix syntax error in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ AC_CHECK_LIB([pthread], [pthread_create])
 
 # Program checks
 AC_CHECK_PROGS(TAR, tar)
-AC_DEFINE(_GNU_SOURCE, 1, [Use non standard gnu functions])]
+AC_DEFINE(_GNU_SOURCE, 1, [Use non standard gnu functions])
 
 # Enable/Disable debug mode
 AC_ARG_ENABLE(


### PR DESCRIPTION
The `configure` script generated from configure.ac tries to run a `]`
command, but that command doesn't exist.

The root cause is a syntax issue configure.ac: there is a stray `]` on
one of the lines.