### PR TITLE
Skip tests that require two builds in a format when there's only one

### DIFF
--- a/test/real_content/real_content_lib.bash
+++ b/test/real_content/real_content_lib.bash
@@ -140,8 +140,7 @@ test_setup() {
 	# Not enough versions to run the test
 	if [ -z "${VERSION[0]}" ] || [ -z "${VERSION[1]}" ]; then
 		# TODO: This is going to break on first release in a new format
-		print "We need at least 2 versions in format $FORMAT to continue with this test"
-		return 1
+		skip "We need at least 2 versions in format $FORMAT to continue with this test"
 	fi
 
 	ROOT_DIR="${BASE_DIR}/${TEST_NAME}"


### PR DESCRIPTION
We already detect and report that certain tests require at least two builds within the current format, but only one exists. Change that from a test *failure* to a *skip*.

Example:
```
We need at least 2 versions in format 38 to continue with this test
Test teardown complete.
not ok 2 RCT002: Repair a big system
# (from function `test_setup' in file test/real_content/real_content_lib.bash, line 144,
#  from function `setup' in test file test/real_content/../functional/testlib.bash, line 4647)
#   `test_setup' failed
#
```
becomes:
```
ok 2 RCT002: Repair a big system # skip We need at least 2 versions in format 38 to continue with this test
```