### PR TITLE
rst2man.py -> rst2man

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -268,7 +268,7 @@ man: $(dist_man_MANS)
 
 .rst:
 	mkdir -p "$$(dirname $@)"
-	rst2man.py "$<" > "$@.tmp" && mv -f "$@.tmp" "$@"
+	$(RST2MAN) "$<" > "$@.tmp" && mv -f "$@.tmp" "$@"
 
 if ENABLE_TESTS
 

--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,7 @@ AC_CHECK_LIB([pthread], [pthread_create])
 
 
 # Program checks
+AC_CHECK_PROGS(RST2MAN, rst2man rst2man.py)
 AC_CHECK_PROGS(TAR, tar)
 AC_DEFINE(_GNU_SOURCE, 1, [Use non standard gnu functions])
 


### PR DESCRIPTION
Fix build failure:
```
rst2man.py "docs/swupd.1.rst" > "docs/swupd.1.tmp" && mv -f "docs/swupd.1.tmp" "docs/swupd.1"
rst2man.py "docs/swupd-alias.7.rst" > "docs/swupd-alias.7.tmp" && mv -f "docs/swupd-alias.7.tmp" "docs/swupd-alias.7"
rst2man.py "docs/swupd-update.service.4.rst" > "docs/swupd-update.service.4.tmp" && mv -f "docs/swupd-update.service.4.tmp" "docs/swupd-update.service.4"
rst2man.py "docs/update-triggers.target.4.rst" > "docs/update-triggers.target.4.tmp" && mv -f "docs/update-triggers.target.4.tmp" "docs/update-triggers.target.4"
/bin/sh: line 1: rst2man.py: command not found
rst2man.py "docs/swupd-update.timer.4.rst" > "docs/swupd-update.timer.4.tmp" && mv -f "docs/swupd-update.timer.4.tmp" "docs/swupd-update.timer.4"
/bin/sh: line 1: rst2man.py: command not found
/bin/sh: line 1: rst2man.py: command not found
/bin/sh: line 1: rst2man.py: command not found
```