### PR TITLE
Test fixups and update for newer systemd

### DIFF
--- a/src/cmds/autoupdate.c
+++ b/src/cmds/autoupdate.c
@@ -156,14 +156,14 @@ enum swupd_code autoupdate_main(int argc, char **argv)
 		return SWUPD_OK;
 	} else {
 		int rc1, rc2;
-		const int STATUS_UNKNOWN = 4;
+		const int STATUS_UNKNOWN = 5;
 		rc1 = systemctl_cmd_path(globals.path_prefix, "is-enabled", "swupd-update.service", NULL);
 		rc2 = systemctl_cmd_path(globals.path_prefix, "is-active", "swupd-update.timer", NULL);
 		if (rc1 == SWUPD_OK && rc2 == SWUPD_OK) {
 			info("Enabled\n");
 			return SWUPD_OK;
 		} else if (rc1 >= STATUS_UNKNOWN || rc2 >= STATUS_UNKNOWN) {
-			/* systemctl returns 1,2, or 3 when program dead or not running */
+			/* systemctl returns 1,2,3, or 4 when program dead, not running or units not found */
 			error("Unable to determine autoupdate status\n");
 			return SWUPD_SUBPROCESS_ERROR;
 			// Swupd-service is unmasked, static but timer is inactive for --path

--- a/test/functional/api/api-autoupdate.bats
+++ b/test/functional/api/api-autoupdate.bats
@@ -16,7 +16,7 @@ test_setup() {
 
 	run sudo sh -c "$SWUPD autoupdate $SWUPD_OPTS --quiet"
 
-	assert_status_is "$SWUPD_NO"
+	assert_status_in "$SWUPD_NO" "$SWUPD_SUBPROCESS_ERROR"
 	assert_output_is_empty
 
 }

--- a/test/functional/testlib.bash
+++ b/test/functional/testlib.bash
@@ -4823,6 +4823,38 @@ assert_status_is() { # assertion
 
 }
 
+assert_status_in() { # assertion
+
+	local expected_statuses="$*"
+	validate_param "$expected_statuses"
+
+	if [ -z "$status" ]; then
+		echo "The \$status environment variable is empty."
+		echo "Please make sure this assertion is used inside a BATS test after a 'run' command."
+		return 1
+	fi
+
+        local found=0
+	for expected_status in $expected_statuses; do
+		if [ "$status" -eq "$expected_status" ]; then
+			found=1
+			break
+		fi
+	done
+	if [ $found -eq 0 ]; then
+		print_assert_failure "Expected statuses: $expected_statuses\\nActual status: $status"
+		return 1
+	else
+		# if the assertion was successful show the output only if the user
+		# runs the test with the -t flag
+		echo -e "\\nCommand output:" >&3
+		echo "------------------------------------------------------------------" >&3
+		echo "$output" >&3
+		echo -e "------------------------------------------------------------------\\n" >&3
+	fi
+
+}
+
 assert_status_is_not() { # assertion
 
 	local not_expected_status=$1


### PR DESCRIPTION
systemctl reports that the timer file is missing now as a return code 4 so update the unknown start number.

Also with this change SWUPD_NO is no longer always returned so add a new helper to check if a status is one of multiple options.