### PR TITLE
Allow paths that contain symlinks for cachedir

### DIFF
--- a/src/lib/archives.c
+++ b/src/lib/archives.c
@@ -32,6 +32,7 @@
 #include "log.h"
 #include "macros.h"
 #include "strings.h"
+#include "sys.h"
 
 /* _archive_check_err(ar, ret)
  *
@@ -176,7 +177,7 @@ int archives_extract_to(const char *tarfile, const char *outputdir)
 
 		/* set output directory */
 		char *fullpath;
-		string_or_die(&fullpath, "%s/%s", outputdir, archive_entry_pathname(entry));
+		fullpath = sys_path_join("%s/%s", outputdir, archive_entry_pathname(entry));
 		archive_entry_set_pathname(entry, fullpath);
 		FREE(fullpath);
 
@@ -184,7 +185,7 @@ int archives_extract_to(const char *tarfile, const char *outputdir)
 		const char *original_hardlink = archive_entry_hardlink(entry);
 		if (original_hardlink) {
 			char *new_hardlink;
-			string_or_die(&new_hardlink, "%s/%s", outputdir, original_hardlink);
+			new_hardlink = sys_path_join("%s/%s", outputdir, original_hardlink);
 			archive_entry_set_hardlink(entry, new_hardlink);
 			FREE(new_hardlink);
 		}
@@ -221,6 +222,7 @@ out:
 	archive_write_free(ext);
 	archive_read_close(a);
 	archive_read_free(a);
+
 	return r;
 }
 

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -662,6 +662,7 @@ set_env_variables() { # swupd_function
 	export SWUPD_OPTS_NO_FMT="-S $testfs_path/state -p $testfs_path/target-dir -C $TEST_DIRNAME/Swupd_Root.pem -I --no-progress"
 	export SWUPD_OPTS_NO_FMT_NO_CERT="-S $testfs_path/state -p $testfs_path/target-dir -I --no-progress"
 	export SWUPD_OPTS_NO_PATH="-S $testfs_path/state -F staging -C $TEST_DIRNAME/Swupd_Root.pem -I --no-progress"
+	export SWUPD_OPTS_NO_STATE="-p $testfs_path/target-dir -F staging -C $TEST_DIRNAME/Swupd_Root.pem -I --no-progress"
 
 	export CLIENT_CERT_DIR="$testfs_path/target-dir/etc/swupd"
 	export CLIENT_CERT="$CLIENT_CERT_DIR/client.pem"

--- a/test/functional/usability/usa-cachedir-with-symlink.bats
+++ b/test/functional/usability/usa-cachedir-with-symlink.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+# Author: Castulo Martinez
+# Email: castulo.martinez@intel.com
+
+load "../testlib"
+
+test_setup() {
+
+	create_test_environment "$TEST_NAME"
+
+	# create a symlink to the the statedir
+	sudo ln -s "$STATEDIR_ABS" "$TEST_DIRNAME"/state_path
+	sudo mkdir "$STATEDIR_ABS"/new_state
+
+}
+
+@test "USA020: Tar files can be extracted into paths that contain symlinks" {
+
+	# swupd should be able to extract files in the cache dir even when the path
+	# provided for the cache directory contains symlinks
+
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_STATE --statedir $TEST_DIRNAME/state_path/new_state"
+	assert_status_is "$SWUPD_OK"
+
+}


### PR DESCRIPTION
When the path provided by a user for the --statedir (or --cachedir)
contains a symlink swupd will fail to extrar tar files since
libarchive does not support extracting files through symlinks.

This commit fixes the issue allowing users to use symlinks in the
--statediri/--cachedir path.

Closes #1581

Signed-off-by: Castulo Martinez <castulo.martinez@intel.com>