### PR TITLE
Testlib env variables

### DIFF
--- a/test/functional/3rd-party/3rd-party-allow-http.bats
+++ b/test/functional/3rd-party/3rd-party-allow-http.bats
@@ -12,13 +12,13 @@ global_setup() {
 
 	# use a web server for serving the content, this is necessary
 	# since the code behaves differently if the content is local (e.g. file://)
-	start_web_server -r -D "$TPWEBDIR"
+	start_web_server -r -D "$TP_WEB_DIR"
 
 }
 
 test_teardown() {
 
-	sudo rm -rf "$TARGETDIR"/etc/swupd
+	sudo rm -rf "$TARGET_DIR"/etc/swupd
 
 }
 
@@ -55,7 +55,7 @@ test_teardown() {
 	assert_in_output "$expected_output"
 	assert_in_output "Repository added successfully"
 
-	run sudo sh -c "cat $PATH_PREFIX/$THIRD_PARTY_DIR/repo.ini"
+	run sudo sh -c "cat $ABS_TARGET_DIR/$TP_ROOT_DIR/repo.ini"
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		[my_repo]
@@ -63,7 +63,7 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output --identical "$expected_output"
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/my_repo/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/my_repo/usr/lib/os-release
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/my_repo/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/my_repo/usr/lib/os-release
 }
 #WEIGHT=4

--- a/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-basic.bats
@@ -45,9 +45,9 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/foo/file_2
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo2/foo/file_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TP_STATE_DIR"/bundles/test-bundle2
 
 }
 
@@ -104,10 +104,10 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/foo/file_2
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle2
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/upstream-bundle
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo2/foo/file_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TP_STATE_DIR"/bundles/test-bundle2
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/upstream-bundle
 
 	# same scenario with the arguments switched
 
@@ -136,8 +136,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/foo/file_2
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo2/foo/file_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TP_STATE_DIR"/bundles/test-bundle2
 }
 #WEIGHT=24

--- a/test/functional/3rd-party/3rd-party-bundle-add-config-file.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-config-file.bats
@@ -17,8 +17,8 @@ test_setup() {
 	create_bundle -n test-bundle3 -f /file_3     -u test-repo "$TEST_NAME"
 
 	# add test-bundle2 as a dependency of test-bundle1 and test-bundle3 as optional
-	add_dependency_to_manifest "$TPWEBDIR"/10/Manifest.test-bundle1 test-bundle2
-	add_dependency_to_manifest -o "$TPWEBDIR"/10/Manifest.test-bundle1 test-bundle3
+	add_dependency_to_manifest "$TP_WEB_DIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest -o "$TP_WEB_DIR"/10/Manifest.test-bundle1 test-bundle3
 
 	create_config_file
 
@@ -57,16 +57,16 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# test-bundle1 is installed and tracked
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TPSTATEDIR"/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TP_STATE_DIR"/bundles/test-bundle1
 
 	# test-bundle2 is installed but not tracked
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo/usr/share/clear/bundles/test-bundle2
-	assert_file_not_exists "$TPSTATEDIR"/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TP_STATE_DIR"/bundles/test-bundle2
 
 	# test-bundle3 is not installed at all
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo/usr/share/clear/bundles/test-bundle3
-	assert_file_not_exists "$TPSTATEDIR"/bundles/test-bundle3
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo/usr/share/clear/bundles/test-bundle3
+	assert_file_not_exists "$TP_STATE_DIR"/bundles/test-bundle3
 
 }
 #WEIGHT=7

--- a/test/functional/3rd-party/3rd-party-bundle-add-dangerous-flags.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-dangerous-flags.bats
@@ -11,10 +11,10 @@ test_setup() {
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
 
 	# create a file with the setuid flag set
-	file_2=$(create_file -u "$TPWEBDIR"/10/files)
+	file_2=$(create_file -u "$TP_WEB_DIR"/10/files)
 
 	# create a file with the setgid flag set
-	file_3=$(create_file -g "$TPWEBDIR"/10/files)
+	file_3=$(create_file -g "$TP_WEB_DIR"/10/files)
 
 	# create a bundle that has the file previosuly created
 	create_bundle -n test-bundle1 -f /foo/file_1,/bar/file_2:"$file_2",/bar/file_3:"$file_3" -u repo1 "$TEST_NAME"

--- a/test/functional/3rd-party/3rd-party-bundle-add-export-bin.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-export-bin.bats
@@ -10,11 +10,11 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
 	# create a 3rd-party bundle that has a couple of binaries
-	bin_file1=$(create_file -x "$TPWEBDIR"/10/files)
+	bin_file1=$(create_file -x "$TP_WEB_DIR"/10/files)
 	create_bundle -n test-bundle1 -f /file1,/foo/file_2,/usr/bin/bin_file1:"$bin_file1",/bin/bin_file2 -u repo1 "$TEST_NAME"
 	create_bundle -n test-bundle2 -f /file3,/usr/bin/bin_file1:"$bin_file1"                            -u repo1 "$TEST_NAME"
 	# let's make test-bundle2 contain /bin/bin_file1 but not export it
-	update_manifest "$TPWEBDIR"/10/Manifest.test-bundle2 file-status /usr/bin/bin_file1 F...
+	update_manifest "$TP_WEB_DIR"/10/Manifest.test-bundle2 file-status /usr/bin/bin_file1 F...
 
 }
 
@@ -48,16 +48,16 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# the script files should have been generated for the exported files
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/bin_file1
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/bin_file2
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/bin_file1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/bin_file2
 
 	# verify the content of the scripts is correct
-	run sudo sh -c "cat $TARGETDIR/$THIRD_PARTY_BIN_DIR/bin_file1"
+	run sudo sh -c "cat $TARGET_DIR/$TP_BIN_DIR/bin_file1"
 	expected_output=$(cat <<-EOM
 		#!/bin/bash
 		export PATH=.*
 		export LD_LIBRARY_PATH=.*
-		$PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/repo1/usr/bin/bin_file1 .*
+		$ABS_TARGET_DIR/$TP_BUNDLES_DIR/repo1/usr/bin/bin_file1 .*
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
@@ -69,8 +69,8 @@ test_setup() {
 	# If a 3rd-party bundle has binaries to be exported but the binary already exists
 	# in the target system, the bundle installation should be aborted
 
-	sudo mkdir -p "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"
-	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/bin_file1
+	sudo mkdir -p "$TARGET_DIR"/"$TP_BIN_DIR"
+	sudo touch "$TARGET_DIR"/"$TP_BIN_DIR"/bin_file1
 
 	run sudo sh -c "$SWUPD 3rd-party bundle-add $SWUPD_OPTS test-bundle1"
 
@@ -81,7 +81,7 @@ test_setup() {
 		Bundles added from a 3rd-party repository are forced to run with the --no-scripts flag for security reasons
 		Loading required manifests...
 		Validating 3rd-party bundle binaries...
-		Error: There is already a binary called bin_file1 in $PATH_PREFIX/opt/3rd-party/bin
+		Error: There is already a binary called bin_file1 in $ABS_TARGET_DIR/opt/3rd-party/bin
 		Aborting bundle installation...
 		Failed to install 1 of 1 bundles
 	EOM
@@ -130,15 +130,15 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/bin_file1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/bin_file1
 
 	# verify the content of the scripts is correct
-	run sudo sh -c "cat $TARGETDIR/$THIRD_PARTY_BIN_DIR/bin_file1"
+	run sudo sh -c "cat $TARGET_DIR/$TP_BIN_DIR/bin_file1"
 	expected_output=$(cat <<-EOM
 		#!/bin/bash
 		export PATH=.*
 		export LD_LIBRARY_PATH=.*
-		$PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/repo1/usr/bin/bin_file1 .*
+		$ABS_TARGET_DIR/$TP_BUNDLES_DIR/repo1/usr/bin/bin_file1 .*
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
@@ -185,17 +185,17 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/bin_file1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/bin_file1
 
 	# verify the content of the scripts is correct
-	run sudo sh -c "cat $TARGETDIR/$THIRD_PARTY_BIN_DIR/bin_file1"
+	run sudo sh -c "cat $TARGET_DIR/$TP_BIN_DIR/bin_file1"
 	expected_output=$(cat <<-EOM
 		#!/bin/bash
 		export PATH=.*
 		export LD_LIBRARY_PATH=.*
 		export XDG_DATA_DIRS=.*
 		export XDG_CONFIG_DIRS=.*
-		$PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/repo1/usr/bin/bin_file1 .*
+		$ABS_TARGET_DIR/$TP_BUNDLES_DIR/repo1/usr/bin/bin_file1 .*
 	EOM
 	)
 	assert_regex_is_output "$expected_output"

--- a/test/functional/3rd-party/3rd-party-bundle-add-multi-repo.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-multi-repo.bats
@@ -36,12 +36,12 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/foo/file_1A
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo2/baz/file_1B
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo2/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$STATEDIR"/3rd-party/repo1/bundles/test-bundle1
-	assert_file_not_exists "$STATEDIR"/3rd-party/repo2/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo1/foo/file_1A
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo2/baz/file_1B
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo2/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$STATE_DIR"/3rd-party/repo1/bundles/test-bundle1
+	assert_file_not_exists "$STATE_DIR"/3rd-party/repo2/bundles/test-bundle1
 
 }
 
@@ -68,12 +68,12 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/foo/file_1A
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo2/baz/file_1B
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo2/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$STATEDIR"/3rd-party/repo1/bundles/test-bundle1
-	assert_file_exists "$STATEDIR"/3rd-party/repo2/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo1/foo/file_1A
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo2/baz/file_1B
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo2/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$STATE_DIR"/3rd-party/repo1/bundles/test-bundle1
+	assert_file_exists "$STATE_DIR"/3rd-party/repo2/bundles/test-bundle1
 
 }
 #WEIGHT=15

--- a/test/functional/3rd-party/3rd-party-bundle-add-state.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-state.bats
@@ -39,10 +39,10 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/foo/file_1
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/home/testdir/file_2
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/etc/file_3
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/boot/file_4
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo1/foo/file_1
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo1/home/testdir/file_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo1/etc/file_3
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo1/boot/file_4
 
 }
 #WEIGHT=5

--- a/test/functional/3rd-party/3rd-party-bundle-add-symlink.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-add-symlink.bats
@@ -41,8 +41,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_symlink_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/foo/symlink
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/test-bundle1
+	assert_symlink_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/foo/symlink
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/test-bundle1
 
 }
 #WEIGHT=5

--- a/test/functional/3rd-party/3rd-party-bundle-info-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-info-basic.bats
@@ -22,7 +22,7 @@ global_setup() {
 	# when swupd initializes, if the tracking directory is empty, it will
 	# mark all installed bundles as tracked, to avoid this, let's add a dummy
 	# value to the tracking directory
-	sudo touch "$STATEDIR"/3rd-party/{repo1,repo2}/bundles/dummy
+	sudo touch "$STATE_DIR"/3rd-party/{repo1,repo2}/bundles/dummy
 
 }
 

--- a/test/functional/3rd-party/3rd-party-bundle-list-deps.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-list-deps.bats
@@ -16,9 +16,9 @@ global_setup() {
 	create_bundle  -n test-bundle3 -f /baz/file_3 -u repo1 "$TEST_NAME"
 	create_bundle  -n test-bundle4 -f /file_4     -u repo1 "$TEST_NAME"
 	create_bundle  -n test-bundle5 -f /bat/file_5 -u repo1 "$TEST_NAME"
-	add_dependency_to_manifest "$TPWEBDIR"/10/Manifest.test-bundle2 test-bundle3
-	add_dependency_to_manifest "$TPWEBDIR"/10/Manifest.test-bundle3 test-bundle4
-	add_dependency_to_manifest "$TPWEBDIR"/10/Manifest.test-bundle2 test-bundle5
+	add_dependency_to_manifest "$TP_WEB_DIR"/10/Manifest.test-bundle2 test-bundle3
+	add_dependency_to_manifest "$TP_WEB_DIR"/10/Manifest.test-bundle3 test-bundle4
+	add_dependency_to_manifest "$TP_WEB_DIR"/10/Manifest.test-bundle2 test-bundle5
 
 }
 

--- a/test/functional/3rd-party/3rd-party-bundle-list-orphans.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-list-orphans.bats
@@ -9,14 +9,14 @@ global_setup() {
 
 	create_test_environment "$TEST_NAME" 10 1
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
-	WEBDIR="$TPWEBDIR"
+	WEB_DIR="$TP_WEB_DIR"
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
 	create_bundle -L -t -n test-bundle1 -f /file_1 -u repo1 "$TEST_NAME"
 	create_bundle -L -t -n test-bundle2 -f /file_2 -u repo1 "$TEST_NAME"
 	create_bundle -L    -n test-bundle3 -f /file_3 -u repo1 "$TEST_NAME"
 	create_bundle -L -t -n test-bundle4 -f /file_4 -u repo2 "$TEST_NAME"
 	create_bundle       -n test-bundle5 -f /file_5 -u repo2 "$TEST_NAME"
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle2
 
 }
 

--- a/test/functional/3rd-party/3rd-party-bundle-remove-basic.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-basic.bats
@@ -38,9 +38,9 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/foo/file_2
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/test-bundle2
-	assert_file_not_exists "$TPSTATEDIR"/bundles/test-bundle2
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo2/foo/file_2
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TP_STATE_DIR"/bundles/test-bundle2
 
 }
 
@@ -71,9 +71,9 @@ test_setup() {
 
 @test "TPR026: Try removing one valid bundle from a third party repo and one invalid" {
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/foo/file_1
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$STATEDIR"/3rd-party/test-repo1/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/foo/file_1
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$STATE_DIR"/3rd-party/test-repo1/bundles/test-bundle1
 
 	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS test-bundle1 upstream-bundle"
 
@@ -92,15 +92,15 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/foo/file_1
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$STATEDIR"/3rd-party/test-repo1/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/foo/file_1
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$STATE_DIR"/3rd-party/test-repo1/bundles/test-bundle1
 
 	# run the same scenario with the arguments switched
 	install_bundle "$TEST_NAME"/3rd-party/test-repo1/10/Manifest.test-bundle1 test-repo1
 	clean_state_dir "$TEST_NAME" test-repo1
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/foo/file_1
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/foo/file_1
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/test-bundle1
 
 	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS upstream-bundle test-bundle1"
 
@@ -119,8 +119,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/foo/file_1
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/foo/file_1
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/test-bundle1
 
 }
 #WEIGHT=24

--- a/test/functional/3rd-party/3rd-party-bundle-remove-exported-bin.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-exported-bin.bats
@@ -10,12 +10,12 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
 	# create 3rd-party bundles that share a binary
-	bin_file1=$(create_file -x "$TPWEBDIR"/10/files)
+	bin_file1=$(create_file -x "$TP_WEB_DIR"/10/files)
 	create_bundle -L -n test-bundle1 -f /file1,/foo/file2,/usr/bin/bin_file1:"$bin_file1",/bin/bin_file2 -u repo1 "$TEST_NAME"
 	create_bundle -L -n test-bundle2 -f /file3,/usr/bin/bin_file1:"$bin_file1"                           -u repo1 "$TEST_NAME"
 	create_bundle -L -n test-bundle3 -f /file1,/usr/bin/bin_file1:"$bin_file1"                           -u repo1 "$TEST_NAME"
 	# let's make test-bundle3 contain /usr/bin/bin_file1 but not export it
-	update_manifest "$TPWEBDIR"/10/Manifest.test-bundle3 file-status /usr/bin/bin_file1 F...
+	update_manifest "$TP_WEB_DIR"/10/Manifest.test-bundle3 file-status /usr/bin/bin_file1 F...
 
 }
 
@@ -23,8 +23,8 @@ test_setup() {
 
 	# when deleting a 3rd-party bundle, all the binaries exported by the
 	# bundle should be removed as well
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file1
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file2
+	assert_file_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/bin_file1
+	assert_file_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/bin_file2
 
 	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS test-bundle1"
 
@@ -43,10 +43,10 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# non-confilcting binary scripts should have been removed
-	assert_file_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file2
+	assert_file_not_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/bin_file2
 
 	# script that are still being used by other bundles should not be removed
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file1
+	assert_file_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/bin_file1
 
 }
 
@@ -56,8 +56,8 @@ test_setup() {
 	# the binary but it did not export that binary, then the file should not be removed
 	# from the system but the script that exports the binary should
 
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file1
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file2
+	assert_file_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/bin_file1
+	assert_file_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/bin_file2
 
 	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS test-bundle1 test-bundle2"
 
@@ -84,9 +84,9 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# non-confilcting scripts to binaries should have been removed
-	assert_file_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file1
-	assert_file_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file2
-	assert_file_exists "$TPTARGETDIR"/usr/bin/bin_file1
+	assert_file_not_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/bin_file1
+	assert_file_not_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/bin_file2
+	assert_file_exists "$TP_TARGET_DIR"/usr/bin/bin_file1
 
 }
 
@@ -95,8 +95,8 @@ test_setup() {
 	# when deleting a 3rd-party bundle that has an non-exported binary,
 	# if another bundle needsthe binary, then the file should not be removed
 
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file1
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file2
+	assert_file_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/bin_file1
+	assert_file_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/bin_file2
 
 	run sudo sh -c "$SWUPD 3rd-party bundle-remove $SWUPD_OPTS test-bundle3"
 
@@ -114,9 +114,9 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file1
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/bin_file2
-	assert_file_exists "$TPTARGETDIR"/usr/bin/bin_file1
+	assert_file_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/bin_file1
+	assert_file_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/bin_file2
+	assert_file_exists "$TP_TARGET_DIR"/usr/bin/bin_file1
 
 }
 #WEIGHT=21

--- a/test/functional/3rd-party/3rd-party-bundle-remove-orphans.bats
+++ b/test/functional/3rd-party/3rd-party-bundle-remove-orphans.bats
@@ -9,15 +9,15 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME" 10 1
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
-	WEBDIR="$TPWEBDIR"
+	WEB_DIR="$TP_WEB_DIR"
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
 	create_bundle -L -t -n test-bundle1 -f /file_1 -u repo1 "$TEST_NAME"
 	create_bundle -L    -n test-bundle2 -f /file_2 -u repo1 "$TEST_NAME"
 	create_bundle -L    -n test-bundle3 -f /file_3 -u repo1 "$TEST_NAME"
 	create_bundle -L    -n test-bundle4 -f /file_4 -u repo1 "$TEST_NAME"
 	create_bundle -L    -n test-bundle5 -f /file_5 -u repo2 "$TEST_NAME"
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle3 test-bundle4
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle3 test-bundle4
 
 }
 

--- a/test/functional/3rd-party/3rd-party-clean.bats
+++ b/test/functional/3rd-party/3rd-party-clean.bats
@@ -62,34 +62,34 @@ test_setup() {
 	create_third_party_repo -a "$TEST_NAME" 10 staging repo1
 	set_current_version "$TEST_NAME" 20 repo1
 
-	sudo mkdir -p "$TPSTATEDIR_MANIFEST"/{10,20}
-	MOM=$(create_manifest "$TPSTATEDIR_MANIFEST"/20 MoM 1 10)
+	sudo mkdir -p "$ABS_TP_MANIFEST_DIR"/{10,20}
+	MOM=$(create_manifest "$ABS_TP_MANIFEST_DIR"/20 MoM 1 10)
 	write_to_protected_file -a "$MOM" "M...	dfd541b1ac9256982044848f2128f51e23ddbb72f68e9de43adaf8f7ead93657	10	p11-kit\n"
 	write_to_protected_file -a "$MOM" "M...	7414710480607fa89c307ad11d145d8bb0cbdbdf3c0692f940d906b670f6fd5d	20	emacs\n"
 	MOM_SIG="$MOM".sig ; sudo touch "$MOM_SIG"
-	FILE1="$TPSTATEDIR_MANIFEST"/10/Manifest.p11-kit ; sudo touch "$FILE1"
-	FILE2="$TPSTATEDIR_MANIFEST"/10/Manifest.p11-kit.dfd541b1ac9256982044848f2128f51e23ddbb72f68e9de43adaf8f7ead93657 ; sudo touch "$FILE2"
-	FILE3="$TPSTATEDIR_MANIFEST"/20/Manifest.emacs ; sudo touch "$FILE3"
-	FILE4="$TPSTATEDIR_MANIFEST"/20/Manifest.emacs.7414710480607fa89c307ad11d145d8bb0cbdbdf3c0692f940d906b670f6fd5d ; sudo touch "$FILE4"
-	FILE5="$TPSTATEDIR_MANIFEST"/Manifest-emacs-delta-from-10-to-20 ; sudo touch "$FILE5"
-	FILE6="$TPSTATEDIR_MANIFEST"/Manifest-vim-delta-from-10-to-20 ; sudo touch "$FILE6"
-	FILE7="$TPSTATEDIR_CACHE"/pack-blender-from-0-to-20.tar ; sudo touch "$FILE7"
-	FILE8="$TPSTATEDIR_CACHE"/pack-vim-from-10-to-20.tar ; sudo touch "$FILE8"
-	FILE9="$TPSTATEDIR_STAGED"/00004ead4b4eb1cef1ebbe13849f6c47c21d325182f98cf8f5333e9a76d2e2df ; sudo touch "$FILE9"
-	FILE10="$TPSTATEDIR_STAGED"/fffe891980af628e498b16a364b5b4d00377485370ccc4d09ac0fc072e85b31d ; sudo touch "$FILE10"
+	FILE1="$ABS_TP_MANIFEST_DIR"/10/Manifest.p11-kit ; sudo touch "$FILE1"
+	FILE2="$ABS_TP_MANIFEST_DIR"/10/Manifest.p11-kit.dfd541b1ac9256982044848f2128f51e23ddbb72f68e9de43adaf8f7ead93657 ; sudo touch "$FILE2"
+	FILE3="$ABS_TP_MANIFEST_DIR"/20/Manifest.emacs ; sudo touch "$FILE3"
+	FILE4="$ABS_TP_MANIFEST_DIR"/20/Manifest.emacs.7414710480607fa89c307ad11d145d8bb0cbdbdf3c0692f940d906b670f6fd5d ; sudo touch "$FILE4"
+	FILE5="$ABS_TP_MANIFEST_DIR"/Manifest-emacs-delta-from-10-to-20 ; sudo touch "$FILE5"
+	FILE6="$ABS_TP_MANIFEST_DIR"/Manifest-vim-delta-from-10-to-20 ; sudo touch "$FILE6"
+	FILE7="$ABS_TP_CACHE_DIR"/pack-blender-from-0-to-20.tar ; sudo touch "$FILE7"
+	FILE8="$ABS_TP_CACHE_DIR"/pack-vim-from-10-to-20.tar ; sudo touch "$FILE8"
+	FILE9="$ABS_TP_STAGED_DIR"/00004ead4b4eb1cef1ebbe13849f6c47c21d325182f98cf8f5333e9a76d2e2df ; sudo touch "$FILE9"
+	FILE10="$ABS_TP_STAGED_DIR"/fffe891980af628e498b16a364b5b4d00377485370ccc4d09ac0fc072e85b31d ; sudo touch "$FILE10"
 
 	# create the cache from "repo2"
 	create_third_party_repo -a "$TEST_NAME" 10 staging repo2
 	set_current_version "$TEST_NAME" 50 repo2
 
-	sudo mkdir -p "$TPSTATEDIR_MANIFEST"/50
-	MOM2=$(create_manifest "$TPSTATEDIR_MANIFEST"/50 MoM 1 40)
+	sudo mkdir -p "$ABS_TP_MANIFEST_DIR"/50
+	MOM2=$(create_manifest "$ABS_TP_MANIFEST_DIR"/50 MoM 1 40)
 	write_to_protected_file -a "$MOM2" "M...	dfd541b1ac9256982044848f2128f51e23ddbb72f68e9de43adaf8f7ead12345	10	blender\n"
 	write_to_protected_file -a "$MOM2" "M...	1234510480607fa89c307ad11d145d8bb0cbdbdf3c0692f940d906b670f6fd5d	20	ansible\n"
 	MOM2_SIG="$MOM2".sig ; sudo touch "$MOM2_SIG"
-	FILE11="$TPSTATEDIR_MANIFEST"/Manifest-qt-basic-delta-from-40-to-50 ; sudo touch "$FILE11"
-	FILE12="$TPSTATEDIR_CACHE"/pack-lib-imageformat-from-30-to-50.tar ; sudo touch "$FILE12"
-	FILE13="$TPSTATEDIR_STAGED"/ffaf66dab58a2074e5fe9dc6ab7bf8773c069817dcccf631148b6afc87166b4b ; sudo touch "$FILE13"
+	FILE11="$ABS_TP_MANIFEST_DIR"/Manifest-qt-basic-delta-from-40-to-50 ; sudo touch "$FILE11"
+	FILE12="$ABS_TP_CACHE_DIR"/pack-lib-imageformat-from-30-to-50.tar ; sudo touch "$FILE12"
+	FILE13="$ABS_TP_STAGED_DIR"/ffaf66dab58a2074e5fe9dc6ab7bf8773c069817dcccf631148b6afc87166b4b ; sudo touch "$FILE13"
 
 }
 
@@ -181,30 +181,30 @@ test_setup() {
 		_____________________________
 		 3rd-Party Repository: repo1
 		_____________________________
-		$STATEDIR_ABS/3rd-party/repo1/cache/.*repo1/pack-.*-from-.*-to-20.tar
-		$STATEDIR_ABS/3rd-party/repo1/cache/.*repo1/pack-.*-from-.*-to-20.tar
-		$STATEDIR_ABS/3rd-party/repo1/cache/.*repo1/delta
-		$STATEDIR_ABS/3rd-party/repo1/cache/.*repo1/download
-		$STATEDIR_ABS/3rd-party/repo1/cache/.*repo1/staged/.*
-		$STATEDIR_ABS/3rd-party/repo1/cache/.*repo1/staged/.*
-		$STATEDIR_ABS/3rd-party/repo1/cache/.*repo1/staged
-		$STATEDIR_ABS/3rd-party/repo1/cache/.*repo1/temp
-		$STATEDIR_ABS/3rd-party/repo1/cache/.*repo1/manifest/Manifest-.*-delta-from-10-to-20
-		$STATEDIR_ABS/3rd-party/repo1/cache/.*repo1/manifest/Manifest-.*-delta-from-10-to-20
-		$STATEDIR_ABS/3rd-party/repo1/cache/.*repo1/manifest/.0/Manifest\\..*\\..*
-		$STATEDIR_ABS/3rd-party/repo1/cache/.*repo1/manifest/.0/Manifest\\..*\\..*
+		$ABS_STATE_DIR/3rd-party/repo1/cache/.*repo1/pack-.*-from-.*-to-20.tar
+		$ABS_STATE_DIR/3rd-party/repo1/cache/.*repo1/pack-.*-from-.*-to-20.tar
+		$ABS_STATE_DIR/3rd-party/repo1/cache/.*repo1/delta
+		$ABS_STATE_DIR/3rd-party/repo1/cache/.*repo1/download
+		$ABS_STATE_DIR/3rd-party/repo1/cache/.*repo1/staged/.*
+		$ABS_STATE_DIR/3rd-party/repo1/cache/.*repo1/staged/.*
+		$ABS_STATE_DIR/3rd-party/repo1/cache/.*repo1/staged
+		$ABS_STATE_DIR/3rd-party/repo1/cache/.*repo1/temp
+		$ABS_STATE_DIR/3rd-party/repo1/cache/.*repo1/manifest/Manifest-.*-delta-from-10-to-20
+		$ABS_STATE_DIR/3rd-party/repo1/cache/.*repo1/manifest/Manifest-.*-delta-from-10-to-20
+		$ABS_STATE_DIR/3rd-party/repo1/cache/.*repo1/manifest/.0/Manifest\\..*\\..*
+		$ABS_STATE_DIR/3rd-party/repo1/cache/.*repo1/manifest/.0/Manifest\\..*\\..*
 		Would remove 12 files
 		Aproximatelly .* KB would be freed
 		_____________________________
 		 3rd-Party Repository: repo2
 		_____________________________
-		$STATEDIR_ABS/3rd-party/repo2/cache/.*repo2/pack-lib-imageformat-from-30-to-50.tar
-		$STATEDIR_ABS/3rd-party/repo2/cache/.*repo2/delta
-		$STATEDIR_ABS/3rd-party/repo2/cache/.*repo2/download
-		$STATEDIR_ABS/3rd-party/repo2/cache/.*repo2/staged/ffaf66dab58a2074e5fe9dc6ab7bf8773c069817dcccf631148b6afc87166b4b
-		$STATEDIR_ABS/3rd-party/repo2/cache/.*repo2/staged
-		$STATEDIR_ABS/3rd-party/repo2/cache/.*repo2/temp
-		$STATEDIR_ABS/3rd-party/repo2/cache/.*repo2/manifest/Manifest-qt-basic-delta-from-40-to-50
+		$ABS_STATE_DIR/3rd-party/repo2/cache/.*repo2/pack-lib-imageformat-from-30-to-50.tar
+		$ABS_STATE_DIR/3rd-party/repo2/cache/.*repo2/delta
+		$ABS_STATE_DIR/3rd-party/repo2/cache/.*repo2/download
+		$ABS_STATE_DIR/3rd-party/repo2/cache/.*repo2/staged/ffaf66dab58a2074e5fe9dc6ab7bf8773c069817dcccf631148b6afc87166b4b
+		$ABS_STATE_DIR/3rd-party/repo2/cache/.*repo2/staged
+		$ABS_STATE_DIR/3rd-party/repo2/cache/.*repo2/temp
+		$ABS_STATE_DIR/3rd-party/repo2/cache/.*repo2/manifest/Manifest-qt-basic-delta-from-40-to-50
 		Would remove 7 files
 		Aproximatelly .* KB would be freed
 	EOM

--- a/test/functional/3rd-party/3rd-party-diagnose-basic.bats
+++ b/test/functional/3rd-party/3rd-party-diagnose-basic.bats
@@ -23,12 +23,12 @@ global_setup() {
 	create_bundle -L -t -n test-bundle2 -f /baz/file_3 -u test-repo2 "$TEST_NAME"
 
 	# adding an untracked files into an untracked directory (/bat)
-	sudo mkdir "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/bat
-	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/bat/untracked_file1
+	sudo mkdir "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/bat
+	sudo touch "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/bat/untracked_file1
 	# adding an untracked file into tracked directory (/bar)
-	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/bar/untracked_file2
+	sudo touch "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/bar/untracked_file2
 	# adding an untracked file into /usr
-	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/untracked_file3
+	sudo touch "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo2/usr/untracked_file3
 
 }
 
@@ -44,13 +44,13 @@ global_setup() {
 		Diagnosing version 20
 		Downloading missing manifests...
 		Checking for missing files
-		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz
-		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz/file_3
+		 -> Missing file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/baz
+		 -> Missing file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/baz/file_3
 		Checking for corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/foo/file_1
-		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/lib/os-release
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/foo/file_1
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/usr/lib/os-release
 		Checking for extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bar/file_2
+		 -> File that should be deleted: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/bar/file_2
 		Inspected 19 files
 		  2 files were missing
 		  2 files did not match
@@ -115,7 +115,7 @@ global_setup() {
 		Downloading missing manifests...
 		Checking for missing files
 		Checking for corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/lib/os-release
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/usr/lib/os-release
 		Checking for extraneous files
 		Inspected 17 files
 		  1 file did not match
@@ -139,14 +139,14 @@ global_setup() {
 		Diagnosing version 20
 		Downloading missing manifests...
 		Checking for missing files
-		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz
-		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz/file_3
+		 -> Missing file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/baz
+		 -> Missing file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/baz/file_3
 		Checking for corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/foo/file_1
-		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/lib/os-release
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/foo/file_1
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/usr/lib/os-release
 		Checking for extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bar/file_2
-		Checking for extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr
+		 -> File that should be deleted: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/bar/file_2
+		Checking for extra files under $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/usr
 		Inspected 19 files
 		  2 files were missing
 		  2 files did not match
@@ -161,8 +161,8 @@ global_setup() {
 		Checking for missing files
 		Checking for corrupt files
 		Checking for extraneous files
-		Checking for extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo2/usr
-		 -> Extra file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo2/usr/untracked_file3
+		Checking for extra files under $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo2/usr
+		 -> Extra file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo2/usr/untracked_file3
 		Inspected 16 files
 		  1 file found which should be deleted
 		Use "swupd repair --picky" to correct the problems in the system
@@ -185,16 +185,16 @@ global_setup() {
 		Diagnosing version 20
 		Downloading missing manifests...
 		Checking for missing files
-		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz
-		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz/file_3
+		 -> Missing file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/baz
+		 -> Missing file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/baz/file_3
 		Checking for corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/foo/file_1
-		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/lib/os-release
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/foo/file_1
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/usr/lib/os-release
 		Checking for extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bar/file_2
-		Checking for extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bat
-		 -> Extra file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bat/untracked_file1
-		 -> Extra file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bat/
+		 -> File that should be deleted: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/bar/file_2
+		Checking for extra files under $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/bat
+		 -> Extra file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/bat/untracked_file1
+		 -> Extra file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/bat/
 		Inspected 21 files
 		  2 files were missing
 		  2 files did not match
@@ -209,7 +209,7 @@ global_setup() {
 		Checking for missing files
 		Checking for corrupt files
 		Checking for extraneous files
-		Checking for extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo2/bat
+		Checking for extra files under $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo2/bat
 		Inspected 15 files
 		Diagnose successful
 	EOM

--- a/test/functional/3rd-party/3rd-party-info.bats
+++ b/test/functional/3rd-party/3rd-party-info.bats
@@ -11,11 +11,11 @@ test_setup() {
 
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
 	create_bundle -n test-bundle1 -f /foo/file_1 -u repo1 "$TEST_NAME"
-	URL1=$TPURL
+	URL1=$ABS_TP_URL
 
 	create_third_party_repo -a "$TEST_NAME" 20 5 repo2
 	create_bundle -n test-bundle2 -f /foo/file_2 -u repo2 "$TEST_NAME"
-	URL2=$TPURL
+	URL2=$ABS_TP_URL
 
 }
 

--- a/test/functional/3rd-party/3rd-party-repair-basic.bats
+++ b/test/functional/3rd-party/3rd-party-repair-basic.bats
@@ -23,12 +23,12 @@ test_setup() {
 	create_bundle -L -t -n test-bundle2 -f /baz/file_3 -u test-repo2 "$TEST_NAME"
 
 	# adding an untracked files into an untracked directory (/bat)
-	sudo mkdir "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/bat
-	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/bat/untracked_file1
+	sudo mkdir "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/bat
+	sudo touch "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/bat/untracked_file1
 	# adding an untracked file into tracked directory (/bar)
-	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/bar/untracked_file2
+	sudo touch "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/bar/untracked_file2
 	# adding an untracked file into /usr
-	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/untracked_file3
+	sudo touch "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo2/usr/untracked_file3
 
 }
 
@@ -47,13 +47,13 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz -> fixed
-		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz/file_3 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/baz -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/baz/file_3 -> fixed
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/foo/file_1 -> fixed
-		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/usr/lib/os-release -> fixed
 		Removing extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bar/file_2 -> deleted
+		 -> File that should be deleted: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/bar/file_2 -> deleted
 		Inspected 19 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
@@ -122,7 +122,7 @@ test_setup() {
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/usr/lib/os-release -> fixed
 		Removing extraneous files
 		Inspected 17 files
 		  1 file did not match
@@ -152,14 +152,14 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz -> fixed
-		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz/file_3 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/baz -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/baz/file_3 -> fixed
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/foo/file_1 -> fixed
-		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/usr/lib/os-release -> fixed
 		Removing extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bar/file_2 -> deleted
-		Removing extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr
+		 -> File that should be deleted: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/bar/file_2 -> deleted
+		Removing extra files under $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/usr
 		Inspected 19 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
@@ -182,8 +182,8 @@ test_setup() {
 		Adding any missing files
 		Repairing corrupt files
 		Removing extraneous files
-		Removing extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo2/usr
-		 -> Extra file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo2/usr/untracked_file3 -> deleted
+		Removing extra files under $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo2/usr
+		 -> Extra file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo2/usr/untracked_file3 -> deleted
 		Inspected 16 files
 		  1 file found which should be deleted
 		    1 of 1 files were deleted
@@ -212,16 +212,16 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz -> fixed
-		 -> Missing file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/baz/file_3 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/baz -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/baz/file_3 -> fixed
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/foo/file_1 -> fixed
-		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/usr/lib/os-release -> fixed
 		Removing extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bar/file_2 -> deleted
-		Removing extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bat
-		 -> Extra file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bat/untracked_file1 -> deleted
-		 -> Extra file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo1/bat/ -> deleted
+		 -> File that should be deleted: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/bar/file_2 -> deleted
+		Removing extra files under $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/bat
+		 -> Extra file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/bat/untracked_file1 -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo1/bat/ -> deleted
 		Inspected 21 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
@@ -244,7 +244,7 @@ test_setup() {
 		Adding any missing files
 		Repairing corrupt files
 		Removing extraneous files
-		Removing extra files under $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/test-repo2/bat
+		Removing extra files under $ABS_TARGET_DIR/$TP_BUNDLES_DIR/test-repo2/bat
 		Inspected 15 files
 		Calling post-update helper scripts
 		Regenerating 3rd-party bundle binaries...

--- a/test/functional/3rd-party/3rd-party-repair-exported-bin.bats
+++ b/test/functional/3rd-party/3rd-party-repair-exported-bin.bats
@@ -12,26 +12,26 @@ test_setup() {
 	create_bundle -L -t -n test-bundle1 -f /foo/file_1,/usr/bin/binary_1,/bin/binary_2,/bin/binary_3 -u repo1 "$TEST_NAME"
 
 	# make a change to a file so we have somthing to repair
-	write_to_protected_file -a "$TPTARGETDIR"/foo/file_1 "corrupting the file"
-	write_to_protected_file -a "$TPTARGETDIR"/bin/binary_2 "corrupting the file"
+	write_to_protected_file -a "$TP_TARGET_DIR"/foo/file_1 "corrupting the file"
+	write_to_protected_file -a "$TP_TARGET_DIR"/bin/binary_2 "corrupting the file"
 
 	# add a line to the wrapper scripts for all binaries so we can tell
 	# if they were re-generated after the repair
-	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1 "TEST_STRING"
-	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2 "TEST_STRING"
-	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3 "TEST_STRING"
+	write_to_protected_file -a "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1 "TEST_STRING"
+	write_to_protected_file -a "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2 "TEST_STRING"
+	write_to_protected_file -a "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3 "TEST_STRING"
 
 }
 
 @test "TPR081: Repair a system that has a bundle with corrupt wrapper scripts from a 3rd-party repo" {
 
 	# pre-test checks
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
-	sudo grep -q "TEST_STRING" "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1 || exit 1
-	sudo grep -q "TEST_STRING" "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2 || exit 1
-	sudo grep -q "TEST_STRING" "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3 || exit 1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
+	sudo grep -q "TEST_STRING" "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1 || exit 1
+	sudo grep -q "TEST_STRING" "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2 || exit 1
+	sudo grep -q "TEST_STRING" "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3 || exit 1
 
 	# every time a user repairs a system all the wrapper scripts for
 	# binaries should be regenerated, not only those that were repaired
@@ -50,8 +50,8 @@ test_setup() {
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/repo1/bin/binary_2 -> fixed
-		 -> Hash mismatch for file: $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/repo1/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/repo1/bin/binary_2 -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/$TP_BUNDLES_DIR/repo1/foo/file_1 -> fixed
 		Removing extraneous files
 		Inspected 20 files
 		  2 files did not match
@@ -64,12 +64,12 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
-	sudo grep -vq "TEST_STRING" "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1 || exit 1
-	sudo grep -vq "TEST_STRING" "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2 || exit 1
-	sudo grep -vq "TEST_STRING" "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3 || exit 1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
+	sudo grep -vq "TEST_STRING" "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1 || exit 1
+	sudo grep -vq "TEST_STRING" "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2 || exit 1
+	sudo grep -vq "TEST_STRING" "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3 || exit 1
 
 }
 #WEIGHT=5

--- a/test/functional/3rd-party/3rd-party-repo-add-force.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add-force.bats
@@ -10,7 +10,7 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 	create_third_party_repo "$TEST_NAME" 10 staging repo1
 	# create an empty content directory that matches the repo name
-	sudo mkdir -p "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1
+	sudo mkdir -p "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo1
 
 }
 
@@ -20,7 +20,7 @@ test_setup() {
 	# and is not empty, swupd should warn the user and abort unless the --force option is used
 	# if the directory exists, but is empty, the process should continue business as usual
 
-	run sudo sh -c "$SWUPD 3rd-party add repo1 file://$TPURL $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD 3rd-party add repo1 file://$ABS_TP_URL $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -49,13 +49,13 @@ test_setup() {
 	# and is not empty, swupd should warn the user and abort unless the --force option is used
 	# if the directory exists, but is empty, the process should continue business as usual
 
-	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/leftover
+	sudo touch "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo1/leftover
 
-	run sudo sh -c "$SWUPD 3rd-party add repo1 file://$TPURL $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD 3rd-party add repo1 file://$ABS_TP_URL $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_INVALID_REPOSITORY"
 	expected_output=$(cat <<-EOM
-		Error: A content directory for a 3rd-party repository called "repo1" already exists at $PATH_PREFIX/opt/3rd-party/bundles/repo1, aborting...
+		Error: A content directory for a 3rd-party repository called "repo1" already exists at $ABS_TARGET_DIR/opt/3rd-party/bundles/repo1, aborting...
 		To force the removal of the directory and continue adding the repository use the --force option
 		Failed to add repository
 	EOM
@@ -70,13 +70,13 @@ test_setup() {
 	# and is not empty, swupd should warn the user and abort unless the --force option is used
 	# if the directory exists, but is empty, the process should continue business as usual
 
-	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/leftover
+	sudo touch "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo1/leftover
 
-	run sudo sh -c "$SWUPD 3rd-party add repo1 file://$TPURL $SWUPD_OPTS --force"
+	run sudo sh -c "$SWUPD 3rd-party add repo1 file://$ABS_TP_URL $SWUPD_OPTS --force"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Warning: A content directory for a 3rd-party repository called "repo1" already exists at $PATH_PREFIX/opt/3rd-party/bundles/repo1
+		Warning: A content directory for a 3rd-party repository called "repo1" already exists at $ABS_TARGET_DIR/opt/3rd-party/bundles/repo1
 		The --force option was used; forcing the removal of the directory
 		Adding 3rd-party repository repo1...
 		Installing the required bundle 'os-core' from the repository...

--- a/test/functional/3rd-party/3rd-party-repo-add-negative.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add-negative.bats
@@ -5,9 +5,6 @@
 
 load "../testlib"
 
-test_path=$(realpath "$TEST_NAME")
-repo="$test_path"/3rd-party/test-repo1
-
 global_setup() {
 
 	create_test_environment "$TEST_NAME"
@@ -33,7 +30,7 @@ global_setup() {
 	)
 	assert_in_output "$expected_output"
 
-	run sudo sh -c "$SWUPD 3rd-party add test-repo1 file://$repo junk_positional $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD 3rd-party add test-repo1 file://$ABS_TP_URL junk_positional $SWUPD_OPTS"
 	assert_status_is "$SWUPD_INVALID_OPTION"
 	expected_output=$(cat <<-EOM
 		Error: Unexpected arguments
@@ -45,7 +42,7 @@ global_setup() {
 
 @test "TPR004: Negative test, Add an already added repo" {
 
-	run sudo sh -c "$SWUPD 3rd-party add test-repo1 file://$repo $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD 3rd-party add test-repo1 file://$ABS_TP_URL $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Repository added successfully
@@ -53,7 +50,7 @@ global_setup() {
 	)
 	assert_in_output "$expected_output"
 
-	run sudo sh -c "$SWUPD 3rd-party add test-repo1 file://$repo $SWUPD_OPTS"
+	run sudo sh -c "$SWUPD 3rd-party add test-repo1 file://$ABS_TP_URL $SWUPD_OPTS"
 	assert_status_is "$SWUPD_INVALID_OPTION"
 	expected_output=$(cat <<-EOM
 		Error: A 3rd-party repository called "test-repo1" already exists

--- a/test/functional/3rd-party/3rd-party-repo-add.bats
+++ b/test/functional/3rd-party/3rd-party-repo-add.bats
@@ -12,9 +12,9 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_third_party_repo "$TEST_NAME" 10 staging test-repo1
-	repo1="$TPURL"
+	repo1="$ABS_TP_URL"
 	create_third_party_repo "$TEST_NAME" 10 staging test-repo2
-	repo2="$TPURL"
+	repo2="$ABS_TP_URL"
 
 }
 
@@ -40,7 +40,7 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 
-	run sudo sh -c "cat $PATH_PREFIX/$THIRD_PARTY_DIR/repo.ini"
+	run sudo sh -c "cat $ABS_TARGET_DIR/$TP_ROOT_DIR/repo.ini"
 	expected_output=$(cat <<-EOM
 			[test-repo1]
 			url=file://$repo1
@@ -49,8 +49,8 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# make sure the os-core bundle of the repo is installed in the appropriate place
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/lib/os-release
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/usr/lib/os-release
 
 }
 
@@ -64,8 +64,8 @@ test_setup() {
 	EOM
 	)
 	assert_in_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/lib/os-release
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/usr/lib/os-release
 
 	run sudo sh -c "$SWUPD 3rd-party add test-repo2 file://$repo2 $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
@@ -74,10 +74,10 @@ test_setup() {
 	EOM
 	)
 	assert_in_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo2/usr/lib/os-release
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo2/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo2/usr/lib/os-release
 
-	run sudo sh -c "cat $PATH_PREFIX/$THIRD_PARTY_DIR/repo.ini"
+	run sudo sh -c "cat $ABS_TARGET_DIR/$TP_ROOT_DIR/repo.ini"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 			[test-repo1]

--- a/test/functional/3rd-party/3rd-party-repo-list.bats
+++ b/test/functional/3rd-party/3rd-party-repo-list.bats
@@ -28,9 +28,9 @@ test_setup(){
 	EOM
 	)
 
-	repo_config_file="$PATH_PREFIX"/"$THIRD_PARTY_DIR"/repo.ini
-	run sudo sh -c "mkdir -p $STATEDIR/3rd-party/"
-	run sudo sh -c "mkdir -p $PATH_PREFIX/$THIRD_PARTY_BUNDLES_DIR/{test1,test2,test3,test4,test5}"
+	repo_config_file="$ABS_TARGET_DIR"/"$TP_ROOT_DIR"/repo.ini
+	run sudo sh -c "mkdir -p $STATE_DIR/3rd-party/"
+	run sudo sh -c "mkdir -p $ABS_TARGET_DIR/$TP_BUNDLES_DIR/{test1,test2,test3,test4,test5}"
 	write_to_protected_file -a "$repo_config_file" "$contents"
 
 }

--- a/test/functional/3rd-party/3rd-party-repo-remove-corrupt.bats
+++ b/test/functional/3rd-party/3rd-party-repo-remove-corrupt.bats
@@ -11,7 +11,7 @@ test_setup() {
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
 	create_bundle -L -t -n test-bundle1 -f /file_1,/bin/binary_1 -u repo1 "$TEST_NAME"
 	# delete some files to make the repo corrupt
-	sudo rm "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/usr/lib/os-release
+	sudo rm "$ABS_TARGET_DIR"/"$TP_BUNDLES_DIR"/repo1/usr/lib/os-release
 
 }
 
@@ -26,7 +26,7 @@ test_setup() {
 		Error: Unable to determine current version for repository repo1
 		Error: The 3rd-party repository repo1 is corrupt and cannot be removed cleanly
 		To force the removal of the repository use the --force option
-		Please be aware that this may leave exported files in $PATH_PREFIX/$THIRD_PARTY_BIN_DIR
+		Please be aware that this may leave exported files in $ABS_TARGET_DIR/$TP_BIN_DIR
 		Failed to remove repository
 	EOM
 	)
@@ -44,7 +44,7 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Error: Unable to determine current version for repository repo1
 		Warning: The --force option is specified; forcing the removal of the repository
-		Please be aware that this may leave exported files in $PATH_PREFIX/$THIRD_PARTY_BIN_DIR
+		Please be aware that this may leave exported files in $ABS_TARGET_DIR/$TP_BIN_DIR
 		Removing repository repo1...
 		Repository and its content partially removed
 	EOM

--- a/test/functional/3rd-party/3rd-party-repo-remove-negative.bats
+++ b/test/functional/3rd-party/3rd-party-repo-remove-negative.bats
@@ -51,7 +51,7 @@ test_setup(){
 
 @test "TPR011: Negative test, Remove a repo on a new system" {
 
-	run sudo sh -c "rm -r $PATH_PREFIX/$THIRD_PARTY_DIR"
+	run sudo sh -c "rm -r $ABS_TARGET_DIR/$TP_ROOT_DIR"
 
 	run sudo sh -c "$SWUPD 3rd-party remove $SWUPD_OPTS repo1"
 	assert_status_is "$SWUPD_INVALID_REPOSITORY"

--- a/test/functional/3rd-party/3rd-party-repo-remove.bats
+++ b/test/functional/3rd-party/3rd-party-repo-remove.bats
@@ -26,13 +26,13 @@ test_setup(){
 @test "TPR008: Remove multiple repos" {
 
 	#remove at start of file
-	assert_dir_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/repo1
-	assert_dir_exists "$STATEDIR"/3rd-party/repo1
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_1
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_2
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_3
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_4
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_5
+	assert_dir_exists "$ABS_TARGET_DIR"/"$TP_BUNDLES_DIR"/repo1
+	assert_dir_exists "$STATE_DIR"/3rd-party/repo1
+	assert_file_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/binary_1
+	assert_file_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/binary_2
+	assert_file_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/binary_3
+	assert_file_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/binary_4
+	assert_file_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/binary_5
 
 	run sudo sh -c "$SWUPD 3rd-party remove $SWUPD_OPTS repo2"
 	assert_status_is "$SWUPD_OK"
@@ -44,17 +44,17 @@ test_setup(){
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_dir_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/repo1
-	assert_dir_exists "$STATEDIR"/3rd-party/repo1
-	assert_dir_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/repo2
-	assert_dir_not_exists "$STATEDIR"/3rd-party/repo2
-	assert_dir_exists "$PATH_PREFIX"/"$THIRD_PARTY_BUNDLES_DIR"/repo3
-	assert_dir_exists "$STATEDIR"/3rd-party/repo3
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_1
-	assert_file_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_2
-	assert_file_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_3
-	assert_file_not_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_4
-	assert_file_exists "$PATH_PREFIX"/"$THIRD_PARTY_BIN_DIR"/binary_5
+	assert_dir_exists "$ABS_TARGET_DIR"/"$TP_BUNDLES_DIR"/repo1
+	assert_dir_exists "$STATE_DIR"/3rd-party/repo1
+	assert_dir_not_exists "$ABS_TARGET_DIR"/"$TP_BUNDLES_DIR"/repo2
+	assert_dir_not_exists "$STATE_DIR"/3rd-party/repo2
+	assert_dir_exists "$ABS_TARGET_DIR"/"$TP_BUNDLES_DIR"/repo3
+	assert_dir_exists "$STATE_DIR"/3rd-party/repo3
+	assert_file_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/binary_1
+	assert_file_not_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/binary_2
+	assert_file_not_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/binary_3
+	assert_file_not_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/binary_4
+	assert_file_exists "$ABS_TARGET_DIR"/"$TP_BIN_DIR"/binary_5
 
 }
 #WEIGHT=12

--- a/test/functional/3rd-party/3rd-party-update-basic.bats
+++ b/test/functional/3rd-party/3rd-party-update-basic.bats
@@ -55,7 +55,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/new_file
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/new_file
 
 }
 
@@ -116,7 +116,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/new_file
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/new_file
 
 }
 

--- a/test/functional/3rd-party/3rd-party-update-dangerous-flags.bats
+++ b/test/functional/3rd-party/3rd-party-update-dangerous-flags.bats
@@ -10,9 +10,9 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 	create_third_party_repo -a "$TEST_NAME" 10 staging repo1
 
-	file_1=$(create_file "$TPWEBDIR"/10/files)
+	file_1=$(create_file "$TP_WEB_DIR"/10/files)
 	# create a file with a dangerous flag (setuid)
-	file_2=$(create_file -u "$TPWEBDIR"/10/files)
+	file_2=$(create_file -u "$TP_WEB_DIR"/10/files)
 
 	# create and install a bundle that already has a file with
 	# a dangerous flag (file_2)
@@ -22,7 +22,7 @@ test_setup() {
 	# that changes the flags of an existing file with dangerous ones
 	create_version -p "$TEST_NAME" 20 10 staging repo1
 	sudo chmod g+s "$file_1"
-	file_4=$(create_file -u "$TPWEBDIR"/20/files)
+	file_4=$(create_file -u "$TP_WEB_DIR"/20/files)
 
 	# file_1 was not dangerous, it now is
 	update_bundle -p "$TEST_NAME" test-bundle1 --update /foo/file_1:"$file_1" repo1

--- a/test/functional/3rd-party/3rd-party-update-export-template-multi-repo.bats
+++ b/test/functional/3rd-party/3rd-party-update-export-template-multi-repo.bats
@@ -20,28 +20,28 @@ test_setup() {
 	update_bundle "$TEST_NAME" test-bundle1 --update /bin/binary_2 repo1
 
 	# add an update to the current template file
-	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE" "\nA little update\n"
+	write_to_protected_file -a "$TARGET_DIR"/"$TP_ROOT_DIR"/"$TP_SCRIPT_TEMPLATE_FILE_NAME" "\nA little update\n"
 
 	# let's add a line to the scripts for all binaries so we can tell if
 	# they were re-generated after the update
-	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1 "TEST_STRING"
-	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2 "TEST_STRING"
-	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3 "TEST_STRING"
-	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_4 "TEST_STRING"
-	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5 "TEST_STRING"
-	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6 "TEST_STRING"
+	write_to_protected_file -a "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1 "TEST_STRING"
+	write_to_protected_file -a "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2 "TEST_STRING"
+	write_to_protected_file -a "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3 "TEST_STRING"
+	write_to_protected_file -a "$TARGET_DIR"/"$TP_BIN_DIR"/binary_4 "TEST_STRING"
+	write_to_protected_file -a "$TARGET_DIR"/"$TP_BIN_DIR"/binary_5 "TEST_STRING"
+	write_to_protected_file -a "$TARGET_DIR"/"$TP_BIN_DIR"/binary_6 "TEST_STRING"
 
 }
 
 @test "TPR085: Update 3rd-party repositories that have exported binaries when the template has changed" {
 
 	# pre-test checks
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_4
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_4
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_5
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_6
 
 	# If the template file is different than that in the swupd binary,
 	# all binaries should be re-generated regardless of if they were updated or not,
@@ -99,34 +99,34 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# post-test checks
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
 	assert_not_in_output "TEST_STRING"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
 	assert_not_in_output "TEST_STRING"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
 	assert_not_in_output "TEST_STRING"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_4
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_4
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_4
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_4
 	assert_not_in_output "TEST_STRING"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_5
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_5
 	assert_not_in_output "TEST_STRING"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_6
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_6
 	assert_not_in_output "TEST_STRING"
 
 	# make sure the template file exists in the system and is correct
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE"
-	template_file=$(sudo cat "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE")
-	template=$(echo -e "$SCRIPT_TEMPLATE")
+	assert_file_exists "$TARGET_DIR"/"$TP_ROOT_DIR"/"$TP_SCRIPT_TEMPLATE_FILE_NAME"
+	template_file=$(sudo cat "$TARGET_DIR"/"$TP_ROOT_DIR"/"$TP_SCRIPT_TEMPLATE_FILE_NAME")
+	template=$(echo -e "$TP_SCRIPT_TEMPLATE_CONTENT")
 	assert_equal "$template_file" "$template"
 
 }
@@ -134,12 +134,12 @@ test_setup() {
 @test "TPR086: Update 3rd-party repository that has exported binaries when the template has changed using --repo" {
 
 	# pre-test checks
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_4
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_4
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_5
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_6
 
 	# If the template file is different than that in the swupd binary,
 	# all binaries should be re-generated for all repositories,
@@ -188,34 +188,34 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# post-test checks
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
 	assert_not_in_output "TEST_STRING"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
 	assert_not_in_output "TEST_STRING"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
 	assert_not_in_output "TEST_STRING"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_4
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_4
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_4
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_4
 	assert_not_in_output "TEST_STRING"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_5
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_5
 	assert_not_in_output "TEST_STRING"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_6
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_6
 	assert_not_in_output "TEST_STRING"
 
 	# make sure the template file exists in the system and is correct
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE"
-	template_file=$(sudo cat "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE")
-	template=$(echo -e "$SCRIPT_TEMPLATE")
+	assert_file_exists "$TARGET_DIR"/"$TP_ROOT_DIR"/"$TP_SCRIPT_TEMPLATE_FILE_NAME"
+	template_file=$(sudo cat "$TARGET_DIR"/"$TP_ROOT_DIR"/"$TP_SCRIPT_TEMPLATE_FILE_NAME")
+	template=$(echo -e "$TP_SCRIPT_TEMPLATE_CONTENT")
 	assert_equal "$template_file" "$template"
 
 }

--- a/test/functional/3rd-party/3rd-party-update-export-template.bats
+++ b/test/functional/3rd-party/3rd-party-update-export-template.bats
@@ -19,18 +19,18 @@ test_setup() {
 
 	# let's add a line to the scripts for all binaries so we can tell if
 	# they were re-generated after the update
-	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1 "TEST_STRING"
-	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2 "TEST_STRING"
-	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3 "TEST_STRING"
+	write_to_protected_file -a "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1 "TEST_STRING"
+	write_to_protected_file -a "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2 "TEST_STRING"
+	write_to_protected_file -a "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3 "TEST_STRING"
 
 }
 
 @test "TPR082: Update a 3rd-party bundle that has exported binaries when the template has not changed" {
 
 	# pre-test checks
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
 
 	# If the template file didn't change then only the binary that was
 	# udpated should be re-generated
@@ -69,22 +69,22 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# post-test checks
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
 	assert_in_output "TEST_STRING"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
 	assert_not_in_output "TEST_STRING"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
 	assert_in_output "TEST_STRING"
 
 	# make sure the template file exists in the system and is correct
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE"
-	template_file=$(sudo cat "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE")
-	template=$(echo -e "$SCRIPT_TEMPLATE")
+	assert_file_exists "$TARGET_DIR"/"$TP_ROOT_DIR"/"$TP_SCRIPT_TEMPLATE_FILE_NAME"
+	template_file=$(sudo cat "$TARGET_DIR"/"$TP_ROOT_DIR"/"$TP_SCRIPT_TEMPLATE_FILE_NAME")
+	template=$(echo -e "$TP_SCRIPT_TEMPLATE_CONTENT")
 	assert_equal "$template_file" "$template"
 
 }
@@ -92,12 +92,12 @@ test_setup() {
 @test "TPR083: Update a 3rd-party bundle that has exported binaries when there is no template" {
 
 	# pre-test checks
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
 
 	# delete the template from the system
-	sudo rm "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE"
+	sudo rm "$TARGET_DIR"/"$TP_ROOT_DIR"/"$TP_SCRIPT_TEMPLATE_FILE_NAME"
 
 	# If the template file is not found all binaries should be re-generated
 	# regardless of if they were updated or not, also the template file
@@ -143,22 +143,22 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# post-test checks
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
 	assert_not_in_output "TEST_STRING"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
 	assert_not_in_output "TEST_STRING"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
 	assert_not_in_output "TEST_STRING"
 
 	# make sure the template file exists in the system and is correct
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE"
-	template_file=$(sudo cat "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE")
-	template=$(echo -e "$SCRIPT_TEMPLATE")
+	assert_file_exists "$TARGET_DIR"/"$TP_ROOT_DIR"/"$TP_SCRIPT_TEMPLATE_FILE_NAME"
+	template_file=$(sudo cat "$TARGET_DIR"/"$TP_ROOT_DIR"/"$TP_SCRIPT_TEMPLATE_FILE_NAME")
+	template=$(echo -e "$TP_SCRIPT_TEMPLATE_CONTENT")
 	assert_equal "$template_file" "$template"
 
 }
@@ -166,12 +166,12 @@ test_setup() {
 @test "TPR084: Update a 3rd-party bundle that has exported binaries when the template has changed" {
 
 	# pre-test checks
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
 
 	# make a change to the template
-	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE" "random update"
+	write_to_protected_file -a "$TARGET_DIR"/"$TP_ROOT_DIR"/"$TP_SCRIPT_TEMPLATE_FILE_NAME" "random update"
 
 	# If the template file is different than that in the swupd binary,
 	# all binaries should be re-generated regardless of if they were updated or not,
@@ -217,25 +217,25 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# post-test checks
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
 	assert_not_in_output "TEST_STRING"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
 	assert_not_in_output "TEST_STRING"
 
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
 	assert_not_in_output "TEST_STRING"
 
-	run sudo cat "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE"
+	run sudo cat "$TARGET_DIR"/"$TP_BIN_DIR"/"$TP_SCRIPT_TEMPLATE_FILE_NAME"
 	assert_not_in_output "random update"
 
 	# make sure the template file exists in the system and is correct
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE"
-	template_file=$(sudo cat "$TARGETDIR"/"$THIRD_PARTY_DIR"/"$THIRD_PARTY_SCRIPT_TEMPLATE")
-	template=$(echo -e "$SCRIPT_TEMPLATE")
+	assert_file_exists "$TARGET_DIR"/"$TP_ROOT_DIR"/"$TP_SCRIPT_TEMPLATE_FILE_NAME"
+	template_file=$(sudo cat "$TARGET_DIR"/"$TP_ROOT_DIR"/"$TP_SCRIPT_TEMPLATE_FILE_NAME")
+	template=$(echo -e "$TP_SCRIPT_TEMPLATE_CONTENT")
 	assert_equal "$template_file" "$template"
 
 }

--- a/test/functional/3rd-party/3rd-party-update-exported-bin.bats
+++ b/test/functional/3rd-party/3rd-party-update-exported-bin.bats
@@ -23,20 +23,20 @@ test_setup() {
 	update_bundle -p "$TEST_NAME" test-bundle1 --add    /usr/local/bin/binary_6     repo1
 	update_bundle -p "$TEST_NAME" test-bundle1 --delete /usr/bin/binary_1           repo1
 	update_bundle    "$TEST_NAME" test-bundle1 --rename /bin/binary_3:/bin/binary_7 repo1
-	add_dependency_to_manifest "$TPWEBDIR"/20/Manifest.test-bundle1 test-bundle3
+	add_dependency_to_manifest "$TP_WEB_DIR"/20/Manifest.test-bundle1 test-bundle3
 
 	# let's add a line to the script for binary_2 so we can tell if it was
 	# re-generated after the update
-	write_to_protected_file -a "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2 "TEST_STRING"
+	write_to_protected_file -a "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2 "TEST_STRING"
 
 }
 
 @test "TPR059: Update a 3rd-party bundle that has exported binaries" {
 
 	# pre-test checks
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
 
 	# During an update, a bundle that contains binaries should have
 	# their scripts updated too
@@ -75,14 +75,14 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_1
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_3
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_4
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_5
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_6
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_7
-	sudo grep -vq "TEST_STRING" "$TARGETDIR"/"$THIRD_PARTY_BIN_DIR"/binary_2 || exit 1
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_1
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_3
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_4
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_5
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_6
+	assert_file_exists "$TARGET_DIR"/"$TP_BIN_DIR"/binary_7
+	sudo grep -vq "TEST_STRING" "$TARGET_DIR"/"$TP_BIN_DIR"/binary_2 || exit 1
 
 }
 #WEIGHT=14

--- a/test/functional/3rd-party/3rd-party-update-specific-version.bats
+++ b/test/functional/3rd-party/3rd-party-update-specific-version.bats
@@ -50,7 +50,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/new_file
+	assert_file_not_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/new_file
 
 }
 

--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -242,11 +242,11 @@ SWUPD_OPTS="-S /home/user/swupd-client/add-boot-file_ADD014/testfs/state
 -p /home/user/swupd-client/add-boot-file_ADD014/testfs/target-dir -F staging
 -C /home/user/swupd-client/Swupd_Root.pem -I --no-progress"
 
-TEST_DIRNAME=/home/user/swupd-client/add-boot-file_ADD014
-PATH_PREFIX=/home/user/swupd-client/add-boot-file_ADD014/testfs/target-dir
-WEBDIR=add-boot-file_ADD014/web-dir
-TARGETDIR=add-boot-file_ADD014/testfs/target-dir
-STATEDIR=add-boot-file_ADD014/testfs/state
+ABS_TEST_DIR=/home/user/swupd-client/add-boot-file_ADD014
+ABS_TARGET_DIR=/home/user/swupd-client/add-boot-file_ADD014/testfs/target-dir
+WEB_DIR=add-boot-file_ADD014/web-dir
+TARGET_DIR=add-boot-file_ADD014/testfs/target-dir
+STATE_DIR=add-boot-file_ADD014/testfs/state
 
 # now that we have created the test environment, we can use the SWUPD_OPTS to
 # debug our swupd code using that environment
@@ -351,11 +351,11 @@ instead of letting the helper functions create a random file for you. This can b
 achieved by using the ':' character and specifying the file you want to use.
 For example:
 ```bash
-$ create_bundle -L -n test-bundle -f /foo/bar/test-file:"$WEBDIR"/10/files/"$hashed_name" my_env
+$ create_bundle -L -n test-bundle -f /foo/bar/test-file:"$WEB_DIR"/10/files/"$hashed_name" my_env
 ```
 This will create a bundle that has the file */foo/bar/test-file* in the manifest and
 will refer to the file specified by you. Note that it is your responsibility to copy
-that file to the appropriate directory first (*"$WEBDIR"/\<version\>/files*), to
+that file to the appropriate directory first (*"$WEB_DIR"/\<version\>/files*), to
 name it properly according to its hash, and to create a tar for that file.
 
 ### Using Multiple Versions

--- a/test/functional/api/api-3rd-party-add.bats
+++ b/test/functional/api/api-3rd-party-add.bats
@@ -9,7 +9,7 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_third_party_repo "$TEST_NAME" 10 staging repo1
-	export repo1="$TPURL"
+	export repo1="$ABS_TP_URL"
 
 }
 

--- a/test/functional/api/api-3rd-party-bundle-info.bats
+++ b/test/functional/api/api-3rd-party-bundle-info.bats
@@ -14,8 +14,8 @@ global_setup() {
 	create_bundle -n test-bundle2 -f /file_2 -u repo2 "$TEST_NAME"
 	create_bundle -n test-bundle3 -f /file_3 -u repo2 "$TEST_NAME"
 	create_bundle -n test-bundle4 -f /file_4 -u repo2 "$TEST_NAME"
-	add_dependency_to_manifest "$TPWEBDIR"/10/Manifest.test-bundle2 test-bundle3
-	add_dependency_to_manifest "$TPWEBDIR"/10/Manifest.test-bundle3 test-bundle4
+	add_dependency_to_manifest "$TP_WEB_DIR"/10/Manifest.test-bundle2 test-bundle3
+	add_dependency_to_manifest "$TP_WEB_DIR"/10/Manifest.test-bundle3 test-bundle4
 
 }
 

--- a/test/functional/api/api-3rd-party-bundle-list.bats
+++ b/test/functional/api/api-3rd-party-bundle-list.bats
@@ -9,7 +9,7 @@ global_setup() {
 
 	create_test_environment "$TEST_NAME" 10 1
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
-	REPO1="$TPWEBDIR"
+	REPO1="$TP_WEB_DIR"
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
 	create_bundle -L -t -n test-bundle1 -f /file_1 -u repo1 "$TEST_NAME"
 	create_bundle -L -t -n test-bundle2 -f /file_2 -u repo1 "$TEST_NAME"

--- a/test/functional/api/api-3rd-party-clean.bats
+++ b/test/functional/api/api-3rd-party-clean.bats
@@ -10,13 +10,13 @@ test_setup() {
 	create_test_environment "$TEST_NAME" 10 1
 
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
-	CACHE1="$TPSTATEDIR_CACHE"
-	sudo mkdir -p "$TPSTATEDIR_MANIFEST"/10
-	sudo touch "$TPSTATEDIR_MANIFEST"/10/Manifest.test{1..3}
+	CACHE1="$ABS_TP_CACHE_DIR"
+	sudo mkdir -p "$ABS_TP_MANIFEST_DIR"/10
+	sudo touch "$ABS_TP_MANIFEST_DIR"/10/Manifest.test{1..3}
 	sudo touch "$CACHE1"/pack-test{1..2}-from-0.tar
 
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
-	CACHE2="$TPSTATEDIR_CACHE"
+	CACHE2="$ABS_TP_CACHE_DIR"
 	sudo touch "$CACHE2"/pack-test3-from-0.tar
 
 }

--- a/test/functional/api/api-3rd-party-diagnose.bats
+++ b/test/functional/api/api-3rd-party-diagnose.bats
@@ -16,7 +16,7 @@ global_setup() {
 	update_bundle -p "$TEST_NAME" test-bundle1 --update /foo/file_1 repo1
 	update_bundle -p "$TEST_NAME" test-bundle1 --delete /bar/file_2 repo1
 	update_bundle    "$TEST_NAME" test-bundle1 --add    /baz/file_3 repo1
-	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/usr/untracked_file
+	sudo touch "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo1/usr/untracked_file
 	set_current_version "$TEST_NAME" 20 repo1
 
 	# add another 3rd-party repo that has nothing to get fixed
@@ -32,12 +32,12 @@ global_setup() {
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
 		[repo1]
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/baz
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/baz/file_3
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/foo/file_1
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/usr/lib/os-release
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/bar/file_2
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/usr/untracked_file
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/baz
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/baz/file_3
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/foo/file_1
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/usr/lib/os-release
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/bar/file_2
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/usr/untracked_file
 		[repo2]
 	EOM
 	)
@@ -51,12 +51,12 @@ global_setup() {
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/baz
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/baz/file_3
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/foo/file_1
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/usr/lib/os-release
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/bar/file_2
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/usr/untracked_file
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/baz
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/baz/file_3
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/foo/file_1
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/usr/lib/os-release
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/bar/file_2
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/usr/untracked_file
 	EOM
 	)
 	assert_is_output "$expected_output"

--- a/test/functional/api/api-3rd-party-list.bats
+++ b/test/functional/api/api-3rd-party-list.bats
@@ -9,9 +9,9 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo1
-	export repo1="$TPURL"
+	export repo1="$ABS_TP_URL"
 	create_third_party_repo -a "$TEST_NAME" 10 1 repo2
-	export repo2="$TPURL"
+	export repo2="$ABS_TP_URL"
 
 }
 

--- a/test/functional/api/api-3rd-party-repair.bats
+++ b/test/functional/api/api-3rd-party-repair.bats
@@ -16,7 +16,7 @@ test_setup() {
 	update_bundle -p "$TEST_NAME" test-bundle1 --update /foo/file_1 repo1
 	update_bundle -p "$TEST_NAME" test-bundle1 --delete /bar/file_2 repo1
 	update_bundle    "$TEST_NAME" test-bundle1 --add    /baz/file_3 repo1
-	sudo touch "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/repo1/usr/untracked_file
+	sudo touch "$TARGET_DIR"/"$TP_BUNDLES_DIR"/repo1/usr/untracked_file
 	set_current_version "$TEST_NAME" 20 repo1
 
 	# add another 3rd-party repo that has nothing to get fixed
@@ -32,12 +32,12 @@ test_setup() {
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		[repo1]
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/baz -> fixed
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/baz/file_3 -> fixed
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/foo/file_1 -> fixed
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/usr/lib/os-release -> fixed
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/bar/file_2 -> deleted
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/usr/untracked_file -> deleted
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/baz -> fixed
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/baz/file_3 -> fixed
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/foo/file_1 -> fixed
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/usr/lib/os-release -> fixed
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/bar/file_2 -> deleted
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/usr/untracked_file -> deleted
 		[repo2]
 	EOM
 	)
@@ -51,12 +51,12 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/baz -> fixed
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/baz/file_3 -> fixed
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/foo/file_1 -> fixed
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/usr/lib/os-release -> fixed
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/bar/file_2 -> deleted
-		$PATH_PREFIX/opt/3rd-party/bundles/repo1/usr/untracked_file -> deleted
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/baz -> fixed
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/baz/file_3 -> fixed
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/foo/file_1 -> fixed
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/usr/lib/os-release -> fixed
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/bar/file_2 -> deleted
+		$ABS_TARGET_DIR/opt/3rd-party/bundles/repo1/usr/untracked_file -> deleted
 	EOM
 	)
 	assert_is_output "$expected_output"

--- a/test/functional/api/api-autoupdate.bats
+++ b/test/functional/api/api-autoupdate.bats
@@ -8,7 +8,7 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment "$TEST_NAME"
-	sudo mkdir -p "$PATH_PREFIX"/etc/systemd/system
+	sudo mkdir -p "$ABS_TARGET_DIR"/etc/systemd/system
 
 }
 
@@ -24,16 +24,16 @@ test_setup() {
 @test "API005: autoupdate --enable" {
 
 	# create mask files manually
-	sudo ln -s /dev/null "$PATH_PREFIX"/etc/systemd/system/swupd-update.service
-	sudo ln -s /dev/null "$PATH_PREFIX"/etc/systemd/system/swupd-update.timer
+	sudo ln -s /dev/null "$ABS_TARGET_DIR"/etc/systemd/system/swupd-update.service
+	sudo ln -s /dev/null "$ABS_TARGET_DIR"/etc/systemd/system/swupd-update.timer
 
 	run sudo sh -c "$SWUPD autoupdate $SWUPD_OPTS --enable --quiet"
 
 	assert_status_is "$SWUPD_OK"
 	assert_output_is_empty
 	# check mask files don't exist
-	assert_file_not_exists "$PATH_PREFIX"/etc/systemd/system/swupd-update.service
-	assert_file_not_exists "$PATH_PREFIX"/etc/systemd/system/swupd-update.timer
+	assert_file_not_exists "$ABS_TARGET_DIR"/etc/systemd/system/swupd-update.service
+	assert_file_not_exists "$ABS_TARGET_DIR"/etc/systemd/system/swupd-update.timer
 
 }
 
@@ -44,8 +44,8 @@ test_setup() {
 	assert_status_is "$SWUPD_OK"
 	assert_output_is_empty
 	# check mask files don't exist
-	assert_symlink_exists "$PATH_PREFIX"/etc/systemd/system/swupd-update.service
-	assert_symlink_exists "$PATH_PREFIX"/etc/systemd/system/swupd-update.timer
+	assert_symlink_exists "$ABS_TARGET_DIR"/etc/systemd/system/swupd-update.service
+	assert_symlink_exists "$ABS_TARGET_DIR"/etc/systemd/system/swupd-update.timer
 
 }
 

--- a/test/functional/api/api-bundle-info.bats
+++ b/test/functional/api/api-bundle-info.bats
@@ -12,8 +12,8 @@ global_setup() {
 	create_bundle -e -n test-bundle2 -f /file_2 "$TEST_NAME"
 	create_bundle -n test-bundle3 -f /file_3 "$TEST_NAME"
 	create_bundle -n test-bundle4 -f /file_4 "$TEST_NAME"
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle2 test-bundle3
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle3 test-bundle4
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle2 test-bundle3
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle3 test-bundle4
 
 }
 

--- a/test/functional/api/api-bundle-list.bats
+++ b/test/functional/api/api-bundle-list.bats
@@ -13,7 +13,7 @@ global_setup() {
 	create_bundle -L -t -n test-bundle3 -f /file_3 "$TEST_NAME"
 	create_bundle -L -e -n test-bundle4 -f /file_4 "$TEST_NAME"
 	create_bundle -L    -n test-bundle5 -f /file_5 "$TEST_NAME"
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle3 test-bundle4
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle3 test-bundle4
 
 }
 

--- a/test/functional/api/api-clean.bats
+++ b/test/functional/api/api-clean.bats
@@ -8,9 +8,9 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment "$TEST_NAME"
-	sudo mkdir "$STATEDIR_MANIFEST"/10
-	sudo touch "$STATEDIR_MANIFEST"/10/Manifest.test{1..3}
-	sudo touch "$STATEDIR_CACHE"/pack-test{1..2}-from-0.tar
+	sudo mkdir "$ABS_MANIFEST_DIR"/10
+	sudo touch "$ABS_MANIFEST_DIR"/10/Manifest.test{1..3}
+	sudo touch "$ABS_CACHE_DIR"/pack-test{1..2}-from-0.tar
 
 }
 
@@ -29,15 +29,15 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		$STATEDIR_CACHE/pack-test.-from-0.tar
-		$STATEDIR_CACHE/pack-test.-from-0.tar
-		$STATEDIR_DELTA
-		$STATEDIR_DOWNLOAD
-		$STATEDIR_STAGED
-		$STATEDIR_TEMP
-		$STATEDIR_MANIFEST/10/Manifest.test.
-		$STATEDIR_MANIFEST/10/Manifest.test.
-		$STATEDIR_MANIFEST/10/Manifest.test.
+		$ABS_CACHE_DIR/pack-test.-from-0.tar
+		$ABS_CACHE_DIR/pack-test.-from-0.tar
+		$ABS_DELTA_DIR
+		$ABS_DOWNLOAD_DIR
+		$ABS_STAGED_DIR
+		$ABS_TEMP_DIR
+		$ABS_MANIFEST_DIR/10/Manifest.test.
+		$ABS_MANIFEST_DIR/10/Manifest.test.
+		$ABS_MANIFEST_DIR/10/Manifest.test.
 	EOM
 	)
 	assert_regex_is_output "$expected_output"

--- a/test/functional/api/api-diagnose.bats
+++ b/test/functional/api/api-diagnose.bats
@@ -32,18 +32,18 @@ global_setup() {
 	# at version 20 so diagnose find issues
 	set_current_version "$TEST_NAME" 20
 	# adding an untracked file into /usr
-	sudo touch "$TARGETDIR"/usr/untracked_file3
+	sudo touch "$TARGET_DIR"/usr/untracked_file3
 
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --picky --quiet"
 
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
-		$PATH_PREFIX/baz
-		$PATH_PREFIX/baz/file_3
-		$PATH_PREFIX/foo/file_1
-		$PATH_PREFIX/usr/lib/os-release
-		$PATH_PREFIX/bar/file_2
-		$PATH_PREFIX/usr/untracked_file3
+		$ABS_TARGET_DIR/baz
+		$ABS_TARGET_DIR/baz/file_3
+		$ABS_TARGET_DIR/foo/file_1
+		$ABS_TARGET_DIR/usr/lib/os-release
+		$ABS_TARGET_DIR/bar/file_2
+		$ABS_TARGET_DIR/usr/untracked_file3
 	EOM
 	)
 	assert_is_output "$expected_output"

--- a/test/functional/api/api-hashdump.bats
+++ b/test/functional/api/api-hashdump.bats
@@ -13,7 +13,7 @@ global_setup() {
 
 @test "API068: hashdump" {
 
-	run sudo sh -c "$SWUPD hashdump $TARGETDIR/etc/swupd --quiet"
+	run sudo sh -c "$SWUPD hashdump $TARGET_DIR/etc/swupd --quiet"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM

--- a/test/functional/api/api-mirror.bats
+++ b/test/functional/api/api-mirror.bats
@@ -17,7 +17,7 @@ global_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		file://$TEST_DIRNAME/web-dir
+		file://$ABS_TEST_DIR/web-dir
 	EOM
 	)
 	assert_is_output "$expected_output"
@@ -32,7 +32,7 @@ global_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		file://$TEST_DIRNAME/web-dir
+		file://$ABS_TEST_DIR/web-dir
 		https://some.url
 	EOM
 	)

--- a/test/functional/api/api-os-install.bats
+++ b/test/functional/api/api-os-install.bats
@@ -14,7 +14,7 @@ global_setup() {
 
 @test "API062: os-install" {
 
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --quiet"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGET_DIR --quiet"
 
 	assert_status_is "$SWUPD_OK"
 	assert_output_is_empty

--- a/test/functional/api/api-repair.bats
+++ b/test/functional/api/api-repair.bats
@@ -20,11 +20,11 @@ test_setup() {
 test_teardown() {
 
 	# return the files to mutable state
-	if [ -e "$TARGETDIR"/usr/untracked_file ]; then
-		sudo chattr -i "$TARGETDIR"/usr/untracked_file
+	if [ -e "$TARGET_DIR"/usr/untracked_file ]; then
+		sudo chattr -i "$TARGET_DIR"/usr/untracked_file
 	fi
-	if [ -e "$TARGETDIR"/baz ]; then
-		sudo chattr -i "$TARGETDIR"/baz
+	if [ -e "$TARGET_DIR"/baz ]; then
+		sudo chattr -i "$TARGET_DIR"/baz
 	fi
 
 }
@@ -42,19 +42,19 @@ test_teardown() {
 
 	# add things to be repaired
 	set_current_version "$TEST_NAME" 20
-	sudo touch "$TARGETDIR"/usr/untracked_file
+	sudo touch "$TARGET_DIR"/usr/untracked_file
 
 	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --picky --quiet"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		$PATH_PREFIX/baz -> fixed
-		$PATH_PREFIX/baz/bat -> fixed
-		$PATH_PREFIX/baz/bat/file_3 -> fixed
-		$PATH_PREFIX/foo/file_1 -> fixed
-		$PATH_PREFIX/usr/lib/os-release -> fixed
-		$PATH_PREFIX/bar/file_2 -> deleted
-		$PATH_PREFIX/usr/untracked_file -> deleted
+		$ABS_TARGET_DIR/baz -> fixed
+		$ABS_TARGET_DIR/baz/bat -> fixed
+		$ABS_TARGET_DIR/baz/bat/file_3 -> fixed
+		$ABS_TARGET_DIR/foo/file_1 -> fixed
+		$ABS_TARGET_DIR/usr/lib/os-release -> fixed
+		$ABS_TARGET_DIR/bar/file_2 -> deleted
+		$ABS_TARGET_DIR/usr/untracked_file -> deleted
 	EOM
 	)
 	assert_is_output --identical "$expected_output"

--- a/test/functional/autoupdate/aup-basic.bats
+++ b/test/functional/autoupdate/aup-basic.bats
@@ -33,8 +33,8 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# check for files(should exist and point to /dev/null)
-	assert_file_exists "$PATH_PREFIX/etc/systemd/system/swupd-update.service"
-	assert_file_exists "$PATH_PREFIX/etc/systemd/system/swupd-update.timer"
+	assert_file_exists "$ABS_TARGET_DIR/etc/systemd/system/swupd-update.service"
+	assert_file_exists "$ABS_TARGET_DIR/etc/systemd/system/swupd-update.timer"
 
 	# perform autoupdate enable
 	run sudo sh -c "$SWUPD autoupdate --enable $SWUPD_OPTS"
@@ -60,8 +60,8 @@ test_setup() {
 
 
 	# check for files(should not exist)
-	assert_file_not_exists "$PATH_PREFIX/etc/systemd/system/swupd-update.service"
-	assert_file_not_exists "$PATH_PREFIX/etc/systemd/system/swupd-update.timer"
+	assert_file_not_exists "$ABS_TARGET_DIR/etc/systemd/system/swupd-update.service"
+	assert_file_not_exists "$ABS_TARGET_DIR/etc/systemd/system/swupd-update.timer"
 
 }
 #WEIGHT=2

--- a/test/functional/bundleadd/add-alias-basic.bats
+++ b/test/functional/bundleadd/add-alias-basic.bats
@@ -20,8 +20,8 @@ test_teardown() {
 	remove_bundle -L "$TEST_NAME"/web-dir/10/Manifest.alias-bundle1
 	remove_bundle -L "$TEST_NAME"/web-dir/10/Manifest.alias-bundle2
 	remove_bundle -L "$TEST_NAME"/web-dir/10/Manifest.alias-bundle3
-	sudo sh -c "rm -rf $TARGETDIR/usr/share/defaults/swupd/alias.d/"
-	sudo sh -c "rm -rf $TARGETDIR/etc/swupd/alias.d/"
+	sudo sh -c "rm -rf $TARGET_DIR/usr/share/defaults/swupd/alias.d/"
+	sudo sh -c "rm -rf $TARGET_DIR/etc/swupd/alias.d/"
 	clean_state_dir "$TEST_NAME"
 
 }
@@ -42,15 +42,15 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
 
 }
 
 @test "ADD034: Add bundle with system alias" {
 
-	sudo sh -c "mkdir -p $TARGETDIR/usr/share/defaults/swupd/alias.d/"
-	sudo sh -c "printf 'alias1\\talias-bundle1' > $TARGETDIR/usr/share/defaults/swupd/alias.d/a1"
+	sudo sh -c "mkdir -p $TARGET_DIR/usr/share/defaults/swupd/alias.d/"
+	sudo sh -c "printf 'alias1\\talias-bundle1' > $TARGET_DIR/usr/share/defaults/swupd/alias.d/a1"
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS alias1"
 
@@ -67,15 +67,15 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/alias-file1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/alias-bundle1
+	assert_file_exists "$TARGET_DIR"/foo/alias-file1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/alias-bundle1
 
 }
 
 @test "ADD035: Add bundle with user alias" {
 
-	sudo sh -c "mkdir -p $TARGETDIR/etc/swupd/alias.d/"
-	sudo sh -c "printf 'alias1\\talias-bundle1' > $TARGETDIR/etc/swupd/alias.d/a1"
+	sudo sh -c "mkdir -p $TARGET_DIR/etc/swupd/alias.d/"
+	sudo sh -c "printf 'alias1\\talias-bundle1' > $TARGET_DIR/etc/swupd/alias.d/a1"
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS alias1"
 
@@ -92,15 +92,15 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/alias-file1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/alias-bundle1
+	assert_file_exists "$TARGET_DIR"/foo/alias-file1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/alias-bundle1
 
 }
 
 @test "ADD036: Add bundles with alias (single file)" {
 
-	sudo sh -c "mkdir -p $TARGETDIR/etc/swupd/alias.d/"
-	sudo sh -c "printf 'alias1\\talias-bundle1\\talias-bundle2' > $TARGETDIR/etc/swupd/alias.d/a1"
+	sudo sh -c "mkdir -p $TARGET_DIR/etc/swupd/alias.d/"
+	sudo sh -c "printf 'alias1\\talias-bundle1\\talias-bundle2' > $TARGET_DIR/etc/swupd/alias.d/a1"
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS alias1"
 
@@ -117,17 +117,17 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/alias-file1
-	assert_file_exists "$TARGETDIR"/foo/alias-file2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/alias-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/alias-bundle2
+	assert_file_exists "$TARGET_DIR"/foo/alias-file1
+	assert_file_exists "$TARGET_DIR"/foo/alias-file2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/alias-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/alias-bundle2
 
 }
 
 @test "ADD037: Add bundles with aliases (single file, multi-line)" {
 
-	sudo sh -c "mkdir -p $TARGETDIR/etc/swupd/alias.d/"
-	sudo sh -c "printf 'alias1\\talias-bundle1\\nalias2\\talias-bundle2' > $TARGETDIR/etc/swupd/alias.d/a1"
+	sudo sh -c "mkdir -p $TARGET_DIR/etc/swupd/alias.d/"
+	sudo sh -c "printf 'alias1\\talias-bundle1\\nalias2\\talias-bundle2' > $TARGET_DIR/etc/swupd/alias.d/a1"
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS alias1 alias2"
 
@@ -145,19 +145,19 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/alias-file1
-	assert_file_exists "$TARGETDIR"/foo/alias-file2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/alias-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/alias-bundle2
+	assert_file_exists "$TARGET_DIR"/foo/alias-file1
+	assert_file_exists "$TARGET_DIR"/foo/alias-file2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/alias-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/alias-bundle2
 
 }
 
 @test "ADD038: Add bundles with aliases (multiple files)" {
 
-	sudo sh -c "mkdir -p $TARGETDIR/usr/share/defaults/swupd/alias.d/"
-	sudo sh -c "mkdir -p $TARGETDIR/etc/swupd/alias.d/"
-	sudo sh -c "printf 'alias1\\talias-bundle1' > $TARGETDIR/etc/swupd/alias.d/a1"
-	sudo sh -c "printf 'alias2\\talias-bundle2' > $TARGETDIR/usr/share/defaults/swupd/alias.d/a2"
+	sudo sh -c "mkdir -p $TARGET_DIR/usr/share/defaults/swupd/alias.d/"
+	sudo sh -c "mkdir -p $TARGET_DIR/etc/swupd/alias.d/"
+	sudo sh -c "printf 'alias1\\talias-bundle1' > $TARGET_DIR/etc/swupd/alias.d/a1"
+	sudo sh -c "printf 'alias2\\talias-bundle2' > $TARGET_DIR/usr/share/defaults/swupd/alias.d/a2"
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS alias1 alias2"
 
@@ -175,20 +175,20 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/alias-file1
-	assert_file_exists "$TARGETDIR"/foo/alias-file2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/alias-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/alias-bundle2
+	assert_file_exists "$TARGET_DIR"/foo/alias-file1
+	assert_file_exists "$TARGET_DIR"/foo/alias-file2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/alias-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/alias-bundle2
 
 }
 
 @test "ADD039: Add bundle with alias (user mask)" {
 
-	sudo sh -c "mkdir -p $TARGETDIR/usr/share/defaults/swupd/alias.d/"
-	sudo sh -c "mkdir -p $TARGETDIR/etc/swupd/alias.d/"
-	sudo sh -c "ln -s /dev/null $TARGETDIR/etc/swupd/alias.d/a1"
-	sudo sh -c "printf 'alias1\\talias-bundle2' > $TARGETDIR/usr/share/defaults/swupd/alias.d/a1"
-	sudo sh -c "printf 'alias1\\talias-bundle1' > $TARGETDIR/usr/share/defaults/swupd/alias.d/b1"
+	sudo sh -c "mkdir -p $TARGET_DIR/usr/share/defaults/swupd/alias.d/"
+	sudo sh -c "mkdir -p $TARGET_DIR/etc/swupd/alias.d/"
+	sudo sh -c "ln -s /dev/null $TARGET_DIR/etc/swupd/alias.d/a1"
+	sudo sh -c "printf 'alias1\\talias-bundle2' > $TARGET_DIR/usr/share/defaults/swupd/alias.d/a1"
+	sudo sh -c "printf 'alias1\\talias-bundle1' > $TARGET_DIR/usr/share/defaults/swupd/alias.d/b1"
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS alias1"
 
@@ -205,17 +205,17 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/alias-file1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/alias-bundle1
+	assert_file_exists "$TARGET_DIR"/foo/alias-file1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/alias-bundle1
 
 }
 
 @test "ADD040: Add bundle with alias (user override for different bundle)" {
 
-	sudo sh -c "mkdir -p $TARGETDIR/usr/share/defaults/swupd/alias.d/"
-	sudo sh -c "mkdir -p $TARGETDIR/etc/swupd/alias.d/"
-	sudo sh -c "printf 'alias1\\talias-bundle1' > $TARGETDIR/etc/swupd/alias.d/a1"
-	sudo sh -c "printf 'test-bundle1\\talias-bundle2' > $TARGETDIR/usr/share/defaults/swupd/alias.d/a1"
+	sudo sh -c "mkdir -p $TARGET_DIR/usr/share/defaults/swupd/alias.d/"
+	sudo sh -c "mkdir -p $TARGET_DIR/etc/swupd/alias.d/"
+	sudo sh -c "printf 'alias1\\talias-bundle1' > $TARGET_DIR/etc/swupd/alias.d/a1"
+	sudo sh -c "printf 'test-bundle1\\talias-bundle2' > $TARGET_DIR/usr/share/defaults/swupd/alias.d/a1"
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS alias1 test-bundle1"
 
@@ -232,19 +232,19 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/alias-file1
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/alias-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/foo/alias-file1
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/alias-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
 
 }
 
 @test "ADD041: Add bundle with alias (user priority for different bundle)" {
 
-	sudo sh -c "mkdir -p $TARGETDIR/usr/share/defaults/swupd/alias.d/"
-	sudo sh -c "mkdir -p $TARGETDIR/etc/swupd/alias.d/"
-	sudo sh -c "printf 'alias1\\talias-bundle1' > $TARGETDIR/etc/swupd/alias.d/b1"
-	sudo sh -c "printf 'alias1\\talias-bundle2' > $TARGETDIR/usr/share/defaults/swupd/alias.d/a1"
+	sudo sh -c "mkdir -p $TARGET_DIR/usr/share/defaults/swupd/alias.d/"
+	sudo sh -c "mkdir -p $TARGET_DIR/etc/swupd/alias.d/"
+	sudo sh -c "printf 'alias1\\talias-bundle1' > $TARGET_DIR/etc/swupd/alias.d/b1"
+	sudo sh -c "printf 'alias1\\talias-bundle2' > $TARGET_DIR/usr/share/defaults/swupd/alias.d/a1"
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS alias1"
 
@@ -261,16 +261,16 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/alias-file1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/alias-bundle1
+	assert_file_exists "$TARGET_DIR"/foo/alias-file1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/alias-bundle1
 
 }
 
 @test "ADD042: Add bundle with alias (name priority for different bundle)" {
 
-	sudo sh -c "mkdir -p $TARGETDIR/etc/swupd/alias.d/"
-	sudo sh -c "printf 'alias1\\talias-bundle1' > $TARGETDIR/etc/swupd/alias.d/a1"
-	sudo sh -c "printf 'alias1\\talias-bundle2' > $TARGETDIR/etc/swupd/alias.d/b1"
+	sudo sh -c "mkdir -p $TARGET_DIR/etc/swupd/alias.d/"
+	sudo sh -c "printf 'alias1\\talias-bundle1' > $TARGET_DIR/etc/swupd/alias.d/a1"
+	sudo sh -c "printf 'alias1\\talias-bundle2' > $TARGET_DIR/etc/swupd/alias.d/b1"
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS alias1"
 
@@ -287,18 +287,18 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/alias-file1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/alias-bundle1
+	assert_file_exists "$TARGET_DIR"/foo/alias-file1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/alias-bundle1
 
 }
 
 @test "ADD043: Add bundle with alias (user+name priority for different bundle)" {
 
-	sudo sh -c "mkdir -p $TARGETDIR/usr/share/defaults/swupd/alias.d/"
-	sudo sh -c "mkdir -p $TARGETDIR/etc/swupd/alias.d/"
-	sudo sh -c "printf 'alias1\\talias-bundle1' > $TARGETDIR/etc/swupd/alias.d/a1"
-	sudo sh -c "printf 'alias1\\talias-bundle2' > $TARGETDIR/etc/swupd/alias.d/b1"
-	sudo sh -c "printf 'alias1\\talias-bundle3' > $TARGETDIR/usr/share/defaults/swupd/alias.d/b1"
+	sudo sh -c "mkdir -p $TARGET_DIR/usr/share/defaults/swupd/alias.d/"
+	sudo sh -c "mkdir -p $TARGET_DIR/etc/swupd/alias.d/"
+	sudo sh -c "printf 'alias1\\talias-bundle1' > $TARGET_DIR/etc/swupd/alias.d/a1"
+	sudo sh -c "printf 'alias1\\talias-bundle2' > $TARGET_DIR/etc/swupd/alias.d/b1"
+	sudo sh -c "printf 'alias1\\talias-bundle3' > $TARGET_DIR/usr/share/defaults/swupd/alias.d/b1"
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS alias1"
 
@@ -315,8 +315,8 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/alias-file1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/alias-bundle1
+	assert_file_exists "$TARGET_DIR"/foo/alias-file1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/alias-bundle1
 
 }
 #WEIGHT=8

--- a/test/functional/bundleadd/add-also-add-flag.bats
+++ b/test/functional/bundleadd/add-also-add-flag.bats
@@ -13,11 +13,11 @@ test_setup() {
 	create_bundle -n test-bundle3 -f /baz/test-file3 "$TEST_NAME"
 	create_bundle -n test-bundle4 -f /bat/test-file4 "$TEST_NAME"
 	# add test-bundle2 as a dependency of test-bundle1 and test-bundle3 as optional
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
-	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle1 test-bundle3
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest -o "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle3
 	# add circular dependency for also-add
-	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle3 test-bundle4
-	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle4 test-bundle3
+	add_dependency_to_manifest -o "$WEB_DIR"/10/Manifest.test-bundle3 test-bundle4
+	add_dependency_to_manifest -o "$WEB_DIR"/10/Manifest.test-bundle4 test-bundle3
 
 }
 
@@ -43,12 +43,12 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/bar/test-file2
-	assert_file_exists "$TARGETDIR"/baz/test-file3
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_exists "$TARGET_DIR"/baz/test-file3
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
 
 }
 
@@ -73,12 +73,12 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/bar/test-file2
-	assert_file_not_exists "$TARGETDIR"/baz/test-file3
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_not_exists "$TARGET_DIR"/baz/test-file3
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
 
 }
 #WEIGHT=11

--- a/test/functional/bundleadd/add-bad-hash-state.bats
+++ b/test/functional/bundleadd/add-bad-hash-state.bats
@@ -8,8 +8,8 @@ test_setup() {
 	create_bundle -n test-bundle -f /usr/bin/test-file "$TEST_NAME"
 	# set up state directory with bad hash file and pack hint
 	file_hash=$(get_hash_from_manifest "$TEST_NAME"/web-dir/10/Manifest.test-bundle /usr/bin/test-file)
-	sudo sh -c "echo \"test file MODIFIED\" > $STATEDIR_STAGED/$file_hash"
-	sudo touch "$STATEDIR_CACHE"/pack-test-bundle-from-0-to-10.tar
+	sudo sh -c "echo \"test file MODIFIED\" > $ABS_STAGED_DIR/$file_hash"
+	sudo touch "$ABS_CACHE_DIR"/pack-test-bundle-from-0-to-10.tar
 
 }
 
@@ -18,13 +18,13 @@ test_setup() {
 	# since one of the files needed to install the bundle is already in the state/staged
 	# directory, in theory this one should be used instead of downloading it again...
 	# however since the hash of this file is wrong it should be deleted and re-downloaded
-	hash_before=$(sudo "$SWUPD" hashdump "$STATEDIR_STAGED"/"$file_hash")
+	hash_before=$(sudo "$SWUPD" hashdump "$ABS_STAGED_DIR"/"$file_hash")
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
 	assert_status_is 0
-	hash_after=$(sudo "$SWUPD" hashdump "$STATEDIR_STAGED"/"$file_hash")
-	assert_file_exists "$TARGETDIR"/usr/bin/test-file
+	hash_after=$(sudo "$SWUPD" hashdump "$ABS_STAGED_DIR"/"$file_hash")
+	assert_file_exists "$TARGET_DIR"/usr/bin/test-file
 	assert_not_equal "$hash_before" "$hash_after"
 	expected_output=$(cat <<-EOM
 		Loading required manifests...

--- a/test/functional/bundleadd/add-bad-hash.bats
+++ b/test/functional/bundleadd/add-bad-hash.bats
@@ -25,13 +25,13 @@ test_setup() {
 	# downloaded fullfile had a bad hash - immediately fatal with a 1 return code
 	assert_status_is 1
 	# the bad hash file should not exist on the system
-	assert_file_not_exists "$TARGETDIR"/usr/bin/file1
+	assert_file_not_exists "$TARGET_DIR"/usr/bin/file1
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		No packs need to be downloaded
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
-		Error: File content hash mismatch for $STATEDIR_STAGED/e6d85023c5e619eb43d5cfbfdbdec784afef5a82ffa54e8c93bda3e0883360a3 (bad server data?)
+		Error: File content hash mismatch for $ABS_STAGED_DIR/e6d85023c5e619eb43d5cfbfdbdec784afef5a82ffa54e8c93bda3e0883360a3 (bad server data?)
 	EOM
 	)
 	assert_is_output "$expected_output"

--- a/test/functional/bundleadd/add-basics.bats
+++ b/test/functional/bundleadd/add-basics.bats
@@ -40,8 +40,8 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
 
 }
 
@@ -60,8 +60,8 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/bar/test-file2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
 
 }
 
@@ -165,10 +165,10 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/baz/test-file3
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/baz/test-file3
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
 
 }
 
@@ -188,8 +188,8 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
 
 }
 
@@ -211,8 +211,8 @@ test_teardown() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
 
 }
 

--- a/test/functional/bundleadd/add-boot-file.bats
+++ b/test/functional/bundleadd/add-boot-file.bats
@@ -15,7 +15,7 @@ test_setup() {
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
 	assert_status_is 0
-	assert_file_exists "$TARGETDIR/usr/lib/kernel/test-file"
+	assert_file_exists "$TARGET_DIR/usr/lib/kernel/test-file"
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		No packs need to be downloaded

--- a/test/functional/bundleadd/add-boot-skip.bats
+++ b/test/functional/bundleadd/add-boot-skip.bats
@@ -15,7 +15,7 @@ test_setup() {
 	run sudo sh -c "$SWUPD bundle-add -b $SWUPD_OPTS test-bundle"
 
 	assert_status_is 0
-	assert_file_exists "$TARGETDIR/usr/lib/kernel/test-file"
+	assert_file_exists "$TARGET_DIR/usr/lib/kernel/test-file"
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		No packs need to be downloaded

--- a/test/functional/bundleadd/add-directory.bats
+++ b/test/functional/bundleadd/add-directory.bats
@@ -14,7 +14,7 @@ test_setup() {
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
 	assert_status_is 0
-	assert_dir_exists "$TARGETDIR"/usr/bin/test
+	assert_dir_exists "$TARGET_DIR"/usr/bin/test
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		No packs need to be downloaded

--- a/test/functional/bundleadd/add-fall-back-to-fullfile.bats
+++ b/test/functional/bundleadd/add-fall-back-to-fullfile.bats
@@ -17,33 +17,33 @@ test_setup() {
 	# ----- extra setup -----
 	# replace the original zero pack with one with one file missing
 	sudo mkdir "$TEST_NAME"/temp
-	sudo tar -C "$TEST_NAME"/temp -xf "$WEBDIR"/10/pack-test-bundle1-from-0.tar
+	sudo tar -C "$TEST_NAME"/temp -xf "$WEB_DIR"/10/pack-test-bundle1-from-0.tar
 	removed_file="$(find "$TEST_NAME"/temp/staged -type f -printf '%f' -quit)"
 	sudo rm "$TEST_NAME"/temp/staged/"$removed_file"
-	sudo rm "$WEBDIR"/10/pack-test-bundle1-from-0.tar
-	sudo tar -C "$TEST_NAME"/temp -cf "$WEBDIR"/10/pack-test-bundle1-from-0.tar staged
+	sudo rm "$WEB_DIR"/10/pack-test-bundle1-from-0.tar
+	sudo tar -C "$TEST_NAME"/temp -cf "$WEB_DIR"/10/pack-test-bundle1-from-0.tar staged
 	# -----------------------
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1"
 
 	assert_status_is 0
 	# validate files are installed in target
-	assert_file_exists "$TARGETDIR"/file1
-	assert_file_exists "$TARGETDIR"/file2
-	assert_file_exists "$TARGETDIR"/file3
-	assert_file_exists "$TARGETDIR"/file4
-	assert_file_exists "$TARGETDIR"/file5
-	assert_file_exists "$TARGETDIR"/file6
-	assert_file_exists "$TARGETDIR"/file7
-	assert_file_exists "$TARGETDIR"/file8
-	assert_file_exists "$TARGETDIR"/file9
-	assert_file_exists "$TARGETDIR"/file10
-	assert_file_exists "$TARGETDIR"/file11
-	assert_file_exists "$TARGETDIR"/file12
+	assert_file_exists "$TARGET_DIR"/file1
+	assert_file_exists "$TARGET_DIR"/file2
+	assert_file_exists "$TARGET_DIR"/file3
+	assert_file_exists "$TARGET_DIR"/file4
+	assert_file_exists "$TARGET_DIR"/file5
+	assert_file_exists "$TARGET_DIR"/file6
+	assert_file_exists "$TARGET_DIR"/file7
+	assert_file_exists "$TARGET_DIR"/file8
+	assert_file_exists "$TARGET_DIR"/file9
+	assert_file_exists "$TARGET_DIR"/file10
+	assert_file_exists "$TARGET_DIR"/file11
+	assert_file_exists "$TARGET_DIR"/file12
 	# validate zero pack was downloaded
-	assert_file_exists "$STATEDIR_CACHE"/pack-test-bundle1-from-0-to-10.tar
+	assert_file_exists "$ABS_CACHE_DIR"/pack-test-bundle1-from-0-to-10.tar
 	# validate the file missing from the zero pack was downloaded
-	assert_file_exists "$STATEDIR_STAGED"/"$removed_file"
+	assert_file_exists "$ABS_STAGED_DIR"/"$removed_file"
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		Downloading packs for:
@@ -64,25 +64,25 @@ test_setup() {
 
 	# ----- extra setup -----
 	# remove the original zero pack
-	sudo rm "$WEBDIR"/10/pack-test-bundle1-from-0.tar
+	sudo rm "$WEB_DIR"/10/pack-test-bundle1-from-0.tar
 	# -----------------------
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1"
 
 	assert_status_is 0
 	# validate files are installed in target
-	assert_file_exists "$TARGETDIR"/file1
-	assert_file_exists "$TARGETDIR"/file2
-	assert_file_exists "$TARGETDIR"/file3
-	assert_file_exists "$TARGETDIR"/file4
-	assert_file_exists "$TARGETDIR"/file5
-	assert_file_exists "$TARGETDIR"/file6
-	assert_file_exists "$TARGETDIR"/file7
-	assert_file_exists "$TARGETDIR"/file8
-	assert_file_exists "$TARGETDIR"/file9
-	assert_file_exists "$TARGETDIR"/file10
-	assert_file_exists "$TARGETDIR"/file11
-	assert_file_exists "$TARGETDIR"/file12
+	assert_file_exists "$TARGET_DIR"/file1
+	assert_file_exists "$TARGET_DIR"/file2
+	assert_file_exists "$TARGET_DIR"/file3
+	assert_file_exists "$TARGET_DIR"/file4
+	assert_file_exists "$TARGET_DIR"/file5
+	assert_file_exists "$TARGET_DIR"/file6
+	assert_file_exists "$TARGET_DIR"/file7
+	assert_file_exists "$TARGET_DIR"/file8
+	assert_file_exists "$TARGET_DIR"/file9
+	assert_file_exists "$TARGET_DIR"/file10
+	assert_file_exists "$TARGET_DIR"/file11
+	assert_file_exists "$TARGET_DIR"/file12
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		Downloading packs for:

--- a/test/functional/bundleadd/add-include.bats
+++ b/test/functional/bundleadd/add-include.bats
@@ -9,7 +9,7 @@ test_setup() {
 	create_bundle -n test-bundle2 -f /bar/test-file2 "$TEST_NAME"
 	create_bundle -n test-bundle3 -f /bar/test-file3 "$TEST_NAME"
 	# add test-bundle2 as a dependency of test-bundle1
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle2
 
 }
 
@@ -21,11 +21,11 @@ test_setup() {
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1"
 
 	assert_status_is "$SWUPD_OK"
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/bar/test-file2
-	assert_file_exists "$STATEDIR"/bundles/test-bundle1
-	assert_file_exists "$STATEDIR"/bundles/test-bundle3
-	assert_file_not_exists "$STATEDIR"/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_exists "$STATE_DIR"/bundles/test-bundle1
+	assert_file_exists "$STATE_DIR"/bundles/test-bundle3
+	assert_file_not_exists "$STATE_DIR"/bundles/test-bundle2
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		No packs need to be downloaded
@@ -44,17 +44,17 @@ test_setup() {
 @test "ADD048: Adding a bundle that includes another bundle (no tracking state)" {
 
 	# simulate as if test-bundle3 is already installed
-	sudo touch "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
+	sudo touch "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1"
 
 	assert_status_is "$SWUPD_OK"
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/bar/test-file2
-	assert_file_exists "$STATEDIR"/bundles/test-bundle1
-	assert_file_exists "$STATEDIR"/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_exists "$STATE_DIR"/bundles/test-bundle1
+	assert_file_exists "$STATE_DIR"/bundles/test-bundle3
 	# When no tracking directly previously existed, all currently installed
 	# bundles are added to the tracked state.
-	assert_file_not_exists "$STATEDIR"/bundles/test-bundle2
+	assert_file_not_exists "$STATE_DIR"/bundles/test-bundle2
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		No packs need to be downloaded
@@ -77,22 +77,22 @@ test_setup() {
 	# count the bundle as dependency if it was not directly added by the user
 	# regardless of the order of the bundles requested
 
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$STATEDIR"/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/foo/test-file1
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_not_exists "$STATEDIR"/bundles/test-bundle2
-	assert_file_not_exists "$TARGETDIR"/bar/test-file2
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$STATE_DIR"/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$STATE_DIR"/bundles/test-bundle2
+	assert_file_not_exists "$TARGET_DIR"/bar/test-file2
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle2 test-bundle1"
 
 	assert_status_is "$SWUPD_OK"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$STATEDIR"/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$STATEDIR"/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/bar/test-file2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$STATE_DIR"/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$STATE_DIR"/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
 
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
@@ -110,22 +110,22 @@ test_setup() {
 	remove_bundle -L "$TEST_NAME"/web-dir/10/Manifest.test-bundle2
 	clean_state_dir "$TEST_NAME"
 
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$STATEDIR"/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/foo/test-file1
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_not_exists "$STATEDIR"/bundles/test-bundle2
-	assert_file_not_exists "$TARGETDIR"/bar/test-file2
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$STATE_DIR"/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$STATE_DIR"/bundles/test-bundle2
+	assert_file_not_exists "$TARGET_DIR"/bar/test-file2
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1 test-bundle2"
 
 	assert_status_is "$SWUPD_OK"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$STATEDIR"/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$STATEDIR"/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/bar/test-file2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$STATE_DIR"/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$STATE_DIR"/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
 
 	expected_output=$(cat <<-EOM
 		Loading required manifests...

--- a/test/functional/bundleadd/add-multiple.bats
+++ b/test/functional/bundleadd/add-multiple.bats
@@ -16,10 +16,10 @@ test_setup() {
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1 test-bundle2"
 
 	assert_status_is 0
-	assert_dir_exists "$TARGETDIR/usr/bin"
-	assert_dir_exists "$TARGETDIR/media/lib"
-	assert_file_exists "$TARGETDIR/usr/bin/10"
-	assert_file_exists "$TARGETDIR/media/lib/file2"
+	assert_dir_exists "$TARGET_DIR/usr/bin"
+	assert_dir_exists "$TARGET_DIR/media/lib"
+	assert_file_exists "$TARGET_DIR/usr/bin/10"
+	assert_file_exists "$TARGET_DIR/media/lib/file2"
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		No packs need to be downloaded

--- a/test/functional/bundleadd/add-no-disk-space.bats
+++ b/test/functional/bundleadd/add-no-disk-space.bats
@@ -12,12 +12,12 @@ test_setup() {
 
 	# create a file with a size of 20 MB and create a bundle
 	# that uses that file and 10 other files (to force pack download)
-	file1=/test-file:"$(create_file "$WEBDIR"/10/files 20MB)"
+	file1=/test-file:"$(create_file "$WEB_DIR"/10/files 20MB)"
 	bfiles="/file1,/file2,/file3,/file4,/file5,/file6,/file7,/file8,/file9,/file10"
 	create_bundle -n test-bundle -f "$bfiles","$file1" "$TEST_NAME"
 
 	# create the state dirs ahead of time (there will be no disk space later)
-	sudo mkdir -p "$STATEDIR_MANIFEST"/10
+	sudo mkdir -p "$ABS_MANIFEST_DIR"/10
 
 }
 
@@ -33,8 +33,8 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/10/Manifest.MoM.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/10/Manifest.MoM.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Error: Failed to retrieve 10 MoM manifest
 		Error: Cannot load official manifest MoM for version 10
 		Failed to install 1 of 1 bundles
@@ -51,20 +51,20 @@ test_setup() {
 
 	# let's replace the bundle Manifest tar with a much larger file that will exceed
 	# the available space on disk
-	sudo rm "$WEBDIR"/10/Manifest.test-bundle
-	sudo rm "$WEBDIR"/10/Manifest.test-bundle.tar
-	fake_manifest=$(create_file "$WEBDIR"/10 15MB)
+	sudo rm "$WEB_DIR"/10/Manifest.test-bundle
+	sudo rm "$WEB_DIR"/10/Manifest.test-bundle.tar
+	fake_manifest=$(create_file "$WEB_DIR"/10 15MB)
 	manifest_name=$(basename "$fake_manifest")
-	sudo mv "$WEBDIR"/10/"$manifest_name" "$WEBDIR"/10/Manifest.test-bundle
-	sudo mv "$WEBDIR"/10/"$manifest_name".tar "$WEBDIR"/10/Manifest.test-bundle.tar
+	sudo mv "$WEB_DIR"/10/"$manifest_name" "$WEB_DIR"/10/Manifest.test-bundle
+	sudo mv "$WEB_DIR"/10/"$manifest_name".tar "$WEB_DIR"/10/Manifest.test-bundle.tar
 
 	run sudo sh -c "timeout 30 $SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
 	assert_status_is "$SWUPD_RECURSE_MANIFEST"
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/10/Manifest.test-bundle.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/10/Manifest.test-bundle.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Error: Failed to retrieve 10 test-bundle manifest
 		Failed to install 1 of 1 bundles
 	EOM
@@ -116,32 +116,32 @@ test_setup() {
 		Downloading packs \\(.* MB\\) for:
 		 - test-bundle
 		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/pack-test-bundle-from-0.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
 		Finishing packs extraction...
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
 		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
 		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
 		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
 		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
 		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
 		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
 		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
 		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
 		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
 		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
 		Error: Could not download some files from bundles, aborting bundle installation
 		Failed to install 1 of 1 bundles
 	EOM

--- a/test/functional/bundleadd/add-no-signature.bats
+++ b/test/functional/bundleadd/add-no-signature.bats
@@ -6,7 +6,7 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle -n test-bundle -f /test-file "$TEST_NAME"
-	sudo rm "$WEBDIR"/10/Manifest.MoM.sig
+	sudo rm "$WEB_DIR"/10/Manifest.MoM.sig
 
 }
 
@@ -23,7 +23,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/test-file
+	assert_file_not_exists "$TARGET_DIR"/test-file
 
 }
 
@@ -34,7 +34,7 @@ test_setup() {
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
 		Warning: The --nosigcheck flag was used and this compromises the system security
-		Warning: THE SIGNATURE OF file://$TEST_DIRNAME/web-dir/10/Manifest.MoM WILL NOT BE VERIFIED
+		Warning: THE SIGNATURE OF file://$ABS_TEST_DIR/web-dir/10/Manifest.MoM WILL NOT BE VERIFIED
 		Loading required manifests...
 		No packs need to be downloaded
 		Validate downloaded files
@@ -45,7 +45,7 @@ test_setup() {
 	EOM
 	)
 	assert_in_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/test-file
+	assert_file_exists "$TARGET_DIR"/test-file
 
 }
 #WEIGHT=4

--- a/test/functional/bundleadd/add-overwrite-files.bats
+++ b/test/functional/bundleadd/add-overwrite-files.bats
@@ -10,23 +10,23 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 
 	# pre-create two files in /usr/bin
-	sudo mkdir -p "$TARGETDIR"/usr/bin
-	write_to_protected_file "$TARGETDIR"/usr/bin/foo "should be replaced"
-	write_to_protected_file "$TARGETDIR"/usr/bin/bar "should NOT be replaced"
+	sudo mkdir -p "$TARGET_DIR"/usr/bin
+	write_to_protected_file "$TARGET_DIR"/usr/bin/foo "should be replaced"
+	write_to_protected_file "$TARGET_DIR"/usr/bin/bar "should NOT be replaced"
 
 	# create a bundle with one of the existing files and install the bundle
-	hash=$(sudo "$SWUPD" hashdump --quiet "$TARGETDIR"/usr/bin/bar)
-	sudo cp "$TARGETDIR"/usr/bin/bar "$WEBDIR"/10/files/"$hash"
-	create_bundle -L -n test-bundle1 -f /usr/bin/bar:"$WEBDIR"/10/files/"$hash" "$TEST_NAME"
-	create_tar "$WEBDIR"/10/files/"$hash"
+	hash=$(sudo "$SWUPD" hashdump --quiet "$TARGET_DIR"/usr/bin/bar)
+	sudo cp "$TARGET_DIR"/usr/bin/bar "$WEB_DIR"/10/files/"$hash"
+	create_bundle -L -n test-bundle1 -f /usr/bin/bar:"$WEB_DIR"/10/files/"$hash" "$TEST_NAME"
+	create_tar "$WEB_DIR"/10/files/"$hash"
 
 	# create another bundle that includes two files:
 	# - /usr/bin/foo: not tracked but already existing in the target system (should be replaced)
 	# - /usr/bin/bar: already tracked by another installed bundle (should not be replaced)
-	create_bundle -n test-bundle2 -f /usr/bin/foo,/usr/bin/bar:"$WEBDIR"/10/files/"$hash" "$TEST_NAME"
+	create_bundle -n test-bundle2 -f /usr/bin/foo,/usr/bin/bar:"$WEB_DIR"/10/files/"$hash" "$TEST_NAME"
 
 	create_bundle -n test-bundle3 -f /file1,/file2,/file3 "$TEST_NAME"
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle2 test-bundle3
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle2 test-bundle3
 
 }
 
@@ -39,11 +39,11 @@ test_setup() {
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle2"
 
 	assert_status_is "$SWUPD_OK"
-	assert_file_exists "$TARGETDIR"/usr/bin/foo
-	assert_not_equal "should be replaced" "$(cat "$TARGETDIR"/usr/bin/foo)"
-	assert_file_exists "$TARGETDIR"/usr/bin/bar
-	assert_equal "should NOT be replaced" "$(cat "$TARGETDIR"/usr/bin/bar)"
-	assert_file_exists "$TARGETDIR"/file1
+	assert_file_exists "$TARGET_DIR"/usr/bin/foo
+	assert_not_equal "should be replaced" "$(cat "$TARGET_DIR"/usr/bin/foo)"
+	assert_file_exists "$TARGET_DIR"/usr/bin/bar
+	assert_equal "should NOT be replaced" "$(cat "$TARGET_DIR"/usr/bin/bar)"
+	assert_file_exists "$TARGET_DIR"/file1
 
 }
 #WEIGHT=4

--- a/test/functional/bundleadd/add-skip-scripts.bats
+++ b/test/functional/bundleadd/add-skip-scripts.bats
@@ -14,7 +14,7 @@ test_setup() {
 
 	run sudo sh -c "$SWUPD bundle-add --no-scripts $SWUPD_OPTS test-bundle"
 	assert_status_is 0
-	assert_file_exists "$TARGETDIR/usr/lib/kernel/test-file"
+	assert_file_exists "$TARGET_DIR/usr/lib/kernel/test-file"
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		No packs need to be downloaded

--- a/test/functional/bundleadd/add-uses-fullfile.bats
+++ b/test/functional/bundleadd/add-uses-fullfile.bats
@@ -15,9 +15,9 @@ test_setup() {
 
 	assert_status_is 0
 	# validate file is installed in target
-	assert_file_exists "$TARGETDIR"/foo
+	assert_file_exists "$TARGET_DIR"/foo
 	# validate zero pack was not downloaded
-	assert_file_not_exists "$STATEDIR"/pack-test-bundle1-from-0-to-10.tar
+	assert_file_not_exists "$STATE_DIR"/pack-test-bundle1-from-0-to-10.tar
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		No packs need to be downloaded

--- a/test/functional/bundleadd/add-uses-zeropack.bats
+++ b/test/functional/bundleadd/add-uses-zeropack.bats
@@ -16,19 +16,19 @@ test_setup() {
 
 	assert_status_is 0
 	# validate files are installed in target
-	assert_file_exists "$TARGETDIR"/file1
-	assert_file_exists "$TARGETDIR"/file2
-	assert_file_exists "$TARGETDIR"/file3
-	assert_file_exists "$TARGETDIR"/file4
-	assert_file_exists "$TARGETDIR"/file5
-	assert_file_exists "$TARGETDIR"/file6
-	assert_file_exists "$TARGETDIR"/file7
-	assert_file_exists "$TARGETDIR"/file8
-	assert_file_exists "$TARGETDIR"/file9
-	assert_file_exists "$TARGETDIR"/file10
-	assert_file_exists "$TARGETDIR"/file11
+	assert_file_exists "$TARGET_DIR"/file1
+	assert_file_exists "$TARGET_DIR"/file2
+	assert_file_exists "$TARGET_DIR"/file3
+	assert_file_exists "$TARGET_DIR"/file4
+	assert_file_exists "$TARGET_DIR"/file5
+	assert_file_exists "$TARGET_DIR"/file6
+	assert_file_exists "$TARGET_DIR"/file7
+	assert_file_exists "$TARGET_DIR"/file8
+	assert_file_exists "$TARGET_DIR"/file9
+	assert_file_exists "$TARGET_DIR"/file10
+	assert_file_exists "$TARGET_DIR"/file11
 	# validate zero pack was downloaded
-	assert_file_exists "$STATEDIR_CACHE"/pack-test-bundle1-from-0-to-10.tar
+	assert_file_exists "$ABS_CACHE_DIR"/pack-test-bundle1-from-0-to-10.tar
 	expected_output=$(cat <<-EOM
 		Loading required manifests...
 		Downloading packs for:

--- a/test/functional/bundleadd/add-verify-fix-path.bats
+++ b/test/functional/bundleadd/add-verify-fix-path.bats
@@ -10,18 +10,18 @@ test_setup() {
 	# bundles created with the testlib add all needed directories to the
 	# manifest by default, so we need to remove the directory from test-bundle1
 	# so its missing the path to the file.
-	remove_from_manifest "$WEBDIR"/10/Manifest.test-bundle1 /foo
-	remove_from_manifest "$WEBDIR"/10/Manifest.test-bundle1 /foo/bar
+	remove_from_manifest "$WEB_DIR"/10/Manifest.test-bundle1 /foo
+	remove_from_manifest "$WEB_DIR"/10/Manifest.test-bundle1 /foo/bar
 	# since test-bundle2 is already installed, both directories defined
 	# there already exist, so we need to delete one of the /foo/bar so it
 	# can be fixed using verify_fix_path
-	sudo rm -rf "$TARGETDIR"/foo/bar
+	sudo rm -rf "$TARGET_DIR"/foo/bar
 
 }
 
 @test "ADD022: When adding a bundle and a path is missing on the fs, bundle-add fixes it" {
 
-	assert_dir_not_exists "$TARGETDIR"/foo/bar
+	assert_dir_not_exists "$TARGET_DIR"/foo/bar
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1"
 
@@ -37,7 +37,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/bar/test-file1
+	assert_file_exists "$TARGET_DIR"/foo/bar/test-file1
 
 }
 #WEIGHT=3

--- a/test/functional/bundleinfo/bundle-info-basic.bats
+++ b/test/functional/bundleinfo/bundle-info-basic.bats
@@ -18,7 +18,7 @@ global_setup() {
 	# when swupd initializes, if the tracking directory is empty, it will
 	# mark all installed bundles as tracked, to avoid this, let's add a dummy
 	# value to the tracking directory
-	sudo touch "$STATEDIR_TRACKING"/dummy
+	sudo touch "$ABS_TRACKING_DIR"/dummy
 
 }
 

--- a/test/functional/bundleinfo/bundle-info-files.bats
+++ b/test/functional/bundleinfo/bundle-info-files.bats
@@ -11,7 +11,7 @@ global_setup() {
 	create_bundle -n test-bundle1 -f /file_1,/foo/file_2 "$TEST_NAME"
 	create_bundle -n test-bundle2 -f /file_3,/bar/file_4 "$TEST_NAME"
 	# add test-bundle2 as a dependency of test-bundle1
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle2
 	create_version "$TEST_NAME" 20 10
 	update_bundle "$TEST_NAME" test-bundle1 --header-only
 	update_bundle "$TEST_NAME" test-bundle2 --add /file_5

--- a/test/functional/bundleinfo/bundle-info-includes.bats
+++ b/test/functional/bundleinfo/bundle-info-includes.bats
@@ -13,15 +13,15 @@ global_setup() {
 	create_bundle -n test-bundle3 -f /file_3 "$TEST_NAME"
 	create_bundle -n test-bundle4 -f /file_4 "$TEST_NAME"
 	# add test-bundle2 as a dependency of test-bundle1 and test-bundle3 as optional
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
-	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle1 test-bundle3
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest -o "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle3
 	# add test-bundle4 as a dependency of test-bundle2
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle2 test-bundle4
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle2 test-bundle4
 	# add one more dependency in a new version
 	create_version "$TEST_NAME" 20 10
 	update_bundle "$TEST_NAME" test-bundle1 --header-only
 	create_bundle -n test-bundle5 -f /file_5 "$TEST_NAME"
-	add_dependency_to_manifest "$WEBDIR"/20/Manifest.test-bundle1 test-bundle5
+	add_dependency_to_manifest "$WEB_DIR"/20/Manifest.test-bundle1 test-bundle5
 
 }
 

--- a/test/functional/bundleinfo/bundle-info-optional.bats
+++ b/test/functional/bundleinfo/bundle-info-optional.bats
@@ -13,10 +13,10 @@ global_setup() {
 	create_bundle -n test-bundle3 -f /file_3 "$TEST_NAME"
 	create_bundle -n test-bundle4 -f /file_4 "$TEST_NAME"
 	create_bundle -n test-bundle5 -f /file_5 "$TEST_NAME"
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
-	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle1 test-bundle3
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle2 test-bundle4
-	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle2 test-bundle5
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest -o "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle3
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle2 test-bundle4
+	add_dependency_to_manifest -o "$WEB_DIR"/10/Manifest.test-bundle2 test-bundle5
 }
 
 @test "BIN011: Show info about a bundle including its optional and non-optional dependencies" {
@@ -48,9 +48,9 @@ global_setup() {
 
 @test "BIN012: Show info about a bundle including its installed optional and non-optional dependencies" {
 
-	install_bundle "$WEBDIR"/10/Manifest.test-bundle1
-	install_bundle "$WEBDIR"/10/Manifest.test-bundle2
-	install_bundle "$WEBDIR"/10/Manifest.test-bundle5
+	install_bundle "$WEB_DIR"/10/Manifest.test-bundle1
+	install_bundle "$WEB_DIR"/10/Manifest.test-bundle2
+	install_bundle "$WEB_DIR"/10/Manifest.test-bundle5
 
 	run sudo sh -c "$SWUPD bundle-info $SWUPD_OPTS test-bundle1 --dependencies"
 

--- a/test/functional/bundlelist/list-experimental.bats
+++ b/test/functional/bundlelist/list-experimental.bats
@@ -61,8 +61,8 @@ global_setup() {
 	# bundle-list with no options should list only installed bundles, there should
 	# be a way to distinguish those that are experimental
 
-	sudo mv "$STATEDIR_MANIFEST"/10/Manifest.MoM "$STATEDIR_MANIFEST"/10/Manifest.MoM.temp
-	sudo mv "$WEBDIR"/10/Manifest.MoM.tar "$WEBDIR"/10/Manifest.MoM.tar.temp
+	sudo mv "$ABS_MANIFEST_DIR"/10/Manifest.MoM "$ABS_MANIFEST_DIR"/10/Manifest.MoM.temp
+	sudo mv "$WEB_DIR"/10/Manifest.MoM.tar "$WEB_DIR"/10/Manifest.MoM.tar.temp
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS"
 
@@ -78,8 +78,8 @@ global_setup() {
 	)
 	assert_in_output "$expected_output"
 
-	sudo mv "$STATEDIR_MANIFEST"/10/Manifest.MoM.temp "$STATEDIR_MANIFEST"/10/Manifest.MoM
-	sudo mv "$WEBDIR"/10/Manifest.MoM.tar.temp "$WEBDIR"/10/Manifest.MoM.tar
+	sudo mv "$ABS_MANIFEST_DIR"/10/Manifest.MoM.temp "$ABS_MANIFEST_DIR"/10/Manifest.MoM
+	sudo mv "$WEB_DIR"/10/Manifest.MoM.tar.temp "$WEB_DIR"/10/Manifest.MoM.tar
 
 }
 

--- a/test/functional/bundlelist/list-no-disk-space.bats
+++ b/test/functional/bundlelist/list-no-disk-space.bats
@@ -15,7 +15,7 @@ test_setup() {
 	create_bundle -n test-bundle2 -f /file_2 "$TEST_NAME"
 
 	# create the state version dirs ahead of time
-	sudo mkdir -p "$STATEDIR_MANIFEST"/10
+	sudo mkdir -p "$ABS_MANIFEST_DIR"/10
 
 }
 
@@ -31,8 +31,8 @@ test_setup() {
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/10/Manifest.MoM.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/10/Manifest.MoM.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Error: Failed to retrieve 10 MoM manifest
 		Warning: Could not determine which installed bundles are experimental
 		Installed bundles:
@@ -57,8 +57,8 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/10/Manifest.MoM.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/10/Manifest.MoM.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Error: Failed to retrieve 10 MoM manifest
 	EOM
 	)

--- a/test/functional/bundlelist/list-orphans.bats
+++ b/test/functional/bundlelist/list-orphans.bats
@@ -14,7 +14,7 @@ global_setup() {
 	create_bundle -L    -n test-bundle4 -f /file4 "$TEST_NAME"
 	create_bundle -L    -n test-bundle5 -f /file5 "$TEST_NAME"
 	create_bundle -L    -n test-bundle6 -f /file6 "$TEST_NAME"
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle3 test-bundle4
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle3 test-bundle4
 
 }
 

--- a/test/functional/bundleremove/remove-basics.bats
+++ b/test/functional/bundleremove/remove-basics.bats
@@ -14,8 +14,8 @@ global_setup() {
 test_teardown() {
 
 	# reinstall test-bundle1 and test-bundle2
-	install_bundle "$WEBDIR"/10/Manifest.test-bundle1
-	install_bundle "$WEBDIR"/10/Manifest.test-bundle2
+	install_bundle "$WEB_DIR"/10/Manifest.test-bundle1
+	install_bundle "$WEB_DIR"/10/Manifest.test-bundle2
 
 }
 
@@ -29,18 +29,18 @@ test_teardown() {
 
 	assert_status_is 0
 	# bundle1 was removed
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/test-file1
-	assert_file_not_exists "$TARGETDIR"/bar/test-file2
-	assert_file_not_exists "$TARGETDIR"/bat/test-file3
-	assert_dir_not_exists "$TARGETDIR"/foo
-	assert_dir_not_exists "$TARGETDIR"/bar
-	assert_file_not_exists "$STATEDIR"/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/test-file1
+	assert_file_not_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_not_exists "$TARGET_DIR"/bat/test-file3
+	assert_dir_not_exists "$TARGET_DIR"/foo
+	assert_dir_not_exists "$TARGET_DIR"/bar
+	assert_file_not_exists "$STATE_DIR"/bundles/test-bundle1
 	# bundle2 was not removed
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/bat/test-file4
-	assert_file_exists "$TARGETDIR"/bat/common
-	assert_file_exists "$STATEDIR"/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/bat/test-file4
+	assert_file_exists "$TARGET_DIR"/bat/common
+	assert_file_exists "$STATE_DIR"/bundles/test-bundle2
 	expected_output=$(cat <<-EOM
 		The following bundles are being removed:
 		 - test-bundle1
@@ -59,18 +59,18 @@ test_teardown() {
 
 	assert_status_is 0
 	# bundle1 and 2 were removed
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_not_exists "$TARGETDIR"/test-file1
-	assert_file_not_exists "$TARGETDIR"/bar/test-file2
-	assert_file_not_exists "$TARGETDIR"/bat/test-file3
-	assert_file_not_exists "$TARGETDIR"/bat/test-file4
-	assert_file_not_exists "$TARGETDIR"/bat/common
-	assert_dir_not_exists "$TARGETDIR"/foo
-	assert_dir_not_exists "$TARGETDIR"/bar
-	assert_dir_not_exists "$TARGETDIR"/bat
-	assert_file_not_exists "$STATEDIR"/bundles/test-bundle1
-	assert_file_not_exists "$STATEDIR"/bundles/test-bundle2
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TARGET_DIR"/test-file1
+	assert_file_not_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_not_exists "$TARGET_DIR"/bat/test-file3
+	assert_file_not_exists "$TARGET_DIR"/bat/test-file4
+	assert_file_not_exists "$TARGET_DIR"/bat/common
+	assert_dir_not_exists "$TARGET_DIR"/foo
+	assert_dir_not_exists "$TARGET_DIR"/bar
+	assert_dir_not_exists "$TARGET_DIR"/bat
+	assert_file_not_exists "$STATE_DIR"/bundles/test-bundle1
+	assert_file_not_exists "$STATE_DIR"/bundles/test-bundle2
 	expected_output=$(cat <<-EOM
 		The following bundles are being removed:
 		 - test-bundle2
@@ -147,16 +147,16 @@ test_teardown() {
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle3 test-bundle1"
 
 	assert_status_is "$SWUPD_BUNDLE_NOT_TRACKED"
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/test-file1
-	assert_file_not_exists "$TARGETDIR"/bar/test-file2
-	assert_file_not_exists "$TARGETDIR"/bat/test-file3
-	assert_dir_not_exists "$TARGETDIR"/foo
-	assert_dir_not_exists "$TARGETDIR"/bar
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/test-file1
+	assert_file_not_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_not_exists "$TARGET_DIR"/bat/test-file3
+	assert_dir_not_exists "$TARGET_DIR"/foo
+	assert_dir_not_exists "$TARGET_DIR"/bar
 	# bundle2 was not removed
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/bat/test-file4
-	assert_file_exists "$TARGETDIR"/bat/common
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/bat/test-file4
+	assert_file_exists "$TARGET_DIR"/bat/common
 	expected_output=$(cat <<-EOM
 		Warning: Bundle "test-bundle3" is not installed, skipping it...
 		The following bundles are being removed:
@@ -175,16 +175,16 @@ test_teardown() {
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS fake-bundle test-bundle1"
 
 	assert_status_is "$SWUPD_INVALID_BUNDLE"
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/test-file1
-	assert_file_not_exists "$TARGETDIR"/bar/test-file2
-	assert_file_not_exists "$TARGETDIR"/bat/test-file3
-	assert_dir_not_exists "$TARGETDIR"/foo
-	assert_dir_not_exists "$TARGETDIR"/bar
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/test-file1
+	assert_file_not_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_not_exists "$TARGET_DIR"/bat/test-file3
+	assert_dir_not_exists "$TARGET_DIR"/foo
+	assert_dir_not_exists "$TARGET_DIR"/bar
 	# bundle2 was not removed
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/bat/test-file4
-	assert_file_exists "$TARGETDIR"/bat/common
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/bat/test-file4
+	assert_file_exists "$TARGET_DIR"/bat/common
 	expected_output=$(cat <<-EOM
 		Warning: Bundle "fake-bundle" is invalid, skipping it...
 		The following bundles are being removed:

--- a/test/functional/bundleremove/remove-boot-file.bats
+++ b/test/functional/bundleremove/remove-boot-file.bats
@@ -14,12 +14,12 @@ test_setup() {
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle"
 
 	assert_status_is 0
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle
-	assert_file_not_exists "$TARGETDIR"/usr/lib/kernel/testfile
-	assert_dir_not_exists "$TARGETDIR"/usr/lib/kernel
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle
+	assert_file_not_exists "$TARGET_DIR"/usr/lib/kernel/testfile
+	assert_dir_not_exists "$TARGET_DIR"/usr/lib/kernel
 	# these files should not be deleted because they are also part of os-core
-	assert_dir_exists "$TARGETDIR"/usr/lib
-	assert_dir_exists "$TARGETDIR"/usr/
+	assert_dir_exists "$TARGET_DIR"/usr/lib
+	assert_dir_exists "$TARGET_DIR"/usr/
 	expected_output=$(cat <<-EOM
 		The following bundles are being removed:
 		 - test-bundle

--- a/test/functional/bundleremove/remove-include-nested.bats
+++ b/test/functional/bundleremove/remove-include-nested.bats
@@ -11,11 +11,11 @@ test_setup() {
 	create_bundle -L -n test-bundle2 -f /test-file2 "$TEST_NAME"
 	create_bundle -L -n test-bundle3 -f /test-file3 "$TEST_NAME"
 	# add dependencies
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle2 test-bundle1
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle3 test-bundle2
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle2 test-bundle1
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle3 test-bundle2
 	# collect info from the common file
-	file_hash=$(get_hash_from_manifest "$WEBDIR"/10/Manifest.test-bundle1 /common)
-	file_path="$WEBDIR"/10/files/"$file_hash"
+	file_hash=$(get_hash_from_manifest "$WEB_DIR"/10/Manifest.test-bundle1 /common)
+	file_path="$WEB_DIR"/10/files/"$file_hash"
 
 }
 
@@ -34,13 +34,13 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
-	assert_file_exists "$TARGETDIR"/test-file1
-	assert_file_exists "$TARGETDIR"/test-file2
-	assert_file_exists "$TARGETDIR"/test-file3
-	assert_file_exists "$TARGETDIR"/common
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/test-file1
+	assert_file_exists "$TARGET_DIR"/test-file2
+	assert_file_exists "$TARGET_DIR"/test-file3
+	assert_file_exists "$TARGET_DIR"/common
 
 }
 
@@ -48,20 +48,20 @@ test_setup() {
 
 	create_bundle -L -n test-bundle4 -f /test-file4,/common:"$file_path" "$TEST_NAME"
 	create_bundle -L -n test-bundle5 -f /test-file5,/common:"$file_path" "$TEST_NAME"
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle3 test-bundle4
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle2 test-bundle5
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle3 test-bundle4
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle2 test-bundle5
 
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle4
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle5
-	assert_file_exists "$TARGETDIR"/test-file1
-	assert_file_exists "$TARGETDIR"/test-file2
-	assert_file_exists "$TARGETDIR"/test-file3
-	assert_file_exists "$TARGETDIR"/test-file4
-	assert_file_exists "$TARGETDIR"/test-file5
-	assert_file_exists "$TARGETDIR"/common
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle4
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle5
+	assert_file_exists "$TARGET_DIR"/test-file1
+	assert_file_exists "$TARGET_DIR"/test-file2
+	assert_file_exists "$TARGET_DIR"/test-file3
+	assert_file_exists "$TARGET_DIR"/test-file4
+	assert_file_exists "$TARGET_DIR"/test-file5
+	assert_file_exists "$TARGET_DIR"/common
 
 	# When removing a bundle that is required by other bundles, if the --force
 	# option is used, it should be allowed, the specified bundle should be deleted
@@ -86,17 +86,17 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle4
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle5
-	assert_file_not_exists "$TARGETDIR"/test-file1
-	assert_file_not_exists "$TARGETDIR"/test-file2
-	assert_file_not_exists "$TARGETDIR"/test-file3
-	assert_file_exists "$TARGETDIR"/test-file4
-	assert_file_exists "$TARGETDIR"/test-file5
-	assert_file_exists "$TARGETDIR"/common
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle4
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle5
+	assert_file_not_exists "$TARGET_DIR"/test-file1
+	assert_file_not_exists "$TARGET_DIR"/test-file2
+	assert_file_not_exists "$TARGET_DIR"/test-file3
+	assert_file_exists "$TARGET_DIR"/test-file4
+	assert_file_exists "$TARGET_DIR"/test-file5
+	assert_file_exists "$TARGET_DIR"/common
 
 }
 
@@ -106,9 +106,9 @@ test_setup() {
 	# be considered for the overall removal operation regardless of the
 	# order of the bundles
 
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
 
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle1 test-bundle2"
 
@@ -127,9 +127,9 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
 
 	# re-try the test inverting the order of the bundles
 
@@ -150,9 +150,9 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
 
 }
 
@@ -162,9 +162,9 @@ test_setup() {
 	# be considered for the overall removal operation regardless of the
 	# order of the bundles
 
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
 
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle2 test-bundle1 test-bundle3"
 
@@ -181,20 +181,20 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
 
 	# reinstall the bundles
-	install_bundle "$WEBDIR"/10/Manifest.test-bundle1
-	install_bundle "$WEBDIR"/10/Manifest.test-bundle2
-	install_bundle "$WEBDIR"/10/Manifest.test-bundle3
+	install_bundle "$WEB_DIR"/10/Manifest.test-bundle1
+	install_bundle "$WEB_DIR"/10/Manifest.test-bundle2
+	install_bundle "$WEB_DIR"/10/Manifest.test-bundle3
 
 	# re-try again using a different order in the bundles
 
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
 
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle1 test-bundle3 test-bundle2"
 
@@ -211,9 +211,9 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
 
 }
 
@@ -237,13 +237,13 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
-	assert_file_exists "$TARGETDIR"/test-file1
-	assert_file_exists "$TARGETDIR"/test-file2
-	assert_file_exists "$TARGETDIR"/test-file3
-	assert_file_exists "$TARGETDIR"/common
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/test-file1
+	assert_file_exists "$TARGET_DIR"/test-file2
+	assert_file_exists "$TARGET_DIR"/test-file3
+	assert_file_exists "$TARGET_DIR"/common
 
 }
 #WEIGHT=22

--- a/test/functional/bundleremove/remove-include.bats
+++ b/test/functional/bundleremove/remove-include.bats
@@ -8,7 +8,7 @@ test_setup() {
 	create_bundle -L -n test-bundle1 -f /foo/test-file1 "$TEST_NAME"
 	create_bundle -L -n test-bundle2 -f /bar/test-file2 "$TEST_NAME"
 	# add test-bundle1 as dependency of test-bundle2
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle2 test-bundle1
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle2 test-bundle1
 
 }
 
@@ -17,10 +17,10 @@ test_setup() {
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle1"
 
 	assert_status_is "$SWUPD_REQUIRED_BUNDLE_ERROR"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/bar/test-file2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
 	expected_output=$(cat <<-EOM
 		Bundle "test-bundle1" is required by the following bundles:
 		 - test-bundle2

--- a/test/functional/bundleremove/remove-no-disk-space.bats
+++ b/test/functional/bundleremove/remove-no-disk-space.bats
@@ -14,7 +14,7 @@ test_setup() {
 	create_bundle -L -n test-bundle -f /file_1 "$TEST_NAME"
 
 	# create the state version dirs ahead of time
-	sudo mkdir -p "$STATEDIR_MANIFEST"/10
+	sudo mkdir -p "$ABS_MANIFEST_DIR"/10
 
 }
 
@@ -30,8 +30,8 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/10/Manifest.MoM.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/10/Manifest.MoM.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Error: Failed to retrieve 10 MoM manifest
 		Error: Unable to download/verify 10 Manifest.MoM
 		Failed to remove bundle(s)
@@ -50,18 +50,18 @@ test_setup() {
 
 	# let's replace the Manifest tar from os-core with a much larger file that will exceed
 	# the available space on disk
-	sudo rm "$WEBDIR"/10/Manifest.os-core
-	sudo rm "$WEBDIR"/10/Manifest.os-core.tar
-	big_manifest=$(create_file "$WEBDIR"/10 15MB)
-	sudo mv "$big_manifest" "$WEBDIR"/10/Manifest.os-core
-	sudo mv "$big_manifest".tar "$WEBDIR"/10/Manifest.os-core.tar
+	sudo rm "$WEB_DIR"/10/Manifest.os-core
+	sudo rm "$WEB_DIR"/10/Manifest.os-core.tar
+	big_manifest=$(create_file "$WEB_DIR"/10 15MB)
+	sudo mv "$big_manifest" "$WEB_DIR"/10/Manifest.os-core
+	sudo mv "$big_manifest".tar "$WEB_DIR"/10/Manifest.os-core.tar
 
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle"
 
 	assert_status_is "$SWUPD_RECURSE_MANIFEST"
 	expected_output=$(cat <<-EOM
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/10/Manifest.os-core.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/10/Manifest.os-core.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Error: Failed to retrieve 10 os-core manifest
 		Error: Cannot load MoM sub-manifests
 		Failed to remove bundle(s)
@@ -78,18 +78,18 @@ test_setup() {
 
 	# let's replace the Manifest tar from the bundle with a much larger file that will exceed
 	# the available space on disk
-	sudo rm "$WEBDIR"/10/Manifest.test-bundle
-	sudo rm "$WEBDIR"/10/Manifest.test-bundle.tar
-	big_manifest=$(create_file "$WEBDIR"/10 15MB)
-	sudo mv "$big_manifest" "$WEBDIR"/10/Manifest.test-bundle
-	sudo mv "$big_manifest".tar "$WEBDIR"/10/Manifest.test-bundle.tar
+	sudo rm "$WEB_DIR"/10/Manifest.test-bundle
+	sudo rm "$WEB_DIR"/10/Manifest.test-bundle.tar
+	big_manifest=$(create_file "$WEB_DIR"/10 15MB)
+	sudo mv "$big_manifest" "$WEB_DIR"/10/Manifest.test-bundle
+	sudo mv "$big_manifest".tar "$WEB_DIR"/10/Manifest.test-bundle.tar
 
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle"
 
 	assert_status_is "$SWUPD_RECURSE_MANIFEST"
 	expected_output=$(cat <<-EOM
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/10/Manifest.test-bundle.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/10/Manifest.test-bundle.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Error: Failed to retrieve 10 test-bundle manifest
 		Error: Cannot load MoM sub-manifests
 		Failed to remove bundle(s)

--- a/test/functional/bundleremove/remove-optional-bundles.bats
+++ b/test/functional/bundleremove/remove-optional-bundles.bats
@@ -14,8 +14,8 @@ test_setup() {
 
 	# add test-bundle2 as a dependency of test-bundle1 and
 	# test-bundle3 as optional
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
-	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle1 test-bundle3
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest -o "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle3
 
 }
 
@@ -36,12 +36,12 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/bar/test-file2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_not_exists "$TARGETDIR"/baz/test-file3
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TARGET_DIR"/baz/test-file3
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
 
 }
 #WEIGHT=4

--- a/test/functional/bundleremove/remove-orphans.bats
+++ b/test/functional/bundleremove/remove-orphans.bats
@@ -13,8 +13,8 @@ test_setup() {
 	create_bundle -L    -n test-bundle3 -f /file3 "$TEST_NAME"
 	create_bundle -L    -n test-bundle4 -f /file4 "$TEST_NAME"
 	create_bundle -L    -n test-bundle5 -f /file5 "$TEST_NAME"
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle4 test-bundle5
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle4 test-bundle5
 
 }
 

--- a/test/functional/bundleremove/remove-os-core.bats
+++ b/test/functional/bundleremove/remove-os-core.bats
@@ -13,8 +13,8 @@ test_setup() {
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS os-core"
 
 	assert_status_is "$SWUPD_REQUIRED_BUNDLE_ERROR"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/core
 	expected_output=$(cat <<-EOM
 		Warning: Bundle "os-core" not allowed to be removed, skipping it...
 		Failed to remove 1 of 1 bundles

--- a/test/functional/bundleremove/remove-recursive.bats
+++ b/test/functional/bundleremove/remove-recursive.bats
@@ -18,27 +18,27 @@ test_setup() {
 	create_bundle -L -t -n test-bundle6 -f /test-file6     "$TEST_NAME"
 	# test-bundle1 has 4 direct dependencies: os-core, test-bundle2,
 	# test-bundle4 (also-add), test-bundle6 (tracked)
-	add_dependency_to_manifest -p    "$WEBDIR"/10/Manifest.test-bundle1 os-core
-	add_dependency_to_manifest -p    "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
-	add_dependency_to_manifest -p -o "$WEBDIR"/10/Manifest.test-bundle1 test-bundle4
-	add_dependency_to_manifest       "$WEBDIR"/10/Manifest.test-bundle1 test-bundle6
+	add_dependency_to_manifest -p    "$WEB_DIR"/10/Manifest.test-bundle1 os-core
+	add_dependency_to_manifest -p    "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest -p -o "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle4
+	add_dependency_to_manifest       "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle6
 	# and 1 indirect dependency: test-bundle3
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle2 test-bundle3
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle2 test-bundle3
 	# test-bundle4 is a dependency of test-bundle1, but it is also a dependency
 	# test-bundle5 which is also installed
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle5 test-bundle4
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle5 test-bundle4
 
 	# make sure all files do exist
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle4
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle5
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle6
-	assert_file_exists "$STATEDIR"/bundles/test-bundle1
-	assert_file_exists "$STATEDIR"/bundles/test-bundle6
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle4
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle5
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle6
+	assert_file_exists "$STATE_DIR"/bundles/test-bundle1
+	assert_file_exists "$STATE_DIR"/bundles/test-bundle6
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 
@@ -68,24 +68,24 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# bundles/files that should be deleted
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
-	assert_file_not_exists "$STATEDIR"/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/foo/test-file1
-	assert_file_not_exists "$TARGETDIR"/bar/test-file2
-	assert_file_not_exists "$TARGETDIR"/bat/test-file3
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_not_exists "$STATE_DIR"/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_not_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_not_exists "$TARGET_DIR"/bat/test-file3
 
 	# bundles/files that should not be deleted
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle4
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle5
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle6
-	assert_file_exists "$STATEDIR"/bundles/test-bundle6
-	assert_file_exists "$TARGETDIR"/baz/test-file4
-	assert_file_exists "$TARGETDIR"/test-file5
-	assert_file_exists "$TARGETDIR"/test-file6
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle4
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle5
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle6
+	assert_file_exists "$STATE_DIR"/bundles/test-bundle6
+	assert_file_exists "$TARGET_DIR"/baz/test-file4
+	assert_file_exists "$TARGET_DIR"/test-file5
+	assert_file_exists "$TARGET_DIR"/test-file6
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 
@@ -116,24 +116,24 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# bundles/files that should be deleted
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle4
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle5
-	assert_file_not_exists "$STATEDIR"/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/foo/test-file1
-	assert_file_not_exists "$TARGETDIR"/bar/test-file2
-	assert_file_not_exists "$TARGETDIR"/bat/test-file3
-	assert_file_not_exists "$TARGETDIR"/baz/test-file4
-	assert_file_not_exists "$TARGETDIR"/test-file5
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle4
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle5
+	assert_file_not_exists "$STATE_DIR"/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_not_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_not_exists "$TARGET_DIR"/bat/test-file3
+	assert_file_not_exists "$TARGET_DIR"/baz/test-file4
+	assert_file_not_exists "$TARGET_DIR"/test-file5
 
 	# bundles/files that should not be deleted
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle6
-	assert_file_exists "$STATEDIR"/bundles/test-bundle6
-	assert_file_exists "$TARGETDIR"/test-file6
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle6
+	assert_file_exists "$STATE_DIR"/bundles/test-bundle6
+	assert_file_exists "$TARGET_DIR"/test-file6
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 
@@ -163,24 +163,24 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# bundles/files that should be deleted
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle4
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle5
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle6
-	assert_file_not_exists "$STATEDIR"/bundles/test-bundle1
-	assert_file_not_exists "$STATEDIR"/bundles/test-bundle6
-	assert_file_not_exists "$TARGETDIR"/foo/test-file1
-	assert_file_not_exists "$TARGETDIR"/bar/test-file2
-	assert_file_not_exists "$TARGETDIR"/bat/test-file3
-	assert_file_not_exists "$TARGETDIR"/baz/test-file4
-	assert_file_not_exists "$TARGETDIR"/test-file5
-	assert_file_not_exists "$TARGETDIR"/test-file6
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle4
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle5
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle6
+	assert_file_not_exists "$STATE_DIR"/bundles/test-bundle1
+	assert_file_not_exists "$STATE_DIR"/bundles/test-bundle6
+	assert_file_not_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_not_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_not_exists "$TARGET_DIR"/bat/test-file3
+	assert_file_not_exists "$TARGET_DIR"/baz/test-file4
+	assert_file_not_exists "$TARGET_DIR"/test-file5
+	assert_file_not_exists "$TARGET_DIR"/test-file6
 
 	# bundles/files that should not be deleted
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 
@@ -188,7 +188,7 @@ test_setup() {
 
 	# when running bundle-remove --recursive, if the tracking directory is
 	# not found or empty, bundle-remove should assume everything is tracked
-	sudo rm -rf "$STATEDIR"/bundles
+	sudo rm -rf "$STATE_DIR"/bundles
 
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle1 --recursive"
 
@@ -205,24 +205,24 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# bundles/files that should be deleted
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$STATEDIR"/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/foo/test-file1
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$STATE_DIR"/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/foo/test-file1
 
 	# bundles/files that should not be deleted
-	assert_file_exists "$STATEDIR"/bundles/test-bundle6
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle4
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle5
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle6
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_exists "$TARGETDIR"/bar/test-file2
-	assert_file_exists "$TARGETDIR"/bat/test-file3
-	assert_file_exists "$TARGETDIR"/baz/test-file4
-	assert_file_exists "$TARGETDIR"/test-file5
-	assert_file_exists "$TARGETDIR"/test-file6
+	assert_file_exists "$STATE_DIR"/bundles/test-bundle6
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle4
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle5
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle6
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_exists "$TARGET_DIR"/bat/test-file3
+	assert_file_exists "$TARGET_DIR"/baz/test-file4
+	assert_file_exists "$TARGET_DIR"/test-file5
+	assert_file_exists "$TARGET_DIR"/test-file6
 
 }
 #WEIGHT=29

--- a/test/functional/bundleremove/remove-with-dependency.bats
+++ b/test/functional/bundleremove/remove-with-dependency.bats
@@ -10,7 +10,7 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle1 -f /file_1 "$TEST_NAME"
 	create_bundle -L -n test-bundle2 -f /file_2 "$TEST_NAME"
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle2
 
 }
 
@@ -23,11 +23,11 @@ test_setup() {
 
 	assert_status_is 0
 	# test-bundle1 is deleted
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/file_1
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/file_1
 	# test-bundle2 is not deleted
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/file_2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/file_2
 	expected_output=$(cat <<-EOM
 		The following bundles are being removed:
 		 - test-bundle1

--- a/test/functional/checkupdate/chk-update-no-target-content.bats
+++ b/test/functional/checkupdate/chk-update-no-target-content.bats
@@ -6,7 +6,7 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME"
 	# remove os-release file from target-dir so no current version can be determined
-	sudo rm "$TARGETDIR"/usr/lib/os-release
+	sudo rm "$TARGET_DIR"/usr/lib/os-release
 
 }
 

--- a/test/functional/clean/clean-basic.bats
+++ b/test/functional/clean/clean-basic.bats
@@ -60,33 +60,33 @@ test_setup() {
 	# ├── swupd_lock
 	# └── version
 
-	sudo mkdir -p "$STATEDIR_CACHE"/{delta,download,manifest,staged}
-	sudo chmod 0700 "$STATEDIR_CACHE"/staged
-	sudo mkdir -p "$STATEDIR_MANIFEST"/{32900,33000}
+	sudo mkdir -p "$ABS_CACHE_DIR"/{delta,download,manifest,staged}
+	sudo chmod 0700 "$ABS_CACHE_DIR"/staged
+	sudo mkdir -p "$ABS_MANIFEST_DIR"/{32900,33000}
 
-	MOM=$(create_manifest "$STATEDIR_MANIFEST"/33000 MoM 1 32900)
+	MOM=$(create_manifest "$ABS_MANIFEST_DIR"/33000 MoM 1 32900)
 	write_to_protected_file -a "$MOM" "M...	dfd541b1ac9256982044848f2128f51e23ddbb72f68e9de43adaf8f7ead93657	32900	p11-kit\n"
 	write_to_protected_file -a "$MOM" "M...	7414710480607fa89c307ad11d145d8bb0cbdbdf3c0692f940d906b670f6fd5d	33000	emacs\n"
 	MOM_SIG="$MOM".sig ; sudo touch "$MOM_SIG"
 
-	FILE1="$STATEDIR_MANIFEST"/32900/Manifest.p11-kit ; sudo touch "$FILE1"
-	FILE2="$STATEDIR_MANIFEST"/32900/Manifest.p11-kit.dfd541b1ac9256982044848f2128f51e23ddbb72f68e9de43adaf8f7ead93657 ; sudo touch "$FILE2"
-	FILE3="$STATEDIR_MANIFEST"/33000/Manifest.emacs ; sudo touch "$FILE3"
-	FILE4="$STATEDIR_MANIFEST"/33000/Manifest.emacs.7414710480607fa89c307ad11d145d8bb0cbdbdf3c0692f940d906b670f6fd5d ; sudo touch "$FILE4"
-	FILE5="$STATEDIR_MANIFEST"/Manifest-emacs-delta-from-32900-to-33000 ; sudo touch "$FILE5"
-	FILE6="$STATEDIR_MANIFEST"/Manifest-vim-delta-from-32900-to-33000 ; sudo touch "$FILE6"
-	FILE7="$STATEDIR_CACHE"/pack-blender-from-0-to-33000.tar ; sudo touch "$FILE7"
-	FILE8="$STATEDIR_CACHE"/pack-vim-from-32800-to-32900.tar ; sudo touch "$FILE8"
-	FILE9="$STATEDIR_STAGED"/00004ead4b4eb1cef1ebbe13849f6c47c21d325182f98cf8f5333e9a76d2e2df ; sudo touch "$FILE9"
-	FILE10="$STATEDIR_STAGED"/fffe891980af628e498b16a364b5b4d00377485370ccc4d09ac0fc072e85b31d ; sudo touch "$FILE10"
+	FILE1="$ABS_MANIFEST_DIR"/32900/Manifest.p11-kit ; sudo touch "$FILE1"
+	FILE2="$ABS_MANIFEST_DIR"/32900/Manifest.p11-kit.dfd541b1ac9256982044848f2128f51e23ddbb72f68e9de43adaf8f7ead93657 ; sudo touch "$FILE2"
+	FILE3="$ABS_MANIFEST_DIR"/33000/Manifest.emacs ; sudo touch "$FILE3"
+	FILE4="$ABS_MANIFEST_DIR"/33000/Manifest.emacs.7414710480607fa89c307ad11d145d8bb0cbdbdf3c0692f940d906b670f6fd5d ; sudo touch "$FILE4"
+	FILE5="$ABS_MANIFEST_DIR"/Manifest-emacs-delta-from-32900-to-33000 ; sudo touch "$FILE5"
+	FILE6="$ABS_MANIFEST_DIR"/Manifest-vim-delta-from-32900-to-33000 ; sudo touch "$FILE6"
+	FILE7="$ABS_CACHE_DIR"/pack-blender-from-0-to-33000.tar ; sudo touch "$FILE7"
+	FILE8="$ABS_CACHE_DIR"/pack-vim-from-32800-to-32900.tar ; sudo touch "$FILE8"
+	FILE9="$ABS_STAGED_DIR"/00004ead4b4eb1cef1ebbe13849f6c47c21d325182f98cf8f5333e9a76d2e2df ; sudo touch "$FILE9"
+	FILE10="$ABS_STAGED_DIR"/fffe891980af628e498b16a364b5b4d00377485370ccc4d09ac0fc072e85b31d ; sudo touch "$FILE10"
 	# second url cache
-	sudo mkdir -p "$STATEDIR_ABS"/cache/https_other.clearlinux.update_site/{delta,download,manifest,staged,temp}
-	sudo mkdir -p "$STATEDIR_ABS"/cache/https_other.clearlinux.update_site/manifest/32900
-	FILE11="$STATEDIR_ABS"/cache/https_other.clearlinux.update_site/pack-lib-imageformat-from-33090-to-33170.tar ; sudo touch "$FILE11"
-	FILE12="$STATEDIR_ABS"/cache/https_other.clearlinux.update_site/manifest/32900/Manifest.MoM ; sudo touch "$FILE12"
-	FILE13="$STATEDIR_ABS"/cache/https_other.clearlinux.update_site/manifest/32900/Manifest.MoM.sig ; sudo touch "$FILE13"
-	FILE14="$STATEDIR_ABS"/cache/https_other.clearlinux.update_site/manifest/Manifest-qt-basic-delta-from-33010-to-33140 ; sudo touch "$FILE14"
-	FILE15="$STATEDIR_ABS"/cache/https_other.clearlinux.update_site/staged/ffaf66dab58a2074e5fe9dc6ab7bf8773c069817dcccf631148b6afc87166b4b ; sudo touch "$FILE15"
+	sudo mkdir -p "$ABS_STATE_DIR"/cache/https_other.clearlinux.update_site/{delta,download,manifest,staged,temp}
+	sudo mkdir -p "$ABS_STATE_DIR"/cache/https_other.clearlinux.update_site/manifest/32900
+	FILE11="$ABS_STATE_DIR"/cache/https_other.clearlinux.update_site/pack-lib-imageformat-from-33090-to-33170.tar ; sudo touch "$FILE11"
+	FILE12="$ABS_STATE_DIR"/cache/https_other.clearlinux.update_site/manifest/32900/Manifest.MoM ; sudo touch "$FILE12"
+	FILE13="$ABS_STATE_DIR"/cache/https_other.clearlinux.update_site/manifest/32900/Manifest.MoM.sig ; sudo touch "$FILE13"
+	FILE14="$ABS_STATE_DIR"/cache/https_other.clearlinux.update_site/manifest/Manifest-qt-basic-delta-from-33010-to-33140 ; sudo touch "$FILE14"
+	FILE15="$ABS_STATE_DIR"/cache/https_other.clearlinux.update_site/staged/ffaf66dab58a2074e5fe9dc6ab7bf8773c069817dcccf631148b6afc87166b4b ; sudo touch "$FILE15"
 
 }
 
@@ -103,10 +103,10 @@ test_setup() {
 	assert_regex_is_output "$expected_output"
 
 	# relevant manifests should still exist
-	assert_file_exists "$STATEDIR_MANIFEST"/32900/Manifest.p11-kit
-	assert_file_exists "$STATEDIR_MANIFEST"/33000/Manifest.emacs
-	assert_file_exists "$STATEDIR_MANIFEST"/33000/Manifest.MoM
-	assert_file_exists "$STATEDIR_MANIFEST"/33000/Manifest.MoM.sig
+	assert_file_exists "$ABS_MANIFEST_DIR"/32900/Manifest.p11-kit
+	assert_file_exists "$ABS_MANIFEST_DIR"/33000/Manifest.emacs
+	assert_file_exists "$ABS_MANIFEST_DIR"/33000/Manifest.MoM
+	assert_file_exists "$ABS_MANIFEST_DIR"/33000/Manifest.MoM.sig
 
 	# the rest of the files should not exist
 	assert_file_not_exists "$FILE2"
@@ -115,10 +115,10 @@ test_setup() {
 	assert_file_not_exists "$FILE6"
 	assert_file_not_exists "$FILE7"
 	assert_file_not_exists "$FILE8"
-	assert_dir_not_exists "$STATEDIR_STAGED"
-	assert_dir_not_exists "$STATEDIR_DOWNLOAD"
-	assert_dir_not_exists "$STATEDIR_DELTA"
-	assert_dir_not_exists "$STATEDIR_ABS"/cache/https_other.clearlinux.update_site
+	assert_dir_not_exists "$ABS_STAGED_DIR"
+	assert_dir_not_exists "$ABS_DOWNLOAD_DIR"
+	assert_dir_not_exists "$ABS_DELTA_DIR"
+	assert_dir_not_exists "$ABS_STATE_DIR"/cache/https_other.clearlinux.update_site
 
 }
 
@@ -135,7 +135,7 @@ test_setup() {
 	assert_regex_is_output "$expected_output"
 
 	# everything should have been cleaned
-	assert_dir_not_exists "$STATEDIR_ABS"/cache
+	assert_dir_not_exists "$ABS_STATE_DIR"/cache
 
 }
 
@@ -145,7 +145,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		$STATEDIR_ABS/cache/https_other.clearlinux.update_site
+		$ABS_STATE_DIR/cache/https_other.clearlinux.update_site
 		Would remove 24 files
 		Aproximatelly .* KB would be freed
 	EOM

--- a/test/functional/clean/clean-grouped-manifests.bats
+++ b/test/functional/clean/clean-grouped-manifests.bats
@@ -52,21 +52,21 @@ test_setup() {
 	# ├── swupd_lock
 	# └── version
 
-	sudo mkdir -p "$STATEDIR_ABS"/manifest/{32900,33000}
-	sudo mkdir -p "$STATEDIR_ABS"/{staged,delta,download}
+	sudo mkdir -p "$ABS_STATE_DIR"/manifest/{32900,33000}
+	sudo mkdir -p "$ABS_STATE_DIR"/{staged,delta,download}
 
-	MOM="$STATEDIR_ABS"/manifest/33000/Manifest.MoM ; sudo touch "$MOM"
-	MOM_SIG="$STATEDIR_ABS"/manifest/33000/Manifest.MoM.sig ; sudo touch "$MOM_SIG"
-	FILE1="$STATEDIR_ABS"/manifest/32900/Manifest.editors ; sudo touch "$FILE1"
-	FILE2="$STATEDIR_ABS"/manifest/32900/Manifest.editors.8f7aca1643c1cd8b109774b65c83c0dad5a2d259348343a9395fd63f71640c63 ; sudo touch "$FILE2"
-	FILE3="$STATEDIR_ABS"/manifest/33000/Manifest.emacs ; sudo touch "$FILE3"
-	FILE4="$STATEDIR_ABS"/manifest/33000/Manifest.emacs.7414710480607fa89c307ad11d145d8bb0cbdbdf3c0692f940d906b670f6fd5d ; sudo touch "$FILE4"
-	FILE5="$STATEDIR_ABS"/manifest/Manifest-emacs-delta-from-32900-to-33000 ; sudo touch "$FILE5"
-	FILE6="$STATEDIR_ABS"/pack-vim-from-32800-to-32900.tar ; sudo touch "$FILE6"
-	FILE7="$STATEDIR_ABS"/staged/00004ead4b4eb1cef1ebbe13849f6c47c21d325182f98cf8f5333e9a76d2e2df ; sudo touch "$FILE7"
-	FILE8="$STATEDIR_ABS"/staged/fffe891980af628e498b16a364b5b4d00377485370ccc4d09ac0fc072e85b31d ; sudo touch "$FILE8"
+	MOM="$ABS_STATE_DIR"/manifest/33000/Manifest.MoM ; sudo touch "$MOM"
+	MOM_SIG="$ABS_STATE_DIR"/manifest/33000/Manifest.MoM.sig ; sudo touch "$MOM_SIG"
+	FILE1="$ABS_STATE_DIR"/manifest/32900/Manifest.editors ; sudo touch "$FILE1"
+	FILE2="$ABS_STATE_DIR"/manifest/32900/Manifest.editors.8f7aca1643c1cd8b109774b65c83c0dad5a2d259348343a9395fd63f71640c63 ; sudo touch "$FILE2"
+	FILE3="$ABS_STATE_DIR"/manifest/33000/Manifest.emacs ; sudo touch "$FILE3"
+	FILE4="$ABS_STATE_DIR"/manifest/33000/Manifest.emacs.7414710480607fa89c307ad11d145d8bb0cbdbdf3c0692f940d906b670f6fd5d ; sudo touch "$FILE4"
+	FILE5="$ABS_STATE_DIR"/manifest/Manifest-emacs-delta-from-32900-to-33000 ; sudo touch "$FILE5"
+	FILE6="$ABS_STATE_DIR"/pack-vim-from-32800-to-32900.tar ; sudo touch "$FILE6"
+	FILE7="$ABS_STATE_DIR"/staged/00004ead4b4eb1cef1ebbe13849f6c47c21d325182f98cf8f5333e9a76d2e2df ; sudo touch "$FILE7"
+	FILE8="$ABS_STATE_DIR"/staged/fffe891980af628e498b16a364b5b4d00377485370ccc4d09ac0fc072e85b31d ; sudo touch "$FILE8"
 
-	sudo chmod -R 0700 "$STATEDIR_ABS"
+	sudo chmod -R 0700 "$ABS_STATE_DIR"
 
 }
 
@@ -89,14 +89,14 @@ test_setup() {
 	assert_regex_is_output "$expected_output"
 
 	# these old directories should be removed since are no longer used
-	assert_dir_not_exists "$STATEDIR_ABS"/delta
-	assert_dir_not_exists "$STATEDIR_ABS"/download
-	assert_dir_not_exists "$STATEDIR_ABS"/staged
-	assert_dir_not_exists "$STATEDIR_ABS"/manifest
+	assert_dir_not_exists "$ABS_STATE_DIR"/delta
+	assert_dir_not_exists "$ABS_STATE_DIR"/download
+	assert_dir_not_exists "$ABS_STATE_DIR"/staged
+	assert_dir_not_exists "$ABS_STATE_DIR"/manifest
 
 	# files in the old structure should no longer be there either
-	assert_file_not_exists "$STATEDIR_ABS"/Manifest-emacs-delta-from-32900-to-33000
-	assert_file_not_exists "$STATEDIR_ABS"/pack-vim-from-32800-to-32900.tar
+	assert_file_not_exists "$ABS_STATE_DIR"/Manifest-emacs-delta-from-32900-to-33000
+	assert_file_not_exists "$ABS_STATE_DIR"/pack-vim-from-32800-to-32900.tar
 
 }
 
@@ -112,26 +112,26 @@ test_setup() {
 	assert_status_is "$SWUPD_OK"
 
 	expected_output=$(cat <<-EOM
-		$STATEDIR_ABS/manifest/Manifest-emacs-delta-from-32900-to-33000
+		$ABS_STATE_DIR/manifest/Manifest-emacs-delta-from-32900-to-33000
 	EOM
 	)
 	assert_regex_in_output "$expected_output"
 
 	expected_output=$(cat <<-EOM
-		$STATEDIR_ABS/manifest/32900/Manifest\\..*
-		$STATEDIR_ABS/manifest/32900/Manifest\\..*
-		$STATEDIR_ABS/manifest/32900
+		$ABS_STATE_DIR/manifest/32900/Manifest\\..*
+		$ABS_STATE_DIR/manifest/32900/Manifest\\..*
+		$ABS_STATE_DIR/manifest/32900
 	EOM
 	)
 	assert_regex_in_output "$expected_output"
 
 	expected_output=$(cat <<-EOM
-		$STATEDIR_ABS/manifest/33000/Manifest\\..*
-		$STATEDIR_ABS/manifest/33000/Manifest\\..*
-		$STATEDIR_ABS/manifest/33000/Manifest\\..*
-		$STATEDIR_ABS/manifest/33000/Manifest\\..*
-		$STATEDIR_ABS/manifest/33000
-		$STATEDIR_ABS/manifest
+		$ABS_STATE_DIR/manifest/33000/Manifest\\..*
+		$ABS_STATE_DIR/manifest/33000/Manifest\\..*
+		$ABS_STATE_DIR/manifest/33000/Manifest\\..*
+		$ABS_STATE_DIR/manifest/33000/Manifest\\..*
+		$ABS_STATE_DIR/manifest/33000
+		$ABS_STATE_DIR/manifest
 	EOM
 	)
 	assert_regex_in_output "$expected_output"

--- a/test/functional/clean/clean-old-statedir.bats
+++ b/test/functional/clean/clean-old-statedir.bats
@@ -49,20 +49,20 @@ test_setup() {
 	# ├── swupd_lock
 	# └── version
 
-	sudo mkdir -p "$STATEDIR_ABS"/{32900,33000,delta,download,staged}
+	sudo mkdir -p "$ABS_STATE_DIR"/{32900,33000,delta,download,staged}
 
-	MOM="$STATEDIR_ABS"/33000/Manifest.MoM ; sudo touch "$MOM"
-	MOM_SIG="$STATEDIR_ABS"/33000/Manifest.MoM.sig ; sudo touch "$MOM_SIG"
-	FILE1="$STATEDIR_ABS"/32900/Manifest.p11-kit ; sudo touch "$FILE1"
-	FILE2="$STATEDIR_ABS"/32900/Manifest.p11-kit.dfd541b1ac9256982044848f2128f51e23ddbb72f68e9de43adaf8f7ead93657 ; sudo touch "$FILE2"
-	FILE3="$STATEDIR_ABS"/33000/Manifest.emacs ; sudo touch "$FILE3"
-	FILE4="$STATEDIR_ABS"/33000/Manifest.emacs.7414710480607fa89c307ad11d145d8bb0cbdbdf3c0692f940d906b670f6fd5d ; sudo touch "$FILE4"
-	FILE5="$STATEDIR_ABS"/Manifest-emacs-delta-from-32900-to-33000 ; sudo touch "$FILE5"
-	FILE6="$STATEDIR_ABS"/pack-vim-from-32800-to-32900.tar ; sudo touch "$FILE6"
-	FILE7="$STATEDIR_ABS"/staged/00004ead4b4eb1cef1ebbe13849f6c47c21d325182f98cf8f5333e9a76d2e2df ; sudo touch "$FILE7"
-	FILE8="$STATEDIR_ABS"/staged/fffe891980af628e498b16a364b5b4d00377485370ccc4d09ac0fc072e85b31d ; sudo touch "$FILE8"
+	MOM="$ABS_STATE_DIR"/33000/Manifest.MoM ; sudo touch "$MOM"
+	MOM_SIG="$ABS_STATE_DIR"/33000/Manifest.MoM.sig ; sudo touch "$MOM_SIG"
+	FILE1="$ABS_STATE_DIR"/32900/Manifest.p11-kit ; sudo touch "$FILE1"
+	FILE2="$ABS_STATE_DIR"/32900/Manifest.p11-kit.dfd541b1ac9256982044848f2128f51e23ddbb72f68e9de43adaf8f7ead93657 ; sudo touch "$FILE2"
+	FILE3="$ABS_STATE_DIR"/33000/Manifest.emacs ; sudo touch "$FILE3"
+	FILE4="$ABS_STATE_DIR"/33000/Manifest.emacs.7414710480607fa89c307ad11d145d8bb0cbdbdf3c0692f940d906b670f6fd5d ; sudo touch "$FILE4"
+	FILE5="$ABS_STATE_DIR"/Manifest-emacs-delta-from-32900-to-33000 ; sudo touch "$FILE5"
+	FILE6="$ABS_STATE_DIR"/pack-vim-from-32800-to-32900.tar ; sudo touch "$FILE6"
+	FILE7="$ABS_STATE_DIR"/staged/00004ead4b4eb1cef1ebbe13849f6c47c21d325182f98cf8f5333e9a76d2e2df ; sudo touch "$FILE7"
+	FILE8="$ABS_STATE_DIR"/staged/fffe891980af628e498b16a364b5b4d00377485370ccc4d09ac0fc072e85b31d ; sudo touch "$FILE8"
 
-	sudo chmod -R 0700 "$STATEDIR_ABS"
+	sudo chmod -R 0700 "$ABS_STATE_DIR"
 
 }
 
@@ -85,15 +85,15 @@ test_setup() {
 	assert_regex_is_output "$expected_output"
 
 	# these old directories should be removed since are no longer used
-	assert_dir_not_exists "$STATEDIR_ABS"/delta
-	assert_dir_not_exists "$STATEDIR_ABS"/download
-	assert_dir_not_exists "$STATEDIR_ABS"/staged
-	assert_dir_not_exists "$STATEDIR_ABS"/32900
-	assert_dir_not_exists "$STATEDIR_ABS"/33000
+	assert_dir_not_exists "$ABS_STATE_DIR"/delta
+	assert_dir_not_exists "$ABS_STATE_DIR"/download
+	assert_dir_not_exists "$ABS_STATE_DIR"/staged
+	assert_dir_not_exists "$ABS_STATE_DIR"/32900
+	assert_dir_not_exists "$ABS_STATE_DIR"/33000
 
 	# files in the old structure should no longer be there either
-	assert_file_not_exists "$STATEDIR_ABS"/Manifest-emacs-delta-from-32900-to-33000
-	assert_file_not_exists "$STATEDIR_ABS"/pack-vim-from-32800-to-32900.tar
+	assert_file_not_exists "$ABS_STATE_DIR"/Manifest-emacs-delta-from-32900-to-33000
+	assert_file_not_exists "$ABS_STATE_DIR"/pack-vim-from-32800-to-32900.tar
 
 }
 
@@ -107,25 +107,25 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		$STATEDIR_DELTA
-		$STATEDIR_DOWNLOAD
-		$STATEDIR_STAGED
-		$STATEDIR_TEMP
-		$STATEDIR_ABS/pack-vim-from-32800-to-32900.tar
-		$STATEDIR_ABS/Manifest-emacs-delta-from-32900-to-33000
-		$STATEDIR_ABS/staged/.*
-		$STATEDIR_ABS/staged/.*
-		$STATEDIR_ABS/staged
-		$STATEDIR_ABS/delta
-		$STATEDIR_ABS/download
-		$STATEDIR_ABS/32900/Manifest\\..*
-		$STATEDIR_ABS/32900/Manifest\\..*
-		$STATEDIR_ABS/32900
-		$STATEDIR_ABS/33000/Manifest\\..*
-		$STATEDIR_ABS/33000/Manifest\\..*
-		$STATEDIR_ABS/33000/Manifest\\..*
-		$STATEDIR_ABS/33000/Manifest\\..*
-		$STATEDIR_ABS/33000
+		$ABS_DELTA_DIR
+		$ABS_DOWNLOAD_DIR
+		$ABS_STAGED_DIR
+		$ABS_TEMP_DIR
+		$ABS_STATE_DIR/pack-vim-from-32800-to-32900.tar
+		$ABS_STATE_DIR/Manifest-emacs-delta-from-32900-to-33000
+		$ABS_STATE_DIR/staged/.*
+		$ABS_STATE_DIR/staged/.*
+		$ABS_STATE_DIR/staged
+		$ABS_STATE_DIR/delta
+		$ABS_STATE_DIR/download
+		$ABS_STATE_DIR/32900/Manifest\\..*
+		$ABS_STATE_DIR/32900/Manifest\\..*
+		$ABS_STATE_DIR/32900
+		$ABS_STATE_DIR/33000/Manifest\\..*
+		$ABS_STATE_DIR/33000/Manifest\\..*
+		$ABS_STATE_DIR/33000/Manifest\\..*
+		$ABS_STATE_DIR/33000/Manifest\\..*
+		$ABS_STATE_DIR/33000
 		Would remove 19 files
 		Aproximatelly .* KB would be freed
 	EOM

--- a/test/functional/diagnose/diagnose-also-add.bats
+++ b/test/functional/diagnose/diagnose-also-add.bats
@@ -13,9 +13,9 @@ test_setup() {
 	create_bundle -n test-bundle3 -f /bar/test-file3 "$TEST_NAME"
 
 	# Create bundle dependencies
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.os-core test-bundle1
-	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.os-core test-bundle2
-	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle1 test-bundle3
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.os-core test-bundle1
+	add_dependency_to_manifest -o "$WEB_DIR"/10/Manifest.os-core test-bundle2
+	add_dependency_to_manifest -o "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle3
 
 }
 
@@ -48,15 +48,15 @@ test_setup() {
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1"
 	assert_status_is "$SWUPD_OK"
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/bar/test-file3
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/bar/test-file3
 
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle3"
 	assert_status_is "$SWUPD_OK"
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_not_exists "$TARGETDIR"/bar/test-file3
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_not_exists "$TARGET_DIR"/bar/test-file3
 
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
 

--- a/test/functional/diagnose/diagnose-basics.bats
+++ b/test/functional/diagnose/diagnose-basics.bats
@@ -15,12 +15,12 @@ test_setup() {
 	update_bundle "$TEST_NAME" test-bundle1 --add /baz/file_3
 	set_current_version "$TEST_NAME" 20
 	# adding an untracked files into an untracked directory (/bat)
-	sudo mkdir "$TARGETDIR"/bat
-	sudo touch "$TARGETDIR"/bat/untracked_file1
+	sudo mkdir "$TARGET_DIR"/bat
+	sudo touch "$TARGET_DIR"/bat/untracked_file1
 	# adding an untracked file into tracked directory (/bar)
-	sudo touch "$TARGETDIR"/bar/untracked_file2
+	sudo touch "$TARGET_DIR"/bar/untracked_file2
 	# adding an untracked file into /usr
-	sudo touch "$TARGETDIR"/usr/untracked_file3
+	sudo touch "$TARGET_DIR"/usr/untracked_file3
 
 }
 
@@ -55,13 +55,13 @@ test_setup() {
 	)
 	assert_regex_is_output "$expected_output"
 	# tracked files
-	assert_file_exists "$TARGETDIR"/foo/file_1
-	assert_file_exists "$TARGETDIR"/bar/file_2
-	assert_file_not_exists "$TARGETDIR"/baz/file_3
+	assert_file_exists "$TARGET_DIR"/foo/file_1
+	assert_file_exists "$TARGET_DIR"/bar/file_2
+	assert_file_not_exists "$TARGET_DIR"/baz/file_3
 	# untracked files
-	assert_file_exists "$TARGETDIR"/bat/untracked_file1
-	assert_file_exists "$TARGETDIR"/bar/untracked_file2
-	assert_file_exists "$TARGETDIR"/usr/untracked_file3
+	assert_file_exists "$TARGET_DIR"/bat/untracked_file1
+	assert_file_exists "$TARGET_DIR"/bar/untracked_file2
+	assert_file_exists "$TARGET_DIR"/usr/untracked_file3
 
 }
 #WEIGHT=5

--- a/test/functional/diagnose/diagnose-boot-file.bats
+++ b/test/functional/diagnose/diagnose-boot-file.bats
@@ -7,7 +7,7 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle -f /usr/lib/kernel/testfile "$TEST_NAME"
 	# change the content of testfile so the hash doesn't match
-	write_to_protected_file -a "$TARGETDIR"/usr/lib/kernel/testfile "some new content"
+	write_to_protected_file -a "$TARGET_DIR"/usr/lib/kernel/testfile "some new content"
 
 }
 
@@ -29,7 +29,7 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/lib/kernel/testfile
+	assert_file_exists "$TARGET_DIR"/usr/lib/kernel/testfile
 
 }
 #WEIGHT=2

--- a/test/functional/diagnose/diagnose-bundles.bats
+++ b/test/functional/diagnose/diagnose-bundles.bats
@@ -9,8 +9,8 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle1 -f /foo/test-file1,/common "$TEST_NAME"
-	file_hash=$(get_hash_from_manifest "$WEBDIR"/10/Manifest.test-bundle1 /common)
-	file_path="$WEBDIR"/10/files/"$file_hash"
+	file_hash=$(get_hash_from_manifest "$WEB_DIR"/10/Manifest.test-bundle1 /common)
+	file_path="$WEB_DIR"/10/files/"$file_hash"
 	create_bundle -L -n test-bundle2 -f /bar/test-file2,/common:"$file_path" "$TEST_NAME"
 	create_bundle -L -n test-bundle3 -f /baz/test-file3,/common:"$file_path" "$TEST_NAME"
 	create_bundle -n test-bundle4 -f /bat/test-file4,/common:"$file_path" "$TEST_NAME"
@@ -19,9 +19,9 @@ test_setup() {
 
 @test "DIA017: Diagnose bundles only checks specified bundles" {
 
-	sudo rm -f "$TARGETDIR"/foo/test-file1
-	sudo rm -f "$TARGETDIR"/common
-	sudo rm -f "$TARGETDIR"/foo/test-file3
+	sudo rm -f "$TARGET_DIR"/foo/test-file1
+	sudo rm -f "$TARGET_DIR"/common
+	sudo rm -f "$TARGET_DIR"/foo/test-file3
 
 	# users can diagnose only specific bundles
 
@@ -35,8 +35,8 @@ test_setup() {
 		 - test-bundle2
 		Downloading missing manifests...
 		Checking for missing files
-		 -> Missing file: $PATH_PREFIX/common
-		 -> Missing file: $PATH_PREFIX/foo/test-file1
+		 -> Missing file: $ABS_TARGET_DIR/common
+		 -> Missing file: $ABS_TARGET_DIR/foo/test-file1
 		Checking for corrupt files
 		Checking for extraneous files
 		Inspected 9 files
@@ -51,8 +51,8 @@ test_setup() {
 
 @test "DIA018: Diagnose bundles requires --force to continue when there is an invalid bundle" {
 
-	sudo rm -f "$TARGETDIR"/foo/test-file1
-	sudo rm -f "$TARGETDIR"/common
+	sudo rm -f "$TARGET_DIR"/foo/test-file1
+	sudo rm -f "$TARGET_DIR"/common
 
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --bundles bad-name,test-bundle1"
 
@@ -80,8 +80,8 @@ test_setup() {
 		 - test-bundle1
 		Downloading missing manifests...
 		Checking for missing files
-		 -> Missing file: $PATH_PREFIX/common
-		 -> Missing file: $PATH_PREFIX/foo/test-file1
+		 -> Missing file: $ABS_TARGET_DIR/common
+		 -> Missing file: $ABS_TARGET_DIR/foo/test-file1
 		Checking for corrupt files
 		Checking for extraneous files
 		Inspected 6 files
@@ -96,8 +96,8 @@ test_setup() {
 
 @test "DIA019: Diagnose bundles do not report deleted files needed by other bundles" {
 
-	update_manifest "$WEBDIR"/10/Manifest.test-bundle1 file-status /foo/test-file1 .d..
-	update_manifest "$WEBDIR"/10/Manifest.test-bundle1 file-status /common .d..
+	update_manifest "$WEB_DIR"/10/Manifest.test-bundle1 file-status /foo/test-file1 .d..
+	update_manifest "$WEB_DIR"/10/Manifest.test-bundle1 file-status /common .d..
 
 	# if a file is marked as deleted in a bundle being diagnosed in isolation
 	# but another bundle needs that file, it should not be reported as extraneous
@@ -114,7 +114,7 @@ test_setup() {
 		Checking for missing files
 		Checking for corrupt files
 		Checking for extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/foo/test-file1
+		 -> File that should be deleted: $ABS_TARGET_DIR/foo/test-file1
 		Inspected 9 files
 		  1 file found which should be deleted
 		Use "swupd repair" to correct the problems in the system

--- a/test/functional/diagnose/diagnose-directory-tree-deleted.bats
+++ b/test/functional/diagnose/diagnose-directory-tree-deleted.bats
@@ -6,12 +6,12 @@ test_setup() {
 
 	create_test_environment -e "$TEST_NAME"
 	create_bundle -L -n os-core -f /testdir1/testdir2/testfile "$TEST_NAME"
-	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-status /testdir1/testdir2/testfile .d..
-	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-status /testdir1/testdir2 .d..
-	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-status /testdir1 .d..
-	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-hash /testdir1/testdir2/testfile "$ZERO_HASH"
-	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-hash /testdir1/testdir2 "$ZERO_HASH"
-	update_manifest "$WEBDIR"/10/Manifest.os-core file-hash /testdir1 "$ZERO_HASH"
+	update_manifest -p "$WEB_DIR"/10/Manifest.os-core file-status /testdir1/testdir2/testfile .d..
+	update_manifest -p "$WEB_DIR"/10/Manifest.os-core file-status /testdir1/testdir2 .d..
+	update_manifest -p "$WEB_DIR"/10/Manifest.os-core file-status /testdir1 .d..
+	update_manifest -p "$WEB_DIR"/10/Manifest.os-core file-hash /testdir1/testdir2/testfile "$ZERO_HASH"
+	update_manifest -p "$WEB_DIR"/10/Manifest.os-core file-hash /testdir1/testdir2 "$ZERO_HASH"
+	update_manifest "$WEB_DIR"/10/Manifest.os-core file-hash /testdir1 "$ZERO_HASH"
 
 }
 
@@ -36,9 +36,9 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_dir_exists "$TARGETDIR"/testdir1
-	assert_dir_exists "$TARGETDIR"/testdir1/testdir2
-	assert_file_exists "$TARGETDIR"/testdir1/testdir2/testfile
+	assert_dir_exists "$TARGET_DIR"/testdir1
+	assert_dir_exists "$TARGET_DIR"/testdir1/testdir2
+	assert_file_exists "$TARGET_DIR"/testdir1/testdir2/testfile
 
 }
 #WEIGHT=2

--- a/test/functional/diagnose/diagnose-directory-tree-deleted.bats
+++ b/test/functional/diagnose/diagnose-directory-tree-deleted.bats
@@ -9,9 +9,9 @@ test_setup() {
 	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-status /testdir1/testdir2/testfile .d..
 	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-status /testdir1/testdir2 .d..
 	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-status /testdir1 .d..
-	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-hash /testdir1/testdir2/testfile "$zero_hash"
-	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-hash /testdir1/testdir2 "$zero_hash"
-	update_manifest "$WEBDIR"/10/Manifest.os-core file-hash /testdir1 "$zero_hash"
+	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-hash /testdir1/testdir2/testfile "$ZERO_HASH"
+	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-hash /testdir1/testdir2 "$ZERO_HASH"
+	update_manifest "$WEBDIR"/10/Manifest.os-core file-hash /testdir1 "$ZERO_HASH"
 
 }
 

--- a/test/functional/diagnose/diagnose-json.bats
+++ b/test/functional/diagnose/diagnose-json.bats
@@ -10,9 +10,9 @@ test_setup() {
 	create_test_environment -r "$TEST_NAME"
 	create_bundle -L -n test-bundle1 -f /foo/test-file1,/bar/test-file2,/baz "$TEST_NAME"
 	create_bundle -n test-bundle2 -f /test-file3,/test-file4 "$TEST_NAME"
-	sudo rm -f "$TARGETDIR"/foo/test-file1
-	sudo rm -f "$TARGETDIR"/baz
-	sudo touch "$TARGETDIR"/usr/extraneous-file
+	sudo rm -f "$TARGET_DIR"/foo/test-file1
+	sudo rm -f "$TARGET_DIR"/baz
+	sudo touch "$TARGET_DIR"/usr/extraneous-file
 
 }
 
@@ -33,12 +33,12 @@ test_setup() {
 		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 4, "stepCompletion" : 5, "stepDescription" : "add_missing_files" },
 		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 4, "stepCompletion" : 11, "stepDescription" : "add_missing_files" },
 		{ "type" : "info", "msg" : " -> Missing file:" },
-		{ "type" : "info", "msg" : "$PATH_PREFIX/baz" },
+		{ "type" : "info", "msg" : "$ABS_TARGET_DIR/baz" },
 		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 4, "stepCompletion" : 17, "stepDescription" : "add_missing_files" },
 		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 4, "stepCompletion" : 23, "stepDescription" : "add_missing_files" },
 		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 4, "stepCompletion" : 29, "stepDescription" : "add_missing_files" },
 		{ "type" : "info", "msg" : " -> Missing file:" },
-		{ "type" : "info", "msg" : "$PATH_PREFIX/foo/test-file1" },
+		{ "type" : "info", "msg" : "$ABS_TARGET_DIR/foo/test-file1" },
 		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 4, "stepCompletion" : 35, "stepDescription" : "add_missing_files" },
 		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 4, "stepCompletion" : 41, "stepDescription" : "add_missing_files" },
 		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 4, "stepCompletion" : 47, "stepDescription" : "add_missing_files" },

--- a/test/functional/diagnose/diagnose-missing-file.bats
+++ b/test/functional/diagnose/diagnose-missing-file.bats
@@ -7,7 +7,7 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle -f /foo/test-file1,/bar/test-file2 "$TEST_NAME"
 	# remove a directory and file that are part of the bundle
-	sudo rm -rf "$TARGETDIR"/foo/test-file1
+	sudo rm -rf "$TARGET_DIR"/foo/test-file1
 
 }
 
@@ -29,8 +29,8 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/bar/test-file2
+	assert_file_not_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
 
 }
 #WEIGHT=2

--- a/test/functional/diagnose/diagnose-path.bats
+++ b/test/functional/diagnose/diagnose-path.bats
@@ -18,12 +18,12 @@ test_setup() {
 	update_bundle "$TEST_NAME" test-bundle1 --add /bar/bat/file_5
 	set_current_version "$TEST_NAME" 20
 	# adding an untracked files into an untracked directory (/bat)
-	sudo mkdir "$TARGETDIR"/bat
-	sudo touch "$TARGETDIR"/bat/untracked_file1
+	sudo mkdir "$TARGET_DIR"/bat
+	sudo touch "$TARGET_DIR"/bat/untracked_file1
 	# adding an untracked file into tracked directory (/bar)
-	sudo touch "$TARGETDIR"/bar/untracked_file2
+	sudo touch "$TARGET_DIR"/bar/untracked_file2
 	# adding an untracked file into /usr
-	sudo touch "$TARGETDIR"/usr/untracked_file3
+	sudo touch "$TARGET_DIR"/usr/untracked_file3
 
 }
 
@@ -41,7 +41,7 @@ test_setup() {
 		Limiting diagnose to the following file:
 		 - /baz/file_3
 		Checking for missing files
-		 -> Missing file: $PATH_PREFIX/baz/file_3
+		 -> Missing file: $ABS_TARGET_DIR/baz/file_3
 		Checking for corrupt files
 		Checking for extraneous files
 		Inspected 1 file
@@ -69,10 +69,10 @@ test_setup() {
 		Limiting diagnose to the following file:
 		 - /baz/file_3
 		Checking for missing files
-		 -> Missing file: $PATH_PREFIX/baz/file_3
+		 -> Missing file: $ABS_TARGET_DIR/baz/file_3
 		Checking for corrupt files
 		Checking for extraneous files
-		Checking for extra files under $PATH_PREFIX/baz/file_3
+		Checking for extra files under $ABS_TARGET_DIR/baz/file_3
 		Inspected 1 file
 		  1 file was missing
 		Use "swupd repair" to correct the problems in the system
@@ -97,12 +97,12 @@ test_setup() {
 		Limiting diagnose to the following directory (recursively):
 		 - /bar
 		Checking for missing files
-		 -> Missing file: $PATH_PREFIX/bar/bat
-		 -> Missing file: $PATH_PREFIX/bar/bat/file_5
-		 -> Missing file: $PATH_PREFIX/bar/file_4
+		 -> Missing file: $ABS_TARGET_DIR/bar/bat
+		 -> Missing file: $ABS_TARGET_DIR/bar/bat/file_5
+		 -> Missing file: $ABS_TARGET_DIR/bar/file_4
 		Checking for corrupt files
 		Checking for extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/bar/file_2
+		 -> File that should be deleted: $ABS_TARGET_DIR/bar/file_2
 		Inspected 5 files
 		  3 files were missing
 		  1 file found which should be deleted
@@ -127,9 +127,9 @@ test_setup() {
 		Downloading missing manifests...
 		Limiting diagnose to the following directory (recursively):
 		 - /bar
-		Checking for extra files under $PATH_PREFIX/bar
-		 -> Extra file: $PATH_PREFIX/bar/untracked_file2
-		 -> Extra file: $PATH_PREFIX/bar/file_2
+		Checking for extra files under $ABS_TARGET_DIR/bar
+		 -> Extra file: $ABS_TARGET_DIR/bar/untracked_file2
+		 -> Extra file: $ABS_TARGET_DIR/bar/file_2
 		Inspected 2 files
 		  2 files found which should be deleted
 		Use "swupd repair --picky" to correct the problems in the system
@@ -154,14 +154,14 @@ test_setup() {
 		Limiting diagnose to the following directory (recursively):
 		 - /bar
 		Checking for missing files
-		 -> Missing file: $PATH_PREFIX/bar/bat
-		 -> Missing file: $PATH_PREFIX/bar/bat/file_5
-		 -> Missing file: $PATH_PREFIX/bar/file_4
+		 -> Missing file: $ABS_TARGET_DIR/bar/bat
+		 -> Missing file: $ABS_TARGET_DIR/bar/bat/file_5
+		 -> Missing file: $ABS_TARGET_DIR/bar/file_4
 		Checking for corrupt files
 		Checking for extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/bar/file_2
-		Checking for extra files under $PATH_PREFIX/usr
-		 -> Extra file: $PATH_PREFIX/usr/untracked_file3
+		 -> File that should be deleted: $ABS_TARGET_DIR/bar/file_2
+		Checking for extra files under $ABS_TARGET_DIR/usr
+		 -> Extra file: $ABS_TARGET_DIR/usr/untracked_file3
 		Inspected 6 files
 		  3 files were missing
 		  2 files found which should be deleted
@@ -179,8 +179,8 @@ test_setup() {
 	# look in the specified path and only for files that are part of the specified
 	# bundle
 
-	write_to_protected_file -a "$PATH_PREFIX"/usr/share/clear/bundles/os-core "corrupting the file"
-	write_to_protected_file -a "$PATH_PREFIX"/usr/share/clear/bundles/test-bundle1 "corrupting the file"
+	write_to_protected_file -a "$ABS_TARGET_DIR"/usr/share/clear/bundles/os-core "corrupting the file"
+	write_to_protected_file -a "$ABS_TARGET_DIR"/usr/share/clear/bundles/test-bundle1 "corrupting the file"
 
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --bundle test-bundle1 --file /usr/share/clear/bundles"
 
@@ -194,8 +194,8 @@ test_setup() {
 		 - /usr/share/clear/bundles
 		Checking for missing files
 		Checking for corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/usr/share/clear/bundles/os-core
-		 -> Hash mismatch for file: $PATH_PREFIX/usr/share/clear/bundles/test-bundle1
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/usr/share/clear/bundles/os-core
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/usr/share/clear/bundles/test-bundle1
 		Checking for extraneous files
 		Inspected 3 files
 		  2 files did not match
@@ -239,8 +239,8 @@ test_setup() {
 		Downloading missing manifests...
 		Limiting diagnose to the following file:
 		 - /usr/untracked_file3
-		Checking for extra files under $PATH_PREFIX/usr/untracked_file3
-		 -> Extra file: $PATH_PREFIX/usr/untracked_file3
+		Checking for extra files under $ABS_TARGET_DIR/usr/untracked_file3
+		 -> Extra file: $ABS_TARGET_DIR/usr/untracked_file3
 		Inspected 1 file
 		  1 file found which should be deleted
 		Use "swupd repair --picky" to correct the problems in the system

--- a/test/functional/diagnose/diagnose-picky-downgrade.bats
+++ b/test/functional/diagnose/diagnose-picky-downgrade.bats
@@ -24,15 +24,15 @@ test_setup() {
 		Warning: One or more installed bundles are not available at version 10
 		Checking for missing files
 		Checking for corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/usr/lib/os-release
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/usr/lib/os-release
 		Checking for extraneous files
-		Checking for extra files under $PATH_PREFIX/usr
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/versionurl
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/contenturl
-		 -> Extra file: $PATH_PREFIX/usr/share/clear/bundles/test-bundle2
-		 -> Extra file: $PATH_PREFIX/usr/foo/file_3
-		 -> Extra file: $PATH_PREFIX/usr/foo/file_2
-		 -> Extra file: $PATH_PREFIX/usr/foo/
+		Checking for extra files under $ABS_TARGET_DIR/usr
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/versionurl
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/contenturl
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/clear/bundles/test-bundle2
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/file_3
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/file_2
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/
 		Inspected 19 files
 		  1 file did not match
 		  6 files found which should be deleted
@@ -41,13 +41,13 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/foo/file_2
-	assert_file_exists "$TARGETDIR"/usr/foo/file_3
-	assert_file_exists "$TARGETDIR"/bar/file_4
-	assert_file_exists "$TARGETDIR"/bar/file_5
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/usr/share/defaults/swupd/versionurl
-	assert_file_exists "$TARGETDIR"/usr/share/defaults/swupd/contenturl
+	assert_file_exists "$TARGET_DIR"/usr/foo/file_2
+	assert_file_exists "$TARGET_DIR"/usr/foo/file_3
+	assert_file_exists "$TARGET_DIR"/bar/file_4
+	assert_file_exists "$TARGET_DIR"/bar/file_5
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/usr/share/defaults/swupd/versionurl
+	assert_file_exists "$TARGET_DIR"/usr/share/defaults/swupd/contenturl
 
 }
 #WEIGHT=5

--- a/test/functional/diagnose/diagnose-picky-whitelist.bats
+++ b/test/functional/diagnose/diagnose-picky-whitelist.bats
@@ -9,13 +9,13 @@ test_setup() {
 
 	create_test_environment -r "$TEST_NAME"
 	# create some extra files in /usr
-	sudo touch "$TARGETDIR"/usr/file1
-	sudo mkdir -p "$TARGETDIR"/usr/foo/bar
-	sudo touch "$TARGETDIR"/usr/foo/bar/file2
-	sudo touch "$TARGETDIR"/usr/foo/bar/file3
-	sudo mkdir -p "$TARGETDIR"/usr/bat/baz
-	sudo touch "$TARGETDIR"/usr/bat/baz/file4
-	sudo touch "$TARGETDIR"/usr/bat/baz/file5
+	sudo touch "$TARGET_DIR"/usr/file1
+	sudo mkdir -p "$TARGET_DIR"/usr/foo/bar
+	sudo touch "$TARGET_DIR"/usr/foo/bar/file2
+	sudo touch "$TARGET_DIR"/usr/foo/bar/file3
+	sudo mkdir -p "$TARGET_DIR"/usr/bat/baz
+	sudo touch "$TARGET_DIR"/usr/bat/baz/file4
+	sudo touch "$TARGET_DIR"/usr/bat/baz/file5
 
 }
 
@@ -33,14 +33,14 @@ test_setup() {
 		Checking for missing files
 		Checking for corrupt files
 		Checking for extraneous files
-		Checking for extra files under $PATH_PREFIX/usr
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/versionurl
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/contenturl
-		 -> Extra file: $PATH_PREFIX/usr/file1
-		 -> Extra file: $PATH_PREFIX/usr/bat/baz/file5
-		 -> Extra file: $PATH_PREFIX/usr/bat/baz/file4
-		 -> Extra file: $PATH_PREFIX/usr/bat/baz/
-		 -> Extra file: $PATH_PREFIX/usr/bat/
+		Checking for extra files under $ABS_TARGET_DIR/usr
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/versionurl
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/contenturl
+		 -> Extra file: $ABS_TARGET_DIR/usr/file1
+		 -> Extra file: $ABS_TARGET_DIR/usr/bat/baz/file5
+		 -> Extra file: $ABS_TARGET_DIR/usr/bat/baz/file4
+		 -> Extra file: $ABS_TARGET_DIR/usr/bat/baz/
+		 -> Extra file: $ABS_TARGET_DIR/usr/bat/
 		Inspected 18 files
 		  7 files found which should be deleted
 		Use "swupd repair --picky" to correct the problems in the system
@@ -48,8 +48,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/file1
-	assert_file_exists "$TARGETDIR"/usr/foo/bar/file2
+	assert_file_exists "$TARGET_DIR"/usr/file1
+	assert_file_exists "$TARGET_DIR"/usr/foo/bar/file2
 
 }
 #WEIGHT=2

--- a/test/functional/diagnose/diagnose-picky.bats
+++ b/test/functional/diagnose/diagnose-picky.bats
@@ -9,11 +9,11 @@ test_setup() {
 
 	create_test_environment -r "$TEST_NAME"
 	# create some extra files in /usr
-	sudo touch "$TARGETDIR"/usr/file1
-	sudo mkdir -p "$TARGETDIR"/usr/foo/bar
-	sudo touch "$TARGETDIR"/usr/foo/bar/file2
+	sudo touch "$TARGET_DIR"/usr/file1
+	sudo mkdir -p "$TARGET_DIR"/usr/foo/bar
+	sudo touch "$TARGET_DIR"/usr/foo/bar/file2
 	# create extra file outside of /usr (should be ignored by picky)
-	sudo touch "$TARGETDIR"/file3
+	sudo touch "$TARGET_DIR"/file3
 
 }
 
@@ -31,13 +31,13 @@ test_setup() {
 		Checking for missing files
 		Checking for corrupt files
 		Checking for extraneous files
-		Checking for extra files under $PATH_PREFIX/usr
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/versionurl
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/contenturl
-		 -> Extra file: $PATH_PREFIX/usr/foo/bar/file2
-		 -> Extra file: $PATH_PREFIX/usr/foo/bar/
-		 -> Extra file: $PATH_PREFIX/usr/foo/
-		 -> Extra file: $PATH_PREFIX/usr/file1
+		Checking for extra files under $ABS_TARGET_DIR/usr
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/versionurl
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/contenturl
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/bar/file2
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/bar/
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/
+		 -> Extra file: $ABS_TARGET_DIR/usr/file1
 		Inspected 17 files
 		  6 files found which should be deleted
 		Use "swupd repair --picky" to correct the problems in the system
@@ -45,8 +45,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/file1
-	assert_file_exists "$TARGETDIR"/usr/foo/bar/file2
+	assert_file_exists "$TARGET_DIR"/usr/file1
+	assert_file_exists "$TARGET_DIR"/usr/foo/bar/file2
 
 }
 
@@ -60,13 +60,13 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Diagnosing version 10
 		Downloading missing manifests...
-		Checking for extra files under $PATH_PREFIX/usr
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/versionurl
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/contenturl
-		 -> Extra file: $PATH_PREFIX/usr/foo/bar/file2
-		 -> Extra file: $PATH_PREFIX/usr/foo/bar/
-		 -> Extra file: $PATH_PREFIX/usr/foo/
-		 -> Extra file: $PATH_PREFIX/usr/file1
+		Checking for extra files under $ABS_TARGET_DIR/usr
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/versionurl
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/contenturl
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/bar/file2
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/bar/
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/
+		 -> Extra file: $ABS_TARGET_DIR/usr/file1
 		Inspected 6 files
 		  6 files found which should be deleted
 		Use "swupd repair --picky" to correct the problems in the system

--- a/test/functional/hashdump/hashdump-file-hash.bats
+++ b/test/functional/hashdump/hashdump-file-hash.bats
@@ -5,13 +5,13 @@ load "../testlib"
 global_setup() {
 
 	create_test_environment "$TEST_NAME"
-	printf "test-data" | sudo tee "$TARGETDIR"/test-hash > /dev/null
+	printf "test-data" | sudo tee "$TARGET_DIR"/test-hash > /dev/null
 
 }
 
 @test "HSD001: Calculate the hash of a file" {
 
-	run sudo sh -c "$SWUPD hashdump $TARGETDIR/test-hash"
+	run sudo sh -c "$SWUPD hashdump $TARGET_DIR/test-hash"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
@@ -28,7 +28,7 @@ global_setup() {
 	# attempting to calculate the hash from a non existent file should still
 	# succeed but should return a hash of all zeros
 
-	run sudo sh -c "$SWUPD hashdump $TARGETDIR/fake-file"
+	run sudo sh -c "$SWUPD hashdump $TARGET_DIR/fake-file"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
@@ -42,7 +42,7 @@ global_setup() {
 
 @test "HSD003: Calculate the hash of a file specifying its path separatelly" {
 
-	run sudo sh -c "$SWUPD hashdump --path=$TARGETDIR test-hash"
+	run sudo sh -c "$SWUPD hashdump --path=$TARGET_DIR test-hash"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM

--- a/test/functional/info/info-basic.bats
+++ b/test/functional/info/info-basic.bats
@@ -18,8 +18,8 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Distribution:      Swupd Test Distro
 		Installed version: 10 (format 1)
-		Version URL:       file://$TEST_DIRNAME/web-dir
-		Content URL:       file://$TEST_DIRNAME/web-dir
+		Version URL:       file://$ABS_TEST_DIR/web-dir
+		Content URL:       file://$ABS_TEST_DIR/web-dir
 	EOM
 	)
 
@@ -34,8 +34,8 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Distribution:      Swupd Test Distro
 		Installed version: 10
-		Version URL:       file://$TEST_DIRNAME/web-dir
-		Content URL:       file://$TEST_DIRNAME/web-dir
+		Version URL:       file://$ABS_TEST_DIR/web-dir
+		Content URL:       file://$ABS_TEST_DIR/web-dir
 	EOM
 	)
 

--- a/test/functional/mirror/mirror-allow-http.bats
+++ b/test/functional/mirror/mirror-allow-http.bats
@@ -42,8 +42,8 @@ global_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_equal "http://invalid_server_for_swupd" "$(<"$TARGETDIR"/etc/swupd/mirror_contenturl)"
-	assert_equal "http://invalid_server_for_swupd" "$(<"$TARGETDIR"/etc/swupd/mirror_versionurl)"
+	assert_equal "http://invalid_server_for_swupd" "$(<"$TARGET_DIR"/etc/swupd/mirror_contenturl)"
+	assert_equal "http://invalid_server_for_swupd" "$(<"$TARGET_DIR"/etc/swupd/mirror_versionurl)"
 }
 
 @test "MIR009: swupd operations when http mirror is used without allow-insecure-http" {

--- a/test/functional/mirror/mirror-createdir-negative.bats
+++ b/test/functional/mirror/mirror-createdir-negative.bats
@@ -10,8 +10,8 @@ global_setup() {
 
 @test "MIR004: Try setting up a mirror when /etc/swupd is a file instead of a directory" {
 
-	sudo rm -rf "$TARGETDIR"/etc/swupd
-	sudo touch "$TARGETDIR"/etc/swupd
+	sudo rm -rf "$TARGET_DIR"/etc/swupd
+	sudo touch "$TARGET_DIR"/etc/swupd
 
 	run sudo sh -c "$SWUPD mirror -s https://example.com/swupd-file $SWUPD_OPTS"
 
@@ -27,9 +27,9 @@ global_setup() {
 
 @test "MIR005: Try setting up a mirror when /etc/swupd is a symlink to a file instead of a directory" {
 
-	sudo rm -rf "$TARGETDIR"/etc/swupd
-	sudo touch "$TARGETDIR"/foo
-	sudo ln -s "$(realpath "$TARGETDIR"/foo)" "$TARGETDIR"/etc/swupd
+	sudo rm -rf "$TARGET_DIR"/etc/swupd
+	sudo touch "$TARGET_DIR"/foo
+	sudo ln -s "$(realpath "$TARGET_DIR"/foo)" "$TARGET_DIR"/etc/swupd
 
 	run sudo sh -c "$SWUPD mirror -s https://example.com/swupd-file $SWUPD_OPTS"
 

--- a/test/functional/mirror/mirror-createdir.bats
+++ b/test/functional/mirror/mirror-createdir.bats
@@ -22,14 +22,14 @@ global_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_equal "https://example.com/swupd-file" "$(<"$TARGETDIR"/etc/swupd/mirror_contenturl)"
-	assert_equal "https://example.com/swupd-file" "$(<"$TARGETDIR"/etc/swupd/mirror_versionurl)"
+	assert_equal "https://example.com/swupd-file" "$(<"$TARGET_DIR"/etc/swupd/mirror_contenturl)"
+	assert_equal "https://example.com/swupd-file" "$(<"$TARGET_DIR"/etc/swupd/mirror_versionurl)"
 
 }
 
 @test "MIR002: Setting a mirror when /etc/swupd already exist" {
 
-	sudo mkdir -p "$TARGETDIR"/etc/swupd
+	sudo mkdir -p "$TARGET_DIR"/etc/swupd
 
 	run sudo sh -c "$SWUPD mirror -s https://example.com/swupd-file $SWUPD_OPTS"
 
@@ -43,15 +43,15 @@ global_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_equal "https://example.com/swupd-file" "$(<"$TARGETDIR"/etc/swupd/mirror_contenturl)"
-	assert_equal "https://example.com/swupd-file" "$(<"$TARGETDIR"/etc/swupd/mirror_versionurl)"
+	assert_equal "https://example.com/swupd-file" "$(<"$TARGET_DIR"/etc/swupd/mirror_contenturl)"
+	assert_equal "https://example.com/swupd-file" "$(<"$TARGET_DIR"/etc/swupd/mirror_versionurl)"
 
 }
 
 @test "MIR003: Setting a mirror when /etc/swupd is a symlink to a directory" {
 
-	sudo mkdir "$TARGETDIR"/foo
-	sudo ln -s "$(realpath "$TARGETDIR"/foo)" "$TARGETDIR"/etc/swupd
+	sudo mkdir "$TARGET_DIR"/foo
+	sudo ln -s "$(realpath "$TARGET_DIR"/foo)" "$TARGET_DIR"/etc/swupd
 
 	run sudo sh -c "$SWUPD mirror -s https://example.com/swupd-file $SWUPD_OPTS"
 
@@ -66,9 +66,9 @@ global_setup() {
 	)
 	assert_is_output "$expected_output"
 
-	! [[ -L "$TARGETDIR/etc/swupd" ]]
-	assert_equal "https://example.com/swupd-file" "$(<"$TARGETDIR"/etc/swupd/mirror_contenturl)"
-	assert_equal "https://example.com/swupd-file" "$(<"$TARGETDIR"/etc/swupd/mirror_versionurl)"
+	! [[ -L "$TARGET_DIR/etc/swupd" ]]
+	assert_equal "https://example.com/swupd-file" "$(<"$TARGET_DIR"/etc/swupd/mirror_contenturl)"
+	assert_equal "https://example.com/swupd-file" "$(<"$TARGET_DIR"/etc/swupd/mirror_versionurl)"
 
 }
 #WEIGHT=2

--- a/test/functional/mirror/mirror-set-unset.bats
+++ b/test/functional/mirror/mirror-set-unset.bats
@@ -24,8 +24,8 @@ global_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_equal "https://example.com/swupd-file" "$(<"$TARGETDIR"/etc/swupd/mirror_contenturl)"
-	assert_equal "https://example.com/swupd-file" "$(<"$TARGETDIR"/etc/swupd/mirror_versionurl)"
+	assert_equal "https://example.com/swupd-file" "$(<"$TARGET_DIR"/etc/swupd/mirror_contenturl)"
+	assert_equal "https://example.com/swupd-file" "$(<"$TARGET_DIR"/etc/swupd/mirror_versionurl)"
 
 	run sudo sh -c "$SWUPD mirror --unset $SWUPD_OPTS"
 	assert_status_is 0
@@ -34,14 +34,14 @@ global_setup() {
 		Mirror url configuration removed
 		Distribution:      Swupd Test Distro
 		Installed version: 10
-		Version URL:       file://$TEST_DIRNAME/web-dir
-		Content URL:       file://$TEST_DIRNAME/web-dir
+		Version URL:       file://$ABS_TEST_DIR/web-dir
+		Content URL:       file://$ABS_TEST_DIR/web-dir
 	EOM
 	)
 	assert_is_output "$expected_output"
 
-	assert_file_not_exists "$TARGETDIR"/etc/swupd/mirror_contenturl
-	assert_file_not_exists "$TARGETDIR"/etc/swupd/mirror_versionurl
+	assert_file_not_exists "$TARGET_DIR"/etc/swupd/mirror_contenturl
+	assert_file_not_exists "$TARGET_DIR"/etc/swupd/mirror_versionurl
 }
 
 @test "MIR012: Unsetting a mirror not set" {
@@ -53,14 +53,14 @@ global_setup() {
 		No mirror url configuration to remove
 		Distribution:      Swupd Test Distro
 		Installed version: 10
-		Version URL:       file://$TEST_DIRNAME/web-dir
-		Content URL:       file://$TEST_DIRNAME/web-dir
+		Version URL:       file://$ABS_TEST_DIR/web-dir
+		Content URL:       file://$ABS_TEST_DIR/web-dir
 	EOM
 	)
 	assert_is_output "$expected_output"
 
-	assert_file_not_exists "$TARGETDIR"/etc/swupd/mirror_contenturl
-	assert_file_not_exists "$TARGETDIR"/etc/swupd/mirror_versionurl
+	assert_file_not_exists "$TARGET_DIR"/etc/swupd/mirror_contenturl
+	assert_file_not_exists "$TARGET_DIR"/etc/swupd/mirror_versionurl
 }
 
 @test "MIR013: Set/Unset a full mirror with globals" {
@@ -76,8 +76,8 @@ global_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_equal "https://example.com/swupd-file" "$(<"$TARGETDIR"/etc/swupd/mirror_contenturl)"
-	assert_equal "https://example.com/swupd-file" "$(<"$TARGETDIR"/etc/swupd/mirror_versionurl)"
+	assert_equal "https://example.com/swupd-file" "$(<"$TARGET_DIR"/etc/swupd/mirror_contenturl)"
+	assert_equal "https://example.com/swupd-file" "$(<"$TARGET_DIR"/etc/swupd/mirror_versionurl)"
 
 	run sudo sh -c "$SWUPD mirror --unset $SWUPD_OPTS"
 	assert_status_is 0
@@ -86,14 +86,14 @@ global_setup() {
 		Mirror url configuration removed
 		Distribution:      Swupd Test Distro
 		Installed version: 10
-		Version URL:       file://$TEST_DIRNAME/web-dir
-		Content URL:       file://$TEST_DIRNAME/web-dir
+		Version URL:       file://$ABS_TEST_DIR/web-dir
+		Content URL:       file://$ABS_TEST_DIR/web-dir
 	EOM
 	)
 	assert_is_output "$expected_output"
 
-	assert_file_not_exists "$TARGETDIR"/etc/swupd/mirror_contenturl
-	assert_file_not_exists "$TARGETDIR"/etc/swupd/mirror_versionurl
+	assert_file_not_exists "$TARGET_DIR"/etc/swupd/mirror_contenturl
+	assert_file_not_exists "$TARGET_DIR"/etc/swupd/mirror_versionurl
 }
 
 @test "MIR014: Set/Unset a content mirror with globals" {
@@ -104,13 +104,13 @@ global_setup() {
 		Mirror url set
 		Distribution:      Swupd Test Distro
 		Installed version: 10
-		Version URL:       file://$TEST_DIRNAME/web-dir
+		Version URL:       file://$ABS_TEST_DIR/web-dir
 		Content URL:       https://example.com/swupd-file
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_equal "https://example.com/swupd-file" "$(<"$TARGETDIR"/etc/swupd/mirror_contenturl)"
-	assert_file_not_exists "$TARGETDIR"/etc/swupd/mirror_versionurl
+	assert_equal "https://example.com/swupd-file" "$(<"$TARGET_DIR"/etc/swupd/mirror_contenturl)"
+	assert_file_not_exists "$TARGET_DIR"/etc/swupd/mirror_versionurl
 
 	run sudo sh -c "$SWUPD mirror --unset $SWUPD_OPTS"
 	assert_status_is 0
@@ -119,14 +119,14 @@ global_setup() {
 		Mirror url configuration removed
 		Distribution:      Swupd Test Distro
 		Installed version: 10
-		Version URL:       file://$TEST_DIRNAME/web-dir
-		Content URL:       file://$TEST_DIRNAME/web-dir
+		Version URL:       file://$ABS_TEST_DIR/web-dir
+		Content URL:       file://$ABS_TEST_DIR/web-dir
 	EOM
 	)
 	assert_is_output "$expected_output"
 
-	assert_file_not_exists "$TARGETDIR"/etc/swupd/mirror_contenturl
-	assert_file_not_exists "$TARGETDIR"/etc/swupd/mirror_versionurl
+	assert_file_not_exists "$TARGET_DIR"/etc/swupd/mirror_contenturl
+	assert_file_not_exists "$TARGET_DIR"/etc/swupd/mirror_versionurl
 }
 
 @test "MIR015: Set/Unset a version mirror with globals" {
@@ -138,12 +138,12 @@ global_setup() {
 		Distribution:      Swupd Test Distro
 		Installed version: 10
 		Version URL:       https://example.com/swupd-file
-		Content URL:       file://$TEST_DIRNAME/web-dir
+		Content URL:       file://$ABS_TEST_DIR/web-dir
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/etc/swupd/mirror_contenturl
-	assert_equal "https://example.com/swupd-file" "$(<"$TARGETDIR"/etc/swupd/mirror_versionurl)"
+	assert_file_not_exists "$TARGET_DIR"/etc/swupd/mirror_contenturl
+	assert_equal "https://example.com/swupd-file" "$(<"$TARGET_DIR"/etc/swupd/mirror_versionurl)"
 
 	run sudo sh -c "$SWUPD mirror --unset $SWUPD_OPTS"
 	assert_status_is 0
@@ -152,13 +152,13 @@ global_setup() {
 		Mirror url configuration removed
 		Distribution:      Swupd Test Distro
 		Installed version: 10
-		Version URL:       file://$TEST_DIRNAME/web-dir
-		Content URL:       file://$TEST_DIRNAME/web-dir
+		Version URL:       file://$ABS_TEST_DIR/web-dir
+		Content URL:       file://$ABS_TEST_DIR/web-dir
 	EOM
 	)
 	assert_is_output "$expected_output"
 
-	assert_file_not_exists "$TARGETDIR"/etc/swupd/mirror_contenturl
-	assert_file_not_exists "$TARGETDIR"/etc/swupd/mirror_versionurl
+	assert_file_not_exists "$TARGET_DIR"/etc/swupd/mirror_contenturl
+	assert_file_not_exists "$TARGET_DIR"/etc/swupd/mirror_versionurl
 }
 #WEIGHT=2

--- a/test/functional/only_in_ci_slow/update-non-responsive.bats
+++ b/test/functional/only_in_ci_slow/update-non-responsive.bats
@@ -24,7 +24,7 @@ test_setup() {
 	update_bundle "$TEST_NAME" os-core --add /test_file1
 
 	# start the web server (the server will hang)
-	start_web_server -r -H -D "$WEBDIR"
+	start_web_server -r -H -D "$WEB_DIR"
 	port=$(get_web_server_port "$TEST_NAME")
 
 	# set the versionurl and contenturl to point to the web server
@@ -56,7 +56,7 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/test_file1
+	assert_file_not_exists "$TARGET_DIR"/test_file1
 
 }
 
@@ -66,8 +66,8 @@ test_setup() {
 	# timeout with a useful message
 
 	# Extra setup: set the mirror in the test environment to point to the web server
-	write_to_protected_file "$TARGETDIR"/etc/swupd/mirror_versionurl http://localhost:"$port"/
-	write_to_protected_file "$TARGETDIR"/etc/swupd/mirror_contenturl http://localhost:"$port"/
+	write_to_protected_file "$TARGET_DIR"/etc/swupd/mirror_versionurl http://localhost:"$port"/
+	write_to_protected_file "$TARGET_DIR"/etc/swupd/mirror_contenturl http://localhost:"$port"/
 
 	run sudo sh -c "$SWUPD update --allow-insecure-http $SWUPD_OPTS"
 
@@ -91,7 +91,7 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/test_file1
+	assert_file_not_exists "$TARGET_DIR"/test_file1
 
 }
 
@@ -132,7 +132,7 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/test_file1
+	assert_file_exists "$TARGET_DIR"/test_file1
 
 }
 #WEIGHT=40

--- a/test/functional/only_in_ci_slow/update-slow-server.bats
+++ b/test/functional/only_in_ci_slow/update-slow-server.bats
@@ -14,7 +14,7 @@ test_setup() {
 	create_version -p "$TEST_NAME" 100 10
 	update_bundle "$TEST_NAME" test-bundle --update /foo/bar
 
-	start_web_server -D "$WEBDIR" -d 100/pack-test-bundle-from-10.tar -s
+	start_web_server -D "$WEB_DIR" -d 100/pack-test-bundle-from-10.tar -s
 
 	# Set the web server as our upstream server
 	port=$(get_web_server_port "$TEST_NAME")
@@ -56,7 +56,7 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/bar
+	assert_file_exists "$TARGET_DIR"/foo/bar
 
 }
 #WEIGHT=40

--- a/test/functional/only_in_ci_system/3rd-party-repo-add-certificate.bats
+++ b/test/functional/only_in_ci_system/3rd-party-repo-add-certificate.bats
@@ -20,14 +20,14 @@ test_setup() {
 
 	if [ ! -f /usr/share/clear/update-ca/Swupd_Root.pem ]; then
 		sudo mkdir -p /usr/share/clear/update-ca
-		sudo cp "$TEST_DIRNAME"/Swupd_Root.pem /usr/share/clear/update-ca
+		sudo cp "$ABS_TEST_DIR"/Swupd_Root.pem /usr/share/clear/update-ca
 		export CERT_WAS_INSTALLED=1
 	fi
 
 	create_third_party_repo "$TEST_NAME" 10 staging test-repo1
-	repo1="$TPURL"
+	repo1="$ABS_TP_URL"
 	create_third_party_repo "$TEST_NAME" 10 staging test-repo2
-	repo2="$TPURL"
+	repo2="$ABS_TP_URL"
 }
 
 test_teardown() {
@@ -67,7 +67,7 @@ test_teardown() {
 	)
 	assert_regex_is_output "$expected_output"
 
-	run sudo sh -c "cat $PATH_PREFIX/$THIRD_PARTY_DIR/repo.ini"
+	run sudo sh -c "cat $ABS_TARGET_DIR/$TP_ROOT_DIR/repo.ini"
 	expected_output=$(cat <<-EOM
 			[test-repo1]
 			url=file://$repo1
@@ -76,8 +76,8 @@ test_teardown() {
 	assert_is_output "$expected_output"
 
 	# make sure the os-core bundle of the repo is installed in the appropriate place
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/"$THIRD_PARTY_BUNDLES_DIR"/test-repo1/usr/lib/os-release
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/"$TP_BUNDLES_DIR"/test-repo1/usr/lib/os-release
 
 }
 

--- a/test/functional/only_in_ci_system/add-client-certificate.bats
+++ b/test/functional/only_in_ci_system/add-client-certificate.bats
@@ -19,7 +19,7 @@ global_setup() {
 	create_test_environment "$TEST_NAME"
 	create_bundle -n test-bundle -f /usr/bin/test-file "$TEST_NAME"
 
-	sudo mkdir -p "$CLIENT_CERT_DIR"
+	sudo mkdir -p "$ABS_CLIENT_CERT_DIR"
 
 	# create client/server certificates
 	generate_certificate "$client_key" "$client_pub"
@@ -43,8 +43,8 @@ test_setup() {
 	fi
 
 	# create client certificate in expected directory
-	sudo cp "$client_key" "$CLIENT_CERT"
-	sudo sh -c "cat $client_pub >> $CLIENT_CERT"
+	sudo cp "$client_key" "$CLIENT_CERT_FILE"
+	sudo sh -c "cat $client_pub >> $CLIENT_CERT_FILE"
 }
 
 test_teardown() {
@@ -53,7 +53,7 @@ test_teardown() {
 		return
 	fi
 
-	sudo rm -f "$CLIENT_CERT"
+	sudo rm -f "$CLIENT_CERT_FILE"
 	remove_bundle -L "$TEST_NAME"/web-dir/10/Manifest.test-bundle
 	clean_state_dir "$TEST_NAME"
 }
@@ -63,13 +63,13 @@ test_teardown() {
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
 	assert_status_is 0
-	assert_file_exists "$TARGETDIR"/usr/bin/test-file
+	assert_file_exists "$TARGET_DIR"/usr/bin/test-file
 }
 
 @test "ADD024: Try adding bundle over HTTPS with no client certificate" {
 
 	# remove client certificate
-	sudo rm "$CLIENT_CERT"
+	sudo rm "$CLIENT_CERT_FILE"
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle --debug"
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
@@ -84,7 +84,7 @@ test_teardown() {
 @test "ADD025: Try adding bundle over HTTPS with an invalid client certificate" {
 
 	# make client certificate invalid
-	sudo sh -c "echo foo > $CLIENT_CERT"
+	sudo sh -c "echo foo > $CLIENT_CERT_FILE"
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle --debug"
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"

--- a/test/functional/only_in_ci_system/api-3rd-party-add.bats
+++ b/test/functional/only_in_ci_system/api-3rd-party-add.bats
@@ -18,12 +18,12 @@ test_setup() {
 
 	if [ ! -f /usr/share/clear/update-ca/Swupd_Root.pem ]; then
 		sudo mkdir -p /usr/share/clear/update-ca
-		sudo cp "$TEST_DIRNAME"/Swupd_Root.pem /usr/share/clear/update-ca
+		sudo cp "$ABS_TEST_DIR"/Swupd_Root.pem /usr/share/clear/update-ca
 		export CERT_WAS_INSTALLED=1
 	fi
 
 	create_third_party_repo "$TEST_NAME" 10 staging repo1
-	export repo1="$TPURL"
+	export repo1="$ABS_TP_URL"
 
 }
 

--- a/test/functional/only_in_ci_system/chk-update-client-certificate.bats
+++ b/test/functional/only_in_ci_system/chk-update-client-certificate.bats
@@ -21,7 +21,7 @@ global_setup() {
 
 	create_bundle -n test-bundle -f /usr/bin/test-file "$TEST_NAME"
 
-	sudo mkdir -p "$CLIENT_CERT_DIR"
+	sudo mkdir -p "$ABS_CLIENT_CERT_DIR"
 
 	# create client/server certificates
 	generate_certificate "$client_key" "$client_pub"
@@ -47,8 +47,8 @@ test_setup() {
 	set_current_version "$TEST_NAME" 10
 
 	# create client certificate in expected directory
-	sudo cp "$client_key" "$CLIENT_CERT"
-	sudo sh -c "cat $client_pub >> $CLIENT_CERT"
+	sudo cp "$client_key" "$CLIENT_CERT_FILE"
+	sudo sh -c "cat $client_pub >> $CLIENT_CERT_FILE"
 }
 
 test_teardown() {
@@ -57,7 +57,7 @@ test_teardown() {
 		return
 	fi
 
-	sudo rm -f "$CLIENT_CERT"
+	sudo rm -f "$CLIENT_CERT_FILE"
 	clean_state_dir "$TEST_NAME"
 }
 
@@ -71,7 +71,7 @@ test_teardown() {
 @test "CHK007: Try checking for available updates over HTTPS with no client certificate" {
 
 	# remove client certificate
-	sudo rm "$CLIENT_CERT"
+	sudo rm "$CLIENT_CERT_FILE"
 
 	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS --debug"
 	assert_status_is "$SWUPD_SERVER_CONNECTION_ERROR"
@@ -86,7 +86,7 @@ test_teardown() {
 @test "CHK008: Try checking for available updates over HTTPS with an invalid client certificate" {
 
 	# make client certificate invalid
-	sudo sh -c "echo foo > $CLIENT_CERT"
+	sudo sh -c "echo foo > $CLIENT_CERT_FILE"
 
 	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS --debug"
 	assert_status_is "$SWUPD_SERVER_CONNECTION_ERROR"

--- a/test/functional/only_in_ci_system/diagnose-client-certificate.bats
+++ b/test/functional/only_in_ci_system/diagnose-client-certificate.bats
@@ -18,7 +18,7 @@ global_setup() {
 
 	create_test_environment "$TEST_NAME"
 
-	sudo mkdir -p "$CLIENT_CERT_DIR"
+	sudo mkdir -p "$ABS_CLIENT_CERT_DIR"
 
 	# create client/server certificates
 	generate_certificate "$client_key" "$client_pub"
@@ -42,8 +42,8 @@ test_setup() {
 	fi
 
 	# create client certificate in expected directory
-	sudo cp "$client_key" "$CLIENT_CERT"
-	sudo sh -c "cat $client_pub >> $CLIENT_CERT"
+	sudo cp "$client_key" "$CLIENT_CERT_FILE"
+	sudo sh -c "cat $client_pub >> $CLIENT_CERT_FILE"
 }
 
 test_teardown() {
@@ -52,7 +52,7 @@ test_teardown() {
 		return
 	fi
 
-	sudo rm -f "$CLIENT_CERT"
+	sudo rm -f "$CLIENT_CERT_FILE"
 	clean_state_dir "$TEST_NAME"
 }
 
@@ -66,7 +66,7 @@ test_teardown() {
 @test "DIA008: Try diagnosing installed content on a system over HTTPS with no client certificate" {
 
 	# remove client certificate
-	sudo rm "$CLIENT_CERT"
+	sudo rm "$CLIENT_CERT_FILE"
 
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --debug"
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
@@ -81,7 +81,7 @@ test_teardown() {
 @test "DIA009: Try diagnosing installed content on a system over HTTPS with an invalid client certificate" {
 
 	# make client certificate invalid
-	sudo sh -c "echo foo > $CLIENT_CERT"
+	sudo sh -c "echo foo > $CLIENT_CERT_FILE"
 
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --debug"
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"

--- a/test/functional/only_in_ci_system/expired-certificate-latest.bats
+++ b/test/functional/only_in_ci_system/expired-certificate-latest.bats
@@ -42,11 +42,11 @@ test_setup() {
 			openssl x509 -days 1 -req -in "$TEST_NAME/cert_latest.csr" -CA "$TEST_NAME/root.pem" -CAkey "$TEST_NAME/root.key" -set_serial 0x1 -out "$TEST_NAME/cert_latest.pem"
 
 			# Sign the MoM with intermediate MoM cert
-			openssl smime -sign -binary -in "$WEBDIR"/10/Manifest.MoM -signer "$TEST_NAME/cert_mom.pem" -inkey "$TEST_NAME/cert_mom.key" -out "$WEBDIR"/10/Manifest.MoM.sig -outform DER
-			openssl smime -sign -binary -in "$WEBDIR"/20/Manifest.MoM -signer "$TEST_NAME/cert_mom.pem" -inkey "$TEST_NAME/cert_mom.key" -out "$WEBDIR"/20/Manifest.MoM.sig -outform DER
+			openssl smime -sign -binary -in "$WEB_DIR"/10/Manifest.MoM -signer "$TEST_NAME/cert_mom.pem" -inkey "$TEST_NAME/cert_mom.key" -out "$WEB_DIR"/10/Manifest.MoM.sig -outform DER
+			openssl smime -sign -binary -in "$WEB_DIR"/20/Manifest.MoM -signer "$TEST_NAME/cert_mom.pem" -inkey "$TEST_NAME/cert_mom.key" -out "$WEB_DIR"/20/Manifest.MoM.sig -outform DER
 
 			# Sign the latest with cert_latest latest cert
-			openssl smime -sign -binary -in "$WEBDIR"/version/formatstaging/latest -signer "$TEST_NAME/cert_latest.pem" -inkey "$TEST_NAME/cert_latest.key" -out "$WEBDIR"/version/formatstaging/latest.sig -outform DER
+			openssl smime -sign -binary -in "$WEB_DIR"/version/formatstaging/latest -signer "$TEST_NAME/cert_latest.pem" -inkey "$TEST_NAME/cert_latest.key" -out "$WEB_DIR"/version/formatstaging/latest.sig -outform DER
 
 	EOM
 	)
@@ -87,6 +87,6 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/file_2
+	assert_file_exists "$TARGET_DIR"/file_2
 
 }

--- a/test/functional/only_in_ci_system/expired-certificate-mom.bats
+++ b/test/functional/only_in_ci_system/expired-certificate-mom.bats
@@ -42,11 +42,11 @@ test_setup() {
 			openssl x509 -days 600 -req -in "$TEST_NAME/cert_latest.csr" -CA "$TEST_NAME/root.pem" -CAkey "$TEST_NAME/root.key" -set_serial 0x1 -out "$TEST_NAME/cert_latest.pem"
 
 			# Sign the MoM with intermediate MoM cert
-			openssl smime -sign -binary -in "$WEBDIR"/10/Manifest.MoM -signer "$TEST_NAME/cert_mom.pem" -inkey "$TEST_NAME/cert_mom.key" -out "$WEBDIR"/10/Manifest.MoM.sig -outform DER
-			openssl smime -sign -binary -in "$WEBDIR"/20/Manifest.MoM -signer "$TEST_NAME/cert_mom.pem" -inkey "$TEST_NAME/cert_mom.key" -out "$WEBDIR"/20/Manifest.MoM.sig -outform DER
+			openssl smime -sign -binary -in "$WEB_DIR"/10/Manifest.MoM -signer "$TEST_NAME/cert_mom.pem" -inkey "$TEST_NAME/cert_mom.key" -out "$WEB_DIR"/10/Manifest.MoM.sig -outform DER
+			openssl smime -sign -binary -in "$WEB_DIR"/20/Manifest.MoM -signer "$TEST_NAME/cert_mom.pem" -inkey "$TEST_NAME/cert_mom.key" -out "$WEB_DIR"/20/Manifest.MoM.sig -outform DER
 
 			# Sign the latest with cert_latest latest cert
-			openssl smime -sign -binary -in "$WEBDIR"/version/formatstaging/latest -signer "$TEST_NAME/cert_latest.pem" -inkey "$TEST_NAME/cert_latest.key" -out "$WEBDIR"/version/formatstaging/latest.sig -outform DER
+			openssl smime -sign -binary -in "$WEB_DIR"/version/formatstaging/latest -signer "$TEST_NAME/cert_latest.pem" -inkey "$TEST_NAME/cert_latest.key" -out "$WEB_DIR"/version/formatstaging/latest.sig -outform DER
 
 	EOM
 	)
@@ -76,6 +76,6 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/file_2
+	assert_file_not_exists "$TARGET_DIR"/file_2
 
 }

--- a/test/functional/only_in_ci_system/expired-certificate.bats
+++ b/test/functional/only_in_ci_system/expired-certificate.bats
@@ -19,15 +19,15 @@ test_setup() {
 	create_bundle -n test-bundle -f /test-file "$TEST_NAME"
 
 	# Resign release with an expired key
-	sudo rm "$WEBDIR"/version/latest_version.sig
-	sudo rm "$WEBDIR"/version/formatstaging/latest.sig
-	sudo rm "$WEBDIR"/10/Manifest.MoM.sig
+	sudo rm "$WEB_DIR"/version/latest_version.sig
+	sudo rm "$WEB_DIR"/version/formatstaging/latest.sig
+	sudo rm "$WEB_DIR"/10/Manifest.MoM.sig
 
 	sudo systemctl stop systemd-timesyncd
 	DATE=$(date "+%Y%m%d %H:%M:%S")
 	sudo date "+%Y%m%d" -s "20000101" #go back to the past
 	sudo sh -c "openssl req -x509 -sha512 -days 1 -newkey rsa:4096  -keyout $TEST_NAME/root.key -out $TEST_NAME/root.pem -nodes -subj '/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost'"
-	sudo sh -c "openssl smime -sign -binary -in $WEBDIR/10/Manifest.MoM -signer $TEST_NAME/root.pem -inkey $TEST_NAME/root.key -out $WEBDIR/10/Manifest.MoM.sig -outform DER"
+	sudo sh -c "openssl smime -sign -binary -in $WEB_DIR/10/Manifest.MoM -signer $TEST_NAME/root.pem -inkey $TEST_NAME/root.key -out $WEB_DIR/10/Manifest.MoM.sig -outform DER"
 	sudo date "+%Y%m%d %H:%M:%S" -s "$DATE"
 	sudo systemctl start systemd-timesyncd
 
@@ -46,7 +46,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/test-file
+	assert_file_not_exists "$TARGET_DIR"/test-file
 
 }
 #WEIGHT=4

--- a/test/functional/only_in_ci_system/list-client-certificate.bats
+++ b/test/functional/only_in_ci_system/list-client-certificate.bats
@@ -18,7 +18,7 @@ global_setup() {
 
 	create_test_environment "$TEST_NAME"
 
-	sudo mkdir -p "$CLIENT_CERT_DIR"
+	sudo mkdir -p "$ABS_CLIENT_CERT_DIR"
 
 	# create client/server certificates
 	generate_certificate "$client_key" "$client_pub"
@@ -42,8 +42,8 @@ test_setup() {
 	fi
 
 	# create client certificate in expected directory
-	sudo cp "$client_key" "$CLIENT_CERT"
-	sudo sh -c "cat $client_pub >> $CLIENT_CERT"
+	sudo cp "$client_key" "$CLIENT_CERT_FILE"
+	sudo sh -c "cat $client_pub >> $CLIENT_CERT_FILE"
 }
 
 test_teardown() {
@@ -52,7 +52,7 @@ test_teardown() {
 		return
 	fi
 
-	sudo rm -f "$CLIENT_CERT"
+	sudo rm -f "$CLIENT_CERT_FILE"
 	clean_state_dir "$TEST_NAME"
 }
 
@@ -66,7 +66,7 @@ test_teardown() {
 @test "LST004: Try listing all available bundles over HTTPS with no client certificate" {
 
 	# remove client certificate
-	sudo rm "$CLIENT_CERT"
+	sudo rm "$CLIENT_CERT_FILE"
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --all --debug"
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
@@ -81,7 +81,7 @@ test_teardown() {
 @test "LST005: Try listing all available bundles over HTTPS with an invalid client certificate" {
 
 	# make client certificate invalid
-	sudo sh -c "echo foo > $CLIENT_CERT"
+	sudo sh -c "echo foo > $CLIENT_CERT_FILE"
 
 	run sudo sh -c "$SWUPD bundle-list $SWUPD_OPTS --all --debug"
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"

--- a/test/functional/only_in_ci_system/remove-client-certificate.bats
+++ b/test/functional/only_in_ci_system/remove-client-certificate.bats
@@ -19,7 +19,7 @@ global_setup() {
 	create_test_environment "$TEST_NAME"
 	create_bundle -n test-bundle -f /foo/test-file "$TEST_NAME"
 
-	sudo mkdir -p "$CLIENT_CERT_DIR"
+	sudo mkdir -p "$ABS_CLIENT_CERT_DIR"
 
 	# create client/server certificates
 	generate_certificate "$client_key" "$client_pub"
@@ -45,8 +45,8 @@ test_setup() {
 	install_bundle "$TEST_NAME"/web-dir/10/Manifest.test-bundle
 
 	# create client certificate in expected directory
-	sudo cp "$client_key" "$CLIENT_CERT"
-	sudo sh -c "cat $client_pub >> $CLIENT_CERT"
+	sudo cp "$client_key" "$CLIENT_CERT_FILE"
+	sudo sh -c "cat $client_pub >> $CLIENT_CERT_FILE"
 }
 
 test_teardown() {
@@ -55,7 +55,7 @@ test_teardown() {
 		return
 	fi
 
-	sudo rm -f "$CLIENT_CERT"
+	sudo rm -f "$CLIENT_CERT_FILE"
 	clean_state_dir "$TEST_NAME"
 }
 
@@ -70,7 +70,7 @@ test_teardown() {
 @test "REM015: Try removing a bundle over HTTPS with no client certificate" {
 
 	# remove client certificate
-	sudo rm "$CLIENT_CERT"
+	sudo rm "$CLIENT_CERT_FILE"
 
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle --debug"
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
@@ -85,7 +85,7 @@ test_teardown() {
 @test "REM016: Try removing a bundle over HTTPS with an invalid client certificate" {
 
 	# make client certificate invalid
-	sudo sh -c "echo foo > $CLIENT_CERT"
+	sudo sh -c "echo foo > $CLIENT_CERT_FILE"
 
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle --debug"
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"

--- a/test/functional/only_in_ci_system/search-client-certificate.bats
+++ b/test/functional/only_in_ci_system/search-client-certificate.bats
@@ -19,7 +19,7 @@ global_setup() {
 	create_test_environment "$TEST_NAME"
 	create_bundle -n test-bundle -f /usr/bin/test-file "$TEST_NAME"
 
-	sudo mkdir -p "$CLIENT_CERT_DIR"
+	sudo mkdir -p "$ABS_CLIENT_CERT_DIR"
 
 	# create client/server certificates
 	generate_certificate "$client_key" "$client_pub"
@@ -43,8 +43,8 @@ test_setup() {
 	fi
 
 	# create client certificate in expected directory
-	sudo cp "$client_key" "$CLIENT_CERT"
-	sudo sh -c "cat $client_pub >> $CLIENT_CERT"
+	sudo cp "$client_key" "$CLIENT_CERT_FILE"
+	sudo sh -c "cat $client_pub >> $CLIENT_CERT_FILE"
 }
 
 test_teardown() {
@@ -53,7 +53,7 @@ test_teardown() {
 		return
 	fi
 
-	sudo rm -f "$CLIENT_CERT"
+	sudo rm -f "$CLIENT_CERT_FILE"
 	clean_state_dir "$TEST_NAME"
 }
 
@@ -67,7 +67,7 @@ test_teardown() {
 @test "SRH013: Try searching for bundles over HTTPS with no client certificate" {
 
 	# remove client certificate
-	sudo rm "$CLIENT_CERT"
+	sudo rm "$CLIENT_CERT_FILE"
 
 	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS test-file --debug"
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
@@ -82,7 +82,7 @@ test_teardown() {
 @test "SRH014: Try searching for bundles over HTTPS with an invalid client certificate" {
 
 	# make client certificate invalid
-	sudo sh -c "echo foo > $CLIENT_CERT"
+	sudo sh -c "echo foo > $CLIENT_CERT_FILE"
 
 	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS test-file --debug"
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"

--- a/test/functional/only_in_ci_system/update-client-certificate.bats
+++ b/test/functional/only_in_ci_system/update-client-certificate.bats
@@ -21,7 +21,7 @@ global_setup() {
 
 	create_bundle -n test-bundle -f /usr/bin/test-file "$TEST_NAME"
 
-	sudo mkdir -p "$CLIENT_CERT_DIR"
+	sudo mkdir -p "$ABS_CLIENT_CERT_DIR"
 
 	# create client/server certificates
 	generate_certificate "$client_key" "$client_pub"
@@ -47,8 +47,8 @@ test_setup() {
 	set_current_version "$TEST_NAME" 10
 
 	# create client certificate in expected directory
-	sudo cp "$client_key" "$CLIENT_CERT"
-	sudo sh -c "cat $client_pub >> $CLIENT_CERT"
+	sudo cp "$client_key" "$CLIENT_CERT_FILE"
+	sudo sh -c "cat $client_pub >> $CLIENT_CERT_FILE"
 }
 
 test_teardown() {
@@ -57,7 +57,7 @@ test_teardown() {
 		return
 	fi
 
-	sudo rm -f "$CLIENT_CERT"
+	sudo rm -f "$CLIENT_CERT_FILE"
 	clean_state_dir "$TEST_NAME"
 }
 
@@ -71,7 +71,7 @@ test_teardown() {
 @test "UPD017: Try updating a system over HTTPS with no client certificate" {
 
 	# remove client certificate
-	sudo rm "$CLIENT_CERT"
+	sudo rm "$CLIENT_CERT_FILE"
 
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS --debug"
 	assert_status_is "$SWUPD_SERVER_CONNECTION_ERROR"
@@ -86,7 +86,7 @@ test_teardown() {
 @test "UPD018: Try updating a system over HTTPS with an invalid client certificate" {
 
 	# make client certificate invalid
-	sudo sh -c "echo foo > $CLIENT_CERT"
+	sudo sh -c "echo foo > $CLIENT_CERT_FILE"
 
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS --debug"
 	assert_status_is "$SWUPD_SERVER_CONNECTION_ERROR"

--- a/test/functional/os-install/install-also-add.bats
+++ b/test/functional/os-install/install-also-add.bats
@@ -13,15 +13,15 @@ test_setup() {
 	create_bundle -n test-bundle3 -f /bar/test-file3 "$TEST_NAME"
 
 	# Create bundle dependencies
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.os-core test-bundle1
-	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.os-core test-bundle2
-	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle2 test-bundle3
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.os-core test-bundle1
+	add_dependency_to_manifest -o "$WEB_DIR"/10/Manifest.os-core test-bundle2
+	add_dependency_to_manifest -o "$WEB_DIR"/10/Manifest.test-bundle2 test-bundle3
 
 }
 
 @test "INS014: Install should include also-add bundles" {
 
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH --path $TARGETDIR"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH --path $TARGET_DIR"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -46,10 +46,10 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/bar/test-file2
-	assert_file_exists "$TARGETDIR"/bar/test-file3
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_exists "$TARGET_DIR"/bar/test-file3
 
 }
 #WEIGHT=5

--- a/test/functional/os-install/install-bad.bats
+++ b/test/functional/os-install/install-bad.bats
@@ -10,7 +10,7 @@ test_setup() {
 	create_test_environment -e "$TEST_NAME" 10
 	create_bundle -n os-core -f /core "$TEST_NAME"
 	create_bundle -n test-bundle -f /file_1,/file_2 "$TEST_NAME"
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle os-core
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle os-core
 
 }
 
@@ -64,11 +64,11 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle
-	assert_file_exists "$TARGETDIR"/file_1
-	assert_file_exists "$TARGETDIR"/file_2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle
+	assert_file_exists "$TARGET_DIR"/file_1
+	assert_file_exists "$TARGET_DIR"/file_2
 
 }
 #WEIGHT=4

--- a/test/functional/os-install/install-basics.bats
+++ b/test/functional/os-install/install-basics.bats
@@ -17,7 +17,7 @@ test_setup() {
 	# os-install will install a basic OS that has only os-core if nothing
 	# else is specified
 
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGET_DIR"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -39,8 +39,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 
@@ -49,7 +49,7 @@ test_setup() {
 	# os-install will install a basic OS that has only os-core if nothing
 	# else is specified
 
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH --path $TARGETDIR"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH --path $TARGET_DIR"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -71,8 +71,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 
@@ -82,7 +82,7 @@ test_setup() {
 	# to be provided by either using the --path option or simply specifying
 	# it with no option, but not both
 
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH --path $TARGETDIR $TARGETDIR"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH --path $TARGET_DIR $TARGET_DIR"
 
 	assert_status_is "$SWUPD_INVALID_OPTION"
 	expected_output=$(cat <<-EOM
@@ -90,8 +90,8 @@ test_setup() {
 	EOM
 	)
 	assert_in_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_not_exists "$TARGETDIR"/core
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_not_exists "$TARGET_DIR"/core
 
 }
 #WEIGHT=4

--- a/test/functional/os-install/install-download.bats
+++ b/test/functional/os-install/install-download.bats
@@ -14,7 +14,7 @@ test_setup() {
 
 @test "INS015: Download os-install content without installing" {
 
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH --download $TARGETDIR"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH --download $TARGET_DIR"
 
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
@@ -31,13 +31,13 @@ test_setup() {
 	)
 
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/core
+	assert_file_not_exists "$TARGET_DIR"/core
 
-	assert_file_exists "$STATEDIR_MANIFEST"/10/Manifest.MoM
-	assert_file_exists "$STATEDIR_MANIFEST"/10/Manifest.os-core
+	assert_file_exists "$ABS_MANIFEST_DIR"/10/Manifest.MoM
+	assert_file_exists "$ABS_MANIFEST_DIR"/10/Manifest.os-core
 
-	core_hash=$(get_hash_from_manifest "$STATEDIR_MANIFEST"/10/Manifest.os-core "/core")
-	assert_file_exists "$STATEDIR_STAGED"/"$core_hash"
+	core_hash=$(get_hash_from_manifest "$ABS_MANIFEST_DIR"/10/Manifest.os-core "/core")
+	assert_file_exists "$ABS_STAGED_DIR"/"$core_hash"
 
 }
 #WEIGHT=1

--- a/test/functional/os-install/install-hardlink-symlink.bats
+++ b/test/functional/os-install/install-hardlink-symlink.bats
@@ -14,20 +14,20 @@ test_setup() {
 
 @test "INS027: Check if hardlinks are preserved" {
 
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS --path $TARGETDIR"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS --path $TARGET_DIR"
 	assert_status_is "$SWUPD_OK"
-	run sudo sh -c "$SWUPD clean --all $SWUPD_OPTS --path $TARGETDIR"
+	run sudo sh -c "$SWUPD clean --all $SWUPD_OPTS --path $TARGET_DIR"
 	assert_status_is "$SWUPD_OK"
 
-	run stat --printf=%h "$TARGETDIR"/core
+	run stat --printf=%h "$TARGET_DIR"/core
 	assert_status_is "0"
 	assert_is_output "3"
 
-	run stat --printf=%h "$TARGETDIR"/core2
+	run stat --printf=%h "$TARGET_DIR"/core2
 	assert_status_is "0"
 	assert_is_output "3"
 
-	run stat --printf=%h "$TARGETDIR"/core3
+	run stat --printf=%h "$TARGET_DIR"/core3
 	assert_status_is "0"
 	assert_is_output "3"
 
@@ -38,20 +38,20 @@ test_setup() {
 	# There are known bugs on bsdtar to extract hardlink to symlinks,
 	# so we avoid to have them on swupd.
 
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS --path $TARGETDIR"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS --path $TARGET_DIR"
 	assert_status_is "$SWUPD_OK"
-	run sudo sh -c "$SWUPD clean --all $SWUPD_OPTS --path $TARGETDIR"
+	run sudo sh -c "$SWUPD clean --all $SWUPD_OPTS --path $TARGET_DIR"
 	assert_status_is "$SWUPD_OK"
 
-	run stat --printf=%h "$TARGETDIR"/symlink
+	run stat --printf=%h "$TARGET_DIR"/symlink
 	assert_status_is "0"
 	assert_is_output "1"
 
-	run stat --printf=%h "$TARGETDIR"/symlink2
+	run stat --printf=%h "$TARGET_DIR"/symlink2
 	assert_status_is "0"
 	assert_is_output "1"
 
-	run stat --printf=%h "$TARGETDIR"/symlink3
+	run stat --printf=%h "$TARGET_DIR"/symlink3
 	assert_status_is "0"
 	assert_is_output "1"
 

--- a/test/functional/os-install/install-json.bats
+++ b/test/functional/os-install/install-json.bats
@@ -61,7 +61,7 @@ test_setup() {
 		{ "type" : "info", "msg" : "    0 of 2 missing files were not installed" },
 		{ "type" : "progress", "currentStep" : 9, "totalSteps" : 9, "stepCompletion" : -1, "stepDescription" : "run_postupdate_scripts" },
 		{ "type" : "info", "msg" : "Calling post-update helper scripts" },
-		{ "type" : "warning", "msg" : "helper script ($TEST_DIRNAME/testfs/target-dir/usr/bin/clr-boot-manager) not found, it will be skipped" },
+		{ "type" : "warning", "msg" : "helper script ($ABS_TEST_DIR/testfs/target-dir/usr/bin/clr-boot-manager) not found, it will be skipped" },
 		{ "type" : "info", "msg" : " Installation successful" },
 		{ "type" : "progress", "currentStep" : 9, "totalSteps" : 9, "stepCompletion" : 100, "stepDescription" : "run_postupdate_scripts" },
 		{ "type" : "end", "section" : "os-install", "status" : 0 }

--- a/test/functional/os-install/install-latest-missing.bats
+++ b/test/functional/os-install/install-latest-missing.bats
@@ -9,7 +9,7 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME"
 	# remove the formatstaging/latest
-	sudo rm -rf "$WEBDIR/version/formatstaging/latest"
+	sudo rm -rf "$WEB_DIR/version/formatstaging/latest"
 
 }
 

--- a/test/functional/os-install/install-multiple.bats
+++ b/test/functional/os-install/install-multiple.bats
@@ -13,9 +13,9 @@ test_setup() {
 	create_bundle -n test-bundle2 -f /foo/file_3 "$TEST_NAME"
 	create_bundle -n test-bundle3 -f /bar/file_4 "$TEST_NAME"
 	# os-core is always included by all manifests
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 os-core
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle2 os-core
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle3 os-core
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle1 os-core
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle2 os-core
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle3 os-core
 
 }
 
@@ -48,20 +48,20 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle3
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_exists "$TARGETDIR"/foo/file_3
-	assert_file_exists "$TARGETDIR"/bar/file_4
-	assert_file_exists "$TARGETDIR"/var/lib/swupd/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/var/lib/swupd/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle3
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_exists "$TARGET_DIR"/foo/file_3
+	assert_file_exists "$TARGET_DIR"/bar/file_4
+	assert_file_exists "$TARGET_DIR"/var/lib/swupd/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/var/lib/swupd/bundles/test-bundle3
 	# make sure non specified bundles were not installed
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/file_1
-	assert_file_not_exists "$TARGETDIR"/file_2
-	assert_file_not_exists "$TARGETDIR"/var/lib/swupd/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/var/lib/swupd/bundles/os-core
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/file_1
+	assert_file_not_exists "$TARGET_DIR"/file_2
+	assert_file_not_exists "$TARGET_DIR"/var/lib/swupd/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/var/lib/swupd/bundles/os-core
 
 }
 
@@ -90,19 +90,19 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_exists "$TARGETDIR"/foo/file_3
-	assert_file_exists "$TARGETDIR"/var/lib/swupd/bundles/test-bundle2
-	assert_file_exists "$TARGETDIR"/var/lib/swupd/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_exists "$TARGET_DIR"/foo/file_3
+	assert_file_exists "$TARGET_DIR"/var/lib/swupd/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/var/lib/swupd/bundles/os-core
 	# make sure non specified bundles were not installed
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/file_1
-	assert_file_not_exists "$TARGETDIR"/file_2
-	assert_file_not_exists "$TARGETDIR"/var/lib/swupd/bundles/test-bundle1
-	assert_file_not_exists "$TARGETDIR"/var/lib/swupd/bundles/test-bundle3
-	assert_file_not_exists "$TARGETDIR"/bar/file_4
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/file_1
+	assert_file_not_exists "$TARGET_DIR"/file_2
+	assert_file_not_exists "$TARGET_DIR"/var/lib/swupd/bundles/test-bundle1
+	assert_file_not_exists "$TARGET_DIR"/var/lib/swupd/bundles/test-bundle3
+	assert_file_not_exists "$TARGET_DIR"/bar/file_4
 
 }
 #WEIGHT=9

--- a/test/functional/os-install/install-no-also-add.bats
+++ b/test/functional/os-install/install-no-also-add.bats
@@ -13,15 +13,15 @@ test_setup() {
 	create_bundle -n test-bundle3 -f /bar/test-file3 "$TEST_NAME"
 
 	# Create bundle dependencies
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.os-core test-bundle1
-	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.os-core test-bundle2
-	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle1 test-bundle3
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.os-core test-bundle1
+	add_dependency_to_manifest -o "$WEB_DIR"/10/Manifest.os-core test-bundle2
+	add_dependency_to_manifest -o "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle3
 
 }
 
 @test "INS016: Install without also-add bundles" {
 
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH --path $TARGETDIR --skip-optional"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH --path $TARGET_DIR --skip-optional"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -44,10 +44,10 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_not_exists "$TARGETDIR"/bar/test-file2
-	assert_file_not_exists "$TARGETDIR"/bar/test-file3
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_not_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_not_exists "$TARGET_DIR"/bar/test-file3
 
 }
 #WEIGHT=5

--- a/test/functional/os-install/install-no-fullfile-fallback.bats
+++ b/test/functional/os-install/install-no-fullfile-fallback.bats
@@ -10,8 +10,8 @@ test_setup() {
 	create_test_environment -e "$TEST_NAME" 10
 	create_bundle -n os-core -f /core "$TEST_NAME"
 	# remove the zero packs and fullfiles
-	sudo rm "$WEBDIR"/10/pack-os-core-from-0.tar
-	sudo rm -rf "$WEBDIR"/10/files/*
+	sudo rm "$WEB_DIR"/10/pack-os-core-from-0.tar
+	sudo rm -rf "$WEB_DIR"/10/files/*
 
 }
 

--- a/test/functional/os-install/install-no-packs.bats
+++ b/test/functional/os-install/install-no-packs.bats
@@ -10,7 +10,7 @@ test_setup() {
 	create_test_environment -e "$TEST_NAME" 10
 	create_bundle -n os-core -f /core "$TEST_NAME"
 	# remove the zero pack
-	sudo rm "$WEBDIR"/10/pack-os-core-from-0.tar
+	sudo rm "$WEB_DIR"/10/pack-os-core-from-0.tar
 
 }
 
@@ -42,8 +42,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 #WEIGHT=2

--- a/test/functional/os-install/install-statedir-cache-offline.bats
+++ b/test/functional/os-install/install-statedir-cache-offline.bats
@@ -11,15 +11,15 @@ test_setup() {
 	create_bundle -n os-core -f /core "$TEST_NAME"
 
 	# Populate statedir-cache
-	statedir_cache_path="$TEST_DIRNAME"/testfs/statedir-cache
-	sudo cp -r "$STATEDIR_ABS" "$statedir_cache_path"
+	statedir_cache_path="$ABS_TEST_DIR"/testfs/statedir-cache
+	sudo cp -r "$ABS_STATE_DIR" "$statedir_cache_path"
 	cache_url=https___localhost
 	sudo mkdir -m 755 -p "$statedir_cache_path"/cache/"$cache_url"/manifest/10
-	sudo cp "$WEBDIR"/10/Manifest.MoM "$statedir_cache_path"/cache/"$cache_url"/manifest/10
-	sudo cp "$WEBDIR"/10/Manifest.MoM.sig "$statedir_cache_path"/cache/"$cache_url"/manifest/10
-	sudo cp "$WEBDIR"/10/Manifest.os-core "$statedir_cache_path"/cache/"$cache_url"/manifest/10
+	sudo cp "$WEB_DIR"/10/Manifest.MoM "$statedir_cache_path"/cache/"$cache_url"/manifest/10
+	sudo cp "$WEB_DIR"/10/Manifest.MoM.sig "$statedir_cache_path"/cache/"$cache_url"/manifest/10
+	sudo cp "$WEB_DIR"/10/Manifest.os-core "$statedir_cache_path"/cache/"$cache_url"/manifest/10
 	sudo touch "$statedir_cache_path"/cache/"$cache_url"/pack-os-core-from-0-to-10.tar
-	sudo rsync -r "$WEBDIR"/10/files/* "$statedir_cache_path"/cache/"$cache_url"/staged --exclude="*.tar"
+	sudo rsync -r "$WEB_DIR"/10/files/* "$statedir_cache_path"/cache/"$cache_url"/staged --exclude="*.tar"
 
 }
 
@@ -28,7 +28,7 @@ test_setup() {
 	# The statedir-cache should be used to successfully perform the install
 	# without an internet connection.
 
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --url=https://localhost --statedir-cache $statedir_cache_path -V 10"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGET_DIR --url=https://localhost --statedir-cache $statedir_cache_path -V 10"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -48,8 +48,8 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 
@@ -58,7 +58,7 @@ test_setup() {
 	# Swupd should attempt to download the missing manifest and fail.
 
 	sudo rm "$statedir_cache_path"/cache/"$cache_url"/manifest/10/Manifest.os-core
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --url=https://localhost --statedir-cache $statedir_cache_path -V 10"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGET_DIR --url=https://localhost --statedir-cache $statedir_cache_path -V 10"
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MANIFEST"
 	expected_output=$(cat <<-EOM
@@ -76,8 +76,8 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_not_exists "$TARGETDIR"/core
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_not_exists "$TARGET_DIR"/core
 
 }
 
@@ -86,7 +86,7 @@ test_setup() {
 	# Swupd should attempt to download the signature and fail.
 
 	sudo rm "$statedir_cache_path"/cache/"$cache_url"/manifest/10/Manifest.MoM.sig
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --url=https://localhost --statedir-cache $statedir_cache_path -V 10"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGET_DIR --url=https://localhost --statedir-cache $statedir_cache_path -V 10"
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
@@ -104,8 +104,8 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_not_exists "$TARGETDIR"/core
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_not_exists "$TARGET_DIR"/core
 
 }
 
@@ -114,7 +114,7 @@ test_setup() {
 	# Swupd should attempt to download the fullfiles and fail.
 
 	sudo rm -r "$statedir_cache_path"/cache/"$cache_url"/staged
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --url=https://localhost --statedir-cache $statedir_cache_path -V 10"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGET_DIR --url=https://localhost --statedir-cache $statedir_cache_path -V 10"
 
 	assert_status_is "$SWUPD_COULDNT_DOWNLOAD_FILE"
 	expected_output=$(cat <<-EOM
@@ -135,8 +135,8 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_not_exists "$TARGETDIR"/core
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_not_exists "$TARGET_DIR"/core
 
 }
 
@@ -145,7 +145,7 @@ test_setup() {
 	# Swupd should fail to download the pack, but continue successfully.
 
 	sudo rm "$statedir_cache_path"/cache/"$cache_url"/pack-os-core-from-0-to-10.tar
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --url=https://localhost --statedir-cache $statedir_cache_path -V 10"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGET_DIR --url=https://localhost --statedir-cache $statedir_cache_path -V 10"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -171,8 +171,8 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 #WEIGHT=6

--- a/test/functional/os-install/install-statedir-cache.bats
+++ b/test/functional/os-install/install-statedir-cache.bats
@@ -11,15 +11,15 @@ test_setup() {
 	create_bundle -n os-core -f /core "$TEST_NAME"
 
 	# Populate statedir-cache
-	statedir_cache_path="$TEST_DIRNAME"/testfs/statedir-cache
-	sudo cp -r "$STATEDIR_ABS" "$statedir_cache_path"
-	cache_url=$(basename "$STATEDIR_CACHE")
+	statedir_cache_path="$ABS_TEST_DIR"/testfs/statedir-cache
+	sudo cp -r "$ABS_STATE_DIR" "$statedir_cache_path"
+	cache_url=$(basename "$ABS_CACHE_DIR")
 	sudo mkdir -m 755 -p "$statedir_cache_path"/cache/"$cache_url"/manifest/10
-	sudo cp "$WEBDIR"/10/Manifest.MoM "$statedir_cache_path"/cache/"$cache_url"/manifest/10
-	sudo cp "$WEBDIR"/10/Manifest.MoM.sig "$statedir_cache_path"/cache/"$cache_url"/manifest/10
-	sudo cp "$WEBDIR"/10/Manifest.os-core "$statedir_cache_path"/cache/"$cache_url"/manifest/10
+	sudo cp "$WEB_DIR"/10/Manifest.MoM "$statedir_cache_path"/cache/"$cache_url"/manifest/10
+	sudo cp "$WEB_DIR"/10/Manifest.MoM.sig "$statedir_cache_path"/cache/"$cache_url"/manifest/10
+	sudo cp "$WEB_DIR"/10/Manifest.os-core "$statedir_cache_path"/cache/"$cache_url"/manifest/10
 	sudo touch "$statedir_cache_path"/cache/"$cache_url"/pack-os-core-from-0-to-10.tar
-	sudo rsync -r "$WEBDIR"/10/files/* "$statedir_cache_path"/cache/"$cache_url"/staged --exclude="*.tar"
+	sudo rsync -r "$WEB_DIR"/10/files/* "$statedir_cache_path"/cache/"$cache_url"/staged --exclude="*.tar"
 
 }
 
@@ -28,7 +28,7 @@ test_setup() {
 	# The statedir-cache should be used for all update content, so the
 	# network should be unused.
 
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --statedir-cache $statedir_cache_path"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGET_DIR --statedir-cache $statedir_cache_path"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -48,8 +48,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 
@@ -61,7 +61,7 @@ test_setup() {
 	sudo rm "$statedir_cache_path"/cache/"$cache_url"/manifest/10/Manifest.os-core
 	sudo rm "$statedir_cache_path"/cache/"$cache_url"/pack-os-core-from-0-to-10.tar
 	sudo rm -r "$statedir_cache_path"/cache/"$cache_url"/staged
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --statedir-cache $statedir_cache_path"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGET_DIR --statedir-cache $statedir_cache_path"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -83,8 +83,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 
@@ -96,7 +96,7 @@ test_setup() {
 	# must not be used to populate the staged directory with fullfiles.
 
 	sudo rm -r "$statedir_cache_path"/cache/"$cache_url"/staged
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --statedir-cache $statedir_cache_path"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGET_DIR --statedir-cache $statedir_cache_path"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -116,8 +116,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 
@@ -127,7 +127,7 @@ test_setup() {
 	# corrupt manifests.
 
 	sudo sh -c "echo invalid > ${statedir_cache_path}/cache/$cache_url/manifest/10/Manifest.os-core"
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR --statedir-cache $statedir_cache_path"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGET_DIR --statedir-cache $statedir_cache_path"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -149,8 +149,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 #WEIGHT=4

--- a/test/functional/os-install/install-var.bats
+++ b/test/functional/os-install/install-var.bats
@@ -18,7 +18,7 @@ test_setup() {
 	# /var is filtered by heuristics, but on install time we want
 	# to create them.
 
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGETDIR"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_PATH $TARGET_DIR"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
@@ -40,7 +40,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/var/file
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/var/file
 
 }

--- a/test/functional/os-install/install-version.bats
+++ b/test/functional/os-install/install-version.bats
@@ -44,9 +44,9 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/core
-	assert_dir_exists "$TARGETDIR"/some_dir
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/core
+	assert_dir_exists "$TARGET_DIR"/some_dir
 
 }
 
@@ -76,9 +76,9 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/core
-	assert_dir_exists "$TARGETDIR"/some_dir
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/core
+	assert_dir_exists "$TARGET_DIR"/some_dir
 
 }
 
@@ -108,8 +108,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/os-core
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/os-core
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 #WEIGHT=8

--- a/test/functional/repair/repair-add-missing-include-old.bats
+++ b/test/functional/repair/repair-add-missing-include-old.bats
@@ -12,7 +12,7 @@ test_setup() {
 	create_bundle -n test-bundle2 -f /test-file2 "$TEST_NAME"
 	create_version "$TEST_NAME" 100 10
 	update_bundle "$TEST_NAME" test-bundle1 --header-only
-	add_dependency_to_manifest "$WEBDIR"/100/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest "$WEB_DIR"/100/Manifest.test-bundle1 test-bundle2
 	set_current_version "$TEST_NAME" 100
 
 }
@@ -44,9 +44,9 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_exists "$TARGETDIR"/test-file1
-	assert_file_exists "$TARGETDIR"/test-file2
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_exists "$TARGET_DIR"/test-file1
+	assert_file_exists "$TARGET_DIR"/test-file2
 
 }
 #WEIGHT=4

--- a/test/functional/repair/repair-add-missing-include.bats
+++ b/test/functional/repair/repair-add-missing-include.bats
@@ -11,8 +11,8 @@ test_setup() {
 	create_bundle -L -n test-bundle1 -f /foo/test-file1 "$TEST_NAME"
 	create_bundle -n test-bundle2 -f /bar/test-file2 "$TEST_NAME"
 	# add test-bundle2 and os-core as dependency of test-bundle1
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 os-core
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle1 os-core
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle2
 
 }
 
@@ -44,9 +44,9 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/bar/test-file2
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
 
 }
 #WEIGHT=3

--- a/test/functional/repair/repair-basics.bats
+++ b/test/functional/repair/repair-basics.bats
@@ -15,12 +15,12 @@ test_setup() {
 	update_bundle "$TEST_NAME" test-bundle1 --add /baz/file_3
 	set_current_version "$TEST_NAME" 20
 	# adding an untracked files into an untracked directory (/bat)
-	sudo mkdir "$TARGETDIR"/bat
-	sudo touch "$TARGETDIR"/bat/untracked_file1
+	sudo mkdir "$TARGET_DIR"/bat
+	sudo touch "$TARGET_DIR"/bat/untracked_file1
 	# adding an untracked file into tracked directory (/bar)
-	sudo touch "$TARGETDIR"/bar/untracked_file2
+	sudo touch "$TARGET_DIR"/bar/untracked_file2
 	# adding an untracked file into /usr
-	sudo touch "$TARGETDIR"/usr/untracked_file3
+	sudo touch "$TARGET_DIR"/usr/untracked_file3
 
 }
 
@@ -41,13 +41,13 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/baz -> fixed
-		 -> Missing file: $PATH_PREFIX/baz/file_3 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/baz -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/baz/file_3 -> fixed
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/foo/file_1 -> fixed
-		 -> Hash mismatch for file: $PATH_PREFIX/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/usr/lib/os-release -> fixed
 		Removing extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/bar/file_2 -> deleted
+		 -> File that should be deleted: $ABS_TARGET_DIR/bar/file_2 -> deleted
 		Inspected 18 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
@@ -64,13 +64,13 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 	# tracked files
-	assert_file_exists "$TARGETDIR"/foo/file_1
-	assert_file_not_exists "$TARGETDIR"/bar/file_2
-	assert_file_exists "$TARGETDIR"/baz/file_3
+	assert_file_exists "$TARGET_DIR"/foo/file_1
+	assert_file_not_exists "$TARGET_DIR"/bar/file_2
+	assert_file_exists "$TARGET_DIR"/baz/file_3
 	# untracked files
-	assert_file_exists "$TARGETDIR"/bat/untracked_file1
-	assert_file_exists "$TARGETDIR"/bar/untracked_file2
-	assert_file_exists "$TARGETDIR"/usr/untracked_file3
+	assert_file_exists "$TARGET_DIR"/bat/untracked_file1
+	assert_file_exists "$TARGET_DIR"/bar/untracked_file2
+	assert_file_exists "$TARGET_DIR"/usr/untracked_file3
 
 }
 
@@ -91,17 +91,17 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/baz -> fixed
-		 -> Missing file: $PATH_PREFIX/baz/file_3 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/baz -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/baz/file_3 -> fixed
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/foo/file_1 -> fixed
-		 -> Hash mismatch for file: $PATH_PREFIX/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/usr/lib/os-release -> fixed
 		Removing extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/bar/file_2 -> deleted
-		Removing extra files under $PATH_PREFIX/usr
-		 -> Extra file: $PATH_PREFIX/usr/untracked_file3 -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/versionurl -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/contenturl -> deleted
+		 -> File that should be deleted: $ABS_TARGET_DIR/bar/file_2 -> deleted
+		Removing extra files under $ABS_TARGET_DIR/usr
+		 -> Extra file: $ABS_TARGET_DIR/usr/untracked_file3 -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/versionurl -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/contenturl -> deleted
 		Inspected 21 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
@@ -118,15 +118,15 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 	# tracked files
-	assert_file_exists "$TARGETDIR"/foo/file_1
-	assert_file_not_exists "$TARGETDIR"/bar/file_2
-	assert_file_exists "$TARGETDIR"/baz/file_3
+	assert_file_exists "$TARGET_DIR"/foo/file_1
+	assert_file_not_exists "$TARGET_DIR"/bar/file_2
+	assert_file_exists "$TARGET_DIR"/baz/file_3
 	# untracked files
-	assert_file_exists "$TARGETDIR"/bat/untracked_file1
-	assert_file_exists "$TARGETDIR"/bar/untracked_file2
-	assert_file_not_exists "$TARGETDIR"/usr/untracked_file3
-	assert_file_not_exists "$TARGETDIR"/usr/share/defaults/swupd/versionurl
-	assert_file_not_exists "$TARGETDIR"/usr/share/defaults/swupd/contenturl
+	assert_file_exists "$TARGET_DIR"/bat/untracked_file1
+	assert_file_exists "$TARGET_DIR"/bar/untracked_file2
+	assert_file_not_exists "$TARGET_DIR"/usr/untracked_file3
+	assert_file_not_exists "$TARGET_DIR"/usr/share/defaults/swupd/versionurl
+	assert_file_not_exists "$TARGET_DIR"/usr/share/defaults/swupd/contenturl
 
 }
 
@@ -147,16 +147,16 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/baz -> fixed
-		 -> Missing file: $PATH_PREFIX/baz/file_3 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/baz -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/baz/file_3 -> fixed
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/foo/file_1 -> fixed
-		 -> Hash mismatch for file: $PATH_PREFIX/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/usr/lib/os-release -> fixed
 		Removing extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/bar/file_2 -> deleted
-		Removing extra files under $PATH_PREFIX/bat
-		 -> Extra file: $PATH_PREFIX/bat/untracked_file1 -> deleted
-		 -> Extra file: $PATH_PREFIX/bat/ -> deleted
+		 -> File that should be deleted: $ABS_TARGET_DIR/bar/file_2 -> deleted
+		Removing extra files under $ABS_TARGET_DIR/bat
+		 -> Extra file: $ABS_TARGET_DIR/bat/untracked_file1 -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/bat/ -> deleted
 		Inspected 20 files
 		  2 files were missing
 		    2 of 2 missing files were replaced
@@ -173,13 +173,13 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 	# tracked files
-	assert_file_exists "$TARGETDIR"/foo/file_1
-	assert_file_not_exists "$TARGETDIR"/bar/file_2
-	assert_file_exists "$TARGETDIR"/baz/file_3
+	assert_file_exists "$TARGET_DIR"/foo/file_1
+	assert_file_not_exists "$TARGET_DIR"/bar/file_2
+	assert_file_exists "$TARGET_DIR"/baz/file_3
 	# untracked files
-	assert_file_not_exists "$TARGETDIR"/bat/untracked_file1
-	assert_file_exists "$TARGETDIR"/bar/untracked_file2
-	assert_file_exists "$TARGETDIR"/usr/untracked_file3
+	assert_file_not_exists "$TARGET_DIR"/bat/untracked_file1
+	assert_file_exists "$TARGET_DIR"/bar/untracked_file2
+	assert_file_exists "$TARGET_DIR"/usr/untracked_file3
 
 }
 #WEIGHT=18

--- a/test/functional/repair/repair-boot-file-deleted.bats
+++ b/test/functional/repair/repair-boot-file-deleted.bats
@@ -9,8 +9,8 @@ test_setup() {
 
 	create_test_environment -e "$TEST_NAME"
 	create_bundle -L -n os-core -f /usr/lib/kernel/testfile "$TEST_NAME"
-	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-status /usr/lib/kernel/testfile .db.
-	update_manifest "$WEBDIR"/10/Manifest.os-core file-hash /usr/lib/kernel/testfile "$ZERO_HASH"
+	update_manifest -p "$WEB_DIR"/10/Manifest.os-core file-status /usr/lib/kernel/testfile .db.
+	update_manifest "$WEB_DIR"/10/Manifest.os-core file-hash /usr/lib/kernel/testfile "$ZERO_HASH"
 
 }
 
@@ -34,7 +34,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/lib/kernel/testfile
+	assert_file_exists "$TARGET_DIR"/usr/lib/kernel/testfile
 
 }
 #WEIGHT=2

--- a/test/functional/repair/repair-boot-file-deleted.bats
+++ b/test/functional/repair/repair-boot-file-deleted.bats
@@ -10,7 +10,7 @@ test_setup() {
 	create_test_environment -e "$TEST_NAME"
 	create_bundle -L -n os-core -f /usr/lib/kernel/testfile "$TEST_NAME"
 	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-status /usr/lib/kernel/testfile .db.
-	update_manifest "$WEBDIR"/10/Manifest.os-core file-hash /usr/lib/kernel/testfile "$zero_hash"
+	update_manifest "$WEBDIR"/10/Manifest.os-core file-hash /usr/lib/kernel/testfile "$ZERO_HASH"
 
 }
 

--- a/test/functional/repair/repair-boot-file.bats
+++ b/test/functional/repair/repair-boot-file.bats
@@ -10,7 +10,7 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle -f /usr/lib/kernel/testfile "$TEST_NAME"
 	# change the content of testfile so the hash doesn't match
-	write_to_protected_file -a "$TARGETDIR"/usr/lib/kernel/testfile "some new content"
+	write_to_protected_file -a "$TARGET_DIR"/usr/lib/kernel/testfile "some new content"
 
 }
 
@@ -29,19 +29,19 @@ test_setup() {
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/usr/lib/kernel/testfile -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/usr/lib/kernel/testfile -> fixed
 		Removing extraneous files
 		Inspected 7 files
 		  1 file did not match
 		    1 of 1 files were repaired
 		    0 of 1 files were not repaired
 		Calling post-update helper scripts
-		Warning: helper script ($PATH_PREFIX/usr/bin/clr-boot-manager) not found, it will be skipped
+		Warning: helper script ($ABS_TARGET_DIR/usr/bin/clr-boot-manager) not found, it will be skipped
 		Repair successful
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/lib/kernel/testfile
+	assert_file_exists "$TARGET_DIR"/usr/lib/kernel/testfile
 
 }
 #WEIGHT=2

--- a/test/functional/repair/repair-boot-skip.bats
+++ b/test/functional/repair/repair-boot-skip.bats
@@ -9,8 +9,8 @@ test_setup() {
 
 	create_test_environment -e "$TEST_NAME"
 	create_bundle -L -n os-core -f /usr/lib/kernel/testfile "$TEST_NAME"
-	update_manifest "$WEBDIR"/10/Manifest.os-core file-status /usr/lib/kernel/testfile .db.
-	update_manifest "$WEBDIR"/10/Manifest.os-core file-hash /usr/lib/kernel/testfile "$ZERO_HASH"
+	update_manifest "$WEB_DIR"/10/Manifest.os-core file-status /usr/lib/kernel/testfile .db.
+	update_manifest "$WEB_DIR"/10/Manifest.os-core file-hash /usr/lib/kernel/testfile "$ZERO_HASH"
 
 }
 
@@ -36,7 +36,7 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 	# this should exist at the end, even if cbm is not run
-	assert_file_exists "$TARGETDIR"/usr/lib/kernel/testfile
+	assert_file_exists "$TARGET_DIR"/usr/lib/kernel/testfile
 
 }
 #WEIGHT=2

--- a/test/functional/repair/repair-boot-skip.bats
+++ b/test/functional/repair/repair-boot-skip.bats
@@ -10,7 +10,7 @@ test_setup() {
 	create_test_environment -e "$TEST_NAME"
 	create_bundle -L -n os-core -f /usr/lib/kernel/testfile "$TEST_NAME"
 	update_manifest "$WEBDIR"/10/Manifest.os-core file-status /usr/lib/kernel/testfile .db.
-	update_manifest "$WEBDIR"/10/Manifest.os-core file-hash /usr/lib/kernel/testfile "$zero_hash"
+	update_manifest "$WEBDIR"/10/Manifest.os-core file-hash /usr/lib/kernel/testfile "$ZERO_HASH"
 
 }
 

--- a/test/functional/repair/repair-bundles.bats
+++ b/test/functional/repair/repair-bundles.bats
@@ -9,8 +9,8 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle1 -f /foo/test-file1,/common "$TEST_NAME"
-	file_hash=$(get_hash_from_manifest "$WEBDIR"/10/Manifest.test-bundle1 /common)
-	file_path="$WEBDIR"/10/files/"$file_hash"
+	file_hash=$(get_hash_from_manifest "$WEB_DIR"/10/Manifest.test-bundle1 /common)
+	file_path="$WEB_DIR"/10/files/"$file_hash"
 	create_bundle -L -n test-bundle2 -f /bar/test-file2,/common:"$file_path" "$TEST_NAME"
 	create_bundle -L -n test-bundle3 -f /baz/test-file3,/common:"$file_path" "$TEST_NAME"
 	create_bundle -n test-bundle4 -f /bat/test-file4,/common:"$file_path" "$TEST_NAME"
@@ -19,9 +19,9 @@ test_setup() {
 
 @test "REP033: Repair bundles only fixes specified bundles" {
 
-	sudo rm -f "$TARGETDIR"/foo/test-file1
-	sudo rm -f "$TARGETDIR"/common
-	sudo rm -f "$TARGETDIR"/foo/test-file3
+	sudo rm -f "$TARGET_DIR"/foo/test-file1
+	sudo rm -f "$TARGET_DIR"/common
+	sudo rm -f "$TARGET_DIR"/foo/test-file3
 
 	# users can diagnose only specific bundles
 
@@ -38,8 +38,8 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/common -> fixed
-		 -> Missing file: $PATH_PREFIX/foo/test-file1 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/common -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/foo/test-file1 -> fixed
 		Repairing corrupt files
 		Removing extraneous files
 		Inspected 9 files
@@ -56,9 +56,9 @@ test_setup() {
 
 @test "REP034: Repair bundles requires --force to continue when there is an invalid bundle" {
 
-	sudo rm -f "$TARGETDIR"/foo/test-file1
-	sudo rm -f "$TARGETDIR"/common
-	write_to_protected_file -a "$TARGETDIR"/usr/share/clear/bundles/test-bundle1 "something"
+	sudo rm -f "$TARGET_DIR"/foo/test-file1
+	sudo rm -f "$TARGET_DIR"/common
+	write_to_protected_file -a "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1 "something"
 
 	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --bundles bad-name,test-bundle1"
 
@@ -89,10 +89,10 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/common -> fixed
-		 -> Missing file: $PATH_PREFIX/foo/test-file1 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/common -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/foo/test-file1 -> fixed
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/usr/share/clear/bundles/test-bundle1 -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/usr/share/clear/bundles/test-bundle1 -> fixed
 		Removing extraneous files
 		Inspected 6 files
 		  2 files were missing
@@ -111,9 +111,9 @@ test_setup() {
 
 @test "REP035: Repair bundles do not delete files needed by other bundles" {
 
-	update_manifest "$WEBDIR"/10/Manifest.test-bundle1 file-status /foo/test-file1 .d..
-	update_manifest "$WEBDIR"/10/Manifest.test-bundle1 file-status /common .d..
-	write_to_protected_file -a "$TARGETDIR"/usr/share/clear/bundles/test-bundle1 "something"
+	update_manifest "$WEB_DIR"/10/Manifest.test-bundle1 file-status /foo/test-file1 .d..
+	update_manifest "$WEB_DIR"/10/Manifest.test-bundle1 file-status /common .d..
+	write_to_protected_file -a "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1 "something"
 
 	# if a file is marked as deleted in a bundle being repaired in isolation
 	# but another bundle needs that file, it should not be deleted
@@ -132,9 +132,9 @@ test_setup() {
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/usr/share/clear/bundles/test-bundle1 -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/usr/share/clear/bundles/test-bundle1 -> fixed
 		Removing extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/foo/test-file1 -> deleted
+		 -> File that should be deleted: $ABS_TARGET_DIR/foo/test-file1 -> deleted
 		Inspected 9 files
 		  1 file did not match
 		    1 of 1 files were repaired
@@ -152,8 +152,8 @@ test_setup() {
 
 @test "REP036: Repair a list of bundles that include a bundle not installed" {
 
-	sudo rm -f "$TARGETDIR"/foo/test-file1
-	sudo rm -f "$TARGETDIR"/common
+	sudo rm -f "$TARGET_DIR"/foo/test-file1
+	sudo rm -f "$TARGET_DIR"/common
 
 	# if a user repairs a list of bundles that include one not installed,
 	# it should warn the user about it, it should ignore the uninstalled bundle
@@ -172,8 +172,8 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/common -> fixed
-		 -> Missing file: $PATH_PREFIX/foo/test-file1 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/common -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/foo/test-file1 -> fixed
 		Repairing corrupt files
 		Removing extraneous files
 		Inspected 6 files

--- a/test/functional/repair/repair-deleted-include-manifest.bats
+++ b/test/functional/repair/repair-deleted-include-manifest.bats
@@ -12,13 +12,13 @@ test_setup() {
 	create_bundle -n test-bundle2 -f /test-file2 "$TEST_NAME"
 	create_version "$TEST_NAME" 100 10
 	update_bundle "$TEST_NAME" test-bundle1 --header-only
-	add_dependency_to_manifest "$WEBDIR"/100/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest "$WEB_DIR"/100/Manifest.test-bundle1 test-bundle2
 	set_current_version "$TEST_NAME" 100
 
 	# Delete the included manifest
-	sudo rm "$WEBDIR"/10/Manifest.test-bundle2
-	sudo rm "$WEBDIR"/10/pack-test-bundle2-from-0.tar
-	sudo rm "$WEBDIR"/10/Manifest.test-bundle2.tar
+	sudo rm "$WEB_DIR"/10/Manifest.test-bundle2
+	sudo rm "$WEB_DIR"/10/pack-test-bundle2-from-0.tar
+	sudo rm "$WEB_DIR"/10/Manifest.test-bundle2.tar
 }
 
 @test "REP037: Report error when an included manifest is deleted" {

--- a/test/functional/repair/repair-directory-tree-deleted.bats
+++ b/test/functional/repair/repair-directory-tree-deleted.bats
@@ -12,9 +12,9 @@ test_setup() {
 	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-status /testdir1/testdir2/testfile .d..
 	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-status /testdir1/testdir2 .d..
 	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-status /testdir1 .d..
-	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-hash /testdir1/testdir2/testfile "$zero_hash"
-	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-hash /testdir1/testdir2 "$zero_hash"
-	update_manifest "$WEBDIR"/10/Manifest.os-core file-hash /testdir1 "$zero_hash"
+	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-hash /testdir1/testdir2/testfile "$ZERO_HASH"
+	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-hash /testdir1/testdir2 "$ZERO_HASH"
+	update_manifest "$WEBDIR"/10/Manifest.os-core file-hash /testdir1 "$ZERO_HASH"
 
 }
 

--- a/test/functional/repair/repair-directory-tree-deleted.bats
+++ b/test/functional/repair/repair-directory-tree-deleted.bats
@@ -9,12 +9,12 @@ test_setup() {
 
 	create_test_environment -e "$TEST_NAME"
 	create_bundle -L -n os-core -f /testdir1/testdir2/testfile "$TEST_NAME"
-	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-status /testdir1/testdir2/testfile .d..
-	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-status /testdir1/testdir2 .d..
-	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-status /testdir1 .d..
-	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-hash /testdir1/testdir2/testfile "$ZERO_HASH"
-	update_manifest -p "$WEBDIR"/10/Manifest.os-core file-hash /testdir1/testdir2 "$ZERO_HASH"
-	update_manifest "$WEBDIR"/10/Manifest.os-core file-hash /testdir1 "$ZERO_HASH"
+	update_manifest -p "$WEB_DIR"/10/Manifest.os-core file-status /testdir1/testdir2/testfile .d..
+	update_manifest -p "$WEB_DIR"/10/Manifest.os-core file-status /testdir1/testdir2 .d..
+	update_manifest -p "$WEB_DIR"/10/Manifest.os-core file-status /testdir1 .d..
+	update_manifest -p "$WEB_DIR"/10/Manifest.os-core file-hash /testdir1/testdir2/testfile "$ZERO_HASH"
+	update_manifest -p "$WEB_DIR"/10/Manifest.os-core file-hash /testdir1/testdir2 "$ZERO_HASH"
+	update_manifest "$WEB_DIR"/10/Manifest.os-core file-hash /testdir1 "$ZERO_HASH"
 
 }
 
@@ -41,9 +41,9 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_dir_not_exists "$TARGETDIR"/testdir1
-	assert_dir_not_exists "$TARGETDIR"/testdir1/testdir2
-	assert_file_not_exists "$TARGETDIR"/testdir1/testdir2/testfile
+	assert_dir_not_exists "$TARGET_DIR"/testdir1
+	assert_dir_not_exists "$TARGET_DIR"/testdir1/testdir2
+	assert_file_not_exists "$TARGET_DIR"/testdir1/testdir2/testfile
 
 }
 #WEIGHT=12

--- a/test/functional/repair/repair-empty-dir-deleted.bats
+++ b/test/functional/repair/repair-empty-dir-deleted.bats
@@ -10,7 +10,7 @@ test_setup() {
 	create_test_environment -e "$TEST_NAME"
 	create_bundle -L -n os-core -d /testdir "$TEST_NAME"
 	update_manifest "$WEBDIR"/10/Manifest.os-core file-status /testdir .d..
-	update_manifest "$WEBDIR"/10/Manifest.os-core file-hash /testdir "$zero_hash"
+	update_manifest "$WEBDIR"/10/Manifest.os-core file-hash /testdir "$ZERO_HASH"
 
 }
 

--- a/test/functional/repair/repair-empty-dir-deleted.bats
+++ b/test/functional/repair/repair-empty-dir-deleted.bats
@@ -9,8 +9,8 @@ test_setup() {
 
 	create_test_environment -e "$TEST_NAME"
 	create_bundle -L -n os-core -d /testdir "$TEST_NAME"
-	update_manifest "$WEBDIR"/10/Manifest.os-core file-status /testdir .d..
-	update_manifest "$WEBDIR"/10/Manifest.os-core file-hash /testdir "$ZERO_HASH"
+	update_manifest "$WEB_DIR"/10/Manifest.os-core file-status /testdir .d..
+	update_manifest "$WEB_DIR"/10/Manifest.os-core file-hash /testdir "$ZERO_HASH"
 
 }
 
@@ -36,7 +36,7 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_dir_not_exists "$TARGETDIR"/testdir
+	assert_dir_not_exists "$TARGET_DIR"/testdir
 
 }
 #WEIGHT=2

--- a/test/functional/repair/repair-error.bats
+++ b/test/functional/repair/repair-error.bats
@@ -17,19 +17,19 @@ test_setup() {
 
 	# force some repairs in the target system
 	set_current_version "$TEST_NAME" 20
-	sudo touch "$TARGETDIR"/usr/untracked_file
+	sudo touch "$TARGET_DIR"/usr/untracked_file
 
 	# force failures while repairing
-	sudo touch "$TARGETDIR"/baz
-	sudo chattr +i "$TARGETDIR"/baz
-	sudo chattr +i "$TARGETDIR"/usr/untracked_file
+	sudo touch "$TARGET_DIR"/baz
+	sudo chattr +i "$TARGET_DIR"/baz
+	sudo chattr +i "$TARGET_DIR"/usr/untracked_file
 
 }
 
 test_teardown() {
 
-	sudo chattr -i "$TARGETDIR"/usr/untracked_file
-	sudo chattr -i "$TARGETDIR"/baz
+	sudo chattr -i "$TARGET_DIR"/usr/untracked_file
+	sudo chattr -i "$TARGET_DIR"/baz
 
 }
 
@@ -47,18 +47,18 @@ test_teardown() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		Error: Target has different file type but could not be removed: $PATH_PREFIX/baz
-		 -> Missing file: $PATH_PREFIX/baz/bat -> not fixed
-		Error: Target has different file type but could not be removed: $PATH_PREFIX/baz
-		 -> Missing file: $PATH_PREFIX/baz/bat/file_3 -> not fixed
+		Error: Target has different file type but could not be removed: $ABS_TARGET_DIR/baz
+		 -> Missing file: $ABS_TARGET_DIR/baz/bat -> not fixed
+		Error: Target has different file type but could not be removed: $ABS_TARGET_DIR/baz
+		 -> Missing file: $ABS_TARGET_DIR/baz/bat/file_3 -> not fixed
 		Repairing corrupt files
-		Error: Target has different file type but could not be removed: $PATH_PREFIX/baz
-		 -> Hash mismatch for file: $PATH_PREFIX/baz -> not fixed
-		 -> Hash mismatch for file: $PATH_PREFIX/foo/file_1 -> fixed
-		 -> Hash mismatch for file: $PATH_PREFIX/usr/lib/os-release -> fixed
+		Error: Target has different file type but could not be removed: $ABS_TARGET_DIR/baz
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/baz -> not fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/foo/file_1 -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/usr/lib/os-release -> fixed
 		The removal of extraneous files will be skipped due to the previous errors found repairing
-		Removing extra files under $PATH_PREFIX/usr
-		 -> Extra file: $PATH_PREFIX/usr/untracked_file -> not deleted (Operation not permitted)
+		Removing extra files under $ABS_TARGET_DIR/usr
+		 -> Extra file: $ABS_TARGET_DIR/usr/untracked_file -> not deleted (Operation not permitted)
 		Inspected 23 files
 		  2 files were missing
 		    0 of 2 missing files were replaced
@@ -83,15 +83,15 @@ test_teardown() {
 
 	assert_status_is_not "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Error: Target has different file type but could not be removed: $PATH_PREFIX/baz
-		$PATH_PREFIX/baz/bat -> not fixed
-		Error: Target has different file type but could not be removed: $PATH_PREFIX/baz
-		$PATH_PREFIX/baz/bat/file_3 -> not fixed
-		Error: Target has different file type but could not be removed: $PATH_PREFIX/baz
-		$PATH_PREFIX/baz -> not fixed
-		$PATH_PREFIX/foo/file_1 -> fixed
-		$PATH_PREFIX/usr/lib/os-release -> fixed
-		$PATH_PREFIX/usr/untracked_file -> not deleted (Operation not permitted)
+		Error: Target has different file type but could not be removed: $ABS_TARGET_DIR/baz
+		$ABS_TARGET_DIR/baz/bat -> not fixed
+		Error: Target has different file type but could not be removed: $ABS_TARGET_DIR/baz
+		$ABS_TARGET_DIR/baz/bat/file_3 -> not fixed
+		Error: Target has different file type but could not be removed: $ABS_TARGET_DIR/baz
+		$ABS_TARGET_DIR/baz -> not fixed
+		$ABS_TARGET_DIR/foo/file_1 -> fixed
+		$ABS_TARGET_DIR/usr/lib/os-release -> fixed
+		$ABS_TARGET_DIR/usr/untracked_file -> not deleted (Operation not permitted)
 	EOM
 	)
 	assert_is_output "$expected_output"

--- a/test/functional/repair/repair-format-mismatch-overdrive.bats
+++ b/test/functional/repair/repair-format-mismatch-overdrive.bats
@@ -29,10 +29,10 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $TEST_DIRNAME/testfs/target-dir/usr/bin -> fixed
+		 -> Missing file: $ABS_TEST_DIR/testfs/target-dir/usr/bin -> fixed
 		Repairing corrupt files
-		 -> Hash mismatch for file: $TEST_DIRNAME/testfs/target-dir/usr/lib/os-release -> fixed
-		 -> Hash mismatch for file: $TEST_DIRNAME/testfs/target-dir/usr/share/defaults/swupd/format -> fixed
+		 -> Hash mismatch for file: $ABS_TEST_DIR/testfs/target-dir/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $ABS_TEST_DIR/testfs/target-dir/usr/share/defaults/swupd/format -> fixed
 		Removing extraneous files
 		Inspected 12 files
 		  1 file was missing

--- a/test/functional/repair/repair-ghosted.bats
+++ b/test/functional/repair/repair-ghosted.bats
@@ -9,7 +9,7 @@ test_setup() {
 
 	create_test_environment -e "$TEST_NAME"
 	create_bundle -L -n os-core -f /foo "$TEST_NAME"
-	update_manifest "$WEBDIR"/10/Manifest.os-core file-status /foo .g..
+	update_manifest "$WEB_DIR"/10/Manifest.os-core file-status /foo .g..
 
 }
 
@@ -33,7 +33,7 @@ test_setup() {
 	assert_is_output "$expected_output"
 	# this should exist at the end, despite being marked as "ghosted" in the
 	# Manifest and treated as deleted for parts of swupd-client.
-	assert_file_exists "$TARGETDIR"/foo
+	assert_file_exists "$TARGET_DIR"/foo
 
 }
 #WEIGHT=2

--- a/test/functional/repair/repair-ignore-also-add.bats
+++ b/test/functional/repair/repair-ignore-also-add.bats
@@ -13,9 +13,9 @@ test_setup() {
 	create_bundle -n test-bundle3 -f /bar/test-file3 "$TEST_NAME"
 
 	# Create bundle dependencies
-	add_dependency_to_manifest "$WEBDIR"/10/Manifest.os-core test-bundle1
-	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.os-core test-bundle2
-	add_dependency_to_manifest -o "$WEBDIR"/10/Manifest.test-bundle1 test-bundle3
+	add_dependency_to_manifest "$WEB_DIR"/10/Manifest.os-core test-bundle1
+	add_dependency_to_manifest -o "$WEB_DIR"/10/Manifest.os-core test-bundle2
+	add_dependency_to_manifest -o "$WEB_DIR"/10/Manifest.test-bundle1 test-bundle3
 
 }
 
@@ -45,9 +45,9 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_not_exists "$TARGETDIR"/bar/test-file2
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_not_exists "$TARGET_DIR"/bar/test-file2
 
 }
 
@@ -55,15 +55,15 @@ test_setup() {
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle1"
 	assert_status_is "$SWUPD_OK"
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/bar/test-file3
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/bar/test-file3
 
 	run sudo sh -c "$SWUPD bundle-remove $SWUPD_OPTS test-bundle3"
 	assert_status_is "$SWUPD_OK"
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_not_exists "$TARGETDIR"/bar/test-file3
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_not_exists "$TARGET_DIR"/bar/test-file3
 
 	run sudo sh -c "$SWUPD repair $SWUPD_OPTS"
 
@@ -81,9 +81,9 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_not_exists "$TARGETDIR"/bar/test-file3
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_not_exists "$TARGET_DIR"/bar/test-file3
 
 }
 #WEIGHT=9

--- a/test/functional/repair/repair-json.bats
+++ b/test/functional/repair/repair-json.bats
@@ -10,9 +10,9 @@ test_setup() {
 	create_test_environment -r "$TEST_NAME"
 	create_bundle -L -n test-bundle1 -f /foo/test-file1,/bar/test-file2,/baz "$TEST_NAME"
 	create_bundle -n test-bundle2 -f /test-file3,/test-file4 "$TEST_NAME"
-	sudo rm -f "$TARGETDIR"/foo/test-file1
-	sudo rm -f "$TARGETDIR"/baz
-	sudo touch "$TARGETDIR"/usr/extraneous-file
+	sudo rm -f "$TARGET_DIR"/foo/test-file1
+	sudo rm -f "$TARGET_DIR"/baz
+	sudo touch "$TARGET_DIR"/usr/extraneous-file
 
 }
 
@@ -79,13 +79,13 @@ test_setup() {
 		{ "type" : "progress", "currentStep" : 6, "totalSteps" : 10, "stepCompletion" : 5, "stepDescription" : "add_missing_files" },
 		{ "type" : "progress", "currentStep" : 6, "totalSteps" : 10, "stepCompletion" : 11, "stepDescription" : "add_missing_files" },
 		{ "type" : "info", "msg" : " -> Missing file:" },
-		{ "type" : "info", "msg" : "$PATH_PREFIX/baz" },
+		{ "type" : "info", "msg" : "$ABS_TARGET_DIR/baz" },
 		{ "type" : "info", "msg" : " -> fixed" },
 		{ "type" : "progress", "currentStep" : 6, "totalSteps" : 10, "stepCompletion" : 17, "stepDescription" : "add_missing_files" },
 		{ "type" : "progress", "currentStep" : 6, "totalSteps" : 10, "stepCompletion" : 23, "stepDescription" : "add_missing_files" },
 		{ "type" : "progress", "currentStep" : 6, "totalSteps" : 10, "stepCompletion" : 29, "stepDescription" : "add_missing_files" },
 		{ "type" : "info", "msg" : " -> Missing file:" },
-		{ "type" : "info", "msg" : "$PATH_PREFIX/foo/test-file1" },
+		{ "type" : "info", "msg" : "$ABS_TARGET_DIR/foo/test-file1" },
 		{ "type" : "info", "msg" : " -> fixed" },
 		{ "type" : "progress", "currentStep" : 6, "totalSteps" : 10, "stepCompletion" : 35, "stepDescription" : "add_missing_files" },
 		{ "type" : "progress", "currentStep" : 6, "totalSteps" : 10, "stepCompletion" : 41, "stepDescription" : "add_missing_files" },
@@ -138,15 +138,15 @@ test_setup() {
 		{ "type" : "progress", "currentStep" : 8, "totalSteps" : 10, "stepCompletion" : 94, "stepDescription" : "remove_extraneous_files" },
 		{ "type" : "progress", "currentStep" : 8, "totalSteps" : 10, "stepCompletion" : 100, "stepDescription" : "remove_extraneous_files" },
 		{ "type" : "progress", "currentStep" : 9, "totalSteps" : 10, "stepCompletion" : -1, "stepDescription" : "remove_extra_files" },
-		{ "type" : "info", "msg" : "Removing extra files under $PATH_PREFIX/usr" },
+		{ "type" : "info", "msg" : "Removing extra files under $ABS_TARGET_DIR/usr" },
 		{ "type" : "info", "msg" : " -> Extra file:" },
-		{ "type" : "info", "msg" : "$PATH_PREFIX/usr/share/defaults/swupd/versionurl" },
+		{ "type" : "info", "msg" : "$ABS_TARGET_DIR/usr/share/defaults/swupd/versionurl" },
 		{ "type" : "info", "msg" : " -> deleted" },
 		{ "type" : "info", "msg" : " -> Extra file:" },
-		{ "type" : "info", "msg" : "$PATH_PREFIX/usr/share/defaults/swupd/contenturl" },
+		{ "type" : "info", "msg" : "$ABS_TARGET_DIR/usr/share/defaults/swupd/contenturl" },
 		{ "type" : "info", "msg" : " -> deleted" },
 		{ "type" : "info", "msg" : " -> Extra file:" },
-		{ "type" : "info", "msg" : "$PATH_PREFIX/usr/extraneous-file" },
+		{ "type" : "info", "msg" : "$ABS_TARGET_DIR/usr/extraneous-file" },
 		{ "type" : "info", "msg" : " -> deleted" },
 		{ "type" : "info", "msg" : "Inspected 20 files" },
 		{ "type" : "info", "msg" : "  2 files were missing" },
@@ -158,7 +158,7 @@ test_setup() {
 		{ "type" : "progress", "currentStep" : 9, "totalSteps" : 10, "stepCompletion" : 100, "stepDescription" : "remove_extra_files" },
 		{ "type" : "progress", "currentStep" : 10, "totalSteps" : 10, "stepCompletion" : -1, "stepDescription" : "run_postupdate_scripts" },
 		{ "type" : "info", "msg" : "Calling post-update helper scripts" },
-		{ "type" : "warning", "msg" : "helper script ($PATH_PREFIX/usr/bin/clr-boot-manager) not found, it will be skipped" },
+		{ "type" : "warning", "msg" : "helper script ($ABS_TARGET_DIR/usr/bin/clr-boot-manager) not found, it will be skipped" },
 		{ "type" : "info", "msg" : " Repair successful" },
 		{ "type" : "progress", "currentStep" : 10, "totalSteps" : 10, "stepCompletion" : 100, "stepDescription" : "run_postupdate_scripts" },
 		{ "type" : "end", "section" : "repair", "status" : 0 }

--- a/test/functional/repair/repair-missing-file.bats
+++ b/test/functional/repair/repair-missing-file.bats
@@ -10,7 +10,7 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle -f /foo/test-file1,/bar/test-file2 "$TEST_NAME"
 	# remove a directory and file that are part of the bundle
-	sudo rm -rf "$TARGETDIR"/foo/test-file1
+	sudo rm -rf "$TARGET_DIR"/foo/test-file1
 
 }
 
@@ -38,8 +38,8 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/bar/test-file2
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
 
 }
 #WEIGHT=2

--- a/test/functional/repair/repair-no-disk-space.bats
+++ b/test/functional/repair/repair-no-disk-space.bats
@@ -19,12 +19,12 @@ test_setup() {
 
 	# create a file with a size of 20 MB and create an
 	# update for the bundle that uses that file
-	file1=/test-file:"$(create_file "$WEBDIR"/10/files 20MB)"
+	file1=/test-file:"$(create_file "$WEB_DIR"/10/files 20MB)"
 	update_bundle "$TEST_NAME" test-bundle --add "$file1"
 
 	# create the state version dirs ahead of time
-	sudo mkdir -p "$STATEDIR_MANIFEST"/10
-	sudo mkdir -p "$STATEDIR_MANIFEST"/20
+	sudo mkdir -p "$ABS_MANIFEST_DIR"/10
+	sudo mkdir -p "$ABS_MANIFEST_DIR"/20
 
 }
 
@@ -41,8 +41,8 @@ test_setup() {
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
 		Diagnosing version 20
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/20/Manifest.MoM.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/20/Manifest.MoM.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Error: Failed to retrieve 20 MoM manifest
 		Error: Unable to download/verify 20 Manifest.MoM
 		Repair did not fully succeed
@@ -59,11 +59,11 @@ test_setup() {
 
 	# let's replace the bundle Manifest tar with a much larger file that will exceed
 	# the available space on disk
-	sudo rm "$WEBDIR"/20/Manifest.test-bundle
-	sudo rm "$WEBDIR"/20/Manifest.test-bundle.tar
-	big_manifest=$(create_file "$WEBDIR"/20 15MB)
-	sudo mv "$big_manifest" "$WEBDIR"/20/Manifest.test-bundle
-	sudo mv "$big_manifest".tar "$WEBDIR"/20/Manifest.test-bundle.tar
+	sudo rm "$WEB_DIR"/20/Manifest.test-bundle
+	sudo rm "$WEB_DIR"/20/Manifest.test-bundle.tar
+	big_manifest=$(create_file "$WEB_DIR"/20 15MB)
+	sudo mv "$big_manifest" "$WEB_DIR"/20/Manifest.test-bundle
+	sudo mv "$big_manifest".tar "$WEB_DIR"/20/Manifest.test-bundle.tar
 
 	run sudo sh -c "timeout 30 $SWUPD repair --force --version=20 $SWUPD_OPTS"
 
@@ -72,8 +72,8 @@ test_setup() {
 		Diagnosing version 20
 		Warning: The --force option is specified; ignoring version mismatch for repair
 		Downloading missing manifests...
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/20/Manifest.test-bundle.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/20/Manifest.test-bundle.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Error: Failed to retrieve 20 test-bundle manifest
 		Error: Unable to download manifest test-bundle version 20, exiting now
 		Repair did not fully succeed
@@ -88,7 +88,7 @@ test_setup() {
 	# When verifying a system and we run out of disk space while downloading the
 	# bundle manifest we should not retry the download since it will fail for sure
 
-	fhash=$(get_hash_from_manifest "$WEBDIR"/20/Manifest.test-bundle /test-file)
+	fhash=$(get_hash_from_manifest "$WEB_DIR"/20/Manifest.test-bundle /test-file)
 
 	run sudo sh -c "timeout 30 $SWUPD repair --force --version=20 $SWUPD_OPTS"
 
@@ -100,8 +100,8 @@ test_setup() {
 		Checking for corrupt files
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/20/files/$fhash.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/20/files/$fhash.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Error: Unable to download necessary files for this OS release
 		Repair did not fully succeed
 	EOM

--- a/test/functional/repair/repair-path.bats
+++ b/test/functional/repair/repair-path.bats
@@ -17,12 +17,12 @@ test_setup() {
 	update_bundle "$TEST_NAME" test-bundle1 --add /bar/bat/file_5
 	set_current_version "$TEST_NAME" 20
 	# adding an untracked files into an untracked directory (/bat)
-	sudo mkdir "$TARGETDIR"/bat
-	sudo touch "$TARGETDIR"/bat/untracked_file1
+	sudo mkdir "$TARGET_DIR"/bat
+	sudo touch "$TARGET_DIR"/bat/untracked_file1
 	# adding an untracked file into tracked directory (/bar)
-	sudo touch "$TARGETDIR"/bar/untracked_file2
+	sudo touch "$TARGET_DIR"/bar/untracked_file2
 	# adding an untracked file into /usr
-	sudo touch "$TARGETDIR"/usr/untracked_file3
+	sudo touch "$TARGET_DIR"/usr/untracked_file3
 
 }
 
@@ -43,7 +43,7 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/baz/testdir/file_3 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/baz/testdir/file_3 -> fixed
 		Repairing corrupt files
 		Removing extraneous files
 		Inspected 1 file
@@ -72,7 +72,7 @@ test_setup() {
 		Downloading missing manifests...
 		Limiting diagnose to the following file:
 		 - /foo/file_1
-		Removing extra files under $PATH_PREFIX/foo/file_1
+		Removing extra files under $ABS_TARGET_DIR/foo/file_1
 		Inspected 0 files
 		Calling post-update helper scripts
 		Repair successful
@@ -88,7 +88,7 @@ test_setup() {
 	# file/directory specified by the user. If a file was specified to be
 	# verified, but part of its path is missing or corrput, fix it anyway
 
-	sudo rm -rf "$PATH_PREFIX"/baz
+	sudo rm -rf "$ABS_TARGET_DIR"/baz
 
 	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --file /baz/testdir/file_3"
 
@@ -102,7 +102,7 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/baz/testdir/file_3 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/baz/testdir/file_3 -> fixed
 		Repairing corrupt files
 		Removing extraneous files
 		Inspected 1 file
@@ -134,12 +134,12 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/bar/bat -> fixed
-		 -> Missing file: $PATH_PREFIX/bar/bat/file_5 -> fixed
-		 -> Missing file: $PATH_PREFIX/bar/file_4 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/bar/bat -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/bar/bat/file_5 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/bar/file_4 -> fixed
 		Repairing corrupt files
 		Removing extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/bar/file_2 -> deleted
+		 -> File that should be deleted: $ABS_TARGET_DIR/bar/file_2 -> deleted
 		Inspected 5 files
 		  3 files were missing
 		    3 of 3 missing files were replaced
@@ -173,14 +173,14 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/bar/bat -> fixed
-		 -> Missing file: $PATH_PREFIX/bar/bat/file_5 -> fixed
-		 -> Missing file: $PATH_PREFIX/bar/file_4 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/bar/bat -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/bar/bat/file_5 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/bar/file_4 -> fixed
 		Repairing corrupt files
 		Removing extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/bar/file_2 -> deleted
-		Removing extra files under $PATH_PREFIX/bar
-		 -> Extra file: $PATH_PREFIX/bar/untracked_file2 -> deleted
+		 -> File that should be deleted: $ABS_TARGET_DIR/bar/file_2 -> deleted
+		Removing extra files under $ABS_TARGET_DIR/bar
+		 -> Extra file: $ABS_TARGET_DIR/bar/untracked_file2 -> deleted
 		Inspected 6 files
 		  3 files were missing
 		    3 of 3 missing files were replaced
@@ -213,16 +213,16 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $PATH_PREFIX/bar/bat -> fixed
-		 -> Missing file: $PATH_PREFIX/bar/bat/file_5 -> fixed
-		 -> Missing file: $PATH_PREFIX/bar/file_4 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/bar/bat -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/bar/bat/file_5 -> fixed
+		 -> Missing file: $ABS_TARGET_DIR/bar/file_4 -> fixed
 		Repairing corrupt files
 		Removing extraneous files
-		 -> File that should be deleted: $PATH_PREFIX/bar/file_2 -> deleted
-		Removing extra files under $PATH_PREFIX/usr
-		 -> Extra file: $PATH_PREFIX/usr/untracked_file3 -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/versionurl -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/contenturl -> deleted
+		 -> File that should be deleted: $ABS_TARGET_DIR/bar/file_2 -> deleted
+		Removing extra files under $ABS_TARGET_DIR/usr
+		 -> Extra file: $ABS_TARGET_DIR/usr/untracked_file3 -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/versionurl -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/contenturl -> deleted
 		Inspected 8 files
 		  3 files were missing
 		    3 of 3 missing files were replaced
@@ -244,8 +244,8 @@ test_setup() {
 	# look in the specified path and only for files that are part of the specified
 	# bundle
 
-	write_to_protected_file -a "$PATH_PREFIX"/usr/share/clear/bundles/os-core "corrupting the file"
-	write_to_protected_file -a "$PATH_PREFIX"/usr/share/clear/bundles/test-bundle1 "corrupting the file"
+	write_to_protected_file -a "$ABS_TARGET_DIR"/usr/share/clear/bundles/os-core "corrupting the file"
+	write_to_protected_file -a "$ABS_TARGET_DIR"/usr/share/clear/bundles/test-bundle1 "corrupting the file"
 
 	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --bundle test-bundle1 --file /usr/share/clear/bundles"
 
@@ -262,8 +262,8 @@ test_setup() {
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/usr/share/clear/bundles/os-core -> fixed
-		 -> Hash mismatch for file: $PATH_PREFIX/usr/share/clear/bundles/test-bundle1 -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/usr/share/clear/bundles/os-core -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/usr/share/clear/bundles/test-bundle1 -> fixed
 		Removing extraneous files
 		Inspected 3 files
 		  2 files did not match

--- a/test/functional/repair/repair-picky-downgrade.bats
+++ b/test/functional/repair/repair-picky-downgrade.bats
@@ -30,11 +30,11 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/foo/file_2
-	assert_file_exists "$TARGETDIR"/usr/foo/file_3
-	assert_file_exists "$TARGETDIR"/bar/file_4
-	assert_file_exists "$TARGETDIR"/bar/file_5
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/usr/foo/file_2
+	assert_file_exists "$TARGET_DIR"/usr/foo/file_3
+	assert_file_exists "$TARGET_DIR"/bar/file_4
+	assert_file_exists "$TARGET_DIR"/bar/file_5
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
 
 }
 
@@ -54,15 +54,15 @@ test_setup() {
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/usr/lib/os-release -> fixed
 		Removing extraneous files
-		Removing extra files under $PATH_PREFIX/usr
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/versionurl -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/contenturl -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/share/clear/bundles/test-bundle2 -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/foo/file_3 -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/foo/file_2 -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/foo/ -> deleted
+		Removing extra files under $ABS_TARGET_DIR/usr
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/versionurl -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/contenturl -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/clear/bundles/test-bundle2 -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/file_3 -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/file_2 -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/ -> deleted
 		Inspected 19 files
 		  1 file did not match
 		    1 of 1 files were repaired
@@ -75,12 +75,12 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/usr/foo/file_2
-	assert_file_not_exists "$TARGETDIR"/usr/foo/file_3
-	assert_file_not_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_not_exists "$TARGET_DIR"/usr/foo/file_2
+	assert_file_not_exists "$TARGET_DIR"/usr/foo/file_3
+	assert_file_not_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
 	# these files should still exist in the target system since they were not in /usr
-	assert_file_exists "$TARGETDIR"/bar/file_4
-	assert_file_exists "$TARGETDIR"/bar/file_5
+	assert_file_exists "$TARGET_DIR"/bar/file_4
+	assert_file_exists "$TARGET_DIR"/bar/file_5
 
 }
 
@@ -100,12 +100,12 @@ test_setup() {
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
 		Repairing corrupt files
-		 -> Hash mismatch for file: $PATH_PREFIX/usr/lib/os-release -> fixed
+		 -> Hash mismatch for file: $ABS_TARGET_DIR/usr/lib/os-release -> fixed
 		Removing extraneous files
-		Removing extra files under $PATH_PREFIX/bar
-		 -> Extra file: $PATH_PREFIX/bar/file_5 -> deleted
-		 -> Extra file: $PATH_PREFIX/bar/file_4 -> deleted
-		 -> Extra file: $PATH_PREFIX/bar/ -> deleted
+		Removing extra files under $ABS_TARGET_DIR/bar
+		 -> Extra file: $ABS_TARGET_DIR/bar/file_5 -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/bar/file_4 -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/bar/ -> deleted
 		Inspected 16 files
 		  1 file did not match
 		    1 of 1 files were repaired
@@ -118,13 +118,13 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/bar/file_4
-	assert_file_not_exists "$TARGETDIR"/bar/file_5
+	assert_file_not_exists "$TARGET_DIR"/bar/file_4
+	assert_file_not_exists "$TARGET_DIR"/bar/file_5
 	# these files should still exist in the target system since we specified /bar
 	# as the dir to look into
-	assert_file_exists "$TARGETDIR"/usr/foo/file_2
-	assert_file_exists "$TARGETDIR"/usr/foo/file_3
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle2
+	assert_file_exists "$TARGET_DIR"/usr/foo/file_2
+	assert_file_exists "$TARGET_DIR"/usr/foo/file_3
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle2
 
 }
 #WEIGHT=12

--- a/test/functional/repair/repair-picky-ghosted-missing.bats
+++ b/test/functional/repair/repair-picky-ghosted-missing.bats
@@ -9,9 +9,9 @@ test_setup() {
 
 	create_test_environment -r "$TEST_NAME"
 	create_bundle -L -n test-bundle -f /usr/foo -d/usr/share/clear/bundles "$TEST_NAME"
-	update_manifest "$WEBDIR"/10/Manifest.test-bundle file-status /usr/foo .g..
+	update_manifest "$WEB_DIR"/10/Manifest.test-bundle file-status /usr/foo .g..
 	# since the files must have been installed by the -L option, remove /usr/foo
-	sudo rm -f "$TARGETDIR"/usr/foo
+	sudo rm -f "$TARGET_DIR"/usr/foo
 
 }
 
@@ -27,9 +27,9 @@ test_setup() {
 		Adding any missing files
 		Repairing corrupt files
 		Removing extraneous files
-		Removing extra files under $PATH_PREFIX/usr
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/versionurl -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/contenturl -> deleted
+		Removing extra files under $ABS_TARGET_DIR/usr
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/versionurl -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/contenturl -> deleted
 		Inspected 15 files
 		  2 files found which should be deleted
 		    2 of 2 files were deleted
@@ -41,7 +41,7 @@ test_setup() {
 	assert_is_output "$expected_output"
 	# this should not exist at the end, despite being marked in the Manifest as
 	# "ghosted". In this case ghosted files should be ignored.
-	assert_file_not_exists "$TARGETDIR"/usr/foo
+	assert_file_not_exists "$TARGET_DIR"/usr/foo
 
 }
 #WEIGHT=4

--- a/test/functional/repair/repair-picky-ghosted.bats
+++ b/test/functional/repair/repair-picky-ghosted.bats
@@ -9,7 +9,7 @@ test_setup() {
 
 	create_test_environment -r "$TEST_NAME"
 	create_bundle -L -n test-bundle -f /usr/foo -d/usr/share/clear/bundles "$TEST_NAME"
-	update_manifest "$WEBDIR"/10/Manifest.test-bundle file-status /usr/foo .g..
+	update_manifest "$WEB_DIR"/10/Manifest.test-bundle file-status /usr/foo .g..
 
 }
 
@@ -25,9 +25,9 @@ test_setup() {
 		Adding any missing files
 		Repairing corrupt files
 		Removing extraneous files
-		Removing extra files under $PATH_PREFIX/usr
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/versionurl -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/contenturl -> deleted
+		Removing extra files under $ABS_TARGET_DIR/usr
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/versionurl -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/contenturl -> deleted
 		Inspected 15 files
 		  2 files found which should be deleted
 		    2 of 2 files were deleted
@@ -40,7 +40,7 @@ test_setup() {
 	# this should exist at the end, despite being marked as "ghosted" in the
 	# Manifest. With the ghosted file existing under /usr this test is to make
 	# sure the ghosted files aren't removed during the --picky flow.
-	assert_file_exists "$TARGETDIR"/usr/foo
+	assert_file_exists "$TARGET_DIR"/usr/foo
 
 }
 #WEIGHT=4

--- a/test/functional/repair/repair-picky.bats
+++ b/test/functional/repair/repair-picky.bats
@@ -9,11 +9,11 @@ test_setup() {
 
 	create_test_environment -r "$TEST_NAME"
 	# create some extra files in /usr
-	sudo touch "$TARGETDIR"/usr/file1
-	sudo mkdir -p "$TARGETDIR"/usr/foo/bar
-	sudo touch "$TARGETDIR"/usr/foo/bar/file2
+	sudo touch "$TARGET_DIR"/usr/file1
+	sudo mkdir -p "$TARGET_DIR"/usr/foo/bar
+	sudo touch "$TARGET_DIR"/usr/foo/bar/file2
 	# create extra file outside of /usr (should be ignored by picky)
-	sudo touch "$TARGETDIR"/file3
+	sudo touch "$TARGET_DIR"/file3
 
 }
 
@@ -32,13 +32,13 @@ test_setup() {
 		Adding any missing files
 		Repairing corrupt files
 		Removing extraneous files
-		Removing extra files under $PATH_PREFIX/usr
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/versionurl -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/contenturl -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/foo/bar/file2 -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/foo/bar/ -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/foo/ -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/file1 -> deleted
+		Removing extra files under $ABS_TARGET_DIR/usr
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/versionurl -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/contenturl -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/bar/file2 -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/bar/ -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/ -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/file1 -> deleted
 		Inspected 17 files
 		  6 files found which should be deleted
 		    6 of 6 files were deleted
@@ -48,8 +48,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/usr/file1
-	assert_file_not_exists "$TARGETDIR"/usr/foo/bar/file2
+	assert_file_not_exists "$TARGET_DIR"/usr/file1
+	assert_file_not_exists "$TARGET_DIR"/usr/foo/bar/file2
 
 }
 
@@ -63,13 +63,13 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Diagnosing version 10
 		Downloading missing manifests...
-		Removing extra files under $PATH_PREFIX/usr
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/versionurl -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/share/defaults/swupd/contenturl -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/foo/bar/file2 -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/foo/bar/ -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/foo/ -> deleted
-		 -> Extra file: $PATH_PREFIX/usr/file1 -> deleted
+		Removing extra files under $ABS_TARGET_DIR/usr
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/versionurl -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/share/defaults/swupd/contenturl -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/bar/file2 -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/bar/ -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/foo/ -> deleted
+		 -> Extra file: $ABS_TARGET_DIR/usr/file1 -> deleted
 		Inspected 6 files
 		  6 files found which should be deleted
 		    6 of 6 files were deleted
@@ -79,8 +79,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/usr/file1
-	assert_file_not_exists "$TARGETDIR"/usr/foo/bar/file2
+	assert_file_not_exists "$TARGET_DIR"/usr/file1
+	assert_file_not_exists "$TARGET_DIR"/usr/foo/bar/file2
 
 }
 #WEIGHT=4

--- a/test/functional/repair/repair-skip-scripts.bats
+++ b/test/functional/repair/repair-skip-scripts.bats
@@ -35,7 +35,7 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 	# this should exist at the end, even if the scripts are not run
-	assert_file_exists "$TARGETDIR"/usr/lib/kernel/testfile
+	assert_file_exists "$TARGET_DIR"/usr/lib/kernel/testfile
 
 }
 #WEIGHT=4

--- a/test/functional/repair/repair-type-changed-system.bats
+++ b/test/functional/repair/repair-type-changed-system.bats
@@ -41,73 +41,73 @@ test_setup() {
 	# Corrupted files could have a type different from the original
 	# and repair should be able to repair them.
 
-	sudo rm -rf "$TARGETDIR"/file_*
-	sudo rm -rf "$TARGETDIR"/dir_*
-	sudo rm -rf "$TARGETDIR"/symlink_*
-	sudo mkdir "$TARGETDIR"/other
-	sudo touch "$TARGETDIR"/other/my_file
+	sudo rm -rf "$TARGET_DIR"/file_*
+	sudo rm -rf "$TARGET_DIR"/dir_*
+	sudo rm -rf "$TARGET_DIR"/symlink_*
+	sudo mkdir "$TARGET_DIR"/other
+	sudo touch "$TARGET_DIR"/other/my_file
 
-	sudo ln -s "$TARGETDIR"/other "$TARGETDIR"/dir_to_symlink_dir
-	sudo ln -s "$TARGETDIR"/other/my_file "$TARGETDIR"/dir_to_symlink
-	sudo ln -s broken "$TARGETDIR"/dir_to_symlink_broken
-	sudo touch "$TARGETDIR"/dir_to_file
+	sudo ln -s "$TARGET_DIR"/other "$TARGET_DIR"/dir_to_symlink_dir
+	sudo ln -s "$TARGET_DIR"/other/my_file "$TARGET_DIR"/dir_to_symlink
+	sudo ln -s broken "$TARGET_DIR"/dir_to_symlink_broken
+	sudo touch "$TARGET_DIR"/dir_to_file
 
-	sudo mkdir -p "$TARGETDIR"/file_to_dir/dir
-	sudo touch "$TARGETDIR"/file_to_dir/dir/file
-	sudo ln -s "$TARGETDIR"/other "$TARGETDIR"/file_to_symlink_dir
-	sudo ln -s "$TARGETDIR"/other/my_file "$TARGETDIR"/file_to_symlink
-	sudo ln -s broken "$TARGETDIR"/file_to_symlink_broken
+	sudo mkdir -p "$TARGET_DIR"/file_to_dir/dir
+	sudo touch "$TARGET_DIR"/file_to_dir/dir/file
+	sudo ln -s "$TARGET_DIR"/other "$TARGET_DIR"/file_to_symlink_dir
+	sudo ln -s "$TARGET_DIR"/other/my_file "$TARGET_DIR"/file_to_symlink
+	sudo ln -s broken "$TARGET_DIR"/file_to_symlink_broken
 
-	sudo touch "$TARGETDIR"/symlink_to_file
-	sudo mkdir -p "$TARGETDIR"/symlink_to_dir/dir/
-	sudo touch "$TARGETDIR"/symlink_to_dir/dir/file
-	sudo ln -s "$TARGETDIR"/other "$TARGETDIR"/symlink_to_symlink
+	sudo touch "$TARGET_DIR"/symlink_to_file
+	sudo mkdir -p "$TARGET_DIR"/symlink_to_dir/dir/
+	sudo touch "$TARGET_DIR"/symlink_to_dir/dir/file
+	sudo ln -s "$TARGET_DIR"/other "$TARGET_DIR"/symlink_to_symlink
 
 	run sudo sh -c "$SWUPD repair $SWUPD_OPTS --quiet"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		$PATH_PREFIX/dir_removed -> fixed
-		$PATH_PREFIX/dir_to_file/test -> fixed
-		$PATH_PREFIX/dir_to_symlink/test -> fixed
-		$PATH_PREFIX/dir_to_symlink_broken/test -> fixed
-		$PATH_PREFIX/dir_to_symlink_dir/test -> fixed
-		$PATH_PREFIX/file_removed -> fixed
-		$PATH_PREFIX/file_to_dir -> fixed
-		$PATH_PREFIX/file_to_symlink -> fixed
-		$PATH_PREFIX/file_to_symlink_broken -> fixed
-		$PATH_PREFIX/file_to_symlink_dir -> fixed
-		$PATH_PREFIX/symlink_to_dir -> fixed
-		$PATH_PREFIX/symlink_to_file -> fixed
-		$PATH_PREFIX/symlink_to_symlink -> fixed
+		$ABS_TARGET_DIR/dir_removed -> fixed
+		$ABS_TARGET_DIR/dir_to_file/test -> fixed
+		$ABS_TARGET_DIR/dir_to_symlink/test -> fixed
+		$ABS_TARGET_DIR/dir_to_symlink_broken/test -> fixed
+		$ABS_TARGET_DIR/dir_to_symlink_dir/test -> fixed
+		$ABS_TARGET_DIR/file_removed -> fixed
+		$ABS_TARGET_DIR/file_to_dir -> fixed
+		$ABS_TARGET_DIR/file_to_symlink -> fixed
+		$ABS_TARGET_DIR/file_to_symlink_broken -> fixed
+		$ABS_TARGET_DIR/file_to_symlink_dir -> fixed
+		$ABS_TARGET_DIR/symlink_to_dir -> fixed
+		$ABS_TARGET_DIR/symlink_to_file -> fixed
+		$ABS_TARGET_DIR/symlink_to_symlink -> fixed
 	EOM
 	)
 	assert_is_output "$expected_output"
 
-	assert_dir_exists "$TARGETDIR"/other
-	assert_regular_file_exists "$TARGETDIR"/other/my_file
+	assert_dir_exists "$TARGET_DIR"/other
+	assert_regular_file_exists "$TARGET_DIR"/other/my_file
 
-	assert_dir_exists "$TARGETDIR"/dir_removed
-	assert_dir_exists "$TARGETDIR"/dir_to_file
-	assert_dir_exists "$TARGETDIR"/dir_to_symlink
-	assert_dir_exists "$TARGETDIR"/dir_to_symlink_dir
-	assert_dir_exists "$TARGETDIR"/dir_to_symlink_broken
+	assert_dir_exists "$TARGET_DIR"/dir_removed
+	assert_dir_exists "$TARGET_DIR"/dir_to_file
+	assert_dir_exists "$TARGET_DIR"/dir_to_symlink
+	assert_dir_exists "$TARGET_DIR"/dir_to_symlink_dir
+	assert_dir_exists "$TARGET_DIR"/dir_to_symlink_broken
 
-	assert_regular_file_exists "$TARGETDIR"/file_removed
-	assert_regular_file_exists "$TARGETDIR"/file_to_dir
-	assert_regular_file_exists "$TARGETDIR"/file_to_symlink
-	assert_regular_file_exists "$TARGETDIR"/file_to_symlink_dir
-	assert_regular_file_exists "$TARGETDIR"/file_to_symlink_broken
+	assert_regular_file_exists "$TARGET_DIR"/file_removed
+	assert_regular_file_exists "$TARGET_DIR"/file_to_dir
+	assert_regular_file_exists "$TARGET_DIR"/file_to_symlink
+	assert_regular_file_exists "$TARGET_DIR"/file_to_symlink_dir
+	assert_regular_file_exists "$TARGET_DIR"/file_to_symlink_broken
 
-	assert_symlink_exists "$TARGETDIR"/symlink_to_file
-	run stat --printf  "%N" "$TARGETDIR"/symlink_to_file
-	assert_is_output "'$TARGETDIR/symlink_to_file' -> 'broken'"
+	assert_symlink_exists "$TARGET_DIR"/symlink_to_file
+	run stat --printf  "%N" "$TARGET_DIR"/symlink_to_file
+	assert_is_output "'$TARGET_DIR/symlink_to_file' -> 'broken'"
 
-	assert_symlink_exists "$TARGETDIR"/symlink_to_dir
-	run stat --printf  "%N" "$TARGETDIR"/symlink_to_dir
-	assert_is_output "'$TARGETDIR/symlink_to_dir' -> 'broken'"
+	assert_symlink_exists "$TARGET_DIR"/symlink_to_dir
+	run stat --printf  "%N" "$TARGET_DIR"/symlink_to_dir
+	assert_is_output "'$TARGET_DIR/symlink_to_dir' -> 'broken'"
 
-	assert_symlink_exists "$TARGETDIR"/symlink_to_symlink
-	run stat --printf  "%N" "$TARGETDIR"/symlink_to_symlink
-	assert_is_output "'$TARGETDIR/symlink_to_symlink' -> 'broken'"
+	assert_symlink_exists "$TARGET_DIR"/symlink_to_symlink
+	run stat --printf  "%N" "$TARGET_DIR"/symlink_to_symlink
+	assert_is_output "'$TARGET_DIR/symlink_to_symlink' -> 'broken'"
 }
 #WEIGHT=6

--- a/test/functional/repair/repair-version-mismatch-overdrive.bats
+++ b/test/functional/repair/repair-version-mismatch-overdrive.bats
@@ -13,7 +13,7 @@ test_setup() {
 	update_bundle "$TEST_NAME" os-core --header-only
 	set_current_version "$TEST_NAME" 20
 	# remove /usr/bin so it is missing in the target system
-	sudo rm -rf "$TARGETDIR"/usr/bin
+	sudo rm -rf "$TARGET_DIR"/usr/bin
 
 }
 
@@ -30,7 +30,7 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $TEST_DIRNAME/testfs/target-dir/usr/bin -> fixed
+		 -> Missing file: $ABS_TEST_DIR/testfs/target-dir/usr/bin -> fixed
 		Repairing corrupt files
 		Removing extraneous files
 		Inspected 3 files

--- a/test/functional/search/search-no-disk-space.bats
+++ b/test/functional/search/search-no-disk-space.bats
@@ -15,7 +15,7 @@ test_setup() {
 	create_bundle -n test-bundle2 -f /file_2 "$TEST_NAME"
 
 	# create the state version dirs ahead of time
-	sudo mkdir -p "$STATEDIR_MANIFEST"/10
+	sudo mkdir -p "$ABS_MANIFEST_DIR"/10
 
 }
 
@@ -31,8 +31,8 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/10/Manifest.MoM.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/10/Manifest.MoM.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Error: Failed to retrieve 10 MoM manifest
 		Error: Cannot load official manifest MoM for version 10
 	EOM
@@ -48,19 +48,19 @@ test_setup() {
 
 	# let's replace the Manifest tar from the bundle with a much larger file that will exceed
 	# the available space on disk
-	sudo rm "$WEBDIR"/10/Manifest.test-bundle1
-	sudo rm "$WEBDIR"/10/Manifest.test-bundle1.tar
-	big_manifest=$(create_file "$WEBDIR"/10 3MB)
-	sudo mv "$big_manifest" "$WEBDIR"/10/Manifest.test-bundle1
-	sudo mv "$big_manifest".tar "$WEBDIR"/10/Manifest.test-bundle1.tar
+	sudo rm "$WEB_DIR"/10/Manifest.test-bundle1
+	sudo rm "$WEB_DIR"/10/Manifest.test-bundle1.tar
+	big_manifest=$(create_file "$WEB_DIR"/10 3MB)
+	sudo mv "$big_manifest" "$WEB_DIR"/10/Manifest.test-bundle1
+	sudo mv "$big_manifest".tar "$WEB_DIR"/10/Manifest.test-bundle1.tar
 
 	run sudo sh -c "$SWUPD search-file $SWUPD_OPTS test-bundle2"
 
 	assert_status_is "$SWUPD_RECURSE_MANIFEST"
 	expected_output=$(cat <<-EOM
 		Downloading all Clear Linux manifests
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/10/Manifest.test-bundle1.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state\\?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/10/Manifest.test-bundle1.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
 		Error: Failed to retrieve 10 test-bundle1 manifest
 		Error: Cannot load test-bundle1 manifest for version 10
 		Warning: Failed to download 1 manifest - search results will be partial

--- a/test/functional/search/search-sort.bats
+++ b/test/functional/search/search-sort.bats
@@ -9,9 +9,9 @@ global_setup() {
 
 	create_test_environment "$TEST_NAME"
 
-	small=/small-file:"$(create_file "$WEBDIR"/10/files 1MB)"
-	medium=/medium-file:"$(create_file "$WEBDIR"/10/files 2MB)"
-	large=/large-file:"$(create_file "$WEBDIR"/10/files 3MB)"
+	small=/small-file:"$(create_file "$WEB_DIR"/10/files 1MB)"
+	medium=/medium-file:"$(create_file "$WEB_DIR"/10/files 2MB)"
+	large=/large-file:"$(create_file "$WEB_DIR"/10/files 3MB)"
 
 	create_bundle -n alfa-zulu -f /yankee/alfalfa,/alfaromeo/echo,/foo/quebec,/foo/alfa,/foo/delta,/bar/alfa,"$small" "$TEST_NAME"
 	create_bundle -n victor -f /yankee,/bar/alfa,/alfa/zulu,/papa,"$large" "$TEST_NAME"

--- a/test/functional/signature/cert-chain.bats
+++ b/test/functional/signature/cert-chain.bats
@@ -19,9 +19,9 @@ test_setup() {
 			# Create a self signed certificate for intermediate
 			openssl req -days 1 -new -x509 -key "$TEST_NAME/intermediate.key" -out "$TEST_NAME/intermediate_self_signed.pem" -set_serial 0x1 -subj '/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=intermediate'
 			# Sign the MoM with intermediate cert
-			openssl smime -sign -binary -in "$WEBDIR"/10/Manifest.MoM -signer "$TEST_NAME/intermediate.pem" -inkey "$TEST_NAME/intermediate.key" -out "$WEBDIR"/10/Manifest.MoM.sig -outform DER
+			openssl smime -sign -binary -in "$WEB_DIR"/10/Manifest.MoM -signer "$TEST_NAME/intermediate.pem" -inkey "$TEST_NAME/intermediate.key" -out "$WEB_DIR"/10/Manifest.MoM.sig -outform DER
 			# Sign the MoM with self signed intermediate cert
-			openssl smime -sign -binary -in "$WEBDIR"/10/Manifest.MoM -signer "$TEST_NAME/intermediate_self_signed.pem" -inkey "$TEST_NAME/intermediate.key" -out "$WEBDIR"/10/Manifest.MoM.sig_self_signed -outform DER
+			openssl smime -sign -binary -in "$WEB_DIR"/10/Manifest.MoM -signer "$TEST_NAME/intermediate_self_signed.pem" -inkey "$TEST_NAME/intermediate.key" -out "$WEB_DIR"/10/Manifest.MoM.sig_self_signed -outform DER
 			# Create a certificate store with both root and self signed intermediate
 			cat "$TEST_NAME/root.pem" > "$TEST_NAME/trust.pem"
 			cat "$TEST_NAME/intermediate_self_signed.pem" >> "$TEST_NAME/trust.pem"
@@ -47,7 +47,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/test-file
+	assert_file_not_exists "$TARGET_DIR"/test-file
 
 }
 
@@ -67,14 +67,14 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/test-file
+	assert_file_exists "$TARGET_DIR"/test-file
 
 }
 
 @test "SIG012: MoM signed with self-signed cert, but using root to validate" {
 
 	# replace sig file to one signed with intermediate_self_signed.pem
-	sudo sh -c "cp $WEBDIR/10/Manifest.MoM.sig_self_signed $WEBDIR/10/Manifest.MoM.sig"
+	sudo sh -c "cp $WEB_DIR/10/Manifest.MoM.sig_self_signed $WEB_DIR/10/Manifest.MoM.sig"
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS_NO_CERT -C $TEST_NAME/root.pem test-bundle"
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
@@ -88,14 +88,14 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/test-file
+	assert_file_not_exists "$TARGET_DIR"/test-file
 
 }
 
 @test "SIG013: MoM signed with self_signed and using correct cert to validate" {
 
 	# replace sig file to one signed with intermediate_self_signed.pem
-	sudo sh -c "cp $WEBDIR/10/Manifest.MoM.sig_self_signed $WEBDIR/10/Manifest.MoM.sig"
+	sudo sh -c "cp $WEB_DIR/10/Manifest.MoM.sig_self_signed $WEB_DIR/10/Manifest.MoM.sig"
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS_NO_CERT -C $TEST_NAME/intermediate_self_signed.pem test-bundle"
 
 	assert_status_is "$SWUPD_OK"
@@ -110,7 +110,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/test-file
+	assert_file_exists "$TARGET_DIR"/test-file
 
 }
 
@@ -129,7 +129,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/test-file
+	assert_file_not_exists "$TARGET_DIR"/test-file
 
 }
 
@@ -149,14 +149,14 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/test-file
+	assert_file_exists "$TARGET_DIR"/test-file
 
 }
 
 @test "SIG016: MoM is signed with self signed certificate and trust store is used" {
 
 	# replace signature with self signed certificate
-	sudo sh -c "cp $WEBDIR/10/Manifest.MoM.sig_self_signed $WEBDIR/10/Manifest.MoM.sig"
+	sudo sh -c "cp $WEB_DIR/10/Manifest.MoM.sig_self_signed $WEB_DIR/10/Manifest.MoM.sig"
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS_NO_CERT -C $TEST_NAME/trust.pem test-bundle"
 
 	assert_status_is "$SWUPD_OK"
@@ -171,7 +171,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/test-file
+	assert_file_exists "$TARGET_DIR"/test-file
 
 }
 #WEIGHT=17

--- a/test/functional/signature/corrupted-certificate.bats
+++ b/test/functional/signature/corrupted-certificate.bats
@@ -24,7 +24,7 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/test-file
+	assert_file_not_exists "$TARGET_DIR"/test-file
 
 }
 
@@ -35,7 +35,7 @@ test_setup() {
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 	Warning: The --nosigcheck flag was used and this compromises the system security
-	Warning: THE SIGNATURE OF file://$TEST_DIRNAME/web-dir/10/Manifest.MoM WILL NOT BE VERIFIED
+	Warning: THE SIGNATURE OF file://$ABS_TEST_DIR/web-dir/10/Manifest.MoM WILL NOT BE VERIFIED
 		Loading required manifests...
 		No packs need to be downloaded
 		Validate downloaded files
@@ -46,7 +46,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/test-file
+	assert_file_exists "$TARGET_DIR"/test-file
 
 }
 #WEIGHT=4

--- a/test/functional/signature/corrupted-signature.bats
+++ b/test/functional/signature/corrupted-signature.bats
@@ -10,7 +10,7 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 	create_bundle -n test-bundle -f /test-file "$TEST_NAME"
 
-	write_to_protected_file "$WEBDIR/10/Manifest.MoM.sig" "bad signature"
+	write_to_protected_file "$WEB_DIR/10/Manifest.MoM.sig" "bad signature"
 
 }
 
@@ -29,7 +29,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/test-file
+	assert_file_not_exists "$TARGET_DIR"/test-file
 
 }
 
@@ -40,7 +40,7 @@ test_setup() {
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Warning: The --nosigcheck flag was used and this compromises the system security
-		Warning: THE SIGNATURE OF file://$TEST_DIRNAME/web-dir/10/Manifest.MoM WILL NOT BE VERIFIED
+		Warning: THE SIGNATURE OF file://$ABS_TEST_DIR/web-dir/10/Manifest.MoM WILL NOT BE VERIFIED
 		Loading required manifests...
 		No packs need to be downloaded
 		Validate downloaded files
@@ -51,7 +51,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/test-file
+	assert_file_exists "$TARGET_DIR"/test-file
 
 }
 #WEIGHT=4

--- a/test/functional/signature/invalid-certificate.bats
+++ b/test/functional/signature/invalid-certificate.bats
@@ -28,7 +28,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/test-file
+	assert_file_not_exists "$TARGET_DIR"/test-file
 
 }
 
@@ -39,7 +39,7 @@ test_setup() {
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Warning: The --nosigcheck flag was used and this compromises the system security
-		Warning: THE SIGNATURE OF file://$TEST_DIRNAME/web-dir/10/Manifest.MoM WILL NOT BE VERIFIED
+		Warning: THE SIGNATURE OF file://$ABS_TEST_DIR/web-dir/10/Manifest.MoM WILL NOT BE VERIFIED
 		Loading required manifests...
 		No packs need to be downloaded
 		Validate downloaded files
@@ -50,7 +50,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/test-file
+	assert_file_exists "$TARGET_DIR"/test-file
 
 }
 #WEIGHT=4

--- a/test/functional/signature/no-signature.bats
+++ b/test/functional/signature/no-signature.bats
@@ -9,7 +9,7 @@ test_setup() {
 
 	create_test_environment "$TEST_NAME"
 	create_bundle -n test-bundle -f /test-file "$TEST_NAME"
-	sudo rm "$WEBDIR"/10/Manifest.MoM.sig
+	sudo rm "$WEB_DIR"/10/Manifest.MoM.sig
 
 }
 
@@ -26,7 +26,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/test-file
+	assert_file_not_exists "$TARGET_DIR"/test-file
 
 }
 
@@ -37,7 +37,7 @@ test_setup() {
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Warning: The --nosigcheck flag was used and this compromises the system security
-		Warning: THE SIGNATURE OF file://$TEST_DIRNAME/web-dir/10/Manifest.MoM WILL NOT BE VERIFIED
+		Warning: THE SIGNATURE OF file://$ABS_TEST_DIR/web-dir/10/Manifest.MoM WILL NOT BE VERIFIED
 		Loading required manifests...
 		No packs need to be downloaded
 		Validate downloaded files
@@ -48,7 +48,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/test-file
+	assert_file_exists "$TARGET_DIR"/test-file
 
 }
 #WEIGHT=4

--- a/test/functional/signature/permission-incorrect.bats
+++ b/test/functional/signature/permission-incorrect.bats
@@ -26,53 +26,53 @@ test_setup() {
 @test "SIG009: Check if state dir permissions are correct after execution" {
 
 	# remove any cache/data directories that may have been created by testlib
-	sudo rm -rf "$STATEDIR"
+	sudo rm -rf "$STATE_DIR"
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
 	assert_status_is "$SWUPD_OK"
-	assert_file_exists "$TARGETDIR"/test-file
+	assert_file_exists "$TARGET_DIR"/test-file
 
 	# cache
-	run sudo sh -c "stat -c '%a' $STATEDIR_ABS/cache"
+	run sudo sh -c "stat -c '%a' $ABS_STATE_DIR/cache"
 	assert_status_is 0
 	assert_in_output "755"
 
 	# usr_baed_dir
-	run sudo sh -c "stat -c '%a' $STATEDIR_CACHE"
+	run sudo sh -c "stat -c '%a' $ABS_CACHE_DIR"
 	assert_status_is 0
 	assert_in_output "755"
 
 	# delta
-	run sudo sh -c "stat -c '%a' $STATEDIR_DELTA"
+	run sudo sh -c "stat -c '%a' $ABS_DELTA_DIR"
 	assert_status_is 0
 	assert_in_output "700"
 
 	# download
-	run sudo sh -c "stat -c '%a' $STATEDIR_DOWNLOAD"
+	run sudo sh -c "stat -c '%a' $ABS_DOWNLOAD_DIR"
 	assert_status_is 0
 	assert_in_output "700"
 
 	# manifest
-	run sudo sh -c "stat -c '%a' $STATEDIR_MANIFEST"
+	run sudo sh -c "stat -c '%a' $ABS_MANIFEST_DIR"
 	assert_status_is 0
 	assert_in_output "755"
-	run sudo sh -c "stat -c '%a' $STATEDIR_MANIFEST/10"
+	run sudo sh -c "stat -c '%a' $ABS_MANIFEST_DIR/10"
 	assert_status_is 0
 	assert_in_output "755"
 
 	# staged
-	run sudo sh -c "stat -c '%a' $STATEDIR_STAGED"
+	run sudo sh -c "stat -c '%a' $ABS_STAGED_DIR"
 	assert_status_is 0
 	assert_in_output "700"
 
 	# temp
-	run sudo sh -c "stat -c '%a' $STATEDIR_TEMP"
+	run sudo sh -c "stat -c '%a' $ABS_TEMP_DIR"
 	assert_status_is 0
 	assert_in_output "700"
 
 	# staged directory should only be accesible by root
-	run sudo sh -c "stat -c '%a' $STATEDIR_STAGED"
+	run sudo sh -c "stat -c '%a' $ABS_STAGED_DIR"
 	assert_status_is 0
 	assert_in_output "700"
 
@@ -81,48 +81,48 @@ test_setup() {
 @test "SIG028: Check if state dir permissions are correct after execution even if they are wrong before" {
 
 	# remove any cache/data directories that may have been created by testlib
-	sudo chmod -R 0755 "$STATEDIR"
+	sudo chmod -R 0755 "$STATE_DIR"
 
 	run sudo sh -c "$SWUPD bundle-add $SWUPD_OPTS test-bundle"
 
 	assert_status_is "$SWUPD_OK"
-	assert_file_exists "$TARGETDIR"/test-file
+	assert_file_exists "$TARGET_DIR"/test-file
 
 	# cache
-	run sudo sh -c "stat -c '%a' $STATEDIR_ABS/cache"
+	run sudo sh -c "stat -c '%a' $ABS_STATE_DIR/cache"
 	assert_status_is 0
 	assert_in_output "755"
 
 	# usr_baed_dir
-	run sudo sh -c "stat -c '%a' $STATEDIR_CACHE"
+	run sudo sh -c "stat -c '%a' $ABS_CACHE_DIR"
 	assert_status_is 0
 	assert_in_output "755"
 
 	# delta
-	run sudo sh -c "stat -c '%a' $STATEDIR_DELTA"
+	run sudo sh -c "stat -c '%a' $ABS_DELTA_DIR"
 	assert_status_is 0
 	assert_in_output "700"
 
 	# download
-	run sudo sh -c "stat -c '%a' $STATEDIR_DOWNLOAD"
+	run sudo sh -c "stat -c '%a' $ABS_DOWNLOAD_DIR"
 	assert_status_is 0
 	assert_in_output "700"
 
 	# manifest
-	run sudo sh -c "stat -c '%a' $STATEDIR_MANIFEST"
+	run sudo sh -c "stat -c '%a' $ABS_MANIFEST_DIR"
 	assert_status_is 0
 	assert_in_output "755"
-	run sudo sh -c "stat -c '%a' $STATEDIR_MANIFEST/10"
+	run sudo sh -c "stat -c '%a' $ABS_MANIFEST_DIR/10"
 	assert_status_is 0
 	assert_in_output "755"
 
 	# staged
-	run sudo sh -c "stat -c '%a' $STATEDIR_STAGED"
+	run sudo sh -c "stat -c '%a' $ABS_STAGED_DIR"
 	assert_status_is 0
 	assert_in_output "700"
 
 	# temp
-	run sudo sh -c "stat -c '%a' $STATEDIR_TEMP"
+	run sudo sh -c "stat -c '%a' $ABS_TEMP_DIR"
 	assert_status_is 0
 	assert_in_output "700"
 

--- a/test/functional/signature/valid-certificate.bats
+++ b/test/functional/signature/valid-certificate.bats
@@ -11,12 +11,12 @@ test_setup() {
 	create_bundle -n test-bundle -f /test-file "$TEST_NAME"
 
 	# Resign release
-	sudo rm "$WEBDIR"/version/latest_version.sig
-	sudo rm "$WEBDIR"/version/formatstaging/latest.sig
-	sudo rm "$WEBDIR"/10/Manifest.MoM.sig
+	sudo rm "$WEB_DIR"/version/latest_version.sig
+	sudo rm "$WEB_DIR"/version/formatstaging/latest.sig
+	sudo rm "$WEB_DIR"/10/Manifest.MoM.sig
 
 	sudo sh -c "openssl req -x509 -sha512 -days 1 -newkey rsa:4096  -keyout $TEST_NAME/root.key -out $TEST_NAME/root.pem -nodes -subj '/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost'"
-	sudo sh -c "openssl smime -sign -binary -in $WEBDIR/10/Manifest.MoM -signer $TEST_NAME/root.pem -inkey $TEST_NAME/root.key -out $WEBDIR/10/Manifest.MoM.sig -outform DER"
+	sudo sh -c "openssl smime -sign -binary -in $WEB_DIR/10/Manifest.MoM -signer $TEST_NAME/root.pem -inkey $TEST_NAME/root.key -out $WEB_DIR/10/Manifest.MoM.sig -outform DER"
 
 }
 

--- a/test/functional/signature/version-sig-check.bats
+++ b/test/functional/signature/version-sig-check.bats
@@ -17,19 +17,19 @@ test_setup() {
 @test "SIG019: Verify signature for absolute latest version with swupd check-update" {
 
 	# absolute latest version get checked during check-update
-	sudo sh -c "mv $WEBDIR/version/latest_version.sig $WEBDIR/version/latest_version_bad_name.sig"
+	sudo sh -c "mv $WEB_DIR/version/latest_version.sig $WEB_DIR/version/latest_version_bad_name.sig"
 	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"
 	assert_status_is "$SWUPD_SIGNATURE_VERIFICATION_FAILED"
 
 	expected_output=$(cat <<-EOM
-		Error: Signature for latest file (file://$TEST_DIRNAME/web-dir/version/latest_version) is missing
+		Error: Signature for latest file (file://$ABS_TEST_DIR/web-dir/version/latest_version) is missing
 		Error: Unable to determine the server version as signature verification failed
 		Current OS version: 10
 	EOM
 	)
 	assert_is_output "$expected_output"
 
-	sudo sh -c "mv $WEBDIR/version/latest_version_bad_name.sig $WEBDIR/version/latest_version.sig"
+	sudo sh -c "mv $WEB_DIR/version/latest_version_bad_name.sig $WEB_DIR/version/latest_version.sig"
 	# check-update succeeds as verification is successful
 	run sudo sh -c "$SWUPD check-update $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"
@@ -46,7 +46,7 @@ test_setup() {
 
 @test "SIG020: Verify fail signature for format staging with swupd update" {
 
-	write_to_protected_file "$WEBDIR/version/formatstaging/latest.sig" "bad signature"
+	write_to_protected_file "$WEB_DIR/version/formatstaging/latest.sig" "bad signature"
 
 	# Update fails as signature match error occurs as expected
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
@@ -54,7 +54,7 @@ test_setup() {
 
 	expected_output=$(cat <<-EOM
 		Update started
-		Error: Signature verification failed for URL: file://$TEST_DIRNAME/web-dir/version/formatstaging/latest
+		Error: Signature verification failed for URL: file://$ABS_TEST_DIR/web-dir/version/formatstaging/latest
 		Error: Unable to determine the server version as signature verification failed
 		Update failed
 	EOM
@@ -65,7 +65,7 @@ test_setup() {
 
 @test "SIG021: Update using nosigcheck" {
 
-	write_to_protected_file "$WEBDIR/version/formatstaging/latest.sig" "bad signature"
+	write_to_protected_file "$WEB_DIR/version/formatstaging/latest.sig" "bad signature"
 
 	# Update fails as signature match error occurs as expected
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS --nosigcheck"
@@ -74,10 +74,10 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Update started
 		Warning: The --nosigcheck flag was used and this compromises the system security
-		Warning: THE SIGNATURE OF file://$TEST_DIRNAME/web-dir/version/formatstaging/latest WILL NOT BE VERIFIED
+		Warning: THE SIGNATURE OF file://$ABS_TEST_DIR/web-dir/version/formatstaging/latest WILL NOT BE VERIFIED
 		Preparing to update from 10 to 20
-		Warning: THE SIGNATURE OF file://$TEST_DIRNAME/web-dir/10/Manifest.MoM WILL NOT BE VERIFIED
-		Warning: THE SIGNATURE OF file://$TEST_DIRNAME/web-dir/20/Manifest.MoM WILL NOT BE VERIFIED
+		Warning: THE SIGNATURE OF file://$ABS_TEST_DIR/web-dir/10/Manifest.MoM WILL NOT BE VERIFIED
+		Warning: THE SIGNATURE OF file://$ABS_TEST_DIR/web-dir/20/Manifest.MoM WILL NOT BE VERIFIED
 		Downloading packs for:
 		 - test-bundle1
 		Finishing packs extraction...
@@ -102,7 +102,7 @@ test_setup() {
 
 @test "SIG022: Update using nosigcheck-latest" {
 
-	write_to_protected_file "$WEBDIR/version/formatstaging/latest.sig" "bad signature"
+	write_to_protected_file "$WEB_DIR/version/formatstaging/latest.sig" "bad signature"
 
 	# Update fails as signature match error occurs as expected
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS --nosigcheck-latest"
@@ -111,7 +111,7 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Update started
 		Warning: The --nosigcheck-latest flag was used and this compromises the system security
-		Warning: THE SIGNATURE OF file://$TEST_DIRNAME/web-dir/version/formatstaging/latest WILL NOT BE VERIFIED
+		Warning: THE SIGNATURE OF file://$ABS_TEST_DIR/web-dir/version/formatstaging/latest WILL NOT BE VERIFIED
 		Preparing to update from 10 to 20
 		Downloading packs for:
 		 - test-bundle1
@@ -137,8 +137,8 @@ test_setup() {
 
 @test "SIG023: Fail update using nosigcheck-latest with an invalid MoM sig" {
 
-	write_to_protected_file "$WEBDIR/version/formatstaging/latest.sig" "bad signature"
-	write_to_protected_file "$WEBDIR/10/Manifest.MoM.sig"
+	write_to_protected_file "$WEB_DIR/version/formatstaging/latest.sig" "bad signature"
+	write_to_protected_file "$WEB_DIR/10/Manifest.MoM.sig"
 
 	# Update fails as signature match error occurs as expected
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS --nosigcheck-latest"
@@ -147,7 +147,7 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Update started
 		Warning: The --nosigcheck-latest flag was used and this compromises the system security
-		Warning: THE SIGNATURE OF file://$TEST_DIRNAME/web-dir/version/formatstaging/latest WILL NOT BE VERIFIED
+		Warning: THE SIGNATURE OF file://$ABS_TEST_DIR/web-dir/version/formatstaging/latest WILL NOT BE VERIFIED
 		Preparing to update from 10 to 20
 		Warning: Signature check failed
 		Warning: Removing corrupt Manifest.MoM artifacts and re-downloading...

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -5069,6 +5069,9 @@ testlib() {
 		echo "            but the test won't be executed. This is useful to manually run a test step"
 		echo "            by step (Alternatively you can use the create_test_environment_only function)."
 		echo "            Example: ENV_ONLY=true bats my_test.bats"
+		echo "SHOW_TARGET: If set to 'true', the tree view of the filesystem in the target system before"
+		echo "            and after the test will be printed. Note that the -t flag is needed as well."
+		echo "            Example: SHOW_TARGET=tru bats my_test.bats"
 	fi
 
 }

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -1,5 +1,14 @@
 #!/usr/bin/bash
 
+# Environment variables provided by BATS
+# $BATS_TEST_FILENAME is the fully expanded path to the Bats test file.
+# $BATS_TEST_DIRNAME is the directory in which the Bats test file is located.
+# $BATS_TEST_NAMES is an array of function names for each test case.
+# $BATS_TEST_NAME is the name of the function containing the current test case.
+# $BATS_TEST_DESCRIPTION is the description of the current test case.
+# $BATS_TEST_NUMBER is the (1-based) index of the current test case in the test file.
+# $BATS_TMPDIR is the location to a directory that may be used to store temporary files.
+
 # global variables
 FUNC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export FUNC_DIR

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -672,6 +672,10 @@ set_env_variables() { # swupd_function
 	debug_msg "TARGET_DIR: $TARGET_DIR"
 	export STATE_DIR="$env_name"/testfs/state
 	debug_msg "STATE_DIR: $STATE_DIR"
+	export SWUPD_CONFIG_DIR="$env_name"/testconfig
+	debug_msg "SWUPD_CONFIG_DIR: $SWUPD_CONFIG_DIR"
+	export SWUPD_CONFIG_FILE="$SWUPD_CONFIG_DIR"/config
+	debug_msg "SWUPD_CONFIG_FILE: $SWUPD_CONFIG_FILE"
 
 	# relevant absolute paths
 	export ABS_TEST_DIR="$path"/"$env_name"
@@ -697,6 +701,8 @@ set_env_variables() { # swupd_function
 	debug_msg "ABS_TEMP_DIR: $ABS_TEMP_DIR"
 	export ABS_CLIENT_CERT_DIR="$testfs_path/target-dir/etc/swupd"
 	debug_msg "ABS_CLIENT_CERT_DIR: $ABS_CLIENT_CERT_DIR"
+	export ABS_MIRROR_DIR="$ABS_TESTLIB_WD"/"$env_name"/mirror/web-dir
+	debug_msg "ABS_MIRROR_DIR: $ABS_MIRROR_DIR"
 
 	# different options for swupd
 	export SWUPD_OPTS="-S $testfs_path/state -p $testfs_path/target-dir -F staging -C $ABS_TEST_DIR/Swupd_Root.pem -I --no-progress"
@@ -2250,10 +2256,6 @@ create_config_file() { # swupd_function
 		terminate "The TEST_NAME needs to be specified to create a config file"
 	fi
 
-	# these values have to be exported in this function because the
-	# TEST_NAME changes during the setup
-	export SWUPD_CONFIG_DIR="$TEST_NAME"/testconfig
-	export SWUPD_CONFIG_FILE="$SWUPD_CONFIG_DIR"/config
 	debug_msg "Creating config file $SWUPD_CONFIG_FILE..."
 
 	if [ "$("$SWUPD" --version | grep "config file path" | awk '{print $4}')" != "./testconfig" ]; then
@@ -2344,9 +2346,8 @@ create_mirror() { # swupd_function
 	validate_param "$env_name"
 
 	# create the mirror
-	sudo mkdir "$env_name"/mirror
-	sudo cp -r "$env_name"/web-dir "$env_name"/mirror
-	export ABS_MIRROR_DIR="$ABS_TESTLIB_WD"/"$env_name"/mirror/web-dir
+	sudo mkdir -p "$ABS_MIRROR_DIR"
+	sudo cp -r "$env_name"/web-dir/* "$ABS_MIRROR_DIR"/
 
 	# set the mirror in the target-dir
 	write_to_protected_file "$env_name"/testfs/target-dir/etc/swupd/mirror_versionurl "file://$ABS_MIRROR_DIR"

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -31,7 +31,6 @@ export THIRD_PARTY_SCRIPT_TEMPLATE="script.template"
 export SPACE=" "
 export TAB="	"
 
-
 # detect where the swupd binary is
 if [ -e "$SWUPD" ]; then
 	# nothing to be done, variable already set up
@@ -86,7 +85,7 @@ export SWUPD_INVALID_REPOSITORY=37  # the specified 3rd-party repository is inva
 export SWUPD_INVALID_FILE=38  # file is missing or invalid
 
 # global constant
-export zero_hash="0000000000000000000000000000000000000000000000000000000000000000"
+export ZERO_HASH="0000000000000000000000000000000000000000000000000000000000000000"
 export SCRIPT_TEMPLATE="\
 #!/bin/bash\n\n\
 export PATH=%s:\$PATH\n\
@@ -1406,7 +1405,7 @@ update_hashes_in_mom() { # swupd_function
 			# if the hash of the manifest changed, update it
 			bundle_old_hash=$(get_hash_from_manifest "$manifest" "$bundle")
 			bundle_new_hash=$(sudo "$SWUPD" hashdump --quiet "$path"/Manifest."$bundle")
-			if [ "$bundle_old_hash" != "$bundle_new_hash" ] && [ "$bundle_new_hash" != "$zero_hash" ]; then
+			if [ "$bundle_old_hash" != "$bundle_new_hash" ] && [ "$bundle_new_hash" != "$ZERO_HASH" ]; then
 				# replace old hash with new hash
 				sudo sed -i "/\\t$bundle_old_hash\\t/s/\\(....\\t\\).*\\(\\t.*\\t\\)/\\1$bundle_new_hash\\2/g" "$manifest"
 				# replace old version with new version
@@ -3347,7 +3346,7 @@ update_content() {
 			# in the new version, it needs to be added to the new manifest as deleted
 			debug_msg "File $filename was deleted in the latest version"
 			entry=$(get_entry_from_manifest "$old_manifest" "$filename")
-			write_to_protected_file -a "$new_manifest" "${entry:0:1}d${entry:2:2}\\t$zero_hash\\t$new_version${entry:72}\\n"
+			write_to_protected_file -a "$new_manifest" "${entry:0:1}d${entry:2:2}\\t$ZERO_HASH\\t$new_version${entry:72}\\n"
 		else
 			# the file in new version is different from old version, the file was updated,
 			# it needs to have a delta created and added to the pack
@@ -3860,7 +3859,7 @@ update_bundle() { # swupd_function
 		fi
 
 		# replace the hash with 0s
-		update_manifest -p "$bundle_manifest" file-hash "$fname" "$zero_hash"
+		update_manifest -p "$bundle_manifest" file-hash "$fname" "$ZERO_HASH"
 
 		# calculate new contentsize (NOTE: filecount is not decreased)
 		contentsize=$((contentsize - fsize))
@@ -3979,7 +3978,7 @@ update_bundle() { # swupd_function
 		add_to_manifest -p "$bundle_manifest" "$oldversion_path"/files/"$fhash" "$new_name"
 		if [ "$option" = "--rename" ]; then
 			# replace the hash of the old record with 0s
-			update_manifest -p "$bundle_manifest" file-hash "$fname" "$zero_hash"
+			update_manifest -p "$bundle_manifest" file-hash "$fname" "$ZERO_HASH"
 		else
 			# replace the fourth character of the old record with "r"
 			sudo sed -i "/\\t$filename$/s/./r/4" "$bundle_manifest"

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -45,6 +45,10 @@ export TEST_NAME_SHORT=${TEST_FILE_NAME%.bats}
 # is going to be used with a global_setup, if not the case, it will be redefined
 # during setup()
 export TEST_NAME="$TEST_NAME_SHORT"
+# file that stores the environment variables of the tests in the file
+# since the path to this file depends on TEST_NAME, its value may also be redefined
+# during setup()
+export ENVIRONMENT_FILE="$ABS_TESTLIB_WD"/"$TEST_NAME"/.env
 
 # 3rd-party variables
 # -------------------
@@ -656,78 +660,135 @@ set_env_variables() { # swupd_function
 	)" "$@"
 
 	local env_name=$1
-	local path
+	validate_path "$env_name"
+
 	local testfs_path
 	local converted_url
-	validate_path "$env_name"
-	path=$(dirname "$(realpath "$env_name")")
-	testfs_path="$path"/"$env_name"/testfs
+
+	testfs_path="$ABS_TESTLIB_WD"/"$env_name"/testfs
+	converted_url=file___"$(echo "$ABS_TESTLIB_WD" | tr / _)"_"$env_name"_web-dir
 
 	debug_msg "Exporting environment variables for $env_name"
 
 	# relevant relative paths
 	export WEB_DIR="$env_name"/web-dir
+	echo "export WEB_DIR=$WEB_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "WEB_DIR: $WEB_DIR"
+
 	export TARGET_DIR="$env_name"/testfs/target-dir
+	echo "export TARGET_DIR=$TARGET_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "TARGET_DIR: $TARGET_DIR"
+
 	export STATE_DIR="$env_name"/testfs/state
+	echo "export STATE_DIR=$STATE_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "STATE_DIR: $STATE_DIR"
+
 	export SWUPD_CONFIG_DIR="$env_name"/testconfig
+	echo "export SWUPD_CONFIG_DIR=$SWUPD_CONFIG_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "SWUPD_CONFIG_DIR: $SWUPD_CONFIG_DIR"
+
 	export SWUPD_CONFIG_FILE="$SWUPD_CONFIG_DIR"/config
+	echo "export SWUPD_CONFIG_FILE=$SWUPD_CONFIG_FILE" >> "$ENVIRONMENT_FILE"
 	debug_msg "SWUPD_CONFIG_FILE: $SWUPD_CONFIG_FILE"
 
 	# relevant absolute paths
-	export ABS_TEST_DIR="$path"/"$env_name"
+	export ABS_TEST_DIR="$ABS_TESTLIB_WD"/"$env_name"
+	echo "export ABS_TEST_DIR=$ABS_TEST_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_TEST_DIR: $ABS_TEST_DIR"
+
 	export ABS_TARGET_DIR="$ABS_TEST_DIR"/testfs/target-dir
+	echo "export ABS_TARGET_DIR=$ABS_TARGET_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_TARGET_DIR: $ABS_TARGET_DIR"
+
 	export ABS_STATE_DIR="$ABS_TEST_DIR"/testfs/state
+	echo "export ABS_STATE_DIR=$ABS_STATE_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_STATE_DIR: $ABS_STATE_DIR"
+
 	export ABS_TRACKING_DIR="$ABS_STATE_DIR"/bundles
+	echo "export ABS_TRACKING_DIR=$ABS_TRACKING_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_TRACKING_DIR: $ABS_TRACKING_DIR"
-	converted_url=file___"$(echo "$path" | tr / _)"_"$env_name"_web-dir
+
 	export ABS_CACHE_DIR="$ABS_STATE_DIR"/cache/"$converted_url"
+	echo "export ABS_CACHE_DIR=$ABS_CACHE_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_CACHE_DIR: $ABS_CACHE_DIR"
+
 	export ABS_DELTA_DIR="$ABS_STATE_DIR"/cache/"$converted_url"/delta
+	echo "export ABS_DELTA_DIR=$ABS_DELTA_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_DELTA_DIR: $ABS_DELTA_DIR"
+
 	export ABS_DOWNLOAD_DIR="$ABS_STATE_DIR"/cache/"$converted_url"/download
+	echo "export ABS_DOWNLOAD_DIR=$ABS_DOWNLOAD_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_DOWNLOAD_DIR: $ABS_DOWNLOAD_DIR"
+
 	export ABS_MANIFEST_DIR="$ABS_STATE_DIR"/cache/"$converted_url"/manifest
+	echo "export ABS_MANIFEST_DIR=$ABS_MANIFEST_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_MANIFEST_DIR: $ABS_MANIFEST_DIR"
+
 	export ABS_STAGED_DIR="$ABS_STATE_DIR"/cache/"$converted_url"/staged
+	echo "export ABS_STAGED_DIR=$ABS_STAGED_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_STAGED_DIR: $ABS_STAGED_DIR"
+
 	export ABS_TEMP_DIR="$ABS_STATE_DIR"/cache/"$converted_url"/temp
+	echo "export ABS_TEMP_DIR=$ABS_TEMP_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_TEMP_DIR: $ABS_TEMP_DIR"
+
 	export ABS_CLIENT_CERT_DIR="$testfs_path/target-dir/etc/swupd"
+	echo "export ABS_CLIENT_CERT_DIR=$ABS_CLIENT_CERT_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_CLIENT_CERT_DIR: $ABS_CLIENT_CERT_DIR"
+
 	export ABS_MIRROR_DIR="$ABS_TESTLIB_WD"/"$env_name"/mirror/web-dir
+	echo "export ABS_MIRROR_DIR=$ABS_MIRROR_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_MIRROR_DIR: $ABS_MIRROR_DIR"
+
 
 	# different options for swupd
 	export SWUPD_OPTS="-S $testfs_path/state -p $testfs_path/target-dir -F staging -C $ABS_TEST_DIR/Swupd_Root.pem -I --no-progress"
+	echo "export SWUPD_OPTS=\"$SWUPD_OPTS\"" >> "$ENVIRONMENT_FILE"
+
 	export SWUPD_OPTS_PROGRESS="-S $testfs_path/state -p $testfs_path/target-dir -F staging -C $ABS_TEST_DIR/Swupd_Root.pem -I"
+	echo "export SWUPD_OPTS_PROGRESS=\"$SWUPD_OPTS_PROGRESS\"" >> "$ENVIRONMENT_FILE"
+
 	export SWUPD_OPTS_KEEPCACHE="$SWUPD_OPTS --keepcache"
+	echo "export SWUPD_OPTS_KEEPCACHE=\"$SWUPD_OPTS_KEEPCACHE\"" >> "$ENVIRONMENT_FILE"
+
 	export SWUPD_OPTS_NO_CERT="-S $testfs_path/state -p $testfs_path/target-dir -F staging -I --no-progress"
+	echo "export SWUPD_OPTS_NO_CERT=\"$SWUPD_OPTS_NO_CERT\"" >> "$ENVIRONMENT_FILE"
+
 	export SWUPD_OPTS_NO_FMT="-S $testfs_path/state -p $testfs_path/target-dir -C $ABS_TEST_DIR/Swupd_Root.pem -I --no-progress"
+	echo "export SWUPD_OPTS_NO_FMT=\"$SWUPD_OPTS_NO_FMT\"" >> "$ENVIRONMENT_FILE"
+
 	export SWUPD_OPTS_NO_FMT_NO_CERT="-S $testfs_path/state -p $testfs_path/target-dir -I --no-progress"
+	echo "export SWUPD_OPTS_NO_FMT_NO_CERT=\"$SWUPD_OPTS_NO_FMT_NO_CERT\"" >> "$ENVIRONMENT_FILE"
+
 	export SWUPD_OPTS_NO_PATH="-S $testfs_path/state -F staging -C $ABS_TEST_DIR/Swupd_Root.pem -I --no-progress"
+	echo "export SWUPD_OPTS_NO_PATH=\"$SWUPD_OPTS_NO_PATH\"" >> "$ENVIRONMENT_FILE"
+
 	export SWUPD_OPTS_NO_STATE="-p $testfs_path/target-dir -F staging -C $ABS_TEST_DIR/Swupd_Root.pem -I --no-progress"
+	echo "export SWUPD_OPTS_NO_STATE=\"$SWUPD_OPTS_NO_STATE\"" >> "$ENVIRONMENT_FILE"
+
 
 	# path to relevant files
 	export CLIENT_CERT_FILE="$ABS_CLIENT_CERT_DIR/client.pem"
-	export PORT_FILE="$path/$env_name/port_file.txt" # stores web server port
-	export SERVER_PID_FILE="$path/$env_name/pid_file.txt" # stores web server pid
+	echo "export CLIENT_CERT_FILE=$CLIENT_CERT_FILE" >> "$ENVIRONMENT_FILE"
+
+	export PORT_FILE="$ABS_TESTLIB_WD/$env_name/port_file.txt" # stores web server port
+	echo "export PORT_FILE=$PORT_FILE" >> "$ENVIRONMENT_FILE"
+
+	export SERVER_PID_FILE="$ABS_TESTLIB_WD/$env_name/pid_file.txt" # stores web server pid
+	echo "export SERVER_PID_FILE=$SERVER_PID_FILE" >> "$ENVIRONMENT_FILE"
+
 
 	# Add environment variables for PORT and SERVER_PID when web server used
 	if [ -f "$PORT_FILE" ]; then
 		PORT=$(cat "$PORT_FILE")
 		export PORT
+		echo "export PORT=$PORT" >> "$ENVIRONMENT_FILE"
 	fi
 
 	if [ -f "$SERVER_PID_FILE" ]; then
 		SERVER_PID=$(cat "$SERVER_PID_FILE")
 		export SERVER_PID
+		echo "export SERVER_PID=$SERVER_PID" >> "$ENVIRONMENT_FILE"
 	fi
 
 }
@@ -760,30 +821,52 @@ set_env_variables_third_party() { # swupd_function
 
 	# relevant relative paths
 	export TP_STATE_DIR="$STATE_DIR"/3rd-party/"$repo_name"
+	echo "export TP_STATE_DIR=$TP_STATE_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "TP_STATE_DIR: $TP_STATE_DIR"
+
 	export TP_WEB_DIR="$env_name"/3rd-party/"$repo_name"
+	echo "export TP_WEB_DIR=$TP_WEB_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "TP_WEB_DIR: $TP_WEB_DIR"
+
 	export TP_TARGET_DIR="$env_name"/testfs/target-dir/"$TP_BUNDLES_DIR"/"$repo_name"
+	echo "export TP_TARGET_DIR=$TP_TARGET_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "TP_TARGET_DIR: $TP_TARGET_DIR"
 
 	# relevant absolute paths
 	export ABS_TP_URL="$url"
+	echo "export ABS_TP_URL=$ABS_TP_URL" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_TP_URL: $ABS_TP_URL"
+
 	export ABS_TP_STATE_DIR="$ABS_TESTLIB_WD"/"$TP_STATE_DIR"
+	echo "export ABS_TP_STATE_DIR=$ABS_TP_STATE_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_TP_STATE_DIR: $ABS_TP_STATE_DIR"
+
 	export ABS_TP_TRACKING_DIR="$ABS_TP_STATE_DIR"/bundles
+	echo "export ABS_TP_TRACKING_DIR=$ABS_TP_TRACKING_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_TP_TRACKING_DIR: $ABS_TP_TRACKING_DIR"
+
 	export ABS_TP_CACHE_DIR="$ABS_TP_STATE_DIR"/cache/"$converted_url"
+	echo "export ABS_TP_CACHE_DIR=$ABS_TP_CACHE_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_TP_CACHE_DIR: $ABS_TP_CACHE_DIR"
+
 	export ABS_TP_DELTA_DIR="$ABS_TP_STATE_DIR"/cache/"$converted_url"/delta
+	echo "export ABS_TP_DELTA_DIR=$ABS_TP_DELTA_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_TP_DELTA_DIR: $ABS_TP_DELTA_DIR"
+
 	export ABS_TP_DOWNLOAD_DIR="$ABS_TP_STATE_DIR"/cache/"$converted_url"/download
+	echo "export ABS_TP_DOWNLOAD_DIR=$ABS_TP_DOWNLOAD_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_TP_DOWNLOAD_DIR: $ABS_TP_DOWNLOAD_DIR"
+
 	export ABS_TP_MANIFEST_DIR="$ABS_TP_STATE_DIR"/cache/"$converted_url"/manifest
+	echo "export ABS_TP_MANIFEST_DIR=$ABS_TP_MANIFEST_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_TP_MANIFEST_DIR: $ABS_TP_MANIFEST_DIR"
+
 	export ABS_TP_STAGED_DIR="$ABS_TP_STATE_DIR"/cache/"$converted_url"/staged
+	echo "export ABS_TP_STAGED_DIR=$ABS_TP_STAGED_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_TP_STAGED_DIR: $ABS_TP_STAGED_DIR"
+
 	export ABS_TP_TEMP_DIR="$ABS_TP_STATE_DIR"/cache/"$converted_url"/temp
+	echo "export ABS_TP_TEMP_DIR=$ABS_TP_TEMP_DIR" >> "$ENVIRONMENT_FILE"
 	debug_msg "ABS_TP_TEMP_DIR: $ABS_TP_TEMP_DIR"
 
 }
@@ -810,9 +893,11 @@ set_env_variables_content() { # swupd_function
 
 	hashed_name=$(sudo "$SWUPD" hashdump --quiet "$content_dir"/"$version"/os-release)
 	export OS_RELEASE_FILE="$content_dir"/"$version"/files/"$hashed_name"
+	echo "export OS_RELEASE_FILE=$OS_RELEASE_FILE" >> "$ENVIRONMENT_FILE"
 
 	hashed_name=$(sudo "$SWUPD" hashdump --quiet "$content_dir"/"$version"/format)
 	export FORMAT_FILE="$content_dir"/"$version"/files/"$hashed_name"
+	echo "export FORMAT_FILE=$FORMAT_FILE" >> "$ENVIRONMENT_FILE"
 
 }
 
@@ -2197,6 +2282,7 @@ destroy_test_environment() { # swupd_function
 	fi
 
 	sudo rm -rf "$env_name"
+
 	if [ ! -e "$env_name" ]; then
 		debug_msg "Environment $env_name deleted successfully"
 	else
@@ -4543,6 +4629,7 @@ setup() {
 			terminate "Bad test, missing test ID: \"$BATS_TEST_DESCRIPTION\""
 		fi
 		TEST_NAME="$TEST_NAME"_"${BATS_TEST_DESCRIPTION%:*}"
+		ENVIRONMENT_FILE="$ABS_TESTLIB_WD"/"$TEST_NAME"/.env
 
 		# if a local environment exists at this point it is a
 		# leftover from a previous execution, remove it
@@ -4560,6 +4647,15 @@ setup() {
 	debug_msg "\\nRunning test_setup..."
 	test_setup
 	debug_msg "Finished running test_setup"
+
+	# export the environment variables
+	# ShellCheck won't be able to include sourced files from paths that are determined
+	# at runtime, this is not a problem in this case, the file has only env variables
+	# shellcheck source=/dev/null
+	if [ -f "$ENVIRONMENT_FILE" ]; then
+		source "$ENVIRONMENT_FILE"
+		debug_msg "Env variables exported"
+	fi
 
 	if [ "$DEBUG_TEST" = true ] || [ "$SHOW_TARGET" = true ]; then
 		print "\nTarget system before the test:"

--- a/test/functional/update/update-attr-change.bats
+++ b/test/functional/update/update-attr-change.bats
@@ -49,21 +49,21 @@ test_setup() {
 	# updates should change all attributes of files, including mode and owner
 
 	# Check user ID
-	run stat --printf  "%u" "$TARGETDIR"/dir_owner
+	run stat --printf  "%u" "$TARGET_DIR"/dir_owner
 	[ "$output" -eq "5001" ]
-	run stat --printf  "%u" "$TARGETDIR"/dir_owner
+	run stat --printf  "%u" "$TARGET_DIR"/dir_owner
 	[ "$output" -eq "5001" ]
 
 	# Check group ID
-	run stat --printf  "%g" "$TARGETDIR"/dir_owner
+	run stat --printf  "%g" "$TARGET_DIR"/dir_owner
 	[ "$output" -eq "5002" ]
-	run stat --printf  "%g" "$TARGETDIR"/dir_owner
+	run stat --printf  "%g" "$TARGET_DIR"/dir_owner
 	[ "$output" -eq "5002" ]
 
 	# Check mode
-	run stat --printf  "%a" "$TARGETDIR"/dir_mode
+	run stat --printf  "%a" "$TARGET_DIR"/dir_mode
 	[ "$output" -eq "777" ]
-	run stat --printf  "%a" "$TARGETDIR"/dir_mode
+	run stat --printf  "%a" "$TARGET_DIR"/dir_mode
 	[ "$output" -eq "777" ]
 
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
@@ -94,29 +94,29 @@ test_setup() {
 	assert_is_output "$expected_output"
 
 	# Check user
-	run stat --printf  "%u" "$TARGETDIR"/dir_owner
+	run stat --printf  "%u" "$TARGET_DIR"/dir_owner
 	[ "$output" -eq "5003" ]
-	run stat --printf  "%u" "$TARGETDIR"/dir_owner
+	run stat --printf  "%u" "$TARGET_DIR"/dir_owner
 	[ "$output" -eq "5003" ]
 
 	# Check group
-	run stat --printf  "%g" "$TARGETDIR"/dir_owner
+	run stat --printf  "%g" "$TARGET_DIR"/dir_owner
 	[ "$output" -eq "5004" ]
-	run stat --printf  "%g" "$TARGETDIR"/dir_owner
+	run stat --printf  "%g" "$TARGET_DIR"/dir_owner
 	[ "$output" -eq "5004" ]
 
 	# Check mode
-	run stat --printf  "%a" "$TARGETDIR"/dir_mode
+	run stat --printf  "%a" "$TARGET_DIR"/dir_mode
 	[ "$output" -eq "707" ]
-	run stat --printf  "%a" "$TARGETDIR"/dir_mode
+	run stat --printf  "%a" "$TARGET_DIR"/dir_mode
 	[ "$output" -eq "707" ]
 
 	# Check extra attribute bits
-	run stat --printf  "%a" "$TARGETDIR"/file_setuid
+	run stat --printf  "%a" "$TARGET_DIR"/file_setuid
 	[ "$output" -eq "4755" ]
-	run stat --printf  "%a" "$TARGETDIR"/file_setgid
+	run stat --printf  "%a" "$TARGET_DIR"/file_setgid
 	[ "$output" -eq "2755" ]
-	run stat --printf  "%a" "$TARGETDIR"/dir_sticky
+	run stat --printf  "%a" "$TARGET_DIR"/dir_sticky
 	[ "$output" -eq "1755" ]
 
 	show_target

--- a/test/functional/update/update-boot-file.bats
+++ b/test/functional/update/update-boot-file.bats
@@ -32,12 +32,12 @@ test_setup() {
 		Installing files...
 		Update was applied
 		Calling post-update helper scripts
-		Warning: helper script ($TEST_DIRNAME/testfs/target-dir/usr/bin/clr-boot-manager) not found, it will be skipped
+		Warning: helper script ($ABS_TEST_DIR/testfs/target-dir/usr/bin/clr-boot-manager) not found, it will be skipped
 		Update successful - System updated from version 10 to version 100
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/lib/kernel/testfile
+	assert_file_exists "$TARGET_DIR"/usr/lib/kernel/testfile
 
 }
 #WEIGHT=2

--- a/test/functional/update/update-boot-skip.bats
+++ b/test/functional/update/update-boot-skip.bats
@@ -38,7 +38,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/usr/lib/kernel/testfile
+	assert_file_exists "$TARGET_DIR"/usr/lib/kernel/testfile
 
 }
 #WEIGHT=3

--- a/test/functional/update/update-bundle-removed.bats
+++ b/test/functional/update/update-bundle-removed.bats
@@ -10,7 +10,7 @@ test_setup() {
 	create_test_environment -r "$TEST_NAME"
 	create_bundle -L -n test-bundle1 -f /file_1 "$TEST_NAME"
 	create_version -r "$TEST_NAME" 20 10
-	remove_from_manifest "$WEBDIR"/20/Manifest.MoM test-bundle1
+	remove_from_manifest "$WEB_DIR"/20/Manifest.MoM test-bundle1
 
 }
 
@@ -49,8 +49,8 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 	# bundle should not be removed
-	assert_file_exists "$TARGETDIR"/file_1
-	assert_file_exists "$TARGETDIR"/usr/share/clear/bundles/test-bundle1
+	assert_file_exists "$TARGET_DIR"/file_1
+	assert_file_exists "$TARGET_DIR"/usr/share/clear/bundles/test-bundle1
 
 }
 #WEIGHT=5

--- a/test/functional/update/update-deleted-include-manifest.bats
+++ b/test/functional/update/update-deleted-include-manifest.bats
@@ -12,12 +12,12 @@ test_setup() {
 	create_bundle -n test-bundle2 -f /bar/testfile2 "$TEST_NAME"
 	create_version -p "$TEST_NAME" 100 10
 	update_bundle "$TEST_NAME" test-bundle1 --header-only
-	add_dependency_to_manifest "$WEBDIR"/100/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest "$WEB_DIR"/100/Manifest.test-bundle1 test-bundle2
 
 	# Delete the included manifest
-	sudo rm "$WEBDIR"/10/Manifest.test-bundle2
-	sudo rm "$WEBDIR"/10/pack-test-bundle2-from-0.tar
-	sudo rm "$WEBDIR"/10/Manifest.test-bundle2.tar
+	sudo rm "$WEB_DIR"/10/Manifest.test-bundle2
+	sudo rm "$WEB_DIR"/10/pack-test-bundle2-from-0.tar
+	sudo rm "$WEB_DIR"/10/Manifest.test-bundle2.tar
 
 }
 

--- a/test/functional/update/update-download.bats
+++ b/test/functional/update/update-download.bats
@@ -33,7 +33,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/foo
+	assert_file_not_exists "$TARGET_DIR"/foo
 }
 
 #WEIGHT=2

--- a/test/functional/update/update-fail-to-get-mom.bats
+++ b/test/functional/update/update-fail-to-get-mom.bats
@@ -12,7 +12,7 @@ test_setup() {
 @test "UPD009: Try updating a system where the 'from' MoM is not found" {
 
 	# remove the "from" mom
-	sudo rm -rf "$WEBDIR"/10/Manifest.MoM.tar
+	sudo rm -rf "$WEB_DIR"/10/Manifest.MoM.tar
 
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
@@ -31,7 +31,7 @@ test_setup() {
 @test "UPD010: Try updating a system where the 'to' MoM is not found" {
 
 	# remove the "to" mom
-	sudo rm -rf "$WEBDIR"/20/Manifest.MoM.tar
+	sudo rm -rf "$WEB_DIR"/20/Manifest.MoM.tar
 
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 

--- a/test/functional/update/update-ignore-also-add.bats
+++ b/test/functional/update/update-ignore-also-add.bats
@@ -18,7 +18,7 @@ test_setup() {
 	update_bundle "$TEST_NAME" test-bundle2 --update /bar/testfile2
 
 	# add dependencies
-	add_dependency_to_manifest -o "$WEBDIR"/100/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest -o "$WEB_DIR"/100/Manifest.test-bundle1 test-bundle2
 
 }
 
@@ -49,8 +49,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/testfile1
-	assert_file_not_exists "$TARGETDIR"/bar/testfile2
+	assert_file_exists "$TARGET_DIR"/foo/testfile1
+	assert_file_not_exists "$TARGET_DIR"/bar/testfile2
 
 }
 #WEIGHT=5

--- a/test/functional/update/update-include-old-bundle-with-tracked-file.bats
+++ b/test/functional/update/update-include-old-bundle-with-tracked-file.bats
@@ -13,7 +13,7 @@ test_setup() {
 	create_version -r "$TEST_NAME" 30 20
 	update_bundle "$TEST_NAME" test-bundle3 --add /tracked_file:"$TEST_NAME"/web-dir/10/files/"$tracked_file"
 	update_bundle "$TEST_NAME" test-bundle2 --header-only
-	add_dependency_to_manifest "$WEBDIR"/30/Manifest.test-bundle2 test-bundle1
+	add_dependency_to_manifest "$WEB_DIR"/30/Manifest.test-bundle2 test-bundle1
 	set_current_version "$TEST_NAME" 20
 
 }
@@ -47,10 +47,10 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_exists "$TARGETDIR"/tracked_file
-	assert_file_exists "$TARGETDIR"/foo/ftb1
-	assert_file_exists "$TARGETDIR"/ftb3
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_exists "$TARGET_DIR"/tracked_file
+	assert_file_exists "$TARGET_DIR"/foo/ftb1
+	assert_file_exists "$TARGET_DIR"/ftb3
 
 }
 #WEIGHT=11

--- a/test/functional/update/update-include-old-bundle.bats
+++ b/test/functional/update/update-include-old-bundle.bats
@@ -9,7 +9,7 @@ test_setup() {
 	create_bundle -n test-bundle2 -f /testfile2 "$TEST_NAME"
 	create_version -p "$TEST_NAME" 100 10
 	update_bundle "$TEST_NAME" test-bundle1 --update /testfile1
-	add_dependency_to_manifest "$WEBDIR"/100/Manifest.test-bundle1 test-bundle2
+	add_dependency_to_manifest "$WEB_DIR"/100/Manifest.test-bundle1 test-bundle2
 
 }
 
@@ -44,9 +44,9 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 	# changed files
-	assert_file_exists "$TARGETDIR"/testfile1
+	assert_file_exists "$TARGET_DIR"/testfile1
 	# new file
-	assert_file_exists "$TARGETDIR"/testfile2
+	assert_file_exists "$TARGET_DIR"/testfile2
 
 }
 

--- a/test/functional/update/update-include.bats
+++ b/test/functional/update/update-include.bats
@@ -20,15 +20,15 @@ test_setup() {
 	create_bundle -v 100 -n test-bundle6 -f /foo/testfile6 "$TEST_NAME"
 	create_bundle -v 100 -n test-bundle7 -f /foo/testfile7 "$TEST_NAME"
 	# add dependencies
-	add_dependency_to_manifest "$WEBDIR"/100/Manifest.test-bundle1 test-bundle3
-	add_dependency_to_manifest "$WEBDIR"/100/Manifest.test-bundle2 test-bundle7
-	add_dependency_to_manifest -p "$WEBDIR"/100/Manifest.test-bundle3 test-bundle2
-	add_dependency_to_manifest "$WEBDIR"/100/Manifest.test-bundle3 test-bundle4
-	add_dependency_to_manifest -p "$WEBDIR"/100/Manifest.test-bundle4 test-bundle5
-	add_dependency_to_manifest "$WEBDIR"/100/Manifest.test-bundle4 test-bundle6
-	add_dependency_to_manifest "$WEBDIR"/100/Manifest.test-bundle5 test-bundle2
-	add_dependency_to_manifest "$WEBDIR"/100/Manifest.test-bundle6 os-core
-	add_dependency_to_manifest "$WEBDIR"/100/Manifest.test-bundle7 os-core
+	add_dependency_to_manifest "$WEB_DIR"/100/Manifest.test-bundle1 test-bundle3
+	add_dependency_to_manifest "$WEB_DIR"/100/Manifest.test-bundle2 test-bundle7
+	add_dependency_to_manifest -p "$WEB_DIR"/100/Manifest.test-bundle3 test-bundle2
+	add_dependency_to_manifest "$WEB_DIR"/100/Manifest.test-bundle3 test-bundle4
+	add_dependency_to_manifest -p "$WEB_DIR"/100/Manifest.test-bundle4 test-bundle5
+	add_dependency_to_manifest "$WEB_DIR"/100/Manifest.test-bundle4 test-bundle6
+	add_dependency_to_manifest "$WEB_DIR"/100/Manifest.test-bundle5 test-bundle2
+	add_dependency_to_manifest "$WEB_DIR"/100/Manifest.test-bundle6 os-core
+	add_dependency_to_manifest "$WEB_DIR"/100/Manifest.test-bundle7 os-core
 
 
 }
@@ -67,14 +67,14 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 	# changed files
-	assert_file_exists "$TARGETDIR"/foo/testfile1
-	assert_file_exists "$TARGETDIR"/bar/testfile2
+	assert_file_exists "$TARGET_DIR"/foo/testfile1
+	assert_file_exists "$TARGET_DIR"/bar/testfile2
 	# new files
-	assert_file_exists "$TARGETDIR"/foo/testfile3
-	assert_file_exists "$TARGETDIR"/foo/testfile4
-	assert_file_exists "$TARGETDIR"/foo/testfile5
-	assert_file_exists "$TARGETDIR"/foo/testfile6
-	assert_file_exists "$TARGETDIR"/foo/testfile7
+	assert_file_exists "$TARGET_DIR"/foo/testfile3
+	assert_file_exists "$TARGET_DIR"/foo/testfile4
+	assert_file_exists "$TARGET_DIR"/foo/testfile5
+	assert_file_exists "$TARGET_DIR"/foo/testfile6
+	assert_file_exists "$TARGET_DIR"/foo/testfile7
 
 }
 #WEIGHT=12

--- a/test/functional/update/update-manifest-delta-recover.bats
+++ b/test/functional/update/update-manifest-delta-recover.bats
@@ -15,8 +15,8 @@ test_setup() {
 	update_bundle "$TEST_NAME" test-bundle1 --add /bar/file_b3
 
 	create_delta_manifest test-bundle1 20 10
-	sudo mv "$WEBDIR"/20/Manifest-test-bundle1-delta-from-10 "$WEBDIR"/30/Manifest-test-bundle1-delta-from-10
-	write_to_protected_file -a "$WEBDIR"/20/Manifest-test-bundle1-delta-from-10 "Invalid delta"
+	sudo mv "$WEB_DIR"/20/Manifest-test-bundle1-delta-from-10 "$WEB_DIR"/30/Manifest-test-bundle1-delta-from-10
+	write_to_protected_file -a "$WEB_DIR"/20/Manifest-test-bundle1-delta-from-10 "Invalid delta"
 
 }
 

--- a/test/functional/update/update-manifest-delta.bats
+++ b/test/functional/update/update-manifest-delta.bats
@@ -18,10 +18,10 @@ test_setup() {
 	create_delta_manifest test-bundle1 20 10
 	create_delta_manifest test-bundle2 30 10
 
-	sudo rm "$WEBDIR/20/Manifest.test-bundle1"
-	sudo rm "$WEBDIR/20/Manifest.test-bundle1.tar"
-	sudo rm "$WEBDIR/30/Manifest.test-bundle2"
-	sudo rm "$WEBDIR/30/Manifest.test-bundle2.tar"
+	sudo rm "$WEB_DIR/20/Manifest.test-bundle1"
+	sudo rm "$WEB_DIR/20/Manifest.test-bundle1.tar"
+	sudo rm "$WEB_DIR/30/Manifest.test-bundle2"
+	sudo rm "$WEB_DIR/30/Manifest.test-bundle2.tar"
 
 }
 
@@ -97,7 +97,7 @@ test_setup() {
 	# Updating fails when there's no Manifests for 20 and 30 and delta
 	# Manifests are valid but generating and incorect Manifest.
 
-	sudo mv "$WEBDIR"/20/Manifest-test-bundle1-delta-from-10 "$WEBDIR"/30/Manifest-test-bundle2-delta-from-10
+	sudo mv "$WEB_DIR"/20/Manifest-test-bundle1-delta-from-10 "$WEB_DIR"/30/Manifest-test-bundle2-delta-from-10
 
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS -V 30"
 

--- a/test/functional/update/update-minversion.bats
+++ b/test/functional/update/update-minversion.bats
@@ -8,9 +8,9 @@ test_setup() {
 	create_bundle -L -n bundle1 -v 10 -f /file1 "$TEST_NAME"
 
 	create_version "$TEST_NAME" 20 10 staging
-	set_as_minversion "$WEBDIR"/20
+	set_as_minversion "$WEB_DIR"/20
 
-	sudo rm -rf "$WEBDIR"/20/files/*
+	sudo rm -rf "$WEB_DIR"/20/files/*
 }
 
 @test "UPD015: Skip fullfile download for unchanged file in minversion update" {

--- a/test/functional/update/update-missing-os-core.bats
+++ b/test/functional/update/update-missing-os-core.bats
@@ -41,7 +41,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/testfile1
+	assert_file_exists "$TARGET_DIR"/testfile1
 
 }
 #WEIGHT=4

--- a/test/functional/update/update-newest-deleted.bats
+++ b/test/functional/update/update-newest-deleted.bats
@@ -47,7 +47,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/testfile
+	assert_file_not_exists "$TARGET_DIR"/testfile
 
 }
 

--- a/test/functional/update/update-newest-ghosted.bats
+++ b/test/functional/update/update-newest-ghosted.bats
@@ -38,7 +38,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 #WEIGHT=2

--- a/test/functional/update/update-no-disk-space.bats
+++ b/test/functional/update/update-no-disk-space.bats
@@ -17,12 +17,12 @@ test_setup() {
 
 	# create a file with a size of 20 MB and create an update
 	# for test-bundle that adds that file
-	file1=/test-file:"$(create_file "$WEBDIR"/20/files 20MB)"
+	file1=/test-file:"$(create_file "$WEB_DIR"/20/files 20MB)"
 	update_bundle "$TEST_NAME" test-bundle --add "$file1"
 
 	# create the state version dirs ahead of time
-	sudo mkdir -p "$STATEDIR_MANIFEST"/10
-	sudo mkdir -p "$STATEDIR_MANIFEST"/20
+	sudo mkdir -p "$ABS_MANIFEST_DIR"/10
+	sudo mkdir -p "$ABS_MANIFEST_DIR"/20
 
 }
 
@@ -40,8 +40,8 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Update started
 		Preparing to update from 10 to 20
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/10/Manifest.MoM.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/10/Manifest.MoM.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Error: Failed to retrieve 10 MoM manifest
 		Update failed
 	EOM
@@ -57,12 +57,12 @@ test_setup() {
 
 	# let's replace the bundle Manifest tar with a much larger file that will exceed
 	# the available space on disk
-	sudo rm "$WEBDIR"/20/Manifest.MoM
-	sudo rm "$WEBDIR"/20/Manifest.MoM.tar
-	fake_manifest=$(create_file "$WEBDIR"/20 15MB)
+	sudo rm "$WEB_DIR"/20/Manifest.MoM
+	sudo rm "$WEB_DIR"/20/Manifest.MoM.tar
+	fake_manifest=$(create_file "$WEB_DIR"/20 15MB)
 	manifest_name=$(basename "$fake_manifest")
-	sudo mv "$WEBDIR"/20/"$manifest_name" "$WEBDIR"/20/Manifest.MoM
-	sudo mv "$WEBDIR"/20/"$manifest_name".tar "$WEBDIR"/20/Manifest.MoM.tar
+	sudo mv "$WEB_DIR"/20/"$manifest_name" "$WEB_DIR"/20/Manifest.MoM
+	sudo mv "$WEB_DIR"/20/"$manifest_name".tar "$WEB_DIR"/20/Manifest.MoM.tar
 
 	run sudo sh -c "timeout 30 $SWUPD update $SWUPD_OPTS"
 
@@ -70,8 +70,8 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Update started
 		Preparing to update from 10 to 20
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/20/Manifest.MoM.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/20/Manifest.MoM.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Error: Failed to retrieve 20 MoM manifest
 		Update failed
 	EOM
@@ -87,12 +87,12 @@ test_setup() {
 
 	# let's replace the bundle Manifest tar with a much larger file that will exceed
 	# the available space on disk
-	sudo rm "$WEBDIR"/10/Manifest.test-bundle
-	sudo rm "$WEBDIR"/10/Manifest.test-bundle.tar
-	fake_manifest=$(create_file "$WEBDIR"/10 15MB)
+	sudo rm "$WEB_DIR"/10/Manifest.test-bundle
+	sudo rm "$WEB_DIR"/10/Manifest.test-bundle.tar
+	fake_manifest=$(create_file "$WEB_DIR"/10 15MB)
 	manifest_name=$(basename "$fake_manifest")
-	sudo mv "$WEBDIR"/10/"$manifest_name" "$WEBDIR"/10/Manifest.test-bundle
-	sudo mv "$WEBDIR"/10/"$manifest_name".tar "$WEBDIR"/10/Manifest.test-bundle.tar
+	sudo mv "$WEB_DIR"/10/"$manifest_name" "$WEB_DIR"/10/Manifest.test-bundle
+	sudo mv "$WEB_DIR"/10/"$manifest_name".tar "$WEB_DIR"/10/Manifest.test-bundle.tar
 
 	run sudo sh -c "timeout 30 $SWUPD update $SWUPD_OPTS"
 
@@ -100,8 +100,8 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Update started
 		Preparing to update from 10 to 20
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/10/Manifest.test-bundle.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/10/Manifest.test-bundle.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Error: Failed to retrieve 10 test-bundle manifest
 		Error: Cannot load current MoM sub-manifests, exiting
 		Update failed
@@ -118,12 +118,12 @@ test_setup() {
 
 	# let's replace the bundle Manifest tar with a much larger file that will exceed
 	# the available space on disk
-	sudo rm "$WEBDIR"/20/Manifest.test-bundle
-	sudo rm "$WEBDIR"/20/Manifest.test-bundle.tar
-	fake_manifest=$(create_file "$WEBDIR"/20 15MB)
+	sudo rm "$WEB_DIR"/20/Manifest.test-bundle
+	sudo rm "$WEB_DIR"/20/Manifest.test-bundle.tar
+	fake_manifest=$(create_file "$WEB_DIR"/20 15MB)
 	manifest_name=$(basename "$fake_manifest")
-	sudo mv "$WEBDIR"/20/"$manifest_name" "$WEBDIR"/20/Manifest.test-bundle
-	sudo mv "$WEBDIR"/20/"$manifest_name".tar "$WEBDIR"/20/Manifest.test-bundle.tar
+	sudo mv "$WEB_DIR"/20/"$manifest_name" "$WEB_DIR"/20/Manifest.test-bundle
+	sudo mv "$WEB_DIR"/20/"$manifest_name".tar "$WEB_DIR"/20/Manifest.test-bundle.tar
 
 	run sudo sh -c "timeout 30 $SWUPD update $SWUPD_OPTS"
 
@@ -131,8 +131,8 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Update started
 		Preparing to update from 10 to 20
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/20/Manifest.test-bundle.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/20/Manifest.test-bundle.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Error: Failed to retrieve 20 test-bundle manifest
 		Error: Unable to download manifest test-bundle version 20, exiting now
 		Update failed
@@ -147,7 +147,7 @@ test_setup() {
 	# When updating a system and we run out of disk space while downloading the
 	# bundle files we should not retry the download since it will fail for sure
 
-	file_hash=$(get_hash_from_manifest "$WEBDIR"/20/Manifest.test-bundle /test-file)
+	file_hash=$(get_hash_from_manifest "$WEB_DIR"/20/Manifest.test-bundle /test-file)
 
 	run sudo sh -c "timeout 30 $SWUPD update $SWUPD_OPTS"
 
@@ -160,8 +160,8 @@ test_setup() {
 	)
 	expected_output2=$(cat <<-EOM
 		 - test-bundle
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/20/pack-test-bundle-from-10.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/20/pack-test-bundle-from-10.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Finishing packs extraction...
 		Statistics for going from version 10 to version 20:
 		    changed bundles   : 1
@@ -172,8 +172,8 @@ test_setup() {
 		    deleted files     : 0
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
-		Error: Curl - Error downloading to local file - 'file://$TEST_DIRNAME/web-dir/20/files/$file_hash.tar'
-		Error: Curl - Check free space for $TEST_DIRNAME/testfs/state?
+		Error: Curl - Error downloading to local file - 'file://$ABS_TEST_DIR/web-dir/20/files/$file_hash.tar'
+		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state?
 		Error: Could not download all files, aborting update
 		Update failed
 	EOM

--- a/test/functional/update/update-older-server-version.bats
+++ b/test/functional/update/update-older-server-version.bats
@@ -27,7 +27,7 @@ test_setup() {
 
 @test "UPD020: Try updating a system where there is no server version file available" {
 
-	sudo rm -rf "$WEBDIR"/version
+	sudo rm -rf "$WEB_DIR"/version
 
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
@@ -43,7 +43,7 @@ test_setup() {
 
 @test "UPD021: Try updating a system where there is no target version file available" {
 
-	sudo rm -rf "$TARGETDIR"/usr/lib/os-release
+	sudo rm -rf "$TARGET_DIR"/usr/lib/os-release
 
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 

--- a/test/functional/update/update-re-update-bad-os-release.bats
+++ b/test/functional/update/update-re-update-bad-os-release.bats
@@ -8,10 +8,10 @@ test_setup() {
 	bump_format "$TEST_NAME"
 	create_version -r "$TEST_NAME" 40 30 2
 	# remove the os-release file from all manifests
-	remove_from_manifest "$WEBDIR"/10/Manifest.os-core /usr/lib/os-release
-	remove_from_manifest "$WEBDIR"/20/Manifest.os-core /usr/lib/os-release
-	remove_from_manifest "$WEBDIR"/30/Manifest.os-core /usr/lib/os-release
-	remove_from_manifest "$WEBDIR"/40/Manifest.os-core /usr/lib/os-release
+	remove_from_manifest "$WEB_DIR"/10/Manifest.os-core /usr/lib/os-release
+	remove_from_manifest "$WEB_DIR"/20/Manifest.os-core /usr/lib/os-release
+	remove_from_manifest "$WEB_DIR"/30/Manifest.os-core /usr/lib/os-release
+	remove_from_manifest "$WEB_DIR"/40/Manifest.os-core /usr/lib/os-release
 
 }
 
@@ -43,7 +43,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 #WEIGHT=8

--- a/test/functional/update/update-re-update-required.bats
+++ b/test/functional/update/update-re-update-required.bats
@@ -55,7 +55,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 #WEIGHT=7

--- a/test/functional/update/update-rename-ghosted.bats
+++ b/test/functional/update/update-rename-ghosted.bats
@@ -10,8 +10,8 @@ test_setup() {
 	update_bundle "$TEST_NAME" test-bundle --rename-legacy /foo/test-file1:/foo/test-file1-renamed
 	update_bundle "$TEST_NAME" test-bundle --rename-legacy /bar/test-file2:/bar/test-file2-renamed
 	update_bundle "$TEST_NAME" test-bundle --update /test-file3
-	update_manifest "$WEBDIR"/20/Manifest.test-bundle file-status /foo/test-file1 .g.r
-	update_manifest "$WEBDIR"/20/Manifest.test-bundle file-status /bar/test-file2 .g.r
+	update_manifest "$WEB_DIR"/20/Manifest.test-bundle file-status /foo/test-file1 .g.r
+	update_manifest "$WEB_DIR"/20/Manifest.test-bundle file-status /bar/test-file2 .g.r
 
 }
 
@@ -43,10 +43,10 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 	# all the files should still exist, including the ghosted ones
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/foo/test-file1-renamed
-	assert_file_exists "$TARGETDIR"/bar/test-file2
-	assert_file_exists "$TARGETDIR"/bar/test-file2-renamed
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/foo/test-file1-renamed
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_exists "$TARGET_DIR"/bar/test-file2-renamed
 
 }
 

--- a/test/functional/update/update-rename.bats
+++ b/test/functional/update/update-rename.bats
@@ -41,8 +41,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo/testfile2
-	assert_file_not_exists "$TARGETDIR"/foo/testfile3
+	assert_file_exists "$TARGET_DIR"/foo/testfile2
+	assert_file_not_exists "$TARGET_DIR"/foo/testfile3
 
 }
 #WEIGHT=3

--- a/test/functional/update/update-search-file-index.bats
+++ b/test/functional/update/update-search-file-index.bats
@@ -39,7 +39,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$STATEDIR_MANIFEST"/10/Manifest.test-bundle1
+	assert_file_exists "$ABS_MANIFEST_DIR"/10/Manifest.test-bundle1
 }
 
 @test "UPD060: Don't download search-file index on update" {
@@ -69,7 +69,7 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_not_exists "$STATEDIR_MANIFEST"/10/Manifest.test-bundle1
+	assert_file_not_exists "$ABS_MANIFEST_DIR"/10/Manifest.test-bundle1
 }
 
 #WEIGHT=5

--- a/test/functional/update/update-skip-scripts.bats
+++ b/test/functional/update/update-skip-scripts.bats
@@ -40,6 +40,6 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 	# The file should still be added
-	assert_file_exists "$TARGETDIR"/testfile
+	assert_file_exists "$TARGET_DIR"/testfile
 }
 #WEIGHT=3

--- a/test/functional/update/update-skip-verified-fullfiles.bats
+++ b/test/functional/update/update-skip-verified-fullfiles.bats
@@ -7,16 +7,16 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle -f /foo "$TEST_NAME"
 	create_version "$TEST_NAME" 100 10
-	filehash=$(get_hash_from_manifest "$WEBDIR"/10/Manifest.test-bundle /foo)
+	filehash=$(get_hash_from_manifest "$WEB_DIR"/10/Manifest.test-bundle /foo)
 	update_bundle "$TEST_NAME" test-bundle --update /foo
 	# restore the hash for /foo in the manifest to the original one so it no longer matches
-	manifest="$WEBDIR"/100/Manifest.test-bundle
+	manifest="$WEB_DIR"/100/Manifest.test-bundle
 	update_manifest "$manifest" file-hash /foo "$filehash"
 	# to make sure they are not used, remove packs and fullfiles
-	sudo rm "$WEBDIR"/100/pack-test-bundle-from-0.tar
-	sudo rm "$WEBDIR"/100/pack-test-bundle-from-10.tar
-	sudo rm "$WEBDIR"/100/delta/*
-	sudo rm -rf "$WEBDIR"/100/files/*
+	sudo rm "$WEB_DIR"/100/pack-test-bundle-from-0.tar
+	sudo rm "$WEB_DIR"/100/pack-test-bundle-from-10.tar
+	sudo rm "$WEB_DIR"/100/delta/*
+	sudo rm -rf "$WEB_DIR"/100/files/*
 
 }
 
@@ -46,7 +46,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/foo
+	assert_file_exists "$TARGET_DIR"/foo
 
 }
 #WEIGHT=3

--- a/test/functional/update/update-statedir-bad-hash.bats
+++ b/test/functional/update/update-statedir-bad-hash.bats
@@ -9,8 +9,8 @@ test_setup() {
 	update_bundle "$TEST_NAME" os-core --add /test-file
 	file_hash=$(get_hash_from_manifest "$TEST_NAME"/web-dir/100/Manifest.os-core /test-file)
 	# copy the file from the files directory to state/staged and modify it
-	sudo cp "$WEBDIR"/100/files/"$file_hash" "$STATEDIR_STAGED"
-	write_to_protected_file -a "$STATEDIR_STAGED"/"$file_hash" "extra string"
+	sudo cp "$WEB_DIR"/100/files/"$file_hash" "$ABS_STAGED_DIR"
+	write_to_protected_file -a "$ABS_STAGED_DIR"/"$file_hash" "extra string"
 
 }
 
@@ -43,7 +43,7 @@ test_setup() {
 	# no errors are printed for a mismatched hash
 	assert_is_output "$expected_output"
 	# the file exists on the filesystem (it does not exist before the test)
-	assert_file_exists "$TARGETDIR"/test-file
+	assert_file_exists "$TARGET_DIR"/test-file
 
 }
 #WEIGHT=2

--- a/test/functional/update/update-status-no-server-content.bats
+++ b/test/functional/update/update-status-no-server-content.bats
@@ -5,7 +5,7 @@ load "../testlib"
 test_setup() {
 
 	create_test_environment -e "$TEST_NAME"
-	sudo rm -rf "$WEBDIR"/version
+	sudo rm -rf "$WEB_DIR"/version
 
 }
 

--- a/test/functional/update/update-status-no-target-content.bats
+++ b/test/functional/update/update-status-no-target-content.bats
@@ -6,7 +6,7 @@ test_setup() {
 
 	create_test_environment -e "$TEST_NAME"
 	create_version "$TEST_NAME" 100
-	sudo rm -f "$TARGETDIR"/usr/lib/os-release
+	sudo rm -f "$TARGET_DIR"/usr/lib/os-release
 
 }
 

--- a/test/functional/update/update-type-changes-dir-to-file.bats
+++ b/test/functional/update/update-type-changes-dir-to-file.bats
@@ -41,9 +41,9 @@ test_setup() {
 	# this test covers the type change directory -> file
 	# this test covers the type change file -> directory
 
-	assert_file_exists "$TARGETDIR"/file1
-	assert_file_exists "$TARGETDIR"/common_file
-	assert_dir_exists "$TARGETDIR"/dir1
+	assert_file_exists "$TARGET_DIR"/file1
+	assert_file_exists "$TARGET_DIR"/common_file
+	assert_dir_exists "$TARGET_DIR"/dir1
 
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
@@ -72,10 +72,10 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 
-	assert_dir_exists "$TARGETDIR"/file1
-	assert_dir_not_exists "$TARGETDIR"/dir1
-	assert_file_exists "$TARGETDIR"/dir1
-	assert_file_exists "$TARGETDIR"/common_file
+	assert_dir_exists "$TARGET_DIR"/file1
+	assert_dir_not_exists "$TARGET_DIR"/dir1
+	assert_file_exists "$TARGET_DIR"/dir1
+	assert_file_exists "$TARGET_DIR"/common_file
 	show_target
 
 }

--- a/test/functional/update/update-type-changes-file-to-recursive-symlink.bats
+++ b/test/functional/update/update-type-changes-file-to-recursive-symlink.bats
@@ -45,15 +45,15 @@ test_setup() {
 	# swupd should still update correctly.
 	# Reference issue https://github.com/clearlinux/swupd-client/issues/890
 
-	assert_file_exists "$TARGETDIR"/bits/f1
-	assert_file_exists "$TARGETDIR"/bits/f2
-	assert_file_exists "$TARGETDIR"/bits/f3
-	assert_file_exists "$TARGETDIR"/ext/f4
-	assert_file_exists "$TARGETDIR"/32/bits/f1
-	assert_file_exists "$TARGETDIR"/32/bits/f2
-	assert_file_exists "$TARGETDIR"/32/bits/f3
-	assert_file_exists "$TARGETDIR"/32/ext/f4
-	assert_symlink_not_exists "$TARGETDIR"/32
+	assert_file_exists "$TARGET_DIR"/bits/f1
+	assert_file_exists "$TARGET_DIR"/bits/f2
+	assert_file_exists "$TARGET_DIR"/bits/f3
+	assert_file_exists "$TARGET_DIR"/ext/f4
+	assert_file_exists "$TARGET_DIR"/32/bits/f1
+	assert_file_exists "$TARGET_DIR"/32/bits/f2
+	assert_file_exists "$TARGET_DIR"/32/bits/f3
+	assert_file_exists "$TARGET_DIR"/32/ext/f4
+	assert_symlink_not_exists "$TARGET_DIR"/32
 
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
@@ -83,15 +83,15 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 
-	assert_file_exists "$TARGETDIR"/bits/f1
-	assert_file_exists "$TARGETDIR"/bits/f2
-	assert_file_exists "$TARGETDIR"/bits/f3
-	assert_file_exists "$TARGETDIR"/ext/f4
-	assert_symlink_exists "$TARGETDIR"/32
-	assert_file_exists "$TARGETDIR"/32/bits/f1
-	assert_file_exists "$TARGETDIR"/32/bits/f2
-	assert_file_exists "$TARGETDIR"/32/bits/f3
-	assert_file_exists "$TARGETDIR"/32/ext/f4
+	assert_file_exists "$TARGET_DIR"/bits/f1
+	assert_file_exists "$TARGET_DIR"/bits/f2
+	assert_file_exists "$TARGET_DIR"/bits/f3
+	assert_file_exists "$TARGET_DIR"/ext/f4
+	assert_symlink_exists "$TARGET_DIR"/32
+	assert_file_exists "$TARGET_DIR"/32/bits/f1
+	assert_file_exists "$TARGET_DIR"/32/bits/f2
+	assert_file_exists "$TARGET_DIR"/32/bits/f3
+	assert_file_exists "$TARGET_DIR"/32/ext/f4
 
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
 	assert_status_is "$SWUPD_OK"

--- a/test/functional/update/update-type-changes-file-to-symlink.bats
+++ b/test/functional/update/update-type-changes-file-to-symlink.bats
@@ -43,10 +43,10 @@ test_setup() {
 	# this test covers the type change file -> symlink
 	# this test covers the type change directory -> symlink
 
-	assert_file_exists "$TARGETDIR"/file1
-	assert_dir_exists "$TARGETDIR"/dir1/dir2
-	assert_file_exists "$TARGETDIR"/dir1/dir2/file2
-	assert_file_exists "$TARGETDIR"/file3
+	assert_file_exists "$TARGET_DIR"/file1
+	assert_dir_exists "$TARGET_DIR"/dir1/dir2
+	assert_file_exists "$TARGET_DIR"/dir1/dir2/file2
+	assert_file_exists "$TARGET_DIR"/file3
 
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
@@ -75,11 +75,11 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 
-	assert_symlink_exists "$TARGETDIR"/file1
-	assert_symlink_exists "$TARGETDIR"/dir1/dir2
-	assert_file_exists "$TARGETDIR"/dir1/dir2/file2
-	assert_file_exists "$TARGETDIR"/file3
-	assert_file_exists "$TARGETDIR"/file4
+	assert_symlink_exists "$TARGET_DIR"/file1
+	assert_symlink_exists "$TARGET_DIR"/dir1/dir2
+	assert_file_exists "$TARGET_DIR"/dir1/dir2/file2
+	assert_file_exists "$TARGET_DIR"/file3
+	assert_file_exists "$TARGET_DIR"/file4
 	show_target
 
 }

--- a/test/functional/update/update-type-changes-symlink-to-file.bats
+++ b/test/functional/update/update-type-changes-symlink-to-file.bats
@@ -54,11 +54,11 @@ test_setup() {
 	# this test covers the type change absolute symlink -> file
 	# this test covers the type change symlink -> directory
 
-	assert_file_exists "$TARGETDIR"/fileA
-	assert_symlink_exists "$TARGETDIR"/file1
-	assert_dir_exists "$TARGETDIR"/dir1/dirA
-	assert_symlink_exists "$TARGETDIR"/dir1/dir2
-	assert_symlink_exists "$TARGETDIR"/external_file
+	assert_file_exists "$TARGET_DIR"/fileA
+	assert_symlink_exists "$TARGET_DIR"/file1
+	assert_dir_exists "$TARGET_DIR"/dir1/dirA
+	assert_symlink_exists "$TARGET_DIR"/dir1/dir2
+	assert_symlink_exists "$TARGET_DIR"/external_file
 
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
@@ -87,15 +87,15 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 
-	assert_symlink_not_exists "$TARGETDIR"/file1
-	assert_file_exists "$TARGETDIR"/file1
-	assert_symlink_not_exists "$TARGETDIR"/dir1/dir2
-	assert_dir_exists "$TARGETDIR"/dir1/dir2
-	assert_symlink_not_exists "$TARGETDIR"/external_file
-	assert_file_exists "$TARGETDIR"/external_file
-	assert_file_exists "$TARGETDIR"/dir1/dir2/file2
-	assert_file_exists "$TARGETDIR"/file3
-	assert_file_exists "$TARGETDIR"/file4
+	assert_symlink_not_exists "$TARGET_DIR"/file1
+	assert_file_exists "$TARGET_DIR"/file1
+	assert_symlink_not_exists "$TARGET_DIR"/dir1/dir2
+	assert_dir_exists "$TARGET_DIR"/dir1/dir2
+	assert_symlink_not_exists "$TARGET_DIR"/external_file
+	assert_file_exists "$TARGET_DIR"/external_file
+	assert_file_exists "$TARGET_DIR"/dir1/dir2/file2
+	assert_file_exists "$TARGET_DIR"/file3
+	assert_file_exists "$TARGET_DIR"/file4
 
 }
 #WEIGHT=6

--- a/test/functional/update/update-unusual-file-names.bats
+++ b/test/functional/update/update-unusual-file-names.bats
@@ -27,7 +27,7 @@ test_setup() {
 
 	# Unusual link names
 	create_bundle -n test-bundle1 -l "/usr/links/'link1'",'/usr/links/"link2"','/usr/links/very_unusual_¹²³!@#$%^&*()_;[]{}\_link3','/usr/links/link:4' "$TEST_NAME"
-	add_dependency_to_manifest "$WEBDIR"/20/Manifest.os-core test-bundle1
+	add_dependency_to_manifest "$WEB_DIR"/20/Manifest.os-core test-bundle1
 
 }
 
@@ -62,24 +62,24 @@ test_setup() {
 	)
 	assert_is_output "$expected_output"
 
-	assert_file_exists "$TARGETDIR""/usr/simple_file"
+	assert_file_exists "$TARGET_DIR""/usr/simple_file"
 
 	# Unusual dir names
-	assert_file_exists "$TARGETDIR""/usr/unusual_'dirname'/normal_file1"
-	assert_file_exists "$TARGETDIR"'/usr/unusual_"dirname"/normal_file2'
-	assert_file_exists "$TARGETDIR"'/usr/very_unusual_,¹²³!@#$%^&*()_;[]{}\`_name/normal_file3'
-	assert_file_exists "$TARGETDIR"'/usr/unusual:dirname/normal_file4'
+	assert_file_exists "$TARGET_DIR""/usr/unusual_'dirname'/normal_file1"
+	assert_file_exists "$TARGET_DIR"'/usr/unusual_"dirname"/normal_file2'
+	assert_file_exists "$TARGET_DIR"'/usr/very_unusual_,¹²³!@#$%^&*()_;[]{}\`_name/normal_file3'
+	assert_file_exists "$TARGET_DIR"'/usr/unusual:dirname/normal_file4'
 
 	# Unusual file names
-	assert_file_exists "$TARGETDIR""/usr/unusual_files/'file1'"
-	assert_file_exists "$TARGETDIR"'/usr/unusual_files/"file2"'
-	assert_file_exists "$TARGETDIR"'/usr/unusual_files/very_unusual_,¹²³!@#$%^&*()_;[]{}\_file3'
-	assert_file_exists "$TARGETDIR""/usr/unusual_files/file:4"
+	assert_file_exists "$TARGET_DIR""/usr/unusual_files/'file1'"
+	assert_file_exists "$TARGET_DIR"'/usr/unusual_files/"file2"'
+	assert_file_exists "$TARGET_DIR"'/usr/unusual_files/very_unusual_,¹²³!@#$%^&*()_;[]{}\_file3'
+	assert_file_exists "$TARGET_DIR""/usr/unusual_files/file:4"
 
 	# Unusual link names
-	assert_symlink_exists "$TARGETDIR""/usr/links/'link1'"
-	assert_symlink_exists "$TARGETDIR"'/usr/links/"link2"'
-	assert_symlink_exists "$TARGETDIR"'/usr/links/very_unusual_¹²³!@#$%^&*()_;[]{}\_link3'
-	assert_symlink_exists "$TARGETDIR""/usr/links/link:4"
+	assert_symlink_exists "$TARGET_DIR""/usr/links/'link1'"
+	assert_symlink_exists "$TARGET_DIR"'/usr/links/"link2"'
+	assert_symlink_exists "$TARGET_DIR"'/usr/links/very_unusual_¹²³!@#$%^&*()_;[]{}\_link3'
+	assert_symlink_exists "$TARGET_DIR""/usr/links/link:4"
 }
 #WEIGHT=10

--- a/test/functional/update/update-use-full-file.bats
+++ b/test/functional/update/update-use-full-file.bats
@@ -8,8 +8,8 @@ test_setup() {
 	create_version "$TEST_NAME" 100 10
 	update_bundle "$TEST_NAME" os-core --update /core
 	# remove packs so full file is used
-	sudo rm -rf "$WEBDIR"/100/pack-*
-	sudo rm -f "$WEBDIR"/100/delta/*
+	sudo rm -rf "$WEB_DIR"/100/pack-*
+	sudo rm -f "$WEB_DIR"/100/delta/*
 
 }
 
@@ -41,7 +41,7 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/core
 
 }
 #WEIGHT=2

--- a/test/functional/update/update-use-pack.bats
+++ b/test/functional/update/update-use-pack.bats
@@ -36,10 +36,10 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/core
+	assert_file_exists "$TARGET_DIR"/core
 	# make sure the file was updated correctly
-	fhash=$(get_hash_from_manifest "$WEBDIR"/100/Manifest.os-core /core)
-	assert_files_equal "$TARGETDIR"/core "$TEST_NAME"/web-dir/100/files/"$fhash"
+	fhash=$(get_hash_from_manifest "$WEB_DIR"/100/Manifest.os-core /core)
+	assert_files_equal "$TARGET_DIR"/core "$TEST_NAME"/web-dir/100/files/"$fhash"
 
 }
 #WEIGHT=2

--- a/test/functional/update/update-verify-fix-path-hash-mismatch.bats
+++ b/test/functional/update/update-verify-fix-path-hash-mismatch.bats
@@ -7,9 +7,9 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle -f /usr/foo/test-file "$TEST_NAME"
 	# remove the installed foo directory
-	sudo rm -rf "$TARGETDIR"/usr/foo
+	sudo rm -rf "$TARGET_DIR"/usr/foo
 	# change permissions of the installed usr directory so the hash doesn't match
-	sudo chmod g+w "$TARGETDIR"/usr
+	sudo chmod g+w "$TARGET_DIR"/usr
 	# create an update
 	create_version "$TEST_NAME" 100 10
 	update_bundle "$TEST_NAME" test-bundle --update /usr/foo/test-file
@@ -19,9 +19,9 @@ test_setup() {
 @test "UPD030: Update corrects a directory that has a hash mismatch" {
 
 	# pre-test validations
-	assert_dir_not_exists "$TARGETDIR"/usr/foo
-	file_hash=$(sudo "$SWUPD" hashdump --quiet "$TARGETDIR"/usr)
-	good_hash=$(get_hash_from_manifest "$WEBDIR"/100/Manifest.test-bundle /usr)
+	assert_dir_not_exists "$TARGET_DIR"/usr/foo
+	file_hash=$(sudo "$SWUPD" hashdump --quiet "$TARGET_DIR"/usr)
+	good_hash=$(get_hash_from_manifest "$WEB_DIR"/100/Manifest.test-bundle /usr)
 	assert_not_equal "$file_hash" "$good_hash"
 
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
@@ -53,8 +53,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_dir_exists "$TARGETDIR"/usr/foo
-	assert_file_exists "$TARGETDIR"/usr/foo/test-file
+	assert_dir_exists "$TARGET_DIR"/usr/foo
+	assert_file_exists "$TARGET_DIR"/usr/foo/test-file
 
 }
 #WEIGHT=3

--- a/test/functional/update/update-verify-fix-path-missing-dir.bats
+++ b/test/functional/update/update-verify-fix-path-missing-dir.bats
@@ -7,7 +7,7 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle -f /foo/bar/baz/test-file "$TEST_NAME"
 	# remove the foo dir
-	sudo rm -rf "$TARGETDIR"/foo
+	sudo rm -rf "$TARGET_DIR"/foo
 	create_version "$TEST_NAME" 100 10
 	update_bundle "$TEST_NAME" test-bundle --update /foo/bar/baz/test-file
 
@@ -15,7 +15,7 @@ test_setup() {
 
 @test "UPD029: Update corrects a missing directory in the target system" {
 
-	assert_dir_not_exists "$TARGETDIR"/foo
+	assert_dir_not_exists "$TARGET_DIR"/foo
 
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
@@ -46,8 +46,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_dir_exists "$TARGETDIR"/foo/bar/baz
-	assert_file_exists "$TARGETDIR"/foo/bar/baz/test-file
+	assert_dir_exists "$TARGET_DIR"/foo/bar/baz
+	assert_file_exists "$TARGET_DIR"/foo/bar/baz/test-file
 
 }
 

--- a/test/functional/update/update-verify-fullfile-hash.bats
+++ b/test/functional/update/update-verify-fullfile-hash.bats
@@ -7,15 +7,15 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 	create_version "$TEST_NAME" 100 10
 	update_bundle "$TEST_NAME" os-core --update /core
-	file_hash=$(get_hash_from_manifest "$WEBDIR"/100/Manifest.os-core /core)
+	file_hash=$(get_hash_from_manifest "$WEB_DIR"/100/Manifest.os-core /core)
 	# remove the /usr/bin/core file from the system
-	sudo rm -f "$TARGETDIR"/core
+	sudo rm -f "$TARGET_DIR"/core
 	# remove packs so fullfiles are used
-	sudo rm -rf "$WEBDIR"/100/pack-*
+	sudo rm -rf "$WEB_DIR"/100/pack-*
 	# modify the fullfile so it is corrupt
-	write_to_protected_file -a "$WEBDIR"/100/files/"$file_hash" "some extra stuff to break the hash"
-	sudo rm "$WEBDIR"/100/files/"$file_hash".tar
-	create_tar "$WEBDIR"/100/files/"$file_hash"
+	write_to_protected_file -a "$WEB_DIR"/100/files/"$file_hash" "some extra stuff to break the hash"
+	sudo rm "$WEB_DIR"/100/files/"$file_hash".tar
+	create_tar "$WEB_DIR"/100/files/"$file_hash"
 
 }
 
@@ -43,7 +43,7 @@ test_setup() {
 	EOM
 	)
 	assert_regex_is_output "$expected_output"
-	assert_file_not_exists "$TARGETDIR"/core
+	assert_file_not_exists "$TARGET_DIR"/core
 
 }
 #WEIGHT=2

--- a/test/functional/update/update-with-mirror-signature.bats
+++ b/test/functional/update/update-with-mirror-signature.bats
@@ -21,14 +21,14 @@ test_setup() {
 
 @test "UPD061: Updating a system using mirror without latest signature" {
 
-	sudo rm "$MIRROR"/version/formatstaging/latest.sig
+	sudo rm "$ABS_MIRROR_DIR"/version/formatstaging/latest.sig
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Update started
 		Checking mirror status
-		Error: Signature for latest file (file://$TEST_ROOT_DIR/$MIRROR/version/formatstaging/latest) is missing
+		Error: Signature for latest file (file://$ABS_MIRROR_DIR/version/formatstaging/latest) is missing
 		Warning: the mirror version could not be determined
 		Removing mirror configuration
 		Preparing to update from 10 to 20
@@ -51,21 +51,21 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/file_2
-	assert_file_exists "$TARGETDIR"/file_3
+	assert_file_exists "$TARGET_DIR"/file_2
+	assert_file_exists "$TARGET_DIR"/file_3
 
 }
 
 @test "UPD062: Updating a system using mirror with invalid latest signature" {
 
-	write_to_protected_file "$MIRROR"/version/formatstaging/latest.sig "1234"
+	write_to_protected_file "$ABS_MIRROR_DIR"/version/formatstaging/latest.sig "1234"
 	run sudo sh -c "$SWUPD update $SWUPD_OPTS"
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
 		Update started
 		Checking mirror status
-		Error: Signature verification failed for URL: file://$TEST_ROOT_DIR/$MIRROR/version/formatstaging/latest
+		Error: Signature verification failed for URL: file://$ABS_MIRROR_DIR/version/formatstaging/latest
 		Warning: the mirror version could not be determined
 		Removing mirror configuration
 		Preparing to update from 10 to 20
@@ -88,8 +88,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/file_2
-	assert_file_exists "$TARGETDIR"/file_3
+	assert_file_exists "$TARGET_DIR"/file_2
+	assert_file_exists "$TARGET_DIR"/file_3
 
 }
 #WEIGHT=7

--- a/test/functional/update/update-with-mirror.bats
+++ b/test/functional/update/update-with-mirror.bats
@@ -54,8 +54,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/file_2
-	assert_file_not_exists "$TARGETDIR"/file_3
+	assert_file_exists "$TARGET_DIR"/file_2
+	assert_file_not_exists "$TARGET_DIR"/file_3
 
 }
 #WEIGHT=4

--- a/test/functional/update/update-with-old-mirror.bats
+++ b/test/functional/update/update-with-old-mirror.bats
@@ -57,8 +57,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/file_2
-	assert_file_exists "$TARGETDIR"/file_3
+	assert_file_exists "$TARGET_DIR"/file_2
+	assert_file_exists "$TARGET_DIR"/file_3
 
 }
 #WEIGHT=4

--- a/test/functional/update/update-with-slightly-old-mirror.bats
+++ b/test/functional/update/update-with-slightly-old-mirror.bats
@@ -57,8 +57,8 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/file_2
-	assert_file_not_exists "$TARGETDIR"/file_3
+	assert_file_exists "$TARGET_DIR"/file_2
+	assert_file_not_exists "$TARGET_DIR"/file_3
 
 }
 #WEIGHT=4

--- a/test/functional/usability/usa-cachedir-with-symlink.bats
+++ b/test/functional/usability/usa-cachedir-with-symlink.bats
@@ -10,8 +10,8 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 
 	# create a symlink to the the statedir
-	sudo ln -s "$STATEDIR_ABS" "$TEST_DIRNAME"/state_path
-	sudo mkdir "$STATEDIR_ABS"/new_state
+	sudo ln -s "$ABS_STATE_DIR" "$ABS_TEST_DIR"/state_path
+	sudo mkdir "$ABS_STATE_DIR"/new_state
 
 }
 
@@ -20,7 +20,7 @@ test_setup() {
 	# swupd should be able to extract files in the cache dir even when the path
 	# provided for the cache directory contains symlinks
 
-	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_STATE --statedir $TEST_DIRNAME/state_path/new_state"
+	run sudo sh -c "$SWUPD os-install $SWUPD_OPTS_NO_STATE --statedir $ABS_TEST_DIR/state_path/new_state"
 	assert_status_is "$SWUPD_OK"
 
 }

--- a/test/functional/usability/usa-completion-basic.bats
+++ b/test/functional/usability/usa-completion-basic.bats
@@ -4,25 +4,25 @@ load "../testlib"
 
 @test "USA001: Verify the script for autocomplete exists" {
 
-	assert_file_exists "$SWUPD_DIR"/swupd.bash
+	assert_file_exists "$ABS_SWUPD_DIR"/swupd.bash
 
 }
 
 @test "USA002: Verify the autocomplete syntax" {
 
-	bash --posix "$SWUPD_DIR"/swupd.bash
+	bash --posix "$ABS_SWUPD_DIR"/swupd.bash
 
 }
 
 @test "USA003: Autocomplete has autoupdate" {
 
-	grep -q  '("bundle-add")' "$SWUPD_DIR"/swupd.bash
+	grep -q  '("bundle-add")' "$ABS_SWUPD_DIR"/swupd.bash
 
 }
 
 @test "USA004: Autocomplete has expected hashdump" {
 
-	grep -q  '("hashdump")' "$SWUPD_DIR"/swupd.bash
+	grep -q  '("hashdump")' "$ABS_SWUPD_DIR"/swupd.bash
 
 }
 #WEIGHT=1

--- a/test/functional/usability/usa-config-file.bats
+++ b/test/functional/usability/usa-config-file.bats
@@ -137,7 +137,7 @@ test_setup() {
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS"
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
-		Checking for extra files under $TEST_DIRNAME/testfs/target-dir/usr
+		Checking for extra files under $ABS_TEST_DIR/testfs/target-dir/usr
 	EOM
 	)
 	assert_in_output "$expected_output"
@@ -175,7 +175,7 @@ test_setup() {
 	run sudo sh -c "$SWUPD diagnose $SWUPD_OPTS --picky-tree /usr/lib"
 	assert_status_is "$SWUPD_NO"
 	expected_output=$(cat <<-EOM
-		Checking for extra files under $TEST_DIRNAME/testfs/target-dir/usr/lib
+		Checking for extra files under $ABS_TEST_DIR/testfs/target-dir/usr/lib
 	EOM
 	)
 	assert_in_output "$expected_output"
@@ -194,8 +194,8 @@ test_setup() {
 	expected_output=$(cat <<-EOM
 		Distribution:      Swupd Test Distro
 		Installed version: 10
-		Version URL:       file://$TEST_DIRNAME/web-dir
-		Content URL:       file://$TEST_DIRNAME/web-dir
+		Version URL:       file://$ABS_TEST_DIR/web-dir
+		Content URL:       file://$ABS_TEST_DIR/web-dir
 	EOM
 	)
 	assert_is_output "$expected_output"
@@ -216,8 +216,8 @@ test_setup() {
 		Warning: Unrecognized option 'invalid_option=true' from section [global] in the configuration file
 		Distribution:      Swupd Test Distro
 		Installed version: 10
-		Version URL:       file://$TEST_DIRNAME/web-dir
-		Content URL:       file://$TEST_DIRNAME/web-dir
+		Version URL:       file://$ABS_TEST_DIR/web-dir
+		Content URL:       file://$ABS_TEST_DIR/web-dir
 	EOM
 	)
 	assert_is_output "$expected_output"
@@ -244,7 +244,7 @@ test_setup() {
 		Checking for missing files
 		Checking for corrupt files
 		Checking for extraneous files
-		Checking for extra files under $TEST_DIRNAME/testfs/target-dir/usr
+		Checking for extra files under $ABS_TEST_DIR/testfs/target-dir/usr
 	EOM
 	)
 	assert_in_output "$expected_output"

--- a/test/functional/usability/usa-download-retries.bats
+++ b/test/functional/usability/usa-download-retries.bats
@@ -10,7 +10,7 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 	create_bundle -n test-bundle -f /file_1 "$TEST_NAME"
 	# start a web server that will return status code 204 for all requests
-	start_web_server -r -D "$WEBDIR" -f 204
+	start_web_server -r -D "$WEB_DIR" -f 204
 	port=$(get_web_server_port "$TEST_NAME")
 	# set the versionurl and contenturl to point to the web server
 	set_upstream_server "$TEST_NAME" http://localhost:"$port"

--- a/test/functional/verify-legacy/verify-bundle.bats
+++ b/test/functional/verify-legacy/verify-bundle.bats
@@ -10,8 +10,8 @@ test_setup() {
 	create_test_environment "$TEST_NAME"
 	create_bundle -L -n test-bundle1 -f /foo/test-file1 "$TEST_NAME"
 	create_bundle -L -n test-bundle2 -f /bar/test-file2 "$TEST_NAME"
-	sudo rm -f "$TARGETDIR"/foo/test-file1
-	sudo rm -f "$TARGETDIR"/bar/test-file2
+	sudo rm -f "$TARGET_DIR"/foo/test-file1
+	sudo rm -f "$TARGET_DIR"/bar/test-file2
 
 }
 
@@ -31,7 +31,7 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $TEST_DIRNAME/testfs/target-dir/bar/test-file2 -> fixed
+		 -> Missing file: $ABS_TEST_DIR/testfs/target-dir/bar/test-file2 -> fixed
 		Repairing corrupt files
 		Removing extraneous files
 		Inspected 5 files
@@ -43,9 +43,9 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_not_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/bar/test-file2
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_not_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
 
 }
 
@@ -66,9 +66,9 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $TEST_DIRNAME/testfs/target-dir/baz -> fixed
-		 -> Missing file: $TEST_DIRNAME/testfs/target-dir/baz/test-file3 -> fixed
-		 -> Missing file: $TEST_DIRNAME/testfs/target-dir/usr/share/clear/bundles/test-bundle3 -> fixed
+		 -> Missing file: $ABS_TEST_DIR/testfs/target-dir/baz -> fixed
+		 -> Missing file: $ABS_TEST_DIR/testfs/target-dir/baz/test-file3 -> fixed
+		 -> Missing file: $ABS_TEST_DIR/testfs/target-dir/usr/share/clear/bundles/test-bundle3 -> fixed
 		Repairing corrupt files
 		Removing extraneous files
 		Inspected 5 files
@@ -80,10 +80,10 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_not_exists "$TARGETDIR"/foo/test-file1
-	assert_file_not_exists "$TARGETDIR"/bar/test-file2
-	assert_file_exists "$TARGETDIR"/baz/test-file3
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_not_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_not_exists "$TARGET_DIR"/bar/test-file2
+	assert_file_exists "$TARGET_DIR"/baz/test-file3
 
 }
 
@@ -103,8 +103,8 @@ test_setup() {
 		Validate downloaded files
 		Starting download of remaining update content. This may take a while...
 		Adding any missing files
-		 -> Missing file: $TEST_DIRNAME/testfs/target-dir/bar/test-file2 -> fixed
-		 -> Missing file: $TEST_DIRNAME/testfs/target-dir/foo/test-file1 -> fixed
+		 -> Missing file: $ABS_TEST_DIR/testfs/target-dir/bar/test-file2 -> fixed
+		 -> Missing file: $ABS_TEST_DIR/testfs/target-dir/foo/test-file1 -> fixed
 		Repairing corrupt files
 		Removing extraneous files
 		Inspected 8 files
@@ -116,9 +116,9 @@ test_setup() {
 	EOM
 	)
 	assert_is_output "$expected_output"
-	assert_file_exists "$TARGETDIR"/core
-	assert_file_exists "$TARGETDIR"/foo/test-file1
-	assert_file_exists "$TARGETDIR"/bar/test-file2
+	assert_file_exists "$TARGET_DIR"/core
+	assert_file_exists "$TARGET_DIR"/foo/test-file1
+	assert_file_exists "$TARGET_DIR"/bar/test-file2
 
 }
 


### PR DESCRIPTION
This PR includes many updates for environment variables in testlib:
- Adds information about BATS env variables
- Makes variable names more consistent by following a local convention for variables
- Moves the location where variables are set and exported so they are easily identified
- Some environment variables were available to all tests within a test file while others were only available to the first test, this PR also makes all variables available to all tests within a file
- Refactors a the setup of tests to make it more straightforward and corrects some loading problems it had

Closes #1479 
Closes #1484 
Closes #1489 

It is still a work in progress. Not ready for review.