### PR TITLE
Add sudo to commands to backup/restore Swupd_Root.pem

### DIFF
--- a/test/functional/only_in_ci_system/api-3rd-party-add.bats
+++ b/test/functional/only_in_ci_system/api-3rd-party-add.bats
@@ -20,7 +20,7 @@ test_setup() {
 
 	# Backup the original certificate
 	[[ -f ${SWUPD_ROOT_CERT} ]] &&
-		mv ${SWUPD_ROOT_CERT} ${SWUPD_ROOT_CERT}.orig
+		sudo mv ${SWUPD_ROOT_CERT} ${SWUPD_ROOT_CERT}.orig
 	sudo mkdir -p /usr/share/clear/update-ca
 	sudo cp test/functional/only_in_ci_system/pemfile ${SWUPD_ROOT_CERT}
 
@@ -38,7 +38,7 @@ test_teardown() {
 	sudo rm -f ${SWUPD_ROOT_CERT}
 	# Restore the original certificate
 	[[ -f ${SWUPD_ROOT_CERT}.orig ]] &&
-		mv ${SWUPD_ROOT_CERT}.orig ${SWUPD_ROOT_CERT}
+		sudo mv ${SWUPD_ROOT_CERT}.orig ${SWUPD_ROOT_CERT}
 
 }
 


### PR DESCRIPTION
`sudo` was mistakenly omitted from the prior commit 695417dca0b39d76464fe510b8f0ff57ca21f228, nullifying the effect of the purported fix.