### PR TITLE
Announce overrides of content and version URLs

### DIFF
--- a/src/swupd_lib/globals.c
+++ b/src/swupd_lib/globals.c
@@ -533,6 +533,7 @@ static bool global_parse_opt(int opt, char *optarg)
 		}
 		return true;
 	case 'u':
+		print("Overriding version and content URLs with %s\n", optarg);
 		set_version_url(optarg);
 		set_content_url(optarg);
 		return true;
@@ -544,9 +545,11 @@ static bool global_parse_opt(int opt, char *optarg)
 		}
 		return true;
 	case 'c':
+		print("Overriding content URL with %s\n", optarg);
 		set_content_url(optarg);
 		return true;
 	case 'v':
+		print("Overriding version URL with %s\n", optarg);
 		set_version_url(optarg);
 		return true;
 	case 'F':

--- a/test/functional/mirror/mirror-set-unset.bats
+++ b/test/functional/mirror/mirror-set-unset.bats
@@ -68,6 +68,7 @@ global_setup() {
 	run sudo sh -c "$SWUPD mirror --set -u https://example.com/swupd-file $SWUPD_OPTS"
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Overriding version and content URLs with https://example.com/swupd-file
 		Mirror url set
 		Distribution:      Swupd Test Distro
 		Installed version: 10
@@ -101,6 +102,7 @@ global_setup() {
 	run sudo sh -c "$SWUPD mirror --set -c https://example.com/swupd-file $SWUPD_OPTS"
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Overriding content URL with https://example.com/swupd-file
 		Mirror url set
 		Distribution:      Swupd Test Distro
 		Installed version: 10
@@ -134,6 +136,7 @@ global_setup() {
 	run sudo sh -c "$SWUPD mirror --set -v https://example.com/swupd-file $SWUPD_OPTS"
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
+		Overriding version URL with https://example.com/swupd-file
 		Mirror url set
 		Distribution:      Swupd Test Distro
 		Installed version: 10

--- a/test/functional/os-install/install-statedir-cache-offline.bats
+++ b/test/functional/os-install/install-statedir-cache-offline.bats
@@ -32,6 +32,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
+		Overriding version and content URLs with https://localhost
 		Installing OS version 10
 		Downloading missing manifests...
 		No packs need to be downloaded
@@ -62,6 +63,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MANIFEST"
 	expected_output=$(cat <<-EOM
+		Overriding version and content URLs with https://localhost
 		Installing OS version 10
 		Downloading missing manifests...
 		Error: Failed to connect to update server: https://localhost/10/Manifest.os-core.tar
@@ -90,6 +92,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
+		Overriding version and content URLs with https://localhost
 		Installing OS version 10
 		Error: Failed to connect to update server: https://localhost/10/Manifest.MoM.sig
 		Possible solutions for this problem are:
@@ -118,6 +121,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_DOWNLOAD_FILE"
 	expected_output=$(cat <<-EOM
+		Overriding version and content URLs with https://localhost
 		Installing OS version 10
 		Downloading missing manifests...
 		No packs need to be downloaded
@@ -149,6 +153,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
+		Overriding version and content URLs with https://localhost
 		Installing OS version 10
 		Downloading missing manifests...
 		Error: Failed to connect to update server: https://localhost


### PR DESCRIPTION
When using -v, -c, or -u to set alternate version or content URLs, print out a message so it's a little bit more obvious when you accidentally use the wrong option.