### PR TITLE
Move packs to download synchronously

### DIFF
--- a/test/functional/bundleadd/add-json.bats
+++ b/test/functional/bundleadd/add-json.bats
@@ -32,11 +32,8 @@ test_setup() {
 		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 8, "stepCompletion" : 0, "stepDescription" : "download_packs" },
 		{ "type" : "info", "msg" : "Downloading packs for:" },
 		{ "type" : "info", "msg" : " - test-bundle" },
-	EOM
-	)
-	expected_output2=$(cat <<-EOM
-		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 8, "stepCompletion" : 100, "stepDescription" : "download_packs" },
 		{ "type" : "info", "msg" : "Finishing packs extraction..." },
+		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 8, "stepCompletion" : 100, "stepDescription" : "download_packs" },
 		{ "type" : "progress", "currentStep" : 3, "totalSteps" : 8, "stepCompletion" : -1, "stepDescription" : "extract_packs" },
 		{ "type" : "progress", "currentStep" : 3, "totalSteps" : 8, "stepCompletion" : 100, "stepDescription" : "extract_packs" },
 		{ "type" : "progress", "currentStep" : 4, "totalSteps" : 8, "stepCompletion" : 0, "stepDescription" : "validate_fullfiles" },
@@ -93,7 +90,6 @@ test_setup() {
 	EOM
 	)
 	assert_in_output "$expected_output1"
-	assert_in_output "$expected_output2"
 
 }
 #WEIGHT=3

--- a/test/functional/only_in_ci_slow/update-slow-server.bats
+++ b/test/functional/only_in_ci_slow/update-slow-server.bats
@@ -35,11 +35,9 @@ test_setup() {
 		Downloading packs for:
 		 - test-bundle
 		Error: Curl - File incompletely downloaded - '.*/100/pack-test-bundle-from-10.tar'
+		Waiting 10 seconds before retrying the download
+		Retry #1 downloading from .*/100/pack-test-bundle-from-10.tar
 		Finishing packs extraction...
-		Curl - Starting download retry #1 for .*/100/pack-test-bundle-from-10.tar
-		Curl - Resuming download for '.*/100/pack-test-bundle-from-10.tar'
-		Error: Curl - Range command not supported by server, download resume disabled - '.*/100/pack-test-bundle-from-10.tar'
-		Curl - Starting download retry #2 for .*/100/pack-test-bundle-from-10.tar
 		Statistics for going from version 10 to version 100:
 		    changed bundles   : 1
 		    new bundles       : 0

--- a/test/functional/only_in_ci_system/add-no-disk-space.bats
+++ b/test/functional/only_in_ci_system/add-no-disk-space.bats
@@ -130,18 +130,6 @@ test_setup() {
 		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
 		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
 		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
-		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
-		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
-		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
-		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
-		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
-		Error: Curl - Error downloading to local file - 'http://localhost:$(get_web_server_port "$TEST_NAME")/$TEST_NAME/web-dir/10/.*.tar'
-		Error: Curl - Check free space for $ABS_TEST_DIR/testfs/state\\?
 		Error: Could not download some files from bundles, aborting bundle installation
 		Failed to install 1 of 1 bundles
 	EOM

--- a/test/functional/os-install/install-json.bats
+++ b/test/functional/os-install/install-json.bats
@@ -31,11 +31,8 @@ test_setup() {
 		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 9, "stepCompletion" : 0, "stepDescription" : "download_packs" },
 		{ "type" : "info", "msg" : "Downloading packs for:" },
 		{ "type" : "info", "msg" : " - os-core" },
-	EOM
-	)
-	expected_output2=$(cat <<-EOM
-		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 9, "stepCompletion" : 100, "stepDescription" : "download_packs" },
 		{ "type" : "info", "msg" : "Finishing packs extraction..." },
+		{ "type" : "progress", "currentStep" : 2, "totalSteps" : 9, "stepCompletion" : 100, "stepDescription" : "download_packs" },
 		{ "type" : "progress", "currentStep" : 3, "totalSteps" : 9, "stepCompletion" : -1, "stepDescription" : "extract_packs" },
 		{ "type" : "progress", "currentStep" : 3, "totalSteps" : 9, "stepCompletion" : 100, "stepDescription" : "extract_packs" },
 		{ "type" : "progress", "currentStep" : 4, "totalSteps" : 9, "stepCompletion" : 0, "stepDescription" : "check_files_hash" },
@@ -61,13 +58,16 @@ test_setup() {
 		{ "type" : "info", "msg" : "    0 of 2 missing files were not installed" },
 		{ "type" : "progress", "currentStep" : 9, "totalSteps" : 9, "stepCompletion" : -1, "stepDescription" : "run_postupdate_scripts" },
 		{ "type" : "info", "msg" : "Calling post-update helper scripts" },
-		{ "type" : "warning", "msg" : "helper script ($ABS_TEST_DIR/testfs/target-dir/usr/bin/clr-boot-manager) not found, it will be skipped" },
+	EOM
+	)
+	expected_output2=$(cat <<-EOM
 		{ "type" : "info", "msg" : " Installation successful" },
 		{ "type" : "progress", "currentStep" : 9, "totalSteps" : 9, "stepCompletion" : 100, "stepDescription" : "run_postupdate_scripts" },
 		{ "type" : "end", "section" : "os-install", "status" : 0 }
 		]
 	EOM
 	)
+
 	assert_in_output "$expected_output1"
 	assert_in_output "$expected_output2"
 

--- a/test/functional/os-install/install-no-fullfile-fallback.bats
+++ b/test/functional/os-install/install-no-fullfile-fallback.bats
@@ -27,7 +27,6 @@ test_setup() {
 		Downloading missing manifests...
 		Downloading packs for:
 		 - os-core
-		Finishing packs extraction...
 		Error: zero pack downloads failed
 		Checking for corrupt files
 		Validate downloaded files

--- a/test/functional/os-install/install-no-packs.bats
+++ b/test/functional/os-install/install-no-packs.bats
@@ -27,7 +27,6 @@ test_setup() {
 		Downloading missing manifests...
 		Downloading packs for:
 		 - os-core
-		Finishing packs extraction...
 		Error: zero pack downloads failed
 		Checking for corrupt files
 		Validate downloaded files

--- a/test/functional/os-install/install-statedir-cache-offline.bats
+++ b/test/functional/os-install/install-statedir-cache-offline.bats
@@ -156,12 +156,14 @@ test_setup() {
 		Overriding version and content URLs with https://localhost
 		Installing OS version 10
 		Downloading missing manifests...
-		Error: Failed to connect to update server: https://localhost
+		Error: Failed to connect to update server: https://localhost/10/pack-os-core-from-0.tar
 		Possible solutions for this problem are:
 		.Check if your network connection is working
 		.Fix the system clock
 		.Run 'swupd info' to check if the urls are correct
 		.Check if the server SSL certificate is trusted by your system \\('clrtrust generate' may help\\)
+		Downloading packs for:
+		 - os-core
 		Error: zero pack downloads failed
 		Checking for corrupt files
 		Validate downloaded files

--- a/test/functional/update/update-json.bats
+++ b/test/functional/update/update-json.bats
@@ -37,11 +37,8 @@ test_setup() {
 		{ "type" : "progress", "currentStep" : 3, "totalSteps" : 10, "stepCompletion" : 0, "stepDescription" : "download_packs" },
 		{ "type" : "info", "msg" : "Downloading packs for:" },
 		{ "type" : "info", "msg" : " - test-bundle" },
-	EOM
-	)
-	expected_output2=$(cat <<-EOM
-		{ "type" : "progress", "currentStep" : 3, "totalSteps" : 10, "stepCompletion" : 100, "stepDescription" : "download_packs" },
 		{ "type" : "info", "msg" : "Finishing packs extraction..." },
+		{ "type" : "progress", "currentStep" : 3, "totalSteps" : 10, "stepCompletion" : 100, "stepDescription" : "download_packs" },
 		{ "type" : "progress", "currentStep" : 4, "totalSteps" : 10, "stepCompletion" : -1, "stepDescription" : "extract_packs" },
 		{ "type" : "progress", "currentStep" : 4, "totalSteps" : 10, "stepCompletion" : 100, "stepDescription" : "extract_packs" },
 		{ "type" : "progress", "currentStep" : 5, "totalSteps" : 10, "stepCompletion" : -1, "stepDescription" : "prepare_for_update" },
@@ -76,7 +73,7 @@ test_setup() {
 		{ "type" : "info", "msg" : "Calling post-update helper scripts" },
 	EOM
 	)
-	expected_output3=$(cat <<-EOM
+	expected_output2=$(cat <<-EOM
 		\{ "type" : "info", "msg" : "Update took ... seconds, 0 MB transferred" \},
 		\{ "type" : "info", "msg" : "Update successful - System updated from version 10 to version 20" \},
 		\{ "type" : "progress", "currentStep" : 10, "totalSteps" : 10, "stepCompletion" : 100, "stepDescription" : "run_postupdate_scripts" \},
@@ -85,8 +82,7 @@ test_setup() {
 	EOM
 	)
 	assert_in_output "$expected_output1"
-	assert_in_output "$expected_output2"
-	assert_regex_in_output "$expected_output3"
+	assert_regex_in_output "$expected_output2"
 
 }
 #WEIGHT=5


### PR DESCRIPTION
There are some problems with how we are using multiplexed curl causing huge slowdowns (2-5 times slower).

For now rather than rework the multiplexed curl code, switch to using the synchronous code path.

Signed-off-by: William Douglas <william.douglas@intel.com>