### PR TITLE
Make directories in cache paths recursively

### DIFF
--- a/src/swupd_lib/curl.c
+++ b/src/swupd_lib/curl.c
@@ -36,6 +36,7 @@
 #include <curl/curl.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -378,6 +379,7 @@ static size_t swupd_download_file_to_memory(void *ptr, size_t size, size_t nmemb
 
 CURLcode swupd_download_file_create(struct curl_file *file)
 {
+	mkdir_p(dirname(strdupa(file->path)));
 	file->fh = fopen(file->path, "w");
 	if (!file->fh) {
 		error("Curl - Cannot open file '%s' for writing - '%s'\n",


### PR DESCRIPTION
When downloading cacheable files from the upstream mirror, swupd fails to write the local cached copy because it doesn't create the directories before attempting to write the files, for example:
`/var/lib/swupd/cache/https___download.clearlinux.org_update/download/latest`

Add a `mkdir -p` call to create those intermediate directories in the intended cache file path.


Failure signature:
```
$ sudo swupd check-update --debug -u https://download.clearlinux.org/update
Warning: Overriding version and content URLs with https://download.clearlinux.org/update
2025-04-23 10:35:19 (src/swupd_lib/curl.c:206)    Debug: Initializing swupd curl library
2025-04-23 10:35:19 (src/swupd_lib/curl.c:141)    Debug: Curl - check_connection url: https://download.clearlinux.org/update/version/latest_version
2025-04-23 10:35:19 (src/swupd_lib/curl.c:605)    Debug: Curl - Start sync download: https://download.clearlinux.org/update/version/latest_version -> <memory>
2025-04-23 10:35:19 (src/swupd_lib/curl.c:440)    Debug: Curl - process_curl_error_codes: curl_ret = 0, response = 200
2025-04-23 10:35:19 (src/swupd_lib/curl.c:623)    Debug: Curl - Complete sync download: https://download.clearlinux.org/update/version/latest_version -> <memory>, status=0
2025-04-23 10:35:19 (src/swupd_lib/progress.c:53)
2025-04-23 10:35:19 (src/swupd_lib/curl.c:605)    Debug: Curl - Start sync download: https://download.clearlinux.org/update/version/latest_version.sig -> <memory>
2025-04-23 10:35:19 (src/swupd_lib/curl.c:440)    Debug: Curl - process_curl_error_codes: curl_ret = 0, response = 200
2025-04-23 10:35:19 (src/swupd_lib/curl.c:623)    Debug: Curl - Complete sync download: https://download.clearlinux.org/update/version/latest_version.sig -> <memory>, status=0
2025-04-23 10:35:19 (src/swupd_lib/progress.c:53)
2025-04-23 10:35:19 (src/swupd_lib/curl.c:605)    Debug: Curl - Start sync download: https://download.clearlinux.org/update/43290/format -> <memory>
2025-04-23 10:35:19 (src/swupd_lib/curl.c:440)    Debug: Curl - process_curl_error_codes: curl_ret = 0, response = 200
2025-04-23 10:35:19 (src/swupd_lib/curl.c:623)    Debug: Curl - Complete sync download: https://download.clearlinux.org/update/43290/format -> <memory>, status=0
2025-04-23 10:35:19 (src/swupd_lib/progress.c:53)
2025-04-23 10:35:19 (src/swupd_lib/curl.c:385)    Error: Curl - Cannot open file '/var/lib/swupd/cache/https___download.clearlinux.org_update/download/latest' for writing - 'No such file or directory'
2025-04-23 10:35:19 (src/swupd_lib/curl.c:471)    Debug: Curl - process_curl_error_codes: curl_ret = 23, response = 0
2025-04-23 10:35:19 (src/swupd_lib/curl.c:483)    Debug: Curl - Download failed: response (0) -  ''
2025-04-23 10:35:19 (src/swupd_lib/curl.c:486)    Debug: Curl - process_curl_error_codes - curl_ret = 23
2025-04-23 10:35:19 (src/swupd_lib/curl.c:506)    Error: Curl - Error downloading to local file - ''
2025-04-23 10:35:19 (src/swupd_lib/curl.c:507)    Error: Curl - Check free space for /var/lib/swupd?
2025-04-23 10:35:19 (src/swupd_lib/curl.c:623)    Debug: Curl - Complete sync download: https://download.clearlinux.org/update/version/format41/latest -> /var/lib/swupd/cache/https___download.clearlinux.org_update/download/latest, status=6
2025-04-23 10:35:19 (src/swupd_lib/progress.c:53)
```

