### PR TITLE
Fix up shellcheck issues

### DIFF
--- a/.github/workflows/shellcheck-all.yml
+++ b/.github/workflows/shellcheck-all.yml
@@ -1,8 +1,6 @@
 name: Shellcheck
 
-on:
-  push:
-    branches: [master]
+on: [push, pull_request]
 
 env:
   RUNNING_IN_CI: true

--- a/scripts/shellcheck.bash
+++ b/scripts/shellcheck.bash
@@ -27,7 +27,7 @@ file="$1"
 if [[ "${file/*./}" == "bats" ]]; then
 	sed 's/^@.*/func() {/' "$file" |
 	sed 's/^load.*/source test\/functional\/testlib.bash/' |
-	shellcheck -s bash -x -e SC1008,SC2119 /dev/stdin
+	shellcheck -s bash -x -e SC1008,SC2119,SC2317 /dev/stdin
 else
 	shellcheck -x "$file" -e SC2119
 fi

--- a/test/real_content/real_content_lib.bash
+++ b/test/real_content/real_content_lib.bash
@@ -133,7 +133,7 @@ test_setup() {
 			continue
 		fi
 
-		VERSION[$i]=$v
+		VERSION[i]=$v
 		i=$((i+1))
 	done
 


### PR DESCRIPTION
The mechanism used to convert bats tests to something shellcheck can verify caused a large number of failures due to the introduction of testing for if a call is possible. Given the tests aren't called in a normal shell script way, it is best to just ignore this error for bats files.

Also fix an index using '$' unnecessarily.