### PR TITLE
Fixing a false positive in a "clean" test

### DIFF
--- a/test/functional/clean/clean-grouped-manifests.bats
+++ b/test/functional/clean/clean-grouped-manifests.bats
@@ -110,32 +110,38 @@ test_setup() {
 	run sudo sh -c "$SWUPD clean $SWUPD_OPTS --dry-run"
 
 	assert_status_is "$SWUPD_OK"
+
 	expected_output=$(cat <<-EOM
-		$STATEDIR_DELTA
-		$STATEDIR_DOWNLOAD
-		$STATEDIR_STAGED
-		$STATEDIR_TEMP
-		$STATEDIR_ABS/pack-vim-from-32800-to-32900.tar
-		$STATEDIR_ABS/staged/.*
-		$STATEDIR_ABS/staged/.*
-		$STATEDIR_ABS/staged
 		$STATEDIR_ABS/manifest/Manifest-emacs-delta-from-32900-to-33000
+	EOM
+	)
+	assert_regex_in_output "$expected_output"
+
+	expected_output=$(cat <<-EOM
 		$STATEDIR_ABS/manifest/32900/Manifest\\..*
 		$STATEDIR_ABS/manifest/32900/Manifest\\..*
 		$STATEDIR_ABS/manifest/32900
+	EOM
+	)
+	assert_regex_in_output "$expected_output"
+
+	expected_output=$(cat <<-EOM
 		$STATEDIR_ABS/manifest/33000/Manifest\\..*
 		$STATEDIR_ABS/manifest/33000/Manifest\\..*
 		$STATEDIR_ABS/manifest/33000/Manifest\\..*
 		$STATEDIR_ABS/manifest/33000/Manifest\\..*
 		$STATEDIR_ABS/manifest/33000
 		$STATEDIR_ABS/manifest
-		$STATEDIR_ABS/delta
-		$STATEDIR_ABS/download
+	EOM
+	)
+	assert_regex_in_output "$expected_output"
+
+	expected_output=$(cat <<-EOM
 		Would remove 20 files
 		Aproximatelly .* KB would be freed
 	EOM
 	)
-	assert_regex_is_output "$expected_output"
+	assert_regex_in_output "$expected_output"
 
 	# non of the files should be removed since it was just a dry run
 	assert_file_exists "$MOM"


### PR DESCRIPTION
When checking the output of the "clean --dry-run" command in the test,
we expect the output to be shown in a specific order, but the order can
change depending on the system since readdir doesn't warranty a specific
order when reading the content of a directory.

This commit fixes the test by only checking for the files we are
intereseted in, and it checks them with separate assertions to make sure
we don't have false positives due to the order.

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>