### PR TITLE
Redirect URL override messages to STDERR

### DIFF
--- a/src/swupd_lib/globals.c
+++ b/src/swupd_lib/globals.c
@@ -551,7 +551,7 @@ static bool global_parse_opt(int opt, char *optarg)
 		}
 		return true;
 	case 'u':
-		print("Overriding version and content URLs with %s\n", optarg);
+		warn("Overriding version and content URLs with %s\n", optarg);
 		set_version_url(optarg);
 		set_content_url(optarg);
 		return true;
@@ -563,11 +563,11 @@ static bool global_parse_opt(int opt, char *optarg)
 		}
 		return true;
 	case 'c':
-		print("Overriding content URL with %s\n", optarg);
+		warn("Overriding content URL with %s\n", optarg);
 		set_content_url(optarg);
 		return true;
 	case 'v':
-		print("Overriding version URL with %s\n", optarg);
+		warn("Overriding version URL with %s\n", optarg);
 		set_version_url(optarg);
 		return true;
 	case 'F':

--- a/test/functional/mirror/mirror-set-unset.bats
+++ b/test/functional/mirror/mirror-set-unset.bats
@@ -74,7 +74,7 @@ teardown_file() {
 	run sudo sh -c "$SWUPD mirror --set -u https://example.com/swupd-file $SWUPD_OPTS"
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
-		Overriding version and content URLs with https://example.com/swupd-file
+		Warning: Overriding version and content URLs with https://example.com/swupd-file
 		Mirror url set
 		Distribution:      Swupd Test Distro
 		Installed version: 10
@@ -108,7 +108,7 @@ teardown_file() {
 	run sudo sh -c "$SWUPD mirror --set -c https://example.com/swupd-file $SWUPD_OPTS"
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
-		Overriding content URL with https://example.com/swupd-file
+		Warning: Overriding content URL with https://example.com/swupd-file
 		Mirror url set
 		Distribution:      Swupd Test Distro
 		Installed version: 10
@@ -142,7 +142,7 @@ teardown_file() {
 	run sudo sh -c "$SWUPD mirror --set -v https://example.com/swupd-file $SWUPD_OPTS"
 	assert_status_is 0
 	expected_output=$(cat <<-EOM
-		Overriding version URL with https://example.com/swupd-file
+		Warning: Overriding version URL with https://example.com/swupd-file
 		Mirror url set
 		Distribution:      Swupd Test Distro
 		Installed version: 10

--- a/test/functional/os-install/install-statedir-cache-offline.bats
+++ b/test/functional/os-install/install-statedir-cache-offline.bats
@@ -32,7 +32,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Overriding version and content URLs with https://localhost
+		Warning: Overriding version and content URLs with https://localhost
 		Installing OS version 10
 		Downloading missing manifests...
 		No packs need to be downloaded
@@ -63,7 +63,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MANIFEST"
 	expected_output=$(cat <<-EOM
-		Overriding version and content URLs with https://localhost
+		Warning: Overriding version and content URLs with https://localhost
 		Installing OS version 10
 		Downloading missing manifests...
 		Error: Failed to connect to update server: https://localhost/10/Manifest.os-core.tar
@@ -92,7 +92,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_LOAD_MOM"
 	expected_output=$(cat <<-EOM
-		Overriding version and content URLs with https://localhost
+		Warning: Overriding version and content URLs with https://localhost
 		Installing OS version 10
 		Error: Failed to connect to update server: https://localhost/10/Manifest.MoM.sig
 		Possible solutions for this problem are:
@@ -121,7 +121,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_COULDNT_DOWNLOAD_FILE"
 	expected_output=$(cat <<-EOM
-		Overriding version and content URLs with https://localhost
+		Warning: Overriding version and content URLs with https://localhost
 		Installing OS version 10
 		Downloading missing manifests...
 		No packs need to be downloaded
@@ -153,7 +153,7 @@ test_setup() {
 
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Overriding version and content URLs with https://localhost
+		Warning: Overriding version and content URLs with https://localhost
 		Installing OS version 10
 		Downloading missing manifests...
 		Error: Failed to connect to update server: https://localhost/10/pack-os-core-from-0.tar

--- a/test/functional/usability/usa-config-file.bats
+++ b/test/functional/usability/usa-config-file.bats
@@ -160,8 +160,8 @@ test_setup() {
 	run sudo sh -c "$SWUPD info $SWUPD_OPTS -v https://anotherurl.com"
 	assert_status_is "$SWUPD_OK"
 	expected_output=$(cat <<-EOM
-		Overriding version and content URLs with https://someurl.com
-		Overriding version URL with https://anotherurl.com
+		Warning: Overriding version and content URLs with https://someurl.com
+		Warning: Overriding version URL with https://anotherurl.com
 		Distribution:      Swupd Test Distro
 		Installed version: 10
 		Version URL:       https://anotherurl.com

--- a/test/real_content/real_content_lib.bash
+++ b/test/real_content/real_content_lib.bash
@@ -49,15 +49,15 @@ install_bundles() {
 	[ "$1" = "-r" ] && { CMD="verify --fix"; shift ; }
 
 	if [ -z "$BUNDLE_LIST" ]; then
-		run sudo sh -c "$SWUPD bundle-list --all $SWUPD_OPTS_SHORT --quiet"
+		run --separate-stderr sudo sh -c "$SWUPD bundle-list --all $SWUPD_OPTS_SHORT --quiet"
 		# shellcheck disable=SC2154
 		# SC2154: output is referenced but not assigned.
 		# the output variable is being assigned and exported by bats
 		BUNDLE_LIST=$(echo "$output" | tr '\n' ' ')
-		num_pkgs=$(echo "$output" | wc -l)
+		num_pkgs=${#lines[@]}
 
 		cur_version=$(grep VERSION_ID "${ROOT_DIR}/usr/lib/os-release" | cut -d = -f 2)
-		num_pkgs_mom=$(sh -c "curl ${URL}/$cur_version/Manifest.MoM 2>/dev/null | grep ^M\\\\. | wc -l")
+		num_pkgs_mom=$(sh -c "curl ${URL}/$cur_version/Manifest.MoM 2>/dev/null | grep -c ^M\\\\.")
 
 		if [ "$num_pkgs" -ne "$num_pkgs_mom" ]; then
 			print "Number of packages on bundle-list --all is $num_pkgs. Expected is $num_pkgs_mom:"
@@ -72,7 +72,7 @@ install_bundles() {
 	CUR_VER=$("$SWUPD" info $SWUPD_OPTS | grep "Installed version"|cut -d ':' -f 2)
 	BUNDLE_LIST="${BUNDLE_LIST// /,}"
 	run sudo sh -c "$SWUPD $CMD $SWUPD_OPTS -B $BUNDLE_LIST -V $CUR_VER"
-	print "Instalation completed"
+	print "Installation completed"
 
 	assert_status_is 0
 	verify_system


### PR DESCRIPTION
Previously, these messages were printed to STDOUT:
Overriding version and content URLs with...
Overriding content URL with...
Overriding version URL with...

But especially with --quiet, the output to STDOUT should be strictly the requested data. So print these as warnings instead.

Fix tests to match this change. Also eliminate some uses of wc -l that don't help. Take advantage of lines array to count bundles.