### PR TITLE
Add CI fixes for github's updated Ubuntu container

### DIFF
--- a/scripts/github_actions/build_ci_dependencies.bash
+++ b/scripts/github_actions/build_ci_dependencies.bash
@@ -10,6 +10,8 @@
 set -e
 CORES=2
 
+sudo apt install libbz2-dev liblzma-dev
+
 # If alread exists, reuse
 if [ -d dependencies ]; then
 	pushd dependencies

--- a/test/functional/only_in_ci_system/add-no-disk-space.ignore-list
+++ b/test/functional/only_in_ci_system/add-no-disk-space.ignore-list
@@ -1,0 +1,1 @@
+Error: Curl - Cannot close file.*


### PR DESCRIPTION
Includes needed dev packages and an ignore for error messages seen on Ubuntu's version of curl but not in Clear Linux.