### PR TITLE
Rework how curl errors are checked

### DIFF
--- a/src/swupd_build_variant.h
+++ b/src/swupd_build_variant.h
@@ -26,7 +26,7 @@
 
 #ifdef SWUPD_TAR_SELINUX
 #define TAR_XATTR_ARGS "--xattrs --xattrs-include='*' --selinux"
-#else  /* SWUPD_TAR_SELINUX */
+#else /* SWUPD_TAR_SELINUX */
 #define TAR_XATTR_ARGS "--xattrs --xattrs-include='*'"
 #endif /* SWUPD_TAR_SELINUX */
 

--- a/src/swupd_lib/curl.c
+++ b/src/swupd_lib/curl.c
@@ -456,6 +456,23 @@ enum download_status process_curl_error_codes(int curl_ret, CURL *curl_handle)
 			return DOWNLOAD_STATUS_ERROR;
 		}
 	} else { /* download failed but let our caller do it */
+		long response = 0;
+		curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &response);
+		debug("Curl - process_curl_error_codes: curl_ret = %d, response = %ld\n", curl_ret, response);
+		switch (response) {
+		case 403:
+			debug("Curl - Download failed - forbidden (403) - '%s'\n", url);
+			return DOWNLOAD_STATUS_FORBIDDEN;
+		case 404:
+			debug("Curl - Download failed - file not found (404) - '%s'\n", url);
+			return DOWNLOAD_STATUS_NOT_FOUND;
+		case 416:
+			debug("Curl - Download failed - range not satisfiable (416) - '%s'\n", url);
+			return DOWNLOAD_STATUS_RANGE_NOT_SATISFIABLE;
+		default:
+			debug("Curl - Download failed: response (%ld) -  '%s'\n", response, url);
+		}
+
 		debug("Curl - process_curl_error_codes - curl_ret = %d\n", curl_ret);
 		switch (curl_ret) {
 		case CURLE_COULDNT_RESOLVE_PROXY:

--- a/src/swupd_lib/curl_async.c
+++ b/src/swupd_lib/curl_async.c
@@ -79,10 +79,10 @@
 #define HASH_TO_KEY(hash) (HASH_VALUE(hash[0]) << 4 | HASH_VALUE(hash[1]))
 
 struct swupd_curl_parallel_handle {
-	int retry_delay;		    /* Retry delay */
-	size_t mcurl_size, max_xfer;	    /* hysteresis parameters */
+	int retry_delay;	     /* Retry delay */
+	size_t mcurl_size, max_xfer; /* hysteresis parameters */
 	bool resume_failed;
-	int last_retry;			    /* keep the largest retry number so far */
+	int last_retry; /* keep the largest retry number so far */
 
 	CURLM *mcurl;			    /* Curl handle */
 	struct list *failed;		    /* List of failed downloads */
@@ -108,8 +108,8 @@ struct multi_curl_file {
 	const char *hash;		/* Unique identifier of this file. */
 	swupd_curl_success_cb callback; /* Holds original success callback to be wrapped */
 
-	void *data;			/* user's data */
-	bool cb_retval;			/* return value from callback */
+	void *data;	/* user's data */
+	bool cb_retval; /* return value from callback */
 	struct file_progress *progress;
 };
 

--- a/src/swupd_lib/filedesc.c
+++ b/src/swupd_lib/filedesc.c
@@ -98,7 +98,7 @@ static void dump_file_descriptor_leaks_int(int n, void *a)
 	char *filename;
 	char buffer[PATH_MAX + 1];
 	ssize_t size;
-	a = a;		/* Silence warning */
+	a = a; /* Silence warning */
 	if (FD_ISSET(n, &open_fds)) {
 		return; /* Was already open */
 	}


### PR DESCRIPTION
In cases where curl perform returns an error but is actually a 400 level response, swupd needs to check curl info to see this. If the info reveals a 400 level response, return the corresponding download status error to prevent useless download retries.